### PR TITLE
Make sequencer L1 block number and timestamp a lot more sturdy

### DIFF
--- a/arbnode/sequencer.go
+++ b/arbnode/sequencer.go
@@ -158,7 +158,7 @@ func (s *Sequencer) sequenceTransactions(ctx context.Context) {
 
 	if s.l1Client != nil && (l1Block == 0 || int64Abs(int64(l1Timestamp)-timestamp) > maxAcceptableTimestampDeltaSeconds) {
 		log.Error(
-			"cannot sequence: unknown L1 block or L1 timestamp too from local clock time",
+			"cannot sequence: unknown L1 block or L1 timestamp too far from local clock time",
 			"l1Block", l1Block,
 			"l1Timestamp", l1Timestamp,
 			"localTimestamp", timestamp,

--- a/arbutil/wait_for_l1.go
+++ b/arbutil/wait_for_l1.go
@@ -158,7 +158,7 @@ func headerSubscribeMainLoop(chanOut chan<- *types.Header, ctx context.Context, 
 	headerSubscription, err := client.SubscribeNewHead(ctx, chanOut)
 	if err != nil {
 		if ctx.Err() == nil {
-			log.Error("failed sunscribing to header", "err", err)
+			log.Error("failed subscribing to header", "err", err)
 		}
 		return
 	}


### PR DESCRIPTION
To prevent any possible timestamp reorg, with this PR we'll have both have a header websocket subscription and query the latest L1 block regularly. It also ensures that the latest L1 block's timestamp is within an hour of the local wall clock.