### PR TITLE
Fix contract verification

### DIFF
--- a/contracts/src/rollup/IRollupCore.sol
+++ b/contracts/src/rollup/IRollupCore.sol
@@ -7,8 +7,6 @@ pragma solidity ^0.8.0;
 import "./Node.sol";
 import "./RollupLib.sol";
 
-import "../osp/IOneStepProofEntry.sol";
-
 interface IRollupCore {
     struct Staker {
         uint256 amountStaked;

--- a/contracts/src/rollup/RollupEventBridge.sol
+++ b/contracts/src/rollup/RollupEventBridge.sol
@@ -4,8 +4,6 @@
 
 pragma solidity ^0.8.0;
 
-import "./IRollupLogic.sol";
-
 import "../bridge/IBridge.sol";
 import "../bridge/IMessageProvider.sol";
 import "../libraries/DelegateCallAware.sol";

--- a/contracts/src/rollup/ValidatorUtils.sol
+++ b/contracts/src/rollup/ValidatorUtils.sol
@@ -7,7 +7,6 @@ pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import "../rollup/IRollupCore.sol";
-import "../rollup/IRollupLogic.sol";
 import "../challenge/IChallengeManager.sol";
 
 import {NO_CHAL_INDEX} from "../libraries/Constants.sol";

--- a/contracts/src/rollup/ValidatorWallet.sol
+++ b/contracts/src/rollup/ValidatorWallet.sol
@@ -4,7 +4,6 @@
 
 pragma solidity ^0.8.0;
 
-import "./IRollupLogic.sol";
 import "../challenge/IChallengeManager.sol";
 import "../libraries/DelegateCallAware.sol";
 import "@openzeppelin/contracts/utils/Address.sol";


### PR DESCRIPTION
Fixed Etherscan verification of `RollupEventBridge` and `ValidatorWalletCreator` by removing unused imports. Still unable to verify `RollupAdminLogic` and `RollupUserLogic` since there are cyclic dependencies which the hardhat-etherscan plugin refused to work.

You can check for cyclic dependencies by
```
> npx hardhat flatten src/rollup/RollupLib.sol
Error HH603: Hardhat flatten doesn't support cyclic dependencies.
```