### PR TITLE
Copy addresses before deleting struct

### DIFF
--- a/solgen/src/challenge/ChallengeManager.sol
+++ b/solgen/src/challenge/ChallengeManager.sol
@@ -313,11 +313,7 @@ contract ChallengeManager is DelegateCallAware, IChallengeManager {
         address next = challenge.next.addr;
         address current = challenge.current.addr;
         delete challenges[challengeIndex];
-        resultReceiver.completeChallenge(
-            challengeIndex,
-            next,
-            current
-        );
+        resultReceiver.completeChallenge(challengeIndex, next, current);
         emit ChallengeEnded(challengeIndex, reason);
     }
 


### PR DESCRIPTION
We currently delete the storage struct before copying the variables we're interested in. At the moment empty addresses are always passed to completeChallenge on the rollup.