### PR TITLE
Fix br_table stack pollution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,9 @@ arbitrator/prover/test-cases/%.wasm: arbitrator/prover/test-cases/%.wat
 contracts/test/prover/proofs/float%.json: arbitrator/prover/test-cases/float%.wasm $(arbitrator_prover_bin) $(output_root)/machines/latest/soft-float.wasm
 	$(arbitrator_prover_bin) $< -l $(output_root)/machines/latest/soft-float.wasm -o $@ -b --allow-hostapi --require-success --always-merkleize
 
+contracts/test/prover/proofs/no-stack-pollution.json: arbitrator/prover/test-cases/no-stack-pollution.wasm $(arbitrator_prover_bin)
+	$(arbitrator_prover_bin) $< -o $@ --allow-hostapi --require-success --always-merkleize
+
 contracts/test/prover/proofs/rust-%.json: arbitrator/prover/test-cases/rust/target/wasm32-wasi/release/%.wasm $(arbitrator_prover_bin) $(arbitrator_wasm_libs_nogo)
 	$(arbitrator_prover_bin) $< $(arbitrator_wasm_lib_flags_nogo) -o $@ -b --allow-hostapi --require-success --inbox-add-stub-headers --inbox arbitrator/prover/test-cases/rust/data/msg0.bin --inbox arbitrator/prover/test-cases/rust/data/msg1.bin --delayed-inbox arbitrator/prover/test-cases/rust/data/msg0.bin --delayed-inbox arbitrator/prover/test-cases/rust/data/msg1.bin --preimages arbitrator/prover/test-cases/rust/data/preimages.bin
 

--- a/arbitrator/prover/test-cases/no-stack-pollution.wat
+++ b/arbitrator/prover/test-cases/no-stack-pollution.wat
@@ -1,0 +1,20 @@
+(import "env" "wavm_halt_and_set_finished" (func $wavm_halt_and_set_finished))
+
+(func
+	(i32.const 1)
+	(block
+		(block
+			(i32.const 2)
+			(br_table 0 0 1 0 0)
+			(unreachable)
+		)
+		(unreachable)
+	)
+	(if (i32.eq (i32.const 1))
+		(then (call $wavm_halt_and_set_finished))
+		(else (unreachable))
+	)
+)
+
+(start 1)
+

--- a/docs/proving/WASMToWAVM.md
+++ b/docs/proving/WASMToWAVM.md
@@ -35,8 +35,11 @@ The jump locations can be known at transpilation time, making blocks obsolete.
 
 ## `br_table`
 
-`br_table` is translated to an `ArbitraryJumpIf` for each possible branch in the table,
-and then if none of the checks hit, an `ArbitraryJump` to the default level.
+`br_table` is translated to a check for each possible branch in the table,
+and then if none of the checks hit, a branch of the default level.
+
+Each of the non-default branches has a conditional jump to a section afterwards,
+containing a `drop` for the selector, and then a jump to the target branch.
 
 ## `local.tee`
 


### PR DESCRIPTION
This was accidentally broken in https://github.com/OffchainLabs/nitro/pull/522 by the removal of the br_table jump table. I thought it was unnecessary, but it is necessary to drop the branch table selector. This PR also adds a test for this scenario.