### PR TITLE
Fix InboxReader's getNextBlockToRead

### DIFF
--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -344,7 +344,7 @@ func (ir *InboxReader) run(ctx context.Context) error {
 				}
 			}
 		}
-		// TODO feed reading
+
 		timer := time.NewTimer(ir.config.CheckDelay)
 		select {
 		case <-ctx.Done():
@@ -393,6 +393,8 @@ func (r *InboxReader) getNextBlockToRead() (*big.Int, error) {
 		return nil, err
 	}
 	msgBlock := new(big.Int).SetUint64(msg.Header.BlockNumber)
+	// Re-check the last few blocks just in case there are delayed messages we missed
+	msgBlock.Sub(msgBlock, big.NewInt(20))
 	if arbmath.BigLessThan(msgBlock, r.firstMessageBlock) {
 		return new(big.Int).Set(r.firstMessageBlock), nil
 	}


### PR DESCRIPTION
It was previously using the request id instead of the block number. I've also added a safety check to ensure it isn't less than firstMessageBlock.