### PR TITLE
Reduce codecov marks on PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,13 @@ codecov:
   fixes:
     - "github.com/offchainlabs/arbstate/::"
     - "github.com/ethereum/::"
+coverage:
+  status:
+    project:
+      default: false
+github_checks:
+  annotations: false
+comment:
+  layout: ""
+  behavior: once
+  after_n_builds: 2


### PR DESCRIPTION
This should disable the status that makes it look like CI is failing when it isn't, disables annotations that make it impossible to read through a Go PR with "if err != nil", and shrinks the comment to just a link to codecov and a report on the overall diff.