### PR TITLE
Limit Batchposter Segments

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -196,7 +196,7 @@ func (s *batchSegments) addSegment(segment []byte, isHeader bool) (bool, error) 
 	if err != nil {
 		return false, err
 	}
-	if overflow {
+	if overflow || len(s.rawSegments) >= arbstate.MaxSegmentsPerSequencerMessage {
 		return false, s.close()
 	}
 	s.rawSegments = append(s.rawSegments, segment)

--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -52,7 +52,7 @@ type sequencerMessage struct {
 }
 
 const maxDecompressedLen int = 1024 * 1024 * 16 // 16 MiB
-const maxSegmentsPerSequencerMessage = 100 * 1024
+const MaxSegmentsPerSequencerMessage = 100 * 1024
 
 func parseSequencerMessage(ctx context.Context, data []byte, das DataAvailabilityServiceReader) *sequencerMessage {
 	if len(data) < 40 {
@@ -96,7 +96,7 @@ func parseSequencerMessage(ctx context.Context, data []byte, das DataAvailabilit
 						}
 						break
 					}
-					if len(segments) >= maxSegmentsPerSequencerMessage {
+					if len(segments) >= MaxSegmentsPerSequencerMessage {
 						log.Warn("too many segments in sequence batch")
 						break
 					}


### PR DESCRIPTION
Updates the batch poster to avoid creating segments that'd hit the `MaxSegmentsPerSequencerMessage` limit