### PR TITLE
Double hash merkle tree leaves

### DIFF
--- a/arbos/merkleAccumulator/merkleAccumulator.go
+++ b/arbos/merkleAccumulator/merkleAccumulator.go
@@ -124,6 +124,7 @@ func (acc *MerkleAccumulator) setPartial(level uint64, val *common.Hash) error {
 	return nil
 }
 
+// Note: itemHash is hashed before being included in the tree, to prevent confusing leafs with branches.
 func (acc *MerkleAccumulator) Append(itemHash common.Hash) ([]MerkleTreeNodeEvent, error) {
 	size, err := acc.size.Increment()
 	if err != nil {
@@ -132,7 +133,7 @@ func (acc *MerkleAccumulator) Append(itemHash common.Hash) ([]MerkleTreeNodeEven
 	events := []MerkleTreeNodeEvent{}
 
 	level := uint64(0)
-	soFar := itemHash.Bytes()
+	soFar := crypto.Keccak256(itemHash.Bytes())
 	for {
 		if level == CalcNumPartials(size-1) { // -1 to counteract the acc.size++ at top of this function
 			h := common.BytesToHash(soFar)

--- a/solgen/src/bridge/Outbox.sol
+++ b/solgen/src/bridge/Outbox.sol
@@ -184,6 +184,6 @@ contract Outbox is DelegateCallAware, IOutbox {
         uint256 path,
         bytes32 item
     ) public pure returns (bytes32) {
-        return MerkleLib.calculateRoot(proof, path, item);
+        return MerkleLib.calculateRoot(proof, path, keccak256(abi.encodePacked(item)));
     }
 }

--- a/system_tests/outbox_test.go
+++ b/system_tests/outbox_test.go
@@ -212,6 +212,10 @@ func TestOutboxProofs(t *testing.T) {
 				level := new(big.Int).SetBytes(position[:8]).Uint64()
 				leaf := new(big.Int).SetBytes(position[8:]).Uint64()
 
+				if level == 0 {
+					hash = crypto.Keccak256Hash(hash.Bytes())
+				}
+
 				place := merkletree.LevelAndLeaf{
 					Level: level,
 					Leaf:  leaf,

--- a/util/merkletree/merkleAccumulator_test.go
+++ b/util/merkletree/merkleAccumulator_test.go
@@ -43,7 +43,7 @@ func TestAccumulator1(t *testing.T) {
 	if mt.Size() != 1 {
 		t.Fatal(mt.Size())
 	}
-	if root(t, acc) != itemHash {
+	if root(t, acc) != crypto.Keccak256Hash(itemHash.Bytes()) {
 		Fail(t)
 	}
 	if root(t, acc) != mt.Hash() {
@@ -79,8 +79,8 @@ func TestAccumulator3(t *testing.T) {
 	}
 
 	expectedHash := crypto.Keccak256(
-		crypto.Keccak256(itemHash0.Bytes(), itemHash1.Bytes()),
-		crypto.Keccak256(itemHash2.Bytes(), make([]byte, 32)),
+		crypto.Keccak256(crypto.Keccak256(itemHash0.Bytes()), crypto.Keccak256(itemHash1.Bytes())),
+		crypto.Keccak256(crypto.Keccak256(itemHash2.Bytes()), make([]byte, 32)),
 	)
 	if root(t, acc) != common.BytesToHash(expectedHash) {
 		Fail(t)
@@ -121,8 +121,8 @@ func TestAccumulator4(t *testing.T) {
 	}
 
 	expectedHash := crypto.Keccak256(
-		crypto.Keccak256(itemHash0.Bytes(), itemHash1.Bytes()),
-		crypto.Keccak256(itemHash2.Bytes(), itemHash3.Bytes()),
+		crypto.Keccak256(crypto.Keccak256(itemHash0.Bytes()), crypto.Keccak256(itemHash1.Bytes())),
+		crypto.Keccak256(crypto.Keccak256(itemHash2.Bytes()), crypto.Keccak256(itemHash3.Bytes())),
 	)
 	if root(t, acc) != common.BytesToHash(expectedHash) {
 		Fail(t)

--- a/util/merkletree/merkleTree.go
+++ b/util/merkletree/merkleTree.go
@@ -60,7 +60,7 @@ func newMerkleLeafFromReader(rd io.Reader) (MerkleTree, error) {
 }
 
 func (leaf *merkleTreeLeaf) Hash() common.Hash {
-	return leaf.hash
+	return crypto.Keccak256Hash(leaf.hash.Bytes())
 }
 
 func (leaf *merkleTreeLeaf) Size() uint64 {
@@ -296,7 +296,7 @@ type MerkleProof struct {
 }
 
 func (proof *MerkleProof) IsCorrect() bool {
-	hash := proof.LeafHash
+	hash := crypto.Keccak256Hash(proof.LeafHash.Bytes())
 	index := proof.LeafIndex
 	for _, hashFromProof := range proof.Proof {
 		if index&1 == 0 {


### PR DESCRIPTION
Based on https://github.com/OffchainLabs/nitro/pull/451 , hashes the leaf contents a second time to disambiguate them with branches