### PR TITLE
Have block validator pull batches and blocks if necessary

### DIFF
--- a/validator/block_validator.go
+++ b/validator/block_validator.go
@@ -194,6 +194,11 @@ func (v *BlockValidator) NewBlock(block *types.Block, prevHeader *types.Header, 
 		Entry:  nil,
 	}
 	blockNum := block.NumberU64()
+	// It's fine to separately load and then store as we have the blockMutex acquired
+	_, present := v.validationEntries.Load(blockNum)
+	if present {
+		return
+	}
 	v.validationEntries.Store(blockNum, status)
 	if v.nextValidationEntryBlock <= blockNum {
 		v.nextValidationEntryBlock = blockNum + 1
@@ -373,11 +378,40 @@ func (v *BlockValidator) sendValidations(ctx context.Context) {
 		}
 		seqBatchEntry, haveBatch := v.sequencerBatches.Load(v.globalPosNextSend.BatchNumber)
 		if !haveBatch {
-			return
+			if batchCount == v.globalPosNextSend.BatchNumber+1 {
+				// This is the latest batch.
+				// To avoid re-querying it unnecessarily, wait for the inbox tracker to provide it to us.
+				return
+			}
+			seqMsg, err := v.inboxReader.GetSequencerMessageBytes(ctx, v.globalPosNextSend.BatchNumber)
+			if err != nil {
+				log.Error("validator failed to read sequencer message", "err", err)
+				return
+			}
+			v.ProcessBatches(v.globalPosNextSend.BatchNumber, [][]byte{seqMsg})
+			seqBatchEntry = seqMsg
+			haveBatch = true
 		}
+		nextMsg := arbutil.BlockNumberToMessageCount(v.nextBlockToValidate, v.genesisBlockNum) - 1
 		// valdationEntries is By blockNumber
 		entry, found := v.validationEntries.Load(v.nextBlockToValidate)
 		if !found {
+			block := v.blockchain.GetBlockByNumber(v.nextBlockToValidate)
+			if block == nil {
+				// This block hasn't been created yet.
+				return
+			}
+			prevHeader := v.blockchain.GetHeaderByHash(block.ParentHash())
+			if prevHeader == nil && block.ParentHash() != (common.Hash{}) {
+				log.Warn("failed to get prevHeader in block validator", "num", v.nextBlockToValidate-1, "hash", block.ParentHash())
+				return
+			}
+			msg, err := v.streamer.GetMessage(nextMsg)
+			if err != nil {
+				log.Warn("failed to get message in block validator", "err", err)
+				return
+			}
+			v.NewBlock(block, prevHeader, msg)
 			return
 		}
 		validationStatus, ok := entry.(*validationStatus)
@@ -385,10 +419,9 @@ func (v *BlockValidator) sendValidations(ctx context.Context) {
 			log.Error("bad entry trying to validate batch")
 			return
 		}
-		if atomic.LoadUint32(&validationStatus.Status) == 0 {
+		if atomic.LoadUint32(&validationStatus.Status) == validationStatusUnprepared {
 			return
 		}
-		nextMsg := arbutil.BlockNumberToMessageCount(v.nextBlockToValidate, v.genesisBlockNum) - 1
 		startPos, endPos, err := GlobalStatePositionsFor(v.inboxTracker, nextMsg, v.globalPosNextSend.BatchNumber)
 		if err != nil {
 			log.Error("failed calculating position for validation", "err", err, "msg", nextMsg, "batch", v.globalPosNextSend.BatchNumber)

--- a/validator/block_validator.go
+++ b/validator/block_validator.go
@@ -390,7 +390,6 @@ func (v *BlockValidator) sendValidations(ctx context.Context) {
 			}
 			v.ProcessBatches(v.globalPosNextSend.BatchNumber, [][]byte{seqMsg})
 			seqBatchEntry = seqMsg
-			haveBatch = true
 		}
 		nextMsg := arbutil.BlockNumberToMessageCount(v.nextBlockToValidate, v.genesisBlockNum) - 1
 		// valdationEntries is By blockNumber


### PR DESCRIPTION
This retains the push based functionality when caught up while allowing pulling batches and blocks when necessary.