### PR TITLE
Minor simplifications to block hooks

### DIFF
--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/offchainlabs/arbstate/arbos/burn"
 	"github.com/offchainlabs/arbstate/arbos/retryables"
 
 	"github.com/offchainlabs/arbstate/arbos/arbosState"
@@ -244,17 +243,11 @@ func (p *TxProcessor) EndTxHook(gasLeft uint64, success bool) {
 }
 
 func (p *TxProcessor) L1BlockNumber(blockCtx vm.BlockContext) (uint64, error) {
-	state, err := arbosState.OpenArbosState(p.stateDB, &burn.SystemBurner{})
-	if err != nil {
-		return 0, err
-	}
+	state := arbosState.OpenSystemArbosState(p.stateDB)
 	return state.Blockhashes().NextBlockNumber()
 }
 
 func (p *TxProcessor) L1BlockHash(blockCtx vm.BlockContext, l1BlocKNumber uint64) (common.Hash, error) {
-	state, err := arbosState.OpenArbosState(p.stateDB, &burn.SystemBurner{})
-	if err != nil {
-		return common.Hash{}, err
-	}
+	state := arbosState.OpenSystemArbosState(p.stateDB)
 	return state.Blockhashes().BlockHash(l1BlocKNumber)
 }

--- a/precompiles/ArbDebug.go
+++ b/precompiles/ArbDebug.go
@@ -8,15 +8,15 @@ package precompiles
 // which ensures these methods are not accessible in production.
 type ArbDebug struct {
 	Address      addr
-	Basic        func(ctx, mech, bool, [32]byte) error                     // index'd: 2nd
-	Mixed        func(ctx, mech, bool, bool, [32]byte, addr, addr) error   // index'd: 1st 3rd 5th
-	Store        func(ctx, mech, bool, addr, huge, [32]byte, []byte) error // index'd: 1st 2nd
-	BasicGasCost func(bool, [32]byte) (uint64, error)
-	MixedGasCost func(bool, bool, [32]byte, addr, addr) (uint64, error)
-	StoreGasCost func(bool, addr, huge, [32]byte, []byte) (uint64, error)
+	Basic        func(ctx, mech, bool, bytes32) error                     // index'd: 2nd
+	Mixed        func(ctx, mech, bool, bool, bytes32, addr, addr) error   // index'd: 1st 3rd 5th
+	Store        func(ctx, mech, bool, addr, huge, bytes32, []byte) error // index'd: 1st 2nd
+	BasicGasCost func(bool, bytes32) (uint64, error)
+	MixedGasCost func(bool, bool, bytes32, addr, addr) (uint64, error)
+	StoreGasCost func(bool, addr, huge, bytes32, []byte) (uint64, error)
 }
 
-func (con ArbDebug) Events(c ctx, evm mech, paid huge, flag bool, value [32]byte) (addr, huge, error) {
+func (con ArbDebug) Events(c ctx, evm mech, paid huge, flag bool, value bytes32) (addr, huge, error) {
 	// Emits 2 events that cover each case
 	//   Basic tests an index'd value & a normal value
 	//   Mixed interleaves index'd and normal values that may need to be padded

--- a/precompiles/ArbRetryableTx.go
+++ b/precompiles/ArbRetryableTx.go
@@ -6,8 +6,9 @@ package precompiles
 
 import (
 	"errors"
-	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/offchainlabs/arbstate/arbos/retryables"
@@ -16,21 +17,21 @@ import (
 
 type ArbRetryableTx struct {
 	Address                 addr
-	TicketCreated           func(ctx, mech, [32]byte) error
-	LifetimeExtended        func(ctx, mech, [32]byte, huge) error
-	RedeemScheduled         func(ctx, mech, [32]byte, [32]byte, uint64, uint64, addr, uint64) error
-	Redeemed                func(ctx, mech, [32]byte) error
-	Canceled                func(ctx, mech, [32]byte) error
-	TicketCreatedGasCost    func([32]byte) (uint64, error)
-	LifetimeExtendedGasCost func([32]byte, huge) (uint64, error)
-	RedeemScheduledGasCost  func([32]byte, [32]byte, uint64, uint64, addr, uint64) (uint64, error)
-	RedeemedGasCost         func([32]byte) (uint64, error)
-	CanceledGasCost         func([32]byte) (uint64, error)
+	TicketCreated           func(ctx, mech, bytes32) error
+	LifetimeExtended        func(ctx, mech, bytes32, huge) error
+	RedeemScheduled         func(ctx, mech, bytes32, bytes32, uint64, uint64, addr, uint64) error
+	Redeemed                func(ctx, mech, bytes32) error
+	Canceled                func(ctx, mech, bytes32) error
+	TicketCreatedGasCost    func(bytes32) (uint64, error)
+	LifetimeExtendedGasCost func(bytes32, huge) (uint64, error)
+	RedeemScheduledGasCost  func(bytes32, bytes32, uint64, uint64, addr, uint64) (uint64, error)
+	RedeemedGasCost         func(bytes32) (uint64, error)
+	CanceledGasCost         func(bytes32) (uint64, error)
 }
 
 var NotFoundError = errors.New("ticketId not found")
 
-func (con ArbRetryableTx) Cancel(c ctx, evm mech, ticketId [32]byte) error {
+func (con ArbRetryableTx) Cancel(c ctx, evm mech, ticketId bytes32) error {
 	retryableState := c.state.RetryableState()
 	retryable, err := retryableState.OpenRetryable(ticketId, evm.Context.Time.Uint64())
 	if err != nil {
@@ -55,7 +56,7 @@ func (con ArbRetryableTx) Cancel(c ctx, evm mech, ticketId [32]byte) error {
 	return con.Canceled(c, evm, ticketId)
 }
 
-func (con ArbRetryableTx) GetBeneficiary(c ctx, evm mech, ticketId [32]byte) (addr, error) {
+func (con ArbRetryableTx) GetBeneficiary(c ctx, evm mech, ticketId bytes32) (addr, error) {
 	retryableState := c.state.RetryableState()
 	retryable, err := retryableState.OpenRetryable(ticketId, evm.Context.Time.Uint64())
 	if err != nil {
@@ -72,7 +73,7 @@ func (con ArbRetryableTx) GetLifetime(c ctx, evm mech) (huge, error) {
 	return big.NewInt(retryables.RetryableLifetimeSeconds), nil
 }
 
-func (con ArbRetryableTx) GetTimeout(c ctx, evm mech, ticketId [32]byte) (huge, error) {
+func (con ArbRetryableTx) GetTimeout(c ctx, evm mech, ticketId bytes32) (huge, error) {
 	retryableState := c.state.RetryableState()
 	retryable, err := retryableState.OpenRetryable(ticketId, evm.Context.Time.Uint64())
 	if err != nil {
@@ -88,7 +89,7 @@ func (con ArbRetryableTx) GetTimeout(c ctx, evm mech, ticketId [32]byte) (huge, 
 	return big.NewInt(int64(timeout)), nil
 }
 
-func (con ArbRetryableTx) Keepalive(c ctx, evm mech, ticketId [32]byte) (huge, error) {
+func (con ArbRetryableTx) Keepalive(c ctx, evm mech, ticketId bytes32) (huge, error) {
 
 	// charge for the expiry update
 	retryableState := c.state.RetryableState()
@@ -126,7 +127,7 @@ func (con ArbRetryableTx) Keepalive(c ctx, evm mech, ticketId [32]byte) (huge, e
 	return big.NewInt(int64(newTimeout)), nil
 }
 
-func (con ArbRetryableTx) Redeem(c ctx, evm mech, ticketId [32]byte) ([32]byte, error) {
+func (con ArbRetryableTx) Redeem(c ctx, evm mech, ticketId bytes32) (bytes32, error) {
 	retryableState := c.state.RetryableState()
 	byteCount, err := retryableState.RetryableSizeBytes(ticketId, evm.Context.Time.Uint64())
 	if err != nil {


### PR DESCRIPTION
Makes minor changes to the `L1BlockNumber` and `L1BlockHash` hooks, along with using `bytes32` everywhere