### PR TITLE
Fix rust 1.59.0 warning in Arbitrator

### DIFF
--- a/arbitrator/prover/src/utils.rs
+++ b/arbitrator/prover/src/utils.rs
@@ -71,7 +71,7 @@ impl IntoIterator for Bytes32 {
     type IntoIter = std::array::IntoIter<u8, 32>;
 
     fn into_iter(self) -> Self::IntoIter {
-        std::array::IntoIter::new(self.0)
+        IntoIterator::into_iter(self.0)
     }
 }
 


### PR DESCRIPTION
This method is being deprecated (part of a long story of const generics and breaking changes). It won't cause any issues, but this just fixes a build warning.