### PR TITLE
Get timestamp in sequencer after getting queue items

### DIFF
--- a/arbnode/sequencer.go
+++ b/arbnode/sequencer.go
@@ -137,22 +137,6 @@ func (s *Sequencer) forwardIfSet(queueItems []txQueueItem) bool {
 }
 
 func (s *Sequencer) sequenceTransactions(ctx context.Context) {
-	timestamp := time.Now().Unix()
-	s.L1BlockAndTimeMutex.Lock()
-	l1Block := s.l1BlockNumber
-	l1Timestamp := s.l1Timestamp
-	s.L1BlockAndTimeMutex.Unlock()
-
-	if s.l1Client != nil && (l1Block == 0 || math.Abs(float64(l1Timestamp)-float64(timestamp)) > s.config.MaxAcceptableTimestampDelta.Seconds()) {
-		log.Error(
-			"cannot sequence: unknown L1 block or L1 timestamp too far from local clock time",
-			"l1Block", l1Block,
-			"l1Timestamp", l1Timestamp,
-			"localTimestamp", timestamp,
-		)
-		return
-	}
-
 	var txes types.Transactions
 	var queueItems []txQueueItem
 	var totalBatchSize int
@@ -207,6 +191,22 @@ func (s *Sequencer) sequenceTransactions(ctx context.Context) {
 	}
 
 	if s.forwardIfSet(queueItems) {
+		return
+	}
+
+	timestamp := time.Now().Unix()
+	s.L1BlockAndTimeMutex.Lock()
+	l1Block := s.l1BlockNumber
+	l1Timestamp := s.l1Timestamp
+	s.L1BlockAndTimeMutex.Unlock()
+
+	if s.l1Client != nil && (l1Block == 0 || math.Abs(float64(l1Timestamp)-float64(timestamp)) > s.config.MaxAcceptableTimestampDelta.Seconds()) {
+		log.Error(
+			"cannot sequence: unknown L1 block or L1 timestamp too far from local clock time",
+			"l1Block", l1Block,
+			"l1Timestamp", l1Timestamp,
+			"localTimestamp", timestamp,
+		)
 		return
 	}
 


### PR DESCRIPTION
Getting the queue items will block on waiting for the next tx, and at that point, the timestamp might be out of date