### PR TITLE
Update Inbox msg value validation

### DIFF
--- a/contracts/src/bridge/Inbox.sol
+++ b/contracts/src/bridge/Inbox.sol
@@ -318,7 +318,7 @@ contract Inbox is DelegateCallAware, PausableUpgradeable, IInbox {
         bytes calldata data
     ) external payable virtual override whenNotPaused returns (uint256) {
         // ensure the user's deposit alone will make submission succeed
-        require(msg.value >= maxSubmissionCost + l2CallValue, "insufficient value");
+        require(msg.value >= maxSubmissionCost, "insufficient value");
 
         // if a refund address is a contract, we apply the alias to it
         // so that it can access its funds on the L2


### PR DESCRIPTION
I believe the invariant we want to enforce here is that the retryable ticket will be successfully created, not that it is redeemable.
The l2CallValue is only needed when the retryable ticket is redeemed, so the L2 aliased account can be funded to cover for the callvalue after the ticket is created