### PR TITLE
Allow multiple preferred and default aggregators

### DIFF
--- a/arbos/addressSet/addressSet_test.go
+++ b/arbos/addressSet/addressSet_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestEmptyAddressSet(t *testing.T) {
 	sto := storage.NewMemoryBacked(burn.NewSystemBurner(false))
-	Require(t, Initialize(sto))
 	aset := OpenAddressSet(sto)
 
 	if size(t, aset) != 0 {
@@ -37,7 +36,6 @@ func TestEmptyAddressSet(t *testing.T) {
 
 func TestAddressSet(t *testing.T) {
 	sto := storage.NewMemoryBacked(burn.NewSystemBurner(false))
-	Require(t, Initialize(sto))
 	aset := OpenAddressSet(sto)
 
 	addr1 := common.BytesToAddress(crypto.Keccak256([]byte{1})[:20])

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -158,7 +158,6 @@ func InitializeArbosState(stateDB vm.StateDB, burner burn.Burner) (*ArbosState, 
 	// the zero address is the initial chain owner
 	ZeroAddressL2 := util.RemapL1Address(common.Address{})
 	ownersStorage := sto.OpenSubStorage(chainOwnerSubspace)
-	_ = addressSet.Initialize(ownersStorage)
 	_ = addressSet.OpenAddressSet(ownersStorage).Add(ZeroAddressL2)
 
 	_ = sto.SetUint64ByUint64(uint64(versionOffset), 1)

--- a/arbos/arbosState/initialize.go
+++ b/arbos/arbosState/initialize.go
@@ -46,10 +46,6 @@ func GetGenesisAllocFromArbos(initData *statetransfer.ArbosInitializationInfo) (
 		}
 	}
 
-	err = arbosState.L1PricingState().SetDefaultAggregator(initData.DefaultAggregator)
-	if err != nil {
-		return nil, err
-	}
 	err = initializeRetryables(arbosState.RetryableState(), initData.RetryableData, 0)
 	if err != nil {
 		return nil, err
@@ -118,7 +114,7 @@ func initializeArbosAccount(statedb *state.StateDB, arbosState *ArbosState, acco
 		}
 	}
 	if account.AggregatorToPay != nil {
-		err := l1pState.SetPreferredAggregator(account.Addr, *account.AggregatorToPay)
+		err := l1pState.AddPreferredAggregator(account.Addr, *account.AggregatorToPay)
 		if err != nil {
 			return err
 		}

--- a/arbos/blsTable/bls.go
+++ b/arbos/blsTable/bls.go
@@ -32,11 +32,7 @@ var (
 )
 
 func InitializeBLSTable(sto *storage.Storage) error {
-	err := addressSet.Initialize(sto.OpenSubStorage(legacyAddressSetKey))
-	if err != nil {
-		return err
-	}
-	return addressSet.Initialize(sto.OpenSubStorage(bls12381AddressSetKey))
+	return nil
 }
 
 func Open(sto *storage.Storage) *BLSTable {

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -67,8 +67,8 @@ func (p *TxProcessor) PopCaller() {
 
 func (p *TxProcessor) getAggregator() *common.Address {
 	coinbase := p.evm.Context.Coinbase
-	preferredAggregator, found, err := p.state.L1PricingState().PreferredAggregator(p.msg.From())
-	if err != nil && found && preferredAggregator == coinbase {
+	isPreferred, err := p.state.L1PricingState().IsPreferredAggregator(p.msg.From(), coinbase, true)
+	if err != nil && isPreferred {
 		return &coinbase
 	}
 	return nil

--- a/precompiles/ArbAggregator.go
+++ b/precompiles/ArbAggregator.go
@@ -6,6 +6,7 @@ package precompiles
 
 import (
 	"errors"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/offchainlabs/arbstate/arbos/arbosState"
 )
@@ -15,31 +16,79 @@ type ArbAggregator struct {
 }
 
 func (con ArbAggregator) GetPreferredAggregator(c ctx, evm mech, address addr) (addr, bool, error) {
-	return c.state.L1PricingState().PreferredAggregator(address)
+	l1p := c.state.L1PricingState()
+	prefAgg, err := l1p.GetAnyPreferredAggregator(address)
+	if err != nil {
+		return common.Address{}, false, err
+	}
+	if prefAgg != nil {
+		return *prefAgg, false, nil
+	}
+	prefAgg, err = l1p.GetAnyDefaultAggregator()
+	if err != nil {
+		return common.Address{}, false, err
+	}
+	if prefAgg == nil {
+		return addr{}, true, err
+	}
+	return *prefAgg, true, nil
 }
 
 func (con ArbAggregator) SetPreferredAggregator(c ctx, evm mech, prefAgg addr) error {
-	return c.state.L1PricingState().SetPreferredAggregator(c.caller, prefAgg)
+	l1p := c.state.L1PricingState()
+	err := l1p.RemoveAllPreferredAggregators(c.caller)
+	if err != nil {
+		return err
+	}
+	if prefAgg == (common.Address{}) {
+		return nil
+	}
+	return l1p.AddPreferredAggregator(c.caller, prefAgg)
+}
+
+func (con ArbAggregator) AddPreferredAggregator(c ctx, evm mech, aggToAdd addr) error {
+	return c.state.L1PricingState().AddPreferredAggregator(c.caller, aggToAdd)
+}
+
+func (con ArbAggregator) RemovePreferredAggregator(c ctx, evm mech, aggToRemove addr) error {
+	return c.state.L1PricingState().RemovePreferredAggregator(c.caller, aggToRemove)
+}
+
+const MaxGetAggregatorSize = 256
+
+func (con ArbAggregator) GetPreferredAggregators(c ctx, evm mech, address addr) ([]common.Address, error) {
+	prefAggs, err := c.state.L1PricingState().GetPreferredAggregators(address, false)
+	if err != nil {
+		return nil, err
+	}
+	if len(prefAggs) > MaxGetAggregatorSize {
+		prefAggs = prefAggs[:MaxGetAggregatorSize]
+	}
+	return prefAggs, nil
+}
+
+func (con ArbAggregator) IsPreferredAggregator(c ctx, evm mech, address addr, agg addr) (bool, error) {
+	return c.state.L1PricingState().IsPreferredAggregator(address, agg, false)
 }
 
 func (con ArbAggregator) GetDefaultAggregator(c ctx, evm mech) (addr, error) {
-	return c.state.L1PricingState().DefaultAggregator()
+	addr, err := c.state.L1PricingState().GetAnyDefaultAggregator()
+	if err != nil || addr == nil {
+		return common.Address{}, err
+	}
+	return *addr, nil
 }
 
 func (con ArbAggregator) SetDefaultAggregator(c ctx, evm mech, newDefault addr) error {
-	l1State := c.state.L1PricingState()
-	defaultAgg, err := l1State.DefaultAggregator()
+	l1p := c.state.L1PricingState()
+	err := l1p.RemoveAllDefaultAggregators()
 	if err != nil {
 		return err
 	}
-	allowed, err := accountIsAggregatorOrCollectorOrOwner(c.caller, defaultAgg, c.state)
-	if err != nil {
-		return err
+	if newDefault == (common.Address{}) {
+		return nil
 	}
-	if !allowed {
-		return errors.New("Only the current default (or its fee collector / chain owner) may change the default")
-	}
-	return l1State.SetDefaultAggregator(newDefault)
+	return l1p.AddDefaultAggregator(newDefault)
 }
 
 func (con ArbAggregator) GetCompressionRatio(c ctx, evm mech, aggregator addr) (uint64, error) {

--- a/precompiles/ArbAggregator_test.go
+++ b/precompiles/ArbAggregator_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/offchainlabs/arbstate/arbos/l1pricing"
 )
 
 func TestDefaultAggregator(t *testing.T) {
@@ -18,13 +17,6 @@ func TestDefaultAggregator(t *testing.T) {
 	context := testContext(common.Address{}, evm)
 
 	addr := common.BytesToAddress(crypto.Keccak256([]byte{})[:20])
-
-	// initial default aggregator should be zero address
-	def, err := ArbAggregator{}.GetDefaultAggregator(context, evm)
-	Require(t, err)
-	if def != (l1pricing.SequencerAddress) {
-		Fail(t)
-	}
 
 	// set default aggregator to addr
 	Require(t, ArbDebug{}.BecomeChainOwner(context, evm))
@@ -49,13 +41,13 @@ func TestPreferredAggregator(t *testing.T) {
 	callerCtx := testContext(common.Address{}, evm)
 	userCtx := testContext(userAddr, evm)
 
-	// initial preferred aggregator should be the default of zero address
-	res, isNonDefault, err := ArbAggregator{}.GetPreferredAggregator(callerCtx, evm, userAddr)
+	// initial preferred aggregator and default aggregator sets should be empty
+	res, isDefault, err := ArbAggregator{}.GetPreferredAggregator(callerCtx, evm, userAddr)
 	Require(t, err)
-	if isNonDefault {
+	if !isDefault {
 		Fail(t)
 	}
-	if res != (l1pricing.SequencerAddress) {
+	if res != (common.Address{}) {
 		Fail(t)
 	}
 
@@ -64,9 +56,9 @@ func TestPreferredAggregator(t *testing.T) {
 	Require(t, agg.SetDefaultAggregator(callerCtx, evm, defaultAggAddr))
 
 	// preferred aggregator should be the new default address
-	res, isNonDefault, err = agg.GetPreferredAggregator(callerCtx, evm, userAddr)
+	res, isDefault, err = agg.GetPreferredAggregator(callerCtx, evm, userAddr)
 	Require(t, err)
-	if isNonDefault {
+	if !isDefault {
 		Fail(t)
 	}
 	if res != defaultAggAddr {
@@ -77,9 +69,9 @@ func TestPreferredAggregator(t *testing.T) {
 	Require(t, agg.SetPreferredAggregator(userCtx, evm, prefAggAddr))
 
 	// preferred aggregator should now be prefAggAddr
-	res, isNonDefault, err = agg.GetPreferredAggregator(callerCtx, evm, userAddr)
+	res, isDefault, err = agg.GetPreferredAggregator(callerCtx, evm, userAddr)
 	Require(t, err)
-	if !isNonDefault {
+	if isDefault {
 		Fail(t)
 	}
 	if res != prefAggAddr {

--- a/precompiles/ArbGasInfo.go
+++ b/precompiles/ArbGasInfo.go
@@ -5,6 +5,7 @@
 package precompiles
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/params"
@@ -56,9 +57,20 @@ func (con ArbGasInfo) GetPricesInWeiWithAggregator(
 }
 
 func (con ArbGasInfo) GetPricesInWei(c ctx, evm mech) (huge, huge, huge, huge, huge, huge, error) {
-	aggregator, _, err := c.state.L1PricingState().PreferredAggregator(c.caller)
+	l1p := c.state.L1PricingState()
+	maybeAggregator, err := l1p.GetAnyPreferredAggregator(c.caller)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, err
+	}
+	if maybeAggregator == nil {
+		maybeAggregator, err = l1p.GetAnyDefaultAggregator()
+		if err != nil {
+			return nil, nil, nil, nil, nil, nil, err
+		}
+	}
+	var aggregator common.Address
+	if maybeAggregator != nil {
+		aggregator = *maybeAggregator
 	}
 	return con.GetPricesInWeiWithAggregator(c, evm, aggregator)
 }
@@ -87,9 +99,20 @@ func (con ArbGasInfo) GetPricesInArbGasWithAggregator(c ctx, evm mech, aggregato
 }
 
 func (con ArbGasInfo) GetPricesInArbGas(c ctx, evm mech) (huge, huge, huge, error) {
-	aggregator, _, err := c.state.L1PricingState().PreferredAggregator(c.caller)
+	l1p := c.state.L1PricingState()
+	maybeAggregator, err := l1p.GetAnyPreferredAggregator(c.caller)
 	if err != nil {
 		return nil, nil, nil, err
+	}
+	if maybeAggregator == nil {
+		maybeAggregator, err = l1p.GetAnyDefaultAggregator()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	var aggregator common.Address
+	if maybeAggregator != nil {
+		aggregator = *maybeAggregator
 	}
 	return con.GetPricesInArbGasWithAggregator(c, evm, aggregator)
 }

--- a/solgen/src/precompiles/ArbAggregator.sol
+++ b/solgen/src/precompiles/ArbAggregator.sol
@@ -1,20 +1,42 @@
 pragma solidity >=0.4.21 <0.9.0;
 
 interface ArbAggregator {
-    // Get the preferred aggregator for an address.
-    // Returns (preferredAggregatorAddress, isDefault)
-    //     isDefault is true if addr is set to prefer the default aggregator
+
+    // DEPRECATED -- use getPreferredAggregators or isDefaultAggregator instead
+    // If address has at least one preferred aggregator, this returns one of them chosen arbitrarily (and false)
+    // If address has no preferred aggregators, this returns a default aggregator chosen arbitrarily (and true)
+    // If address has no preferred aggregator and there is no default aggregator, this returns (address(0), true).
     function getPreferredAggregator(address addr) external view returns (address, bool);
 
-    // Set the caller's preferred aggregator.
-    // If prefAgg is zero, this sets the caller to prefer the default aggregator
+    // DEPRECATED -- use addPreferredAggregator and/or removePreferredAggregator instead
+    // If prefAgg is zero, this removes all of the caller's preferred aggregators.
+    // Otherwise, this sets caller's preferred aggregator set to a singleton set containing prefAgg.
     function setPreferredAggregator(address prefAgg) external;
 
-    // Get default aggregator.
+    // Add a preferred aggregator for an address
+    // This reverts unless called by the address or a chain owner
+    function addPreferredAggregator(address newAgg) external;
+
+    // Remove a preferred aggregator for an address, or do nothing if the aggregator was not preferred.
+    // This reverts unless called by the address or a chain owner
+    function removePreferredAggregator(address aggToRemove) external;
+
+    // Returns true iff if addr's preferred aggregator set contains aggregator.
+    function isPreferredAggregator(address addr, address aggregator) external view returns(bool);
+
+    // Get an address's list of preferred aggregators.
+    // If there are more than 256 on the list, this will return an arbitrary subset of size 256.
+    function getPreferredAggregators(address addr) external view returns (address[] memory);
+
+    // DEPRECATED -- use getDefaultAggregators or isDefaultAggregator instead
+    // Return a default aggregator, or zero if there are none.
+    // If there are more than one default aggregator, this chooses one to return, arbitrarily.
     function getDefaultAggregator() external view returns (address);
 
-    // Set the preferred aggregator.
-    // This reverts unless called by the aggregator, its fee collector, or a chain owner
+    // DEPRECATED -- use addDefaultAggregator and/or removeDefaultAggregator instead
+    // If newDefault is zero, this removes all of the default aggregators.
+    // Otherwise, this sets the default aggregator set to a singleton set containing newDefault.
+    // This reverts unless called by the default aggregator, its fee collector, or a chain owner
     function setDefaultAggregator(address newDefault) external;
 
     // Get the aggregator's compression ratio, as measured in ppm (100% = 1,000,000)

--- a/solgen/src/precompiles/ArbGasInfo.sol
+++ b/solgen/src/precompiles/ArbGasInfo.sol
@@ -12,16 +12,20 @@ interface ArbGasInfo {
     //        )
     function getPricesInWeiWithAggregator(address aggregator) external view returns (uint, uint, uint, uint, uint, uint);
 
-    // return gas prices in wei, as described above, assuming the caller's preferred aggregator is used
-    //     if the caller hasn't specified a preferred aggregator, the default aggregator is assumed
+    // DEPRECATED -- use getPricesInWeiWithAggregator instead
+    // return gas prices in wei, as described above, assuming that an aggregator chosen arbitrarily from the
+    //     caller's preferred aggregator set is used
+    // if the caller's preferred aggregator set is empty, an arbitrarily chosen default aggregator is assumed
     function getPricesInWei() external view returns (uint, uint, uint, uint, uint, uint);
 
     // return prices in ArbGas (per L2 tx, per L1 calldata unit, per storage allocation),
     //       assuming the specified aggregator is used
     function getPricesInArbGasWithAggregator(address aggregator) external view returns (uint, uint, uint);
 
-    // return gas prices in ArbGas, as described above, assuming the caller's preferred aggregator is used
-    //     if the caller hasn't specified a preferred aggregator, the default aggregator is assumed
+    // DEPRECATED -- use getPricesInArbGasWithAggregator instead
+    // return gas prices in ArbGas, as described above, assuming that an aggregator chosen arbitrarily from the
+    //     caller's preferred aggregator set is used
+    // if the caller's preferred aggregator set is empty, an arbitrarily chosen default aggregator is assumed
     function getPricesInArbGas() external view returns (uint, uint, uint);
 
     // return gas accounting parameters (speedLimitPerSecond, gasPoolMax, maxTxGasLimit)

--- a/statetransfer/data.go
+++ b/statetransfer/data.go
@@ -12,7 +12,6 @@ import (
 
 type ArbosInitializationInfo struct {
 	AddressTableContents []common.Address
-	DefaultAggregator    common.Address
 	RetryableData        []InitializationDataForRetryable
 	Accounts             []AccountInitializationInfo
 }


### PR DESCRIPTION
This makes the default aggregator, and every sender's preferred aggregator, into sets of addresses rather than (optional) singleton addresses as they were before.

This requires adding new methods to the ArbAggregator precompile.  Some legacy methods are now deprecated.