### PR TITLE
Support prefixed code lookup in replay preimage DB

### DIFF
--- a/cmd/replay/db.go
+++ b/cmd/replay/db.go
@@ -4,8 +4,12 @@
 package main
 
 import (
+	"bytes"
+	"encoding/hex"
 	"errors"
+	"fmt"
 
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/offchainlabs/nitro/wavmio"
 )
@@ -20,11 +24,16 @@ func (db PreimageDb) Has(key []byte) (bool, error) {
 }
 
 func (db PreimageDb) Get(key []byte) ([]byte, error) {
-	if len(key) != 32 {
-		return nil, errors.New("Preimage DB keys must be 32 bytes long")
-	}
 	var hash [32]byte
 	copy(hash[:], key)
+	if len(key) == 32 {
+		copy(hash[:], key)
+	} else if len(key) == len(rawdb.CodePrefix)+32 && bytes.HasPrefix(key, rawdb.CodePrefix) {
+		// Retrieving code
+		copy(hash[:], key[len(rawdb.CodePrefix):])
+	} else {
+		return nil, fmt.Errorf("preimage DB attempted to access non-hash key %v", hex.EncodeToString(key))
+	}
 	return wavmio.ResolvePreImage(hash), nil
 }
 


### PR DESCRIPTION
I'm marking this as a draft for now as it isn't necessary and changes the replay binary hash of course