### PR TITLE
Support marshalling & unmarshalling arbitrum tx types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ target/
 yarn-error.log
 das/dasrpc/wireFormat.pb.go
 das/dasrpc/wireFormat_grpc.pb.go
-
+local/

--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -196,9 +196,9 @@ func TestTransactionStreamer(t *testing.T) {
 	}
 }
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/arbos/addressSet/addressSet_test.go
+++ b/arbos/addressSet/addressSet_test.go
@@ -137,9 +137,9 @@ func size(t *testing.T, aset *AddressSet) uint64 {
 	return size
 }
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/arbos/addressTable/addressTable_test.go
+++ b/arbos/addressTable/addressTable_test.go
@@ -140,9 +140,9 @@ func size(t *testing.T, atab *AddressTable) uint64 {
 	return size
 }
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/arbos/arbosState/common_test.go
+++ b/arbos/arbosState/common_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/arbos/blockhash/blockhash_test.go
+++ b/arbos/blockhash/blockhash_test.go
@@ -75,9 +75,9 @@ func TestBlockhash(t *testing.T) {
 
 }
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/arbos/blsTable/bls_test.go
+++ b/arbos/blsTable/bls_test.go
@@ -45,9 +45,9 @@ func TestLegacyBLS(t *testing.T) {
 	}
 }
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/arbos/common_test.go
+++ b/arbos/common_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -40,7 +40,7 @@ func InternalTxStartBlock(
 	}
 	return &types.ArbitrumInternalTx{
 		ChainId:       chainId,
-		Type:          arbInternalTxStartBlock,
+		SubType:       arbInternalTxStartBlock,
 		Data:          data,
 		L2BlockNumber: l2BlockNum,
 	}

--- a/arbos/l1pricing/common_test.go
+++ b/arbos/l1pricing/common_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/arbos/l2pricing/l2pricing_test.go
+++ b/arbos/l2pricing/l2pricing_test.go
@@ -155,9 +155,9 @@ func rateEstimate(t *testing.T, pricing *L2PricingState) uint64 {
 	return value
 }
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/arbstate/geth_test.go
+++ b/arbstate/geth_test.go
@@ -137,9 +137,9 @@ func RunMessagesThroughAPI(t *testing.T, msgs [][]byte, statedb *state.StateDB) 
 	}
 }
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/blsSignatures/blsSignatures_test.go
+++ b/blsSignatures/blsSignatures_test.go
@@ -4,8 +4,9 @@
 package blsSignatures
 
 import (
-	"github.com/offchainlabs/nitro/util/testhelpers"
 	"testing"
+
+	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 
 func TestValidSignature(t *testing.T) {
@@ -106,9 +107,9 @@ func TestSignatureAggregationDifferentMessages(t *testing.T) {
 	}
 }
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/broadcaster/broadcaster_test.go
+++ b/broadcaster/broadcaster_test.go
@@ -127,9 +127,9 @@ func TestBroadcasterMessagesRemovedOnConfirmation(t *testing.T) {
 
 }
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/das/das_test.go
+++ b/das/das_test.go
@@ -71,9 +71,9 @@ func TestDASMissingMessage(t *testing.T) {
 	}
 }
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/precompiles/ArbAddressTable_test.go
+++ b/precompiles/ArbAddressTable_test.go
@@ -162,9 +162,9 @@ func newMockEVMForTesting() *vm.EVM {
 	return evm
 }
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -249,7 +249,7 @@ func CreateTestL2WithConfig(t *testing.T, ctx context.Context, l2Info *Blockchai
 	return l2info, node, client
 }
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, text ...interface{}) {
 	t.Helper()
 	testhelpers.RequireImpl(t, err, text...)
 }

--- a/system_tests/retryable_test.go
+++ b/system_tests/retryable_test.go
@@ -67,6 +67,18 @@ func retryableSetup(t *testing.T) (
 	TransferBalance(t, "Faucet", "Burn", discard, l2info, l2client, ctx)
 
 	teardown := func() {
+
+		// check the integrity of the RPC
+		blockNum, err := l2client.BlockNumber(ctx)
+		Require(t, err, "failed to get L2 block number")
+		for number := uint64(0); number < blockNum; number++ {
+			block, err := l2client.BlockByNumber(ctx, arbmath.UintToBig(number))
+			Require(t, err, "failed to get L2 block", number, "of", blockNum)
+			if block.Number().Uint64() != number {
+				Fail(t, "block number mismatch", number, block.Number().Uint64())
+			}
+		}
+
 		cancel()
 		stack.Close()
 	}

--- a/util/merkletree/common_test.go
+++ b/util/merkletree/common_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/util/testhelpers/testhelpers.go
+++ b/util/testhelpers/testhelpers.go
@@ -12,10 +12,10 @@ import (
 )
 
 // Fail a test should an error occur
-func RequireImpl(t *testing.T, err error, text ...string) {
+func RequireImpl(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
 	if err != nil {
-		t.Fatal(colors.Red, text, err, colors.Clear)
+		t.Fatal(colors.Red, printables, err, colors.Clear)
 	}
 }
 

--- a/validator/common_test.go
+++ b/validator/common_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/zeroheavy/common_test.go
+++ b/zeroheavy/common_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 
-func Require(t *testing.T, err error, text ...string) {
+func Require(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
-	testhelpers.RequireImpl(t, err, text...)
+	testhelpers.RequireImpl(t, err, printables...)
 }
 
 func Fail(t *testing.T, printables ...interface{}) {


### PR DESCRIPTION
Changes
- Supports JSON marshalling & unmarshalling of arbitrum-specific tx types
- Tests this functionality via calls to `BlockNumber` in the retryable tests
- Improves `Require()` so tests can print variables on failure

Associated PRs
- https://github.com/OffchainLabs/go-ethereum/pull/92

Resolves: #499 