### PR TITLE
Trace state accesses and retryable auto redemption

### DIFF
--- a/arbnode/node-interface.go
+++ b/arbnode/node-interface.go
@@ -72,7 +72,7 @@ func ApplyNodeInterface(
 			pRetryTo = &retryTo
 		}
 
-		state, _ := arbosState.OpenSystemArbosState(statedb, true)
+		state, _ := arbosState.OpenSystemArbosState(statedb, nil, true)
 		l1BaseFee, _ := state.L1PricingState().L1BaseFeeEstimateWei()
 		maxSubmissionFee := retryables.RetryableSubmissionFee(len(retryData), l1BaseFee)
 
@@ -418,7 +418,7 @@ func init() {
 			// ArbOS hasn't been installed, so use the vanilla gas cap
 			return
 		}
-		state, err := arbosState.OpenSystemArbosState(statedb, true)
+		state, err := arbosState.OpenSystemArbosState(statedb, nil, true)
 		if err != nil {
 			log.Error("failed to open ArbOS state", "err", err)
 			return

--- a/arbos/addressSet/addressSet_test.go
+++ b/arbos/addressSet/addressSet_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestEmptyAddressSet(t *testing.T) {
-	sto := storage.NewMemoryBacked(burn.NewSystemBurner(false))
+	sto := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	Require(t, Initialize(sto))
 	aset := OpenAddressSet(sto)
 
@@ -38,7 +38,7 @@ func TestEmptyAddressSet(t *testing.T) {
 
 func TestAddressSet(t *testing.T) {
 	db := storage.NewMemoryBackedStateDB()
-	sto := storage.NewGeth(db, burn.NewSystemBurner(false))
+	sto := storage.NewGeth(db, burn.NewSystemBurner(nil, false))
 	Require(t, Initialize(sto))
 	aset := OpenAddressSet(sto)
 

--- a/arbos/addressTable/addressTable_test.go
+++ b/arbos/addressTable/addressTable_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAddressTableInit(t *testing.T) {
-	sto := storage.NewMemoryBacked(burn.NewSystemBurner(false))
+	sto := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	Initialize(sto)
 	atab := Open(sto)
 	if size(t, atab) != 0 {
@@ -35,7 +35,7 @@ func TestAddressTableInit(t *testing.T) {
 }
 
 func TestAddressTable1(t *testing.T) {
-	sto := storage.NewMemoryBacked(burn.NewSystemBurner(false))
+	sto := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	Initialize(sto)
 	atab := Open(sto)
 	addr := common.BytesToAddress(crypto.Keccak256([]byte{})[:20])
@@ -81,7 +81,7 @@ func TestAddressTable1(t *testing.T) {
 }
 
 func TestAddressTableCompressNotInTable(t *testing.T) {
-	sto := storage.NewMemoryBacked(burn.NewSystemBurner(false))
+	sto := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	Initialize(sto)
 	atab := Open(sto)
 	addr := common.BytesToAddress(crypto.Keccak256([]byte{})[:20])
@@ -108,7 +108,7 @@ func TestAddressTableCompressNotInTable(t *testing.T) {
 }
 
 func TestAddressTableCompressInTable(t *testing.T) {
-	sto := storage.NewMemoryBacked(burn.NewSystemBurner(false))
+	sto := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	Initialize(sto)
 	atab := Open(sto)
 	addr := common.BytesToAddress(crypto.Keccak256([]byte{})[:20])

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -83,11 +83,19 @@ func OpenArbosState(stateDB vm.StateDB, burner burn.Burner) (*ArbosState, error)
 	}, nil
 }
 
-func OpenSystemArbosState(stateDB vm.StateDB, readOnly bool) (*ArbosState, error) {
-	burner := burn.NewSystemBurner(readOnly)
+func OpenSystemArbosState(stateDB vm.StateDB, tracingInfo *util.TracingInfo, readOnly bool) (*ArbosState, error) {
+	burner := burn.NewSystemBurner(tracingInfo, readOnly)
 	state, err := OpenArbosState(stateDB, burner)
 	burner.Restrict(err)
 	return state, err
+}
+
+func OpenSystemArbosStateOrPanic(stateDB vm.StateDB, tracingInfo *util.TracingInfo, readOnly bool) *ArbosState {
+	state, err := OpenSystemArbosState(stateDB, tracingInfo, readOnly)
+	if err != nil {
+		panic(err)
+	}
+	return state
 }
 
 // Create and initialize a memory-backed ArbOS state (for testing only)
@@ -98,7 +106,7 @@ func NewArbosMemoryBackedArbOSState() (*ArbosState, *state.StateDB) {
 	if err != nil {
 		log.Fatal("failed to init empty statedb", err)
 	}
-	burner := burn.NewSystemBurner(false)
+	burner := burn.NewSystemBurner(nil, false)
 	state, err := InitializeArbosState(statedb, burner, params.ArbitrumDevTestChainConfig())
 	if err != nil {
 		log.Fatal("failed to open the ArbOS state", err)
@@ -108,7 +116,7 @@ func NewArbosMemoryBackedArbOSState() (*ArbosState, *state.StateDB) {
 
 // Get the ArbOS version
 func ArbOSVersion(stateDB vm.StateDB) uint64 {
-	backingStorage := storage.NewGeth(stateDB, burn.NewSystemBurner(false))
+	backingStorage := storage.NewGeth(stateDB, burn.NewSystemBurner(nil, false))
 	arbosVersion, err := backingStorage.GetUint64ByUint64(uint64(versionOffset))
 	if err != nil {
 		log.Fatal("faled to get the ArbOS version", err)

--- a/arbos/arbosState/arbosstate_test.go
+++ b/arbos/arbosState/arbosstate_test.go
@@ -19,7 +19,7 @@ func TestStorageOpenFromEmpty(t *testing.T) {
 }
 
 func TestMemoryBackingEvmStorage(t *testing.T) {
-	sto := storage.NewMemoryBacked(burn.NewSystemBurner(false))
+	sto := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	value, err := sto.Get(common.Hash{})
 	Require(t, err)
 	if value != (common.Hash{}) {

--- a/arbos/arbosState/initialize.go
+++ b/arbos/arbosState/initialize.go
@@ -53,7 +53,7 @@ func InitializeArbosInDatabase(db ethdb.Database, initData statetransfer.InitDat
 		log.Fatal("failed to init empty statedb", err)
 	}
 
-	burner := burn.NewSystemBurner(false)
+	burner := burn.NewSystemBurner(nil, false)
 	arbosState, err := InitializeArbosState(statedb, burner, chainConfig)
 	if err != nil {
 		log.Fatal("failed to open the ArbOS state", err)

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -126,7 +126,7 @@ func ProduceBlockAdvanced(
 	sequencingHooks *SequencingHooks,
 ) (*types.Block, types.Receipts) {
 
-	state, err := arbosState.OpenSystemArbosState(statedb, true)
+	state, err := arbosState.OpenSystemArbosState(statedb, nil, true)
 	if err != nil {
 		panic(err)
 	}
@@ -374,7 +374,7 @@ func ProduceBlockAdvanced(
 
 func FinalizeBlock(header *types.Header, txs types.Transactions, statedb *state.StateDB) {
 	if header != nil {
-		state, _ := arbosState.OpenSystemArbosState(statedb, true)
+		state, _ := arbosState.OpenSystemArbosState(statedb, nil, true)
 
 		// Add outbox info to the header for client-side proving
 		acc := state.SendMerkleAccumulator()

--- a/arbos/blockhash/blockhash_test.go
+++ b/arbos/blockhash/blockhash_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestBlockhash(t *testing.T) {
-	sto := storage.NewMemoryBacked(burn.NewSystemBurner(false))
+	sto := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	InitializeBlockhashes(sto)
 
 	bh := OpenBlockhashes(sto)

--- a/arbos/blsTable/bls_test.go
+++ b/arbos/blsTable/bls_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestLegacyBLS(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
-	sto := storage.NewMemoryBacked(burn.NewSystemBurner(false))
+	sto := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	tab := Open(sto)
 
 	maxInt64 := big.NewInt(math.MaxInt64)

--- a/arbos/burn/burn.go
+++ b/arbos/burn/burn.go
@@ -5,6 +5,7 @@ package burn
 
 import (
 	glog "github.com/ethereum/go-ethereum/log"
+	"github.com/offchainlabs/nitro/arbos/util"
 )
 
 type Burner interface {
@@ -12,16 +13,19 @@ type Burner interface {
 	Burned() uint64
 	Restrict(err error)
 	ReadOnly() bool
+	TracingInfo() *util.TracingInfo
 }
 
 type SystemBurner struct {
-	gasBurnt uint64
-	readOnly bool
+	gasBurnt    uint64
+	tracingInfo *util.TracingInfo
+	readOnly    bool
 }
 
-func NewSystemBurner(readOnly bool) *SystemBurner {
+func NewSystemBurner(tracingInfo *util.TracingInfo, readOnly bool) *SystemBurner {
 	return &SystemBurner{
-		readOnly: readOnly,
+		tracingInfo: tracingInfo,
+		readOnly:    readOnly,
 	}
 }
 
@@ -42,4 +46,8 @@ func (burner *SystemBurner) Restrict(err error) {
 
 func (burner *SystemBurner) ReadOnly() bool {
 	return burner.readOnly
+}
+
+func (burner *SystemBurner) TracingInfo() *util.TracingInfo {
+	return burner.tracingInfo
 }

--- a/arbos/l1pricing/l1pricing_test.go
+++ b/arbos/l1pricing/l1pricing_test.go
@@ -52,7 +52,7 @@ func TestTxFixedCost(t *testing.T) {
 }
 
 func TestL1PriceUpdate(t *testing.T) {
-	sto := storage.NewMemoryBacked(burn.NewSystemBurner(false))
+	sto := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	err := InitializeL1PricingState(sto)
 	Require(t, err)
 	ps := OpenL1PricingState(sto)

--- a/arbos/l2pricing/l2pricing_test.go
+++ b/arbos/l2pricing/l2pricing_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func PricingForTest(t *testing.T) *L2PricingState {
-	storage := storage.NewMemoryBacked(burn.NewSystemBurner(false))
+	storage := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	err := InitializeL2PricingState(storage)
 	Require(t, err)
 	return OpenL2PricingState(storage)

--- a/arbos/storage/storage.go
+++ b/arbos/storage/storage.go
@@ -107,6 +107,9 @@ func (store *Storage) Get(key common.Hash) (common.Hash, error) {
 	if err != nil {
 		return common.Hash{}, err
 	}
+	if info := store.burner.TracingInfo(); info != nil {
+		info.RecordStorageGet(key)
+	}
 	return store.db.GetState(store.account, mapAddress(store.storageKey, key)), nil
 }
 
@@ -135,6 +138,9 @@ func (store *Storage) Set(key common.Hash, value common.Hash) error {
 	err := store.burner.Burn(writeCost(value))
 	if err != nil {
 		return err
+	}
+	if info := store.burner.TracingInfo(); info != nil {
+		info.RecordStorageSet(key, value)
 	}
 	store.db.SetState(store.account, mapAddress(store.storageKey, key), value)
 	return nil
@@ -280,6 +286,9 @@ func (ss *StorageSlot) Get() (common.Hash, error) {
 	if err != nil {
 		return common.Hash{}, err
 	}
+	if info := ss.burner.TracingInfo(); info != nil {
+		info.RecordStorageGet(ss.slot)
+	}
 	return ss.db.GetState(ss.account, ss.slot), nil
 }
 
@@ -291,6 +300,9 @@ func (ss *StorageSlot) Set(value common.Hash) error {
 	err := ss.burner.Burn(writeCost(value))
 	if err != nil {
 		return err
+	}
+	if info := ss.burner.TracingInfo(); info != nil {
+		info.RecordStorageSet(ss.slot, value)
 	}
 	ss.db.SetState(ss.account, ss.slot, value)
 	return nil

--- a/arbos/util/tracing.go
+++ b/arbos/util/tracing.go
@@ -79,7 +79,7 @@ func (info *TracingInfo) MockCall(input []byte, gas uint64, from, to common.Addr
 	tracer := info.Tracer
 	depth := info.Depth
 
-	contract := vm.NewContract(addressHolder{to}, addressHolder{from}, big.NewInt(0), 0)
+	contract := vm.NewContract(addressHolder{to}, addressHolder{from}, amount, gas)
 
 	scope := &vm.ScopeContext{
 		Memory: TracingMemoryFromBytes(input),

--- a/arbos/util/tracing.go
+++ b/arbos/util/tracing.go
@@ -1,0 +1,144 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package util
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/holiman/uint256"
+)
+
+type TracingScenario uint64
+
+const (
+	TracingBeforeEVM TracingScenario = iota
+	TracingDuringEVM
+	TracingAfterEVM
+)
+
+type TracingInfo struct {
+	Tracer   vm.EVMLogger
+	Scenario TracingScenario
+	Contract *vm.Contract
+	Depth    int
+}
+
+// holds an address to satisfy core/vm's ContractRef() interface
+type addressHolder struct {
+	addr common.Address
+}
+
+func (a addressHolder) Address() common.Address {
+	return a.addr
+}
+
+func NewTracingInfo(evm *vm.EVM, actor common.Address, scenario TracingScenario) *TracingInfo {
+	if evm.Config.Tracer == nil || !evm.Config.Debug {
+		return nil
+	}
+	return &TracingInfo{
+		Tracer:   evm.Config.Tracer,
+		Scenario: scenario,
+		Contract: vm.NewContract(addressHolder{actor}, addressHolder{actor}, big.NewInt(0), 0),
+		Depth:    evm.Depth(),
+	}
+}
+
+func (info *TracingInfo) RecordStorageGet(key common.Hash) {
+	tracer := info.Tracer
+	if info.Scenario == TracingDuringEVM {
+		scope := &vm.ScopeContext{
+			Memory:   vm.NewMemory(),
+			Stack:    TracingStackFromArgs(HashToUint256(key)),
+			Contract: info.Contract,
+		}
+		tracer.CaptureState(0, vm.SLOAD, 0, 0, scope, []byte{}, info.Depth, nil)
+	} else {
+		tracer.CaptureArbitrumStorageGet(key, info.Depth, info.Scenario == TracingBeforeEVM)
+	}
+}
+
+func (info *TracingInfo) RecordStorageSet(key, value common.Hash) {
+	tracer := info.Tracer
+	if info.Scenario == TracingDuringEVM {
+		scope := &vm.ScopeContext{
+			Memory:   vm.NewMemory(),
+			Stack:    TracingStackFromArgs(HashToUint256(key), HashToUint256(value)),
+			Contract: info.Contract,
+		}
+		tracer.CaptureState(0, vm.SSTORE, 0, 0, scope, []byte{}, info.Depth, nil)
+	} else {
+		tracer.CaptureArbitrumStorageSet(key, value, info.Depth, info.Scenario == TracingBeforeEVM)
+	}
+}
+
+func (info *TracingInfo) MockCall(input []byte, gas uint64, to common.Address, amount *big.Int) {
+	tracer := info.Tracer
+	depth := info.Depth
+
+	scope := &vm.ScopeContext{
+		Memory: TracingMemoryFromBytes(input),
+		Stack: TracingStackFromArgs(
+			*uint256.NewInt(gas),                        // gas
+			*uint256.NewInt(0).SetBytes(to.Bytes()),     // to address
+			*uint256.NewInt(0).SetBytes(amount.Bytes()), // call value
+			*uint256.NewInt(0),                          // memory offset
+			*uint256.NewInt(uint64(len(input))),         // memory length
+			*uint256.NewInt(0),                          // return offset
+			*uint256.NewInt(0),                          // return size
+		),
+		Contract: info.Contract,
+	}
+	from := info.Contract.CallerAddress
+	tracer.CaptureState(0, vm.CALL, 0, 0, scope, []byte{}, depth, nil)
+	tracer.CaptureEnter(vm.INVALID, from, to, input, 0, amount)
+
+	retScope := &vm.ScopeContext{
+		Memory: vm.NewMemory(),
+		Stack: TracingStackFromArgs(
+			*uint256.NewInt(0), // return offset
+			*uint256.NewInt(0), // return size
+		),
+		Contract: info.Contract,
+	}
+	tracer.CaptureState(0, vm.RETURN, 0, 0, retScope, []byte{}, depth+1, nil)
+	tracer.CaptureExit(nil, 0, nil)
+
+	popScope := &vm.ScopeContext{
+		Memory: vm.NewMemory(),
+		Stack: TracingStackFromArgs(
+			*uint256.NewInt(1), // CALL result success
+		),
+		Contract: info.Contract,
+	}
+	tracer.CaptureState(0, vm.POP, 0, 0, popScope, []byte{}, depth, nil)
+}
+
+func HashToUint256(hash common.Hash) uint256.Int {
+	value := uint256.Int{}
+	value.SetBytes(hash.Bytes())
+	return value
+}
+
+// Creates an EVM Memory consisting of the bytes provided
+func TracingMemoryFromBytes(input []byte) *vm.Memory {
+	memory := vm.NewMemory()
+	inputLen := uint64(len(input))
+	memory.Resize(inputLen)
+	memory.Set(0, inputLen, input)
+	return memory
+}
+
+// Creates an EVM Stack with the given arguments in canonical order
+func TracingStackFromArgs(args ...uint256.Int) *vm.Stack {
+	stack := &vm.Stack{}
+	for flip := 0; flip < len(args)/2; flip++ { // reverse the order
+		flop := len(args) - flip - 1
+		args[flip], args[flop] = args[flop], args[flip]
+	}
+	stack.SetData(args)
+	return stack
+}

--- a/arbos/util/transfer.go
+++ b/arbos/util/transfer.go
@@ -55,7 +55,7 @@ func TransferBalance(from, to *common.Address, amount *big.Int, evm *vm.EVM, sce
 			Contract: vm.NewContract(addressHolder{*to}, addressHolder{*from}, big.NewInt(0), 0),
 			Depth:    evm.Depth(),
 		}
-		info.MockCall([]byte("Transfer Balance"), 0, *to, amount)
+		info.MockCall([]byte("Transfer Balance"), 0, *from, *to, amount)
 	}
 	return nil
 }

--- a/arbos/util/transfer.go
+++ b/arbos/util/transfer.go
@@ -55,7 +55,7 @@ func TransferBalance(from, to *common.Address, amount *big.Int, evm *vm.EVM, sce
 			Contract: vm.NewContract(addressHolder{*to}, addressHolder{*from}, big.NewInt(0), 0),
 			Depth:    evm.Depth(),
 		}
-		info.MockCall([]byte("Transfer Balance"), 0, *from, *to, amount)
+		info.MockCall([]byte{}, 0, *from, *to, amount)
 	}
 	return nil
 }

--- a/arbos/util/transfer.go
+++ b/arbos/util/transfer.go
@@ -12,26 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/holiman/uint256"
 	"github.com/offchainlabs/nitro/util/arbmath"
 )
-
-type TracingScenario uint64
-
-const (
-	TracingBeforeEVM TracingScenario = iota
-	TracingDuringEVM
-	TracingAfterEVM
-)
-
-// holds an address to satisfy core/vm's ContractRef() interface
-type addressHolder struct {
-	addr common.Address
-}
-
-func (a addressHolder) Address() common.Address {
-	return a.addr
-}
 
 // Represents a balance change occuring aside from a call.
 // While most uses will be transfers, setting `from` or `to` to nil will mint or burn funds, respectively.
@@ -67,53 +49,13 @@ func TransferBalance(from, to *common.Address, amount *big.Int, evm *vm.EVM, sce
 			to = &common.Address{}
 		}
 
-		input := []byte("Transfer Balance")
-		inputLen := uint64(len(input))
-		memory := vm.NewMemory()
-		memory.Resize(inputLen)
-		memory.Set(0, inputLen, input)
-		stack := &vm.Stack{}
-		stack.SetData([]uint256.Int{
-			*uint256.NewInt(0),                          // return size
-			*uint256.NewInt(0),                          // return offset
-			*uint256.NewInt(inputLen),                   // memory length
-			*uint256.NewInt(0),                          // memory offset
-			*uint256.NewInt(0).SetBytes(amount.Bytes()), // call value
-			*uint256.NewInt(0).SetBytes(to.Bytes()),     // to address
-			*uint256.NewInt(0),                          // 0 gas
-		})
-		contract := vm.NewContract(addressHolder{*to}, addressHolder{*from}, big.NewInt(0), 0)
-		scope := &vm.ScopeContext{
-			Memory:   memory,
-			Stack:    stack,
-			Contract: contract,
+		info := &TracingInfo{
+			Tracer:   evm.Config.Tracer,
+			Scenario: scenario,
+			Contract: vm.NewContract(addressHolder{*to}, addressHolder{*from}, big.NewInt(0), 0),
+			Depth:    evm.Depth(),
 		}
-		tracer.CaptureState(0, vm.CALL, 0, 0, scope, []byte{}, evm.Depth(), nil)
-		tracer.CaptureEnter(vm.INVALID, *from, *to, input, 0, amount)
-
-		retStack := &vm.Stack{}
-		retStack.SetData([]uint256.Int{
-			*uint256.NewInt(0), // return size
-			*uint256.NewInt(0), // return offset
-		})
-		retScope := &vm.ScopeContext{
-			Memory:   vm.NewMemory(),
-			Stack:    retStack,
-			Contract: contract,
-		}
-		tracer.CaptureState(0, vm.RETURN, 0, 0, retScope, []byte{}, evm.Depth()+1, nil)
-		tracer.CaptureExit(nil, 0, nil)
-
-		popStack := &vm.Stack{}
-		popStack.SetData([]uint256.Int{
-			*uint256.NewInt(1), // CALL result success
-		})
-		popScope := &vm.ScopeContext{
-			Memory:   vm.NewMemory(),
-			Stack:    popStack,
-			Contract: contract,
-		}
-		tracer.CaptureState(0, vm.POP, 0, 0, popScope, []byte{}, evm.Depth(), nil)
+		info.MockCall([]byte("Transfer Balance"), 0, *to, amount)
 	}
 	return nil
 }

--- a/arbos/util/util.go
+++ b/arbos/util/util.go
@@ -24,6 +24,7 @@ var ParseL2ToL1TransactionLog func(interface{}, *types.Log) error
 var PackInternalTxDataStartBlock func(...interface{}) ([]byte, error)
 var UnpackInternalTxDataStartBlock func([]byte) ([]interface{}, error)
 var PackArbRetryableTxSubmitRetryable func(...interface{}) ([]byte, error)
+var PackArbRetryableTxRedeem func(...interface{}) ([]byte, error)
 
 func init() {
 	offset, success := new(big.Int).SetString("0x1111000000000000000000000000000000001111", 0)
@@ -87,6 +88,7 @@ func init() {
 	acts := precompilesgen.ArbosActsABI
 	PackInternalTxDataStartBlock, UnpackInternalTxDataStartBlock = callParser(acts, "startBlock")
 	PackArbRetryableTxSubmitRetryable, _ = callParser(precompilesgen.ArbRetryableTxABI, "submitRetryable")
+	PackArbRetryableTxRedeem, _ = callParser(precompilesgen.ArbRetryableTxABI, "redeem")
 }
 
 func AddressToHash(address common.Address) common.Hash {

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -321,10 +321,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		arbosState, err := arbosState.OpenSystemArbosState(statedb, true)
-		if err != nil {
-			panic(err)
-		}
+		arbosState := arbosState.OpenSystemArbosStateOrPanic(statedb, nil, true)
 		chainId, err := arbosState.ChainId()
 		if err != nil {
 			panic(err)

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -141,7 +141,7 @@ func main() {
 		// ArbOS has already been initialized.
 		// Load the chain config and then produce a block normally.
 
-		initialArbosState, err := arbosState.OpenSystemArbosState(statedb, true)
+		initialArbosState, err := arbosState.OpenSystemArbosState(statedb, nil, true)
 		if err != nil {
 			panic(fmt.Sprintf("Error opening initial ArbOS state: %v", err.Error()))
 		}
@@ -172,7 +172,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		_, err = arbosState.InitializeArbosState(statedb, burn.NewSystemBurner(false), chainConfig)
+		_, err = arbosState.InitializeArbosState(statedb, burn.NewSystemBurner(nil, false), chainConfig)
 		if err != nil {
 			panic(fmt.Sprintf("Error initializing ArbOS: %v", err.Error()))
 		}

--- a/precompiles/ArbOwner_test.go
+++ b/precompiles/ArbOwner_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/burn"
+	"github.com/offchainlabs/nitro/util/testhelpers"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -18,7 +19,7 @@ import (
 func TestAddressSet(t *testing.T) {
 	evm := newMockEVMForTesting()
 	caller := common.BytesToAddress(crypto.Keccak256([]byte{})[:20])
-	tracer := util.NewTracingInfo(evm, types.ArbosAddress, util.TracingDuringEVM)
+	tracer := util.NewTracingInfo(evm, testhelpers.RandomAddress(), types.ArbosAddress, util.TracingDuringEVM)
 	state, err := arbosState.OpenArbosState(evm.StateDB, burn.NewSystemBurner(tracer, false))
 	Require(t, err)
 	Require(t, state.ChainOwners().Add(caller))

--- a/precompiles/ArbOwner_test.go
+++ b/precompiles/ArbOwner_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos/burn"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/offchainlabs/nitro/arbos/util"
 )
@@ -17,7 +18,8 @@ import (
 func TestAddressSet(t *testing.T) {
 	evm := newMockEVMForTesting()
 	caller := common.BytesToAddress(crypto.Keccak256([]byte{})[:20])
-	state, err := arbosState.OpenArbosState(evm.StateDB, burn.NewSystemBurner(false))
+	tracer := util.NewTracingInfo(evm, types.ArbosAddress, util.TracingDuringEVM)
+	state, err := arbosState.OpenArbosState(evm.StateDB, burn.NewSystemBurner(tracer, false))
 	Require(t, err)
 	Require(t, state.ChainOwners().Add(caller))
 

--- a/precompiles/context.go
+++ b/precompiles/context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos/util"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -61,7 +62,7 @@ func (c *context) TracingInfo() *util.TracingInfo {
 }
 
 func testContext(caller addr, evm mech) *context {
-	tracingInfo := util.NewTracingInfo(evm, common.Address{}, util.TracingDuringEVM)
+	tracingInfo := util.NewTracingInfo(evm, common.Address{}, types.ArbosAddress, util.TracingDuringEVM)
 	ctx := &context{
 		caller:      caller,
 		gasSupplied: ^uint64(0),

--- a/precompiles/context.go
+++ b/precompiles/context.go
@@ -10,6 +10,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/burn"
+	"github.com/offchainlabs/nitro/arbos/util"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -29,6 +30,7 @@ type context struct {
 	gasLeft     uint64
 	txProcessor *arbos.TxProcessor
 	state       *arbosState.ArbosState
+	tracingInfo *util.TracingInfo
 	readOnly    bool
 }
 
@@ -54,14 +56,20 @@ func (c *context) ReadOnly() bool {
 	return c.readOnly
 }
 
+func (c *context) TracingInfo() *util.TracingInfo {
+	return c.tracingInfo
+}
+
 func testContext(caller addr, evm mech) *context {
+	tracingInfo := util.NewTracingInfo(evm, common.Address{}, util.TracingDuringEVM)
 	ctx := &context{
 		caller:      caller,
 		gasSupplied: ^uint64(0),
 		gasLeft:     ^uint64(0),
+		tracingInfo: tracingInfo,
 		readOnly:    false,
 	}
-	state, err := arbosState.OpenArbosState(evm.StateDB, burn.NewSystemBurner(false))
+	state, err := arbosState.OpenArbosState(evm.StateDB, burn.NewSystemBurner(tracingInfo, false))
 	if err != nil {
 		panic(err)
 	}

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -594,7 +594,7 @@ func (p Precompile) Call(
 		gasSupplied: gasSupplied,
 		gasLeft:     gasSupplied,
 		readOnly:    method.purity <= view,
-		tracingInfo: util.NewTracingInfo(evm, precompileAddress, util.TracingDuringEVM),
+		tracingInfo: util.NewTracingInfo(evm, caller, precompileAddress, util.TracingDuringEVM),
 	}
 
 	argsCost := params.CopyGas * arbmath.WordsForBytes(uint64(len(input)-4))

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
+	"github.com/offchainlabs/nitro/arbos/util"
 	templates "github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/util/arbmath"
 
@@ -593,6 +594,7 @@ func (p Precompile) Call(
 		gasSupplied: gasSupplied,
 		gasLeft:     gasSupplied,
 		readOnly:    method.purity <= view,
+		tracingInfo: util.NewTracingInfo(evm, precompileAddress, util.TracingDuringEVM),
 	}
 
 	argsCost := params.CopyGas * arbmath.WordsForBytes(uint64(len(input)-4))

--- a/precompiles/wrapper.go
+++ b/precompiles/wrapper.go
@@ -79,7 +79,7 @@ func (wrapper *OwnerPrecompile) Call(
 	burner := &context{
 		gasSupplied: gasSupplied,
 		gasLeft:     gasSupplied,
-		tracingInfo: util.NewTracingInfo(evm, precompileAddress, util.TracingDuringEVM),
+		tracingInfo: util.NewTracingInfo(evm, caller, precompileAddress, util.TracingDuringEVM),
 	}
 	state, err := arbosState.OpenArbosState(evm.StateDB, burner)
 	if err != nil {

--- a/precompiles/wrapper.go
+++ b/precompiles/wrapper.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 
 	"github.com/offchainlabs/nitro/arbos/arbosState"
+	"github.com/offchainlabs/nitro/arbos/util"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -78,6 +79,7 @@ func (wrapper *OwnerPrecompile) Call(
 	burner := &context{
 		gasSupplied: gasSupplied,
 		gasLeft:     gasSupplied,
+		tracingInfo: util.NewTracingInfo(evm, precompileAddress, util.TracingDuringEVM),
 	}
 	state, err := arbosState.OpenArbosState(evm.StateDB, burner)
 	if err != nil {

--- a/system_tests/precompile_fuzz/precompile_fuzz.go
+++ b/system_tests/precompile_fuzz/precompile_fuzz.go
@@ -29,7 +29,8 @@ func Fuzz(input []byte) int {
 	if err != nil {
 		panic(err)
 	}
-	_, err = arbosState.InitializeArbosState(sdb, burn.NewSystemBurner(false), params.ArbitrumDevTestChainConfig())
+	burner := burn.NewSystemBurner(nil, false)
+	_, err = arbosState.InitializeArbosState(sdb, burner, params.ArbitrumDevTestChainConfig())
 	if err != nil {
 		panic(err)
 	}

--- a/util/merkletree/merkleEventProof_test.go
+++ b/util/merkletree/merkleEventProof_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func initializedMerkleAccumulatorForTesting() *merkleAccumulator.MerkleAccumulator {
-	sto := storage.NewMemoryBacked(burn.NewSystemBurner(false))
+	sto := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	merkleAccumulator.InitializeMerkleAccumulator(sto)
 	return merkleAccumulator.OpenMerkleAccumulator(sto)
 }

--- a/validator/stateless_block_validator.go
+++ b/validator/stateless_block_validator.go
@@ -212,7 +212,7 @@ func RecordBlockCreation(blockchain *core.BlockChain, prevHeader *types.Header, 
 	// Get the chain ID, both to validate and because the replay binary also gets the chain ID,
 	// so we need to populate the recordingdb with preimages for retrieving the chain ID.
 	if prevHeader != nil {
-		initialArbosState, err := arbosState.OpenSystemArbosState(recordingdb, true)
+		initialArbosState, err := arbosState.OpenSystemArbosState(recordingdb, nil, true)
 		if err != nil {
 			return common.Hash{}, nil, fmt.Errorf("error opening initial ArbOS state: %w", err)
 		}


### PR DESCRIPTION
Adds tracing support for state accesses and a mock-call to `redeem` for retryable auto redemption

Associated PRs
- https://github.com/OffchainLabs/go-ethereum/pull/85
- https://github.com/OffchainLabs/blockscout/pull/7