### PR TITLE
More intuitive approach to BLS domain separation

### DIFF
--- a/blsSignatures/blsSignatures.go
+++ b/blsSignatures/blsSignatures.go
@@ -173,10 +173,8 @@ func VerifyAggregatedSignatureDifferentMessages(sig Signature, messages [][]byte
 // the Simplified Shallue-van de Woestijne-Ulas Method, described in Section 6.6.2 of
 // https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-06
 //
-// If keyValidationMode is true, this uses a tweaked version of the hash function,
-// so that the result will not collide with a hash generated in an ordinary signature.
-// The tweaked hash function is the same as keccak256, except that the two halves
-// of the output are interchanged.
+// If keyValidationMode is true, this uses a tweaked version of the padding,
+// so that the result will not collide with a result generated in an ordinary signature.
 func hashToG1Curve(message []byte, keyValidationMode bool) (*bls12381.PointG1, error) {
 	var padding [16]byte
 	h := crypto.Keccak256(message)


### PR DESCRIPTION
This switches to a more intuitive approach to ensuring domain separation between signatures and key validity proofs in the BLS signatures package.