### PR TITLE
Expose gas pool

### DIFF
--- a/contracts/src/precompiles/ArbGasInfo.sol
+++ b/contracts/src/precompiles/ArbGasInfo.sol
@@ -115,4 +115,7 @@ interface ArbGasInfo {
 
     /// @notice Get L1 gas fees paid by the current transaction
     function getCurrentTxL1GasFees() external view returns (uint256);
+
+    /// @notice Get the amount of gas remaining in the gas pool
+    function getGasPool() external view returns (int64);
 }

--- a/precompiles/ArbGasInfo.go
+++ b/precompiles/ArbGasInfo.go
@@ -160,3 +160,8 @@ func (con ArbGasInfo) GetL1GasPriceEstimate(c ctx, evm mech) (huge, error) {
 func (con ArbGasInfo) GetCurrentTxL1GasFees(c ctx, evm mech) (huge, error) {
 	return c.txProcessor.PosterFee, nil
 }
+
+// Get the amount of gas remaining in the gas pool
+func (con ArbGasInfo) GetGasPool(c ctx, evm mech) (int64, error) {
+	return c.state.L2PricingState().GasPool()
+}


### PR DESCRIPTION
Exposes the L2 gas pool via the new `GetGasPool` precompile method in `ArbGasInfo`

Associated PRs
- https://github.com/OffchainLabs/blockscout/pull/6