### PR TITLE
Get rid of global blsState

### DIFF
--- a/blsSignatures/blsSignatures.go
+++ b/blsSignatures/blsSignatures.go
@@ -23,7 +23,8 @@ type PrivateKey *big.Int
 type Signature *bls12381.PointG1
 
 func GenerateKeys() (PublicKey, PrivateKey, error) {
-	seed, err := cryptorand.Int(cryptorand.Reader, bls12381.NewG2().Q())
+	g2 := bls12381.NewG2()
+	seed, err := cryptorand.Int(cryptorand.Reader, g2.Q())
 	if err != nil {
 		return PublicKey{}, nil, err
 	}
@@ -60,8 +61,9 @@ func KeyValidityProof(pubKey *bls12381.PointG2, privateKey PrivateKey) (Signatur
 }
 
 func NewPublicKey(pubKey *bls12381.PointG2, validityProof *bls12381.PointG1) (PublicKey, error) {
+	g2 := bls12381.NewG2()
 	unverifiedPublicKey := PublicKey{pubKey, validityProof}
-	verified, err := verifySignature2(validityProof, bls12381.NewG2().ToBytes(pubKey), unverifiedPublicKey, true)
+	verified, err := verifySignature2(validityProof, g2.ToBytes(pubKey), unverifiedPublicKey, true)
 	if err != nil {
 		return PublicKey{}, err
 	}
@@ -91,8 +93,9 @@ func signMessage2(priv PrivateKey, message []byte, keyValidationMode bool) (Sign
 	if err != nil {
 		return nil, err
 	}
+	g1 := bls12381.NewG1()
 	result := &bls12381.PointG1{}
-	bls12381.NewG1().MulScalar(result, pointOnCurve, priv)
+	g1.MulScalar(result, pointOnCurve, priv)
 	return Signature(result), nil
 }
 
@@ -172,7 +175,8 @@ func hashToG1Curve(message []byte, keyValidationMode bool) (*bls12381.PointG1, e
 		// modify padding, for domain separation
 		padding[0] = 1
 	}
-	return bls12381.NewG1().MapToCurve(append(padding[:], h...))
+	g1 := bls12381.NewG1()
+	return g1.MapToCurve(append(padding[:], h...))
 }
 
 func PublicKeyToBytes(pub PublicKey) []byte {


### PR DESCRIPTION
Targets https://github.com/OffchainLabs/nitro/pull/306

The things stored in blsState aren't thread safe, and looking at their impls, it seems they largely just house scratch space for field elements. This PR removes it and instead just creates the scratch space when it's needed. This matches how geth seems to implement EIP-2537, creating a new pairing engine on every call to the precompile: https://github.com/OffchainLabs/go-ethereum/blob/6acb1bd4988207773bfb317e06518ea98503a38d/core/vm/contracts.go#L932