### PR TITLE
Fix full challenge test and move impl into separate file

### DIFF
--- a/system_tests/full_challenge_impl_test.go
+++ b/system_tests/full_challenge_impl_test.go
@@ -175,7 +175,7 @@ func confirmLatestBlock(ctx context.Context, t *testing.T, l1Info *BlockchainTes
 	}
 }
 
-func runChallengeTest(t *testing.T, asserterIsCorrect bool) {
+func RunChallengeTest(t *testing.T, asserterIsCorrect bool) {
 	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
 	glogger.Verbosity(log.LvlInfo)
 	log.Root().SetHandler(glogger)

--- a/system_tests/full_challenge_test.go
+++ b/system_tests/full_challenge_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestFullChallengeAsserterIncorrect(t *testing.T) {
-	runChallengeTest(t, false)
+	RunChallengeTest(t, false)
 }
 
 func TestFullChallengeAsserterCorrect(t *testing.T) {
-	runChallengeTest(t, true)
+	RunChallengeTest(t, true)
 }


### PR DESCRIPTION
Moving the impl to a file without the build tag means that if anything breaks in the build we'll notice without needing to build with the tag.