### PR TITLE
Precisely enforce MaxBlockSpeed

### DIFF
--- a/arbnode/sequencer.go
+++ b/arbnode/sequencer.go
@@ -331,7 +331,7 @@ func (s *Sequencer) Start(ctxIn context.Context) error {
 		nextBlock := time.Now().Add(s.config.MaxBlockSpeed)
 		s.sequenceTransactions(ctx)
 		// Note: this may return a negative duration, but timers are fine with that (they treat negative durations as 0).
-		return nextBlock.Sub(time.Now())
+		return time.Until(nextBlock)
 	})
 
 	return nil


### PR DESCRIPTION
This now takes into account time spent in sequenceTransactions