### PR TITLE
Fix full challenge test

### DIFF
--- a/system_tests/full_challenge_test.go
+++ b/system_tests/full_challenge_test.go
@@ -210,7 +210,7 @@ func runChallengeTest(t *testing.T, asserterIsCorrect bool) {
 	conf.BlockValidator = false
 	conf.BatchPoster = false
 	conf.InboxReaderConfig.CheckDelay = time.Second
-	rollupAddresses := TestDeployOnL1(t, ctx, l1Info)
+	rollupAddresses := DeployOnTestL1(t, ctx, l1Info)
 
 	deployerTxOpts := l1Info.GetDefaultTransactOpts("deployer")
 	deployerTxOpts.GasLimit = 15_000_000


### PR DESCRIPTION
This was previously broken as it was missed during a refactor, because it isn't run by default and isn't run in CI. In the future, we might want to consider running it in parallel with the other tests as a different CI job, so it doesn't slow down CI.