### PR TITLE
Improve inbox tracker sync logging

### DIFF
--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -499,19 +499,23 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L
 	}
 
 	newMessageCount := prevbatchmeta.MessageCount + arbutil.MessageIndex(len(messages))
-	latestBlock, err := t.txStreamer.MessageCountToBlockNumber(newMessageCount)
+	latestL2Block, err := t.txStreamer.MessageCountToBlockNumber(newMessageCount)
 	if err != nil {
 		return err
 	}
+	var latestL1Block uint64
 	var latestTimestamp uint64
 	if len(messages) > 0 {
-		latestTimestamp = messages[len(messages)-1].Message.Header.Timestamp
+		lastHeader := messages[len(messages)-1].Message.Header
+		latestL1Block = lastHeader.BlockNumber
+		latestTimestamp = lastHeader.Timestamp
 	}
 	log.Info(
 		"InboxTracker sync",
 		"sequencerBatchCount", pos,
-		"l2BlockNumber", latestBlock,
-		"timestamp", time.Unix(int64(latestTimestamp), 0),
+		"l1Block", latestL1Block,
+		"l2Block", latestL2Block,
+		"blockTimestamp", time.Unix(int64(latestTimestamp), 0),
 	)
 
 	if t.validator != nil {

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -510,7 +510,6 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L
 	log.Info(
 		"InboxTracker sync",
 		"sequencerBatchCount", pos,
-		"messageCount", newMessageCount,
 		"l2BlockNumber", latestBlock,
 		"timestamp", time.Unix(int64(latestTimestamp), 0),
 	)

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -314,7 +315,7 @@ func (t *InboxTracker) setDelayedCountReorgAndWriteBatch(batch ethdb.Batch, newD
 		if err != nil {
 			return err
 		}
-		log.Info("InboxTracker", "SequencerBatchCount", count)
+		log.Info("InboxTracker", "sequencerBatchCount", count)
 		err = deleteStartingAt(t.db, batch, sequencerBatchMetaPrefix, uint64ToBytes(count))
 		if err != nil {
 			return err
@@ -496,7 +497,23 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L
 	if err != nil {
 		return err
 	}
-	log.Info("InboxTracker", "sequencerBatchCount", pos, "prevMessageCount", prevbatchmeta.MessageCount, "newMessageCount", int(prevbatchmeta.MessageCount)+len(messages))
+
+	newMessageCount := prevbatchmeta.MessageCount + arbutil.MessageIndex(len(messages))
+	latestBlock, err := t.txStreamer.MessageCountToBlockNumber(newMessageCount)
+	if err != nil {
+		return err
+	}
+	var latestTimestamp uint64
+	if len(messages) > 0 {
+		latestTimestamp = messages[len(messages)-1].Message.Header.Timestamp
+	}
+	log.Info(
+		"InboxTracker sync",
+		"sequencerBatchCount", pos,
+		"messageCount", newMessageCount,
+		"l2BlockNumber", latestBlock,
+		"timestamp", time.Unix(int64(latestTimestamp), 0),
+	)
 
 	if t.validator != nil {
 		t.validator.ReorgToBatchCount(startPos)

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -499,23 +499,20 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L
 	}
 
 	newMessageCount := prevbatchmeta.MessageCount + arbutil.MessageIndex(len(messages))
-	latestL2Block, err := t.txStreamer.MessageCountToBlockNumber(newMessageCount)
-	if err != nil {
-		return err
-	}
 	var latestL1Block uint64
+	if len(batches) > 0 {
+		latestL1Block = batches[len(batches)-1].BlockNumber
+	}
 	var latestTimestamp uint64
 	if len(messages) > 0 {
-		lastHeader := messages[len(messages)-1].Message.Header
-		latestL1Block = lastHeader.BlockNumber
-		latestTimestamp = lastHeader.Timestamp
+		latestTimestamp = messages[len(messages)-1].Message.Header.Timestamp
 	}
 	log.Info(
-		"InboxTracker sync",
+		"InboxTracker",
 		"sequencerBatchCount", pos,
+		"messageCount", newMessageCount,
 		"l1Block", latestL1Block,
-		"l2Block", latestL2Block,
-		"blockTimestamp", time.Unix(int64(latestTimestamp), 0),
+		"l1Timestamp", time.Unix(int64(latestTimestamp), 0),
 	)
 
 	if t.validator != nil {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -753,9 +753,6 @@ func (s *TransactionStreamer) createBlocks(ctx context.Context) error {
 	return nil
 }
 
-func logCreatedBlock(block *types.Block, message *arbos.L1IncomingMessage) {
-}
-
 func (s *TransactionStreamer) Initialize() error {
 	return s.cleanupInconsistentState()
 }


### PR DESCRIPTION
Example of new logging:
```
INFO [04-20|22:59:40.344] created block                            l2Block=18860 l2BlockHash=cfb013..926d05 l1Block=6,752,219 l1Timestamp=2022-04-20T22:59:40-0500
INFO [04-20|23:00:16.319] InboxTracker                             sequencerBatchCount=6044 messageCount=18858 l1Block=6,752,218 l1Timestamp=2022-04-20T22:58:51-0500
```