### PR TITLE
Call Context for Precompiles

### DIFF
--- a/arbstate/geth-hook.go
+++ b/arbstate/geth-hook.go
@@ -27,12 +27,12 @@ func (p ArbosPrecompileWrapper) Run(input []byte) ([]byte, error) {
 
 func (p ArbosPrecompileWrapper) RunAdvanced(
 	input []byte,
-	suppliedGas uint64,
+	gasSupplied uint64,
 	info *vm.AdvancedPrecompileCall,
 ) (ret []byte, gasLeft uint64, err error) {
 	return p.inner.Call(
 		input, info.PrecompileAddress, info.ActingAsAddress,
-		info.Caller, info.Value, info.ReadOnly, suppliedGas, info.Evm,
+		info.Caller, info.Value, info.ReadOnly, gasSupplied, info.Evm,
 	)
 }
 

--- a/precompiles/ArbAddressTable.go
+++ b/precompiles/ArbAddressTable.go
@@ -15,28 +15,22 @@ type ArbAddressTable struct {
 	Address addr
 }
 
-func (con ArbAddressTable) AddressExists(b burn, caller addr, evm mech, addr addr) (bool, error) {
-	if err := b(params.SloadGas); err != nil {
+func (con ArbAddressTable) AddressExists(c ctx, evm mech, addr addr) (bool, error) {
+	if err := c.burn(params.SloadGas); err != nil {
 		return false, err
 	}
 	return arbos.OpenArbosState(evm.StateDB).AddressTable().AddressExists(addr), nil
 }
 
-func (con ArbAddressTable) Compress(b burn, caller addr, evm mech, addr addr) ([]uint8, error) {
-	if err := b(params.SloadGas); err != nil {
+func (con ArbAddressTable) Compress(c ctx, evm mech, addr addr) ([]uint8, error) {
+	if err := c.burn(params.SloadGas); err != nil {
 		return nil, err
 	}
 	return arbos.OpenArbosState(evm.StateDB).AddressTable().Compress(addr), nil
 }
 
-func (con ArbAddressTable) Decompress(
-	b burn,
-	caller addr,
-	evm mech,
-	buf []uint8,
-	offset huge,
-) (addr, huge, error) {
-	if err := b(params.SloadGas); err != nil {
+func (con ArbAddressTable) Decompress(c ctx, evm mech, buf []uint8, offset huge) (addr, huge, error) {
+	if err := c.burn(params.SloadGas); err != nil {
 		return addr{}, nil, err
 	}
 	if !offset.IsInt64() {
@@ -50,8 +44,8 @@ func (con ArbAddressTable) Decompress(
 	return result, big.NewInt(int64(nbytes)), err
 }
 
-func (con ArbAddressTable) Lookup(b burn, caller addr, evm mech, addr addr) (huge, error) {
-	if err := b(params.SloadGas); err != nil {
+func (con ArbAddressTable) Lookup(c ctx, evm mech, addr addr) (huge, error) {
+	if err := c.burn(params.SloadGas); err != nil {
 		return nil, err
 	}
 	result, exists := arbos.OpenArbosState(evm.StateDB).AddressTable().Lookup(addr)
@@ -61,13 +55,8 @@ func (con ArbAddressTable) Lookup(b burn, caller addr, evm mech, addr addr) (hug
 	return big.NewInt(int64(result)), nil
 }
 
-func (con ArbAddressTable) LookupIndex(
-	b burn,
-	caller addr,
-	evm mech,
-	index huge,
-) (addr, error) {
-	if err := b(params.SloadGas); err != nil {
+func (con ArbAddressTable) LookupIndex(c ctx, evm mech, index huge) (addr, error) {
+	if err := c.burn(params.SloadGas); err != nil {
 		return addr{}, err
 	}
 	if !index.IsUint64() {
@@ -80,15 +69,15 @@ func (con ArbAddressTable) LookupIndex(
 	return result, nil
 }
 
-func (con ArbAddressTable) Register(b burn, caller addr, evm mech, addr addr) (huge, error) {
-	if err := b(params.SstoreSetGas); err != nil {
+func (con ArbAddressTable) Register(c ctx, evm mech, addr addr) (huge, error) {
+	if err := c.burn(params.SstoreSetGas); err != nil {
 		return nil, err
 	}
 	return big.NewInt(int64(arbos.OpenArbosState(evm.StateDB).AddressTable().Register(addr))), nil
 }
 
-func (con ArbAddressTable) Size(b burn, caller addr, evm mech) (huge, error) {
-	if err := b(params.SloadGas); err != nil {
+func (con ArbAddressTable) Size(c ctx, evm mech) (huge, error) {
+	if err := c.burn(params.SloadGas); err != nil {
 		return nil, err
 	}
 	return big.NewInt(int64(arbos.OpenArbosState(evm.StateDB).AddressTable().Size())), nil

--- a/precompiles/ArbAddressTable_test.go
+++ b/precompiles/ArbAddressTable_test.go
@@ -15,16 +15,12 @@ import (
 	"testing"
 )
 
-func fakeBurnGas(amount uint64) error {
-	return nil
-}
-
 func TestArbAddressTableInit(t *testing.T) {
-	caller := common.Address{}
 	st := newMockEVMForTesting(t)
 	atab := ArbAddressTable{}
+	context := testContext(common.Address{})
 
-	sz, err := atab.Size(fakeBurnGas, caller, st)
+	sz, err := atab.Size(context, st)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,26 +28,26 @@ func TestArbAddressTableInit(t *testing.T) {
 		t.Fatal()
 	}
 
-	_, err = atab.Lookup(fakeBurnGas, caller, st, common.Address{})
+	_, err = atab.Lookup(context, st, common.Address{})
 	if err == nil {
 		t.Fatal()
 	}
 
-	_, err = atab.LookupIndex(fakeBurnGas, caller, st, big.NewInt(0))
+	_, err = atab.LookupIndex(context, st, big.NewInt(0))
 	if err == nil {
 		t.Fatal()
 	}
 }
 
 func TestAddressTable1(t *testing.T) {
-	caller := common.Address{}
 	st := newMockEVMForTesting(t)
 	atab := ArbAddressTable{}
+	context := testContext(common.Address{})
 
 	addr := common.BytesToAddress(crypto.Keccak256([]byte{})[:20])
 
 	// register addr
-	slot, err := atab.Register(fakeBurnGas, caller, st, addr)
+	slot, err := atab.Register(context, st, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +56,7 @@ func TestAddressTable1(t *testing.T) {
 	}
 
 	// verify Size() is 1
-	sz, err := atab.Size(fakeBurnGas, caller, st)
+	sz, err := atab.Size(context, st)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +65,7 @@ func TestAddressTable1(t *testing.T) {
 	}
 
 	// verify Lookup of addr returns 0
-	index, err := atab.Lookup(fakeBurnGas, caller, st, addr)
+	index, err := atab.Lookup(context, st, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,13 +74,13 @@ func TestAddressTable1(t *testing.T) {
 	}
 
 	// verify Lookup of nonexistent address returns error
-	_, err = atab.Lookup(fakeBurnGas, caller, st, common.Address{})
+	_, err = atab.Lookup(context, st, common.Address{})
 	if err == nil {
 		t.Fatal()
 	}
 
 	// verify LookupIndex of 0 returns addr
-	addr2, err := atab.LookupIndex(fakeBurnGas, caller, st, big.NewInt(0))
+	addr2, err := atab.LookupIndex(context, st, big.NewInt(0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,21 +89,21 @@ func TestAddressTable1(t *testing.T) {
 	}
 
 	// verify LookupIndex of 1 returns error
-	_, err = atab.LookupIndex(fakeBurnGas, caller, st, big.NewInt(1))
+	_, err = atab.LookupIndex(context, st, big.NewInt(1))
 	if err == nil {
 		t.Fatal()
 	}
 }
 
 func TestAddressTableCompressNotInTable(t *testing.T) {
-	caller := common.Address{}
 	st := newMockEVMForTesting(t)
 	atab := ArbAddressTable{}
+	context := testContext(common.Address{})
 
 	addr := common.BytesToAddress(crypto.Keccak256([]byte{})[:20])
 
 	// verify that compressing addr produces the 21-byte format
-	res, err := atab.Compress(fakeBurnGas, caller, st, addr)
+	res, err := atab.Compress(context, st, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +115,7 @@ func TestAddressTableCompressNotInTable(t *testing.T) {
 	}
 
 	// verify that decompressing res consumes 21 bytes and returns the original addr
-	dec, nbytes, err := atab.Decompress(fakeBurnGas, caller, st, res, big.NewInt(0))
+	dec, nbytes, err := atab.Decompress(context, st, res, big.NewInt(0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,19 +128,19 @@ func TestAddressTableCompressNotInTable(t *testing.T) {
 }
 
 func TestAddressTableCompressInTable(t *testing.T) {
-	caller := common.Address{}
 	st := newMockEVMForTesting(t)
 	atab := ArbAddressTable{}
+	context := testContext(common.Address{})
 
 	addr := common.BytesToAddress(crypto.Keccak256([]byte{})[:20])
 
 	// Register addr
-	if _, err := atab.Register(fakeBurnGas, caller, st, addr); err != nil {
+	if _, err := atab.Register(context, st, addr); err != nil {
 		t.Fatal(err)
 	}
 
 	// verify that compressing addr yields the <= 9 byte format
-	res, err := atab.Compress(fakeBurnGas, caller, st, addr)
+	res, err := atab.Compress(context, st, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +153,7 @@ func TestAddressTableCompressInTable(t *testing.T) {
 	res = append(res, 33)
 
 	// verify that decompressing res consumes all but two bytes of res and produces addr
-	dec, nbytes, err := atab.Decompress(fakeBurnGas, caller, st, res, big.NewInt(1))
+	dec, nbytes, err := atab.Decompress(context, st, res, big.NewInt(1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/precompiles/ArbAggregator.go
+++ b/precompiles/ArbAggregator.go
@@ -14,66 +14,66 @@ type ArbAggregator struct {
 	Address addr
 }
 
-func (con ArbAggregator) GetFeeCollector(b burn, caller addr, evm mech, aggregator addr) (addr, error) {
-	if err := b(params.SloadGas); err != nil {
+func (con ArbAggregator) GetFeeCollector(c ctx, evm mech, aggregator addr) (addr, error) {
+	if err := c.burn(params.SloadGas); err != nil {
 		return addr{}, err
 	}
 	return arbos.OpenArbosState(evm.StateDB).L1PricingState().AggregatorFeeCollector(aggregator), nil
 }
 
-func (con ArbAggregator) GetDefaultAggregator(b burn, caller addr, evm mech) (addr, error) {
-	if err := b(params.SloadGas); err != nil {
+func (con ArbAggregator) GetDefaultAggregator(c ctx, evm mech) (addr, error) {
+	if err := c.burn(params.SloadGas); err != nil {
 		return addr{}, err
 	}
 	return arbos.OpenArbosState(evm.StateDB).L1PricingState().DefaultAggregator(), nil
 }
 
-func (con ArbAggregator) GetPreferredAggregator(b burn, caller addr, evm mech, address addr) (addr, bool, error) {
-	if err := b(params.SloadGas); err != nil {
+func (con ArbAggregator) GetPreferredAggregator(c ctx, evm mech, address addr) (addr, bool, error) {
+	if err := c.burn(params.SloadGas); err != nil {
 		return addr{}, false, err
 	}
 	res, exists := arbos.OpenArbosState(evm.StateDB).L1PricingState().PreferredAggregator(address)
 	return res, exists, nil
 }
 
-func (con ArbAggregator) GetTxBaseFee(b burn, caller addr, evm mech, aggregator addr) (huge, error) {
-	if err := b(params.SloadGas); err != nil {
+func (con ArbAggregator) GetTxBaseFee(c ctx, evm mech, aggregator addr) (huge, error) {
+	if err := c.burn(params.SloadGas); err != nil {
 		return nil, err
 	}
 	return arbos.OpenArbosState(evm.StateDB).L1PricingState().FixedChargeForAggregatorL1Gas(aggregator), nil
 }
 
-func (con ArbAggregator) SetFeeCollector(b burn, caller addr, evm mech, aggregator addr, newFeeCollector addr) error {
-	if err := b(params.SloadGas + params.SstoreSetGas); err != nil {
+func (con ArbAggregator) SetFeeCollector(c ctx, evm mech, aggregator addr, newFeeCollector addr) error {
+	if err := c.burn(params.SloadGas + params.SstoreSetGas); err != nil {
 		return err
 	}
 	l1State := arbos.OpenArbosState(evm.StateDB).L1PricingState()
-	if (caller != aggregator) && (caller != l1State.AggregatorFeeCollector(aggregator)) {
+	if (c.caller != aggregator) && (c.caller != l1State.AggregatorFeeCollector(aggregator)) {
 		// only the aggregator and its current fee collector can change the aggregator's fee collector
-		return errors.New("non-authorized caller in ArbAggregator.SetFeeCollector")
+		return errors.New("non-authorized c.caller in ArbAggregator.SetFeeCollector")
 	}
 	l1State.SetAggregatorFeeCollector(aggregator, newFeeCollector)
 	return nil
 }
 
-func (con ArbAggregator) SetDefaultAggregator(b burn, caller addr, evm mech, newDefault addr) error {
-	if err := b(params.SstoreSetGas); err != nil {
+func (con ArbAggregator) SetDefaultAggregator(c ctx, evm mech, newDefault addr) error {
+	if err := c.burn(params.SstoreSetGas); err != nil {
 		return err
 	}
 	arbos.OpenArbosState(evm.StateDB).L1PricingState().SetDefaultAggregator(newDefault)
 	return nil
 }
 
-func (con ArbAggregator) SetPreferredAggregator(b burn, caller addr, evm mech, prefAgg addr) error {
-	if err := b(params.SstoreSetGas); err != nil {
+func (con ArbAggregator) SetPreferredAggregator(c ctx, evm mech, prefAgg addr) error {
+	if err := c.burn(params.SstoreSetGas); err != nil {
 		return err
 	}
-	arbos.OpenArbosState(evm.StateDB).L1PricingState().SetPreferredAggregator(caller, prefAgg)
+	arbos.OpenArbosState(evm.StateDB).L1PricingState().SetPreferredAggregator(c.caller, prefAgg)
 	return nil
 }
 
-func (con ArbAggregator) SetTxBaseFee(b burn, caller addr, evm mech, aggregator addr, feeInL1Gas huge) error {
-	if err := b(params.SstoreSetGas); err != nil {
+func (con ArbAggregator) SetTxBaseFee(c ctx, evm mech, aggregator addr, feeInL1Gas huge) error {
+	if err := c.burn(params.SstoreSetGas); err != nil {
 		return err
 	}
 	arbos.OpenArbosState(evm.StateDB).L1PricingState().SetFixedChargeForAggregatorL1Gas(aggregator, feeInL1Gas)

--- a/precompiles/ArbAggregator_test.go
+++ b/precompiles/ArbAggregator_test.go
@@ -12,14 +12,14 @@ import (
 )
 
 func TestDefaultAggregator(t *testing.T) {
-	caller := common.Address{}
 	evm := newMockEVMForTesting(t)
 	agg := ArbAggregator{}
+	context := testContext(common.Address{})
 
 	addr := common.BytesToAddress(crypto.Keccak256([]byte{})[:20])
 
 	// initial default aggregator should be zero address
-	def, err := agg.GetDefaultAggregator(fakeBurnGas, caller, evm)
+	def, err := agg.GetDefaultAggregator(context, evm)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,12 +28,12 @@ func TestDefaultAggregator(t *testing.T) {
 	}
 
 	// set default aggregator to addr
-	if err := agg.SetDefaultAggregator(fakeBurnGas, caller, evm, addr); err != nil {
+	if err := agg.SetDefaultAggregator(context, evm, addr); err != nil {
 		t.Fatal(err)
 	}
 
 	// default aggregator should now be addr
-	res, err := agg.GetDefaultAggregator(fakeBurnGas, caller, evm)
+	res, err := agg.GetDefaultAggregator(context, evm)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,6 @@ func TestDefaultAggregator(t *testing.T) {
 }
 
 func TestPreferredAggregator(t *testing.T) {
-	caller := common.Address{}
 	evm := newMockEVMForTesting(t)
 	agg := ArbAggregator{}
 
@@ -51,8 +50,11 @@ func TestPreferredAggregator(t *testing.T) {
 	defaultAggAddr := common.BytesToAddress(crypto.Keccak256([]byte{1})[:20])
 	prefAggAddr := common.BytesToAddress(crypto.Keccak256([]byte{2})[:20])
 
+	callerCtx := testContext(common.Address{})
+	userCtx := testContext(userAddr)
+
 	// initial preferred aggregator should be the default of zero address
-	res, isNonDefault, err := agg.GetPreferredAggregator(fakeBurnGas, caller, evm, userAddr)
+	res, isNonDefault, err := agg.GetPreferredAggregator(callerCtx, evm, userAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,12 +66,12 @@ func TestPreferredAggregator(t *testing.T) {
 	}
 
 	// set default aggregator
-	if err := agg.SetDefaultAggregator(fakeBurnGas, caller, evm, defaultAggAddr); err != nil {
+	if err := agg.SetDefaultAggregator(callerCtx, evm, defaultAggAddr); err != nil {
 		t.Fatal(err)
 	}
 
 	// preferred aggregator should be the new default address
-	res, isNonDefault, err = agg.GetPreferredAggregator(fakeBurnGas, caller, evm, userAddr)
+	res, isNonDefault, err = agg.GetPreferredAggregator(callerCtx, evm, userAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,12 +83,12 @@ func TestPreferredAggregator(t *testing.T) {
 	}
 
 	// set preferred aggregator
-	if err := agg.SetPreferredAggregator(fakeBurnGas, userAddr, evm, prefAggAddr); err != nil {
+	if err := agg.SetPreferredAggregator(userCtx, evm, prefAggAddr); err != nil {
 		t.Fatal(err)
 	}
 
 	// preferred aggregator should now be prefAggAddr
-	res, isNonDefault, err = agg.GetPreferredAggregator(fakeBurnGas, caller, evm, userAddr)
+	res, isNonDefault, err = agg.GetPreferredAggregator(callerCtx, evm, userAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +101,6 @@ func TestPreferredAggregator(t *testing.T) {
 }
 
 func TestFeeCollector(t *testing.T) {
-	caller := common.Address{}
 	evm := newMockEVMForTesting(t)
 	agg := ArbAggregator{}
 
@@ -107,8 +108,13 @@ func TestFeeCollector(t *testing.T) {
 	collectorAddr := common.BytesToAddress(crypto.Keccak256([]byte{1})[:20])
 	impostorAddr := common.BytesToAddress(crypto.Keccak256([]byte{2})[:20])
 
+	aggCtx := testContext(aggAddr)
+	callerCtx := testContext(common.Address{})
+	collectorCtx := testContext(collectorAddr)
+	imposterCtx := testContext(impostorAddr)
+
 	// initial result should be addr
-	coll, err := agg.GetFeeCollector(fakeBurnGas, caller, evm, aggAddr)
+	coll, err := agg.GetFeeCollector(callerCtx, evm, aggAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,12 +123,12 @@ func TestFeeCollector(t *testing.T) {
 	}
 
 	// set fee collector to collectorAddr
-	if err := agg.SetFeeCollector(fakeBurnGas, aggAddr, evm, aggAddr, collectorAddr); err != nil {
+	if err := agg.SetFeeCollector(aggCtx, evm, aggAddr, collectorAddr); err != nil {
 		t.Fatal(err)
 	}
 
 	// fee collector should now be collectorAddr
-	coll, err = agg.GetFeeCollector(fakeBurnGas, caller, evm, aggAddr)
+	coll, err = agg.GetFeeCollector(callerCtx, evm, aggAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,28 +137,30 @@ func TestFeeCollector(t *testing.T) {
 	}
 
 	// trying to set someone else's collector is an error
-	err = agg.SetFeeCollector(fakeBurnGas, impostorAddr, evm, aggAddr, impostorAddr)
+	err = agg.SetFeeCollector(imposterCtx, evm, aggAddr, impostorAddr)
 	if err == nil {
 		t.Fatal()
 	}
 
 	// but the fee collector can replace itself
-	err = agg.SetFeeCollector(fakeBurnGas, collectorAddr, evm, aggAddr, impostorAddr)
+	err = agg.SetFeeCollector(collectorCtx, evm, aggAddr, impostorAddr)
 	if err != nil {
 		t.Fatal()
 	}
 }
 
 func TestTxBaseFee(t *testing.T) {
-	caller := common.Address{}
 	evm := newMockEVMForTesting(t)
 	agg := ArbAggregator{}
 
 	aggAddr := common.BytesToAddress(crypto.Keccak256([]byte{0})[:20])
 	targetFee := big.NewInt(973)
 
+	aggCtx := testContext(aggAddr)
+	callerCtx := testContext(common.Address{})
+
 	// initial result should be zero
-	fee, err := agg.GetTxBaseFee(fakeBurnGas, caller, evm, aggAddr)
+	fee, err := agg.GetTxBaseFee(callerCtx, evm, aggAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,12 +169,12 @@ func TestTxBaseFee(t *testing.T) {
 	}
 
 	// set base fee to value
-	if err := agg.SetTxBaseFee(fakeBurnGas, aggAddr, evm, aggAddr, targetFee); err != nil {
+	if err := agg.SetTxBaseFee(aggCtx, evm, aggAddr, targetFee); err != nil {
 		t.Fatal(err)
 	}
 
 	// base fee should now be targetFee
-	fee, err = agg.GetTxBaseFee(fakeBurnGas, caller, evm, aggAddr)
+	fee, err = agg.GetTxBaseFee(callerCtx, evm, aggAddr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/precompiles/ArbBLS.go
+++ b/precompiles/ArbBLS.go
@@ -12,10 +12,10 @@ type ArbBLS struct {
 	Address addr
 }
 
-func (con ArbBLS) GetPublicKey(b burn, caller addr, evm mech, addr addr) (huge, huge, huge, huge, error) {
+func (con ArbBLS) GetPublicKey(c ctx, evm mech, addr addr) (huge, huge, huge, huge, error) {
 	return nil, nil, nil, nil, errors.New("unimplemented")
 }
 
-func (con ArbBLS) Register(b burn, caller addr, evm mech, x0, x1, y0, y1 huge) error {
+func (con ArbBLS) Register(c ctx, evm mech, x0, x1, y0, y1 huge) error {
 	return errors.New("unimplemented")
 }

--- a/precompiles/ArbDebug.go
+++ b/precompiles/ArbDebug.go
@@ -14,18 +14,18 @@ type ArbDebug struct {
 	StoreGasCost func(bool, addr, huge, [32]byte, []byte) uint64
 }
 
-func (con ArbDebug) Events(b burn, caller addr, evm mech, paid huge, flag bool, value [32]byte) (addr, huge, error) {
+func (con ArbDebug) Events(c ctx, evm mech, paid huge, flag bool, value [32]byte) (addr, huge, error) {
 	// Emits 2 events that cover each case
 	//   Basic tests an index'd value & a normal value
 	//   Mixed interleaves index'd and normal values that may need to be padded
 
-	cost := con.BasicGasCost(true, value) + con.MixedGasCost(true, true, value, caller, caller)
-	if err := b(cost); err != nil {
-		return caller, paid, err
+	cost := con.BasicGasCost(true, value) + con.MixedGasCost(true, true, value, c.caller, c.caller)
+	if err := c.burn(cost); err != nil {
+		return c.caller, paid, err
 	}
 
 	con.Basic(evm, !flag, value)
-	con.Mixed(evm, flag, !flag, value, con.Address, caller)
+	con.Mixed(evm, flag, !flag, value, con.Address, c.caller)
 
-	return caller, paid, nil
+	return c.caller, paid, nil
 }

--- a/precompiles/ArbFunctionTable.go
+++ b/precompiles/ArbFunctionTable.go
@@ -12,14 +12,14 @@ type ArbFunctionTable struct {
 	Address addr
 }
 
-func (con ArbFunctionTable) Get(b burn, caller addr, evm mech, addr addr, index huge) (huge, bool, huge, error) {
+func (con ArbFunctionTable) Get(c ctx, evm mech, addr addr, index huge) (huge, bool, huge, error) {
 	return nil, false, nil, errors.New("unimplemented")
 }
 
-func (con ArbFunctionTable) Size(b burn, caller addr, evm mech, addr addr) (huge, error) {
+func (con ArbFunctionTable) Size(c ctx, evm mech, addr addr) (huge, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbFunctionTable) Upload(b burn, caller addr, evm mech, buf []byte) error {
+func (con ArbFunctionTable) Upload(c ctx, evm mech, buf []byte) error {
 	return errors.New("unimplemented")
 }

--- a/precompiles/ArbGasInfo.go
+++ b/precompiles/ArbGasInfo.go
@@ -12,40 +12,34 @@ type ArbGasInfo struct {
 	Address addr
 }
 
-func (con ArbGasInfo) GetGasAccountingParams(b burn, caller addr, evm mech) (huge, huge, huge, error) {
+func (con ArbGasInfo) GetGasAccountingParams(c ctx, evm mech) (huge, huge, huge, error) {
 	return nil, nil, nil, errors.New("unimplemented")
 }
 
-func (con ArbGasInfo) GetPricesInArbGas(b burn, caller addr, evm mech) (huge, huge, huge, error) {
+func (con ArbGasInfo) GetPricesInArbGas(c ctx, evm mech) (huge, huge, huge, error) {
 	return nil, nil, nil, errors.New("unimplemented")
 }
 
-func (con ArbGasInfo) GetPricesInArbGasWithAggregator(
-	b burn,
-	caller addr,
-	evm mech,
-	aggregator addr,
-) (huge, huge, huge, error) {
+func (con ArbGasInfo) GetPricesInArbGasWithAggregator(c ctx, evm mech, aggregator addr) (huge, huge, huge, error) {
 	return nil, nil, nil, errors.New("unimplemented")
 }
 
-func (con ArbGasInfo) GetPricesInWei(b burn, caller addr, evm mech) (huge, huge, huge, huge, huge, huge, error) {
+func (con ArbGasInfo) GetPricesInWei(c ctx, evm mech) (huge, huge, huge, huge, huge, huge, error) {
 	return nil, nil, nil, nil, nil, nil, errors.New("unimplemented")
 }
 
 func (con ArbGasInfo) GetPricesInWeiWithAggregator(
-	b burn,
-	caller addr,
+	c ctx,
 	evm mech,
 	aggregator addr,
 ) (huge, huge, huge, huge, huge, huge, error) {
 	return nil, nil, nil, nil, nil, nil, errors.New("unimplemented")
 }
 
-func (con ArbGasInfo) GetL1GasPriceEstimate(b burn, caller addr, evm mech) (huge, error) {
+func (con ArbGasInfo) GetL1GasPriceEstimate(c ctx, evm mech) (huge, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbGasInfo) SetL1GasPriceEstimate(b burn, caller addr, evm mech, priceInWei huge) error {
+func (con ArbGasInfo) SetL1GasPriceEstimate(c ctx, evm mech, priceInWei huge) error {
 	return errors.New("unimplemented")
 }

--- a/precompiles/ArbInfo.go
+++ b/precompiles/ArbInfo.go
@@ -12,10 +12,10 @@ type ArbInfo struct {
 	Address addr
 }
 
-func (con ArbInfo) GetBalance(b burn, caller addr, evm mech, account addr) (huge, error) {
+func (con ArbInfo) GetBalance(c ctx, evm mech, account addr) (huge, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbInfo) GetCode(b burn, caller addr, evm mech, account addr) ([]byte, error) {
+func (con ArbInfo) GetCode(c ctx, evm mech, account addr) ([]byte, error) {
 	return nil, errors.New("unimplemented")
 }

--- a/precompiles/ArbOwner.go
+++ b/precompiles/ArbOwner.go
@@ -12,41 +12,40 @@ type ArbOwner struct {
 	Address addr
 }
 
-func (con ArbOwner) AddAllowedSender(b burn, caller addr, evm mech, addr addr) error {
+func (con ArbOwner) AddAllowedSender(c ctx, evm mech, addr addr) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) AddChainOwner(b burn, caller addr, evm mech, newOwner addr) error {
+func (con ArbOwner) AddChainOwner(c ctx, evm mech, newOwner addr) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) AllowAllSenders(b burn, caller addr, evm mech) error {
+func (con ArbOwner) AllowAllSenders(c ctx, evm mech) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) AddMappingException(b burn, caller addr, evm mech, from huge, to huge) error {
+func (con ArbOwner) AddMappingException(c ctx, evm mech, from huge, to huge) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) AllowOnlyOwnerToSend(b burn, caller addr, evm mech) error {
+func (con ArbOwner) AllowOnlyOwnerToSend(c ctx, evm mech) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) AddToReserveFunds(b burn, caller addr, evm mech, value huge) error {
+func (con ArbOwner) AddToReserveFunds(c ctx, evm mech, value huge) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) ContinueCodeUpload(b burn, caller addr, evm mech, marshalledCode []byte) error {
+func (con ArbOwner) ContinueCodeUpload(c ctx, evm mech, marshalledCode []byte) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) CreateChainParameter(b burn, caller addr, evm mech, which [32]byte, value huge) error {
+func (con ArbOwner) CreateChainParameter(c ctx, evm mech, which [32]byte, value huge) error {
 	return errors.New("unimplemented")
 }
 
 func (con ArbOwner) DeployContract(
-	b burn,
-	caller addr,
+	c ctx,
 	evm mech,
 	value huge,
 	constructorData []byte,
@@ -56,96 +55,90 @@ func (con ArbOwner) DeployContract(
 	return addr{}, errors.New("unimplemented")
 }
 
-func (con ArbOwner) FinishCodeUploadAsArbosUpgrade(
-	b burn,
-	caller addr,
-	evm mech,
-	newCodeHash [32]byte,
-	oldCodeHash [32]byte,
-) error {
+func (con ArbOwner) FinishCodeUploadAsArbosUpgrade(c ctx, evm mech, newCodeHash [32]byte, oldCodeHash [32]byte) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) GetAllAllowedSenders(b burn, caller addr, evm mech) ([]byte, error) {
+func (con ArbOwner) GetAllAllowedSenders(c ctx, evm mech) ([]byte, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbOwner) GetAllChainOwners(b burn, caller addr, evm mech) ([]byte, error) {
+func (con ArbOwner) GetAllChainOwners(c ctx, evm mech) ([]byte, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbOwner) GetAllFairGasPriceSenders(b burn, caller addr, evm mech) ([]byte, error) {
+func (con ArbOwner) GetAllFairGasPriceSenders(c ctx, evm mech) ([]byte, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbOwner) GetAllMappingExceptions(b burn, caller addr, evm mech) ([]byte, error) {
+func (con ArbOwner) GetAllMappingExceptions(c ctx, evm mech) ([]byte, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbOwner) GetChainParameter(b burn, caller addr, evm mech, which [32]byte) (huge, error) {
+func (con ArbOwner) GetChainParameter(c ctx, evm mech, which [32]byte) (huge, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbOwner) GetTotalOfEthBalances(b burn, caller addr, evm mech) (huge, error) {
+func (con ArbOwner) GetTotalOfEthBalances(c ctx, evm mech) (huge, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbOwner) GetLastUpgradeHash(b burn, caller addr, evm mech) ([32]byte, error) {
+func (con ArbOwner) GetLastUpgradeHash(c ctx, evm mech) ([32]byte, error) {
 	return [32]byte{}, errors.New("unimplemented")
 }
 
-func (con ArbOwner) GetUploadedCodeHash(b burn, caller addr, evm mech) ([32]byte, error) {
+func (con ArbOwner) GetUploadedCodeHash(c ctx, evm mech) ([32]byte, error) {
 	return [32]byte{}, errors.New("unimplemented")
 }
 
-func (con ArbOwner) IsAllowedSender(b burn, caller addr, evm mech, addr addr) (bool, error) {
+func (con ArbOwner) IsAllowedSender(c ctx, evm mech, addr addr) (bool, error) {
 	return false, errors.New("unimplemented")
 }
 
-func (con ArbOwner) IsChainOwner(b burn, caller addr, evm mech, addr addr) (bool, error) {
+func (con ArbOwner) IsChainOwner(c ctx, evm mech, addr addr) (bool, error) {
 	return false, errors.New("unimplemented")
 }
 
-func (con ArbOwner) IsFairGasPriceSender(b burn, caller addr, evm mech, addr addr) (bool, error) {
+func (con ArbOwner) IsFairGasPriceSender(c ctx, evm mech, addr addr) (bool, error) {
 	return false, errors.New("unimplemented")
 }
 
-func (con ArbOwner) IsMappingException(b burn, caller addr, evm mech, from huge, to huge) (bool, error) {
+func (con ArbOwner) IsMappingException(c ctx, evm mech, from huge, to huge) (bool, error) {
 	return false, errors.New("unimplemented")
 }
 
-func (con ArbOwner) RemoveAllowedSender(b burn, caller addr, evm mech, addr addr) error {
+func (con ArbOwner) RemoveAllowedSender(c ctx, evm mech, addr addr) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) RemoveChainOwner(b burn, caller addr, evm mech, addr addr) error {
+func (con ArbOwner) RemoveChainOwner(c ctx, evm mech, addr addr) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) RemoveMappingException(b burn, caller addr, evm mech, from huge, to huge) error {
+func (con ArbOwner) RemoveMappingException(c ctx, evm mech, from huge, to huge) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) SerializeAllParameters(b burn, caller addr, evm mech) ([]byte, error) {
+func (con ArbOwner) SerializeAllParameters(c ctx, evm mech) ([]byte, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbOwner) SetChainParameter(b burn, caller addr, evm mech, which [32]byte, value huge) error {
+func (con ArbOwner) SetChainParameter(c ctx, evm mech, which [32]byte, value huge) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) SetFairGasPriceSender(b burn, caller addr, evm mech, addr addr, isFairGasPriceSender bool) error {
+func (con ArbOwner) SetFairGasPriceSender(c ctx, evm mech, addr addr, isFairGasPriceSender bool) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) SetL1GasPriceEstimate(b burn, caller addr, evm mech, priceInGwei huge) error {
+func (con ArbOwner) SetL1GasPriceEstimate(c ctx, evm mech, priceInGwei huge) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) StartCodeUpload(b burn, caller addr, evm mech) error {
+func (con ArbOwner) StartCodeUpload(c ctx, evm mech) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbOwner) StartCodeUploadWithCheck(b burn, caller addr, evm mech, oldCodeHash [32]byte) error {
+func (con ArbOwner) StartCodeUploadWithCheck(c ctx, evm mech, oldCodeHash [32]byte) error {
 	return errors.New("unimplemented")
 }

--- a/precompiles/ArbRetryableTx.go
+++ b/precompiles/ArbRetryableTx.go
@@ -20,34 +20,34 @@ type ArbRetryableTx struct {
 	CanceledGasCost         func([32]byte) uint64
 }
 
-func (con ArbRetryableTx) Cancel(b burn, caller addr, evm mech, ticketId [32]byte) error {
+func (con ArbRetryableTx) Cancel(c ctx, evm mech, ticketId [32]byte) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbRetryableTx) GetBeneficiary(b burn, caller addr, evm mech, ticketId [32]byte) (addr, error) {
+func (con ArbRetryableTx) GetBeneficiary(c ctx, evm mech, ticketId [32]byte) (addr, error) {
 	return addr{}, errors.New("unimplemented")
 }
 
-func (con ArbRetryableTx) GetKeepalivePrice(b burn, caller addr, evm mech, ticketId [32]byte) (huge, huge, error) {
+func (con ArbRetryableTx) GetKeepalivePrice(c ctx, evm mech, ticketId [32]byte) (huge, huge, error) {
 	return nil, nil, errors.New("unimplemented")
 }
 
-func (con ArbRetryableTx) GetLifetime(b burn, caller addr, evm mech) (huge, error) {
+func (con ArbRetryableTx) GetLifetime(c ctx, evm mech) (huge, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbRetryableTx) GetSubmissionPrice(b burn, caller addr, evm mech, calldataSize huge) (huge, huge, error) {
+func (con ArbRetryableTx) GetSubmissionPrice(c ctx, evm mech, calldataSize huge) (huge, huge, error) {
 	return nil, nil, errors.New("unimplemented")
 }
 
-func (con ArbRetryableTx) GetTimeout(b burn, caller addr, evm mech, ticketId [32]byte) (huge, error) {
+func (con ArbRetryableTx) GetTimeout(c ctx, evm mech, ticketId [32]byte) (huge, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbRetryableTx) Keepalive(b burn, caller addr, evm mech, value huge, ticketId [32]byte) (huge, error) {
+func (con ArbRetryableTx) Keepalive(c ctx, evm mech, value huge, ticketId [32]byte) (huge, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con ArbRetryableTx) Redeem(b burn, caller addr, evm mech, txId [32]byte) error {
+func (con ArbRetryableTx) Redeem(c ctx, evm mech, txId [32]byte) error {
 	return errors.New("unimplemented")
 }

--- a/precompiles/ArbStatistics.go
+++ b/precompiles/ArbStatistics.go
@@ -12,6 +12,6 @@ type ArbStatistics struct {
 	Address addr
 }
 
-func (con ArbStatistics) GetStats(b burn, caller addr, evm mech) (huge, huge, huge, huge, huge, huge, error) {
+func (con ArbStatistics) GetStats(c ctx, evm mech) (huge, huge, huge, huge, huge, huge, error) {
 	return nil, nil, nil, nil, nil, nil, errors.New("unimplemented")
 }

--- a/precompiles/ArbSys.go
+++ b/precompiles/ArbSys.go
@@ -21,62 +21,50 @@ type ArbSys struct {
 	SendMerkleUpdateGasCost  func(huge, huge, [32]byte) uint64
 }
 
-func (con *ArbSys) ArbBlockNumber(b burn, caller addr, evm mech) (huge, error) {
+func (con *ArbSys) ArbBlockNumber(c ctx, evm mech) (huge, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con *ArbSys) ArbChainID(b burn, caller addr, evm mech) (huge, error) {
+func (con *ArbSys) ArbChainID(c ctx, evm mech) (huge, error) {
 	return big.NewInt(412345), nil
 }
 
-func (con *ArbSys) ArbOSVersion(b burn, caller addr) (huge, error) {
+func (con *ArbSys) ArbOSVersion(c ctx) (huge, error) {
 	return big.NewInt(1000), nil
 }
 
-func (con *ArbSys) GetStorageAt(b burn, caller addr, evm mech, address addr, index huge) (huge, error) {
+func (con *ArbSys) GetStorageAt(c ctx, evm mech, address addr, index huge) (huge, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con *ArbSys) GetStorageGasAvailable(b burn, caller addr, evm mech) (huge, error) {
+func (con *ArbSys) GetStorageGasAvailable(c ctx, evm mech) (huge, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con *ArbSys) GetTransactionCount(b burn, caller addr, evm mech, account addr) (huge, error) {
+func (con *ArbSys) GetTransactionCount(c ctx, evm mech, account addr) (huge, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (con *ArbSys) IsTopLevelCall(b burn, caller addr, evm mech) (bool, error) {
+func (con *ArbSys) IsTopLevelCall(c ctx, evm mech) (bool, error) {
 	return false, errors.New("unimplemented")
 }
 
-func (con *ArbSys) MapL1SenderContractAddressToL2Alias(
-	b burn,
-	caller addr,
-	sender addr,
-	dest addr,
-) (addr, error) {
+func (con *ArbSys) MapL1SenderContractAddressToL2Alias(c ctx, sender addr, dest addr) (addr, error) {
 	return addr{}, errors.New("unimplemented")
 }
 
-func (con *ArbSys) MyCallersAddressWithoutAliasing(b burn, caller addr, evm mech) (addr, error) {
+func (con *ArbSys) MyCallersAddressWithoutAliasing(c ctx, evm mech) (addr, error) {
 	return addr{}, errors.New("unimplemented")
 }
 
-func (con *ArbSys) SendTxToL1(
-	b burn,
-	caller addr,
-	evm mech,
-	value huge,
-	destination addr,
-	calldataForL1 []byte,
-) (*big.Int, error) {
+func (con *ArbSys) SendTxToL1(c ctx, evm mech, value huge, destination addr, calldataForL1 []byte) (*big.Int, error) {
 
 	cost := params.CallValueTransferGas
 	zero := new(big.Int)
 	dest := destination
 	cost += con.SendMerkleUpdateGasCost(zero, zero, common.Hash{})
 	cost += con.L2ToL1TransactionGasCost(dest, dest, zero, zero, zero, zero, zero, zero, zero, calldataForL1)
-	if err := b(cost); err != nil {
+	if err := c.burn(cost); err != nil {
 		return nil, err
 	}
 
@@ -97,7 +85,7 @@ func (con *ArbSys) SendTxToL1(
 
 	con.L2ToL1Transaction(
 		evm,
-		caller,
+		c.caller,
 		destination,
 		sendHash.Big(),
 		big.NewInt(int64(merkleAcc.Size()-1)),
@@ -112,8 +100,8 @@ func (con *ArbSys) SendTxToL1(
 	return sendHash.Big(), nil
 }
 
-func (con ArbSys) SendMerkleTreeState(b burn, caller addr, evm mech) (*big.Int, [32]byte, [][32]byte, error) {
-	if caller != (common.Address{}) {
+func (con ArbSys) SendMerkleTreeState(c ctx, evm mech) (*big.Int, [32]byte, [][32]byte, error) {
+	if c.caller != (common.Address{}) {
 		return nil, [32]byte{}, nil, errors.New("method can only be called by address zero")
 	}
 
@@ -127,16 +115,10 @@ func (con ArbSys) SendMerkleTreeState(b burn, caller addr, evm mech) (*big.Int, 
 	return big.NewInt(int64(size)), [32]byte(rootHash), partials, nil
 }
 
-func (con *ArbSys) WasMyCallersAddressAliased(b burn, caller addr, evm mech) (bool, error) {
+func (con *ArbSys) WasMyCallersAddressAliased(c ctx, evm mech) (bool, error) {
 	return false, errors.New("unimplemented")
 }
 
-func (con ArbSys) WithdrawEth(
-	b burn,
-	caller common.Address,
-	evm mech,
-	value *big.Int,
-	destination common.Address,
-) (*big.Int, error) {
-	return con.SendTxToL1(b, caller, evm, value, destination, []byte{})
+func (con ArbSys) WithdrawEth(c ctx, evm mech, value *big.Int, destination common.Address) (*big.Int, error) {
+	return con.SendTxToL1(c, evm, value, destination, []byte{})
 }

--- a/precompiles/ArbosTest.go
+++ b/precompiles/ArbosTest.go
@@ -12,26 +12,25 @@ type ArbosTest struct {
 	Address addr
 }
 
-func (con ArbosTest) BurnArbGas(b burn, caller addr, evm mech, gasAmount huge) error {
+func (con ArbosTest) BurnArbGas(c ctx, evm mech, gasAmount huge) error {
 	if !gasAmount.IsUint64() {
 		return errors.New("Not a uint64")
 	}
 	//nolint:errcheck
-	b(gasAmount.Uint64()) // burn the amount, even if it's more than the user has
+	c.burn(gasAmount.Uint64()) // burn the amount, even if it's more than the user has
 	return nil
 }
 
-func (con ArbosTest) GetAccountInfo(b burn, caller addr, evm mech, addr addr) error {
+func (con ArbosTest) GetAccountInfo(c ctx, evm mech, addr addr) error {
 	return errors.New("unimplemented")
 }
 
-func (con ArbosTest) GetMarshalledStorage(b burn, caller addr, evm mech, addr addr) error {
+func (con ArbosTest) GetMarshalledStorage(c ctx, evm mech, addr addr) error {
 	return errors.New("unimplemented")
 }
 
 func (con ArbosTest) InstallAccount(
-	b burn,
-	caller addr,
+	c ctx,
 	evm mech,
 	addr addr,
 	isEOA bool,
@@ -43,6 +42,6 @@ func (con ArbosTest) InstallAccount(
 	return errors.New("unimplemented")
 }
 
-func (con ArbosTest) SetNonce(b burn, caller addr, evm mech, addr addr, nonce huge) error {
+func (con ArbosTest) SetNonce(c ctx, evm mech, addr addr, nonce huge) error {
 	return errors.New("unimplemented")
 }

--- a/precompiles/context.go
+++ b/precompiles/context.go
@@ -1,0 +1,44 @@
+//
+// Copyright 2021, Offchain Labs, Inc. All rights reserved.
+//
+
+package precompiles
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"math/big"
+)
+
+type addr = common.Address
+type mech = *vm.EVM
+type huge = *big.Int
+type ctx = *context
+
+type context struct {
+	caller      addr
+	gasSupplied uint64
+	gasLeft     uint64
+}
+
+func (c *context) burn(amount uint64) error {
+	if c.gasLeft < amount {
+		c.gasLeft = 0
+		return vm.ErrOutOfGas
+	}
+	c.gasLeft -= amount
+	return nil
+}
+
+//nolint:unused
+func (c *context) burned() uint64 {
+	return c.gasSupplied - c.gasLeft
+}
+
+func testContext(caller addr) *context {
+	return &context{
+		caller:      caller,
+		gasSupplied: ^uint64(0),
+		gasLeft:     ^uint64(0),
+	}
+}


### PR DESCRIPTION
Refactors precompile gas burning to provide a `context` struct useful for determining the state of a given call.