### PR TITLE
Move stopwaiter to its own go package

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -23,12 +23,12 @@ import (
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/das"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
-	"github.com/offchainlabs/nitro/util"
 	"github.com/offchainlabs/nitro/util/arbmath"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
 type BatchPoster struct {
-	util.StopWaiter
+	stopwaiter.StopWaiter
 	l1Reader      *L1Reader
 	inbox         *InboxTracker
 	streamer      *TransactionStreamer

--- a/arbnode/delayed_sequencer.go
+++ b/arbnode/delayed_sequencer.go
@@ -15,12 +15,12 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/offchainlabs/nitro/arbos"
-	"github.com/offchainlabs/nitro/util"
 	"github.com/offchainlabs/nitro/util/arbmath"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
 type DelayedSequencer struct {
-	util.StopWaiter
+	stopwaiter.StopWaiter
 	l1Reader        *L1Reader
 	bridge          *DelayedBridge
 	inbox           *InboxTracker

--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -15,8 +15,8 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/util"
 	"github.com/offchainlabs/nitro/util/arbmath"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
 type InboxReaderConfig struct {
@@ -44,7 +44,7 @@ var TestInboxReaderConfig = InboxReaderConfig{
 }
 
 type InboxReader struct {
-	util.StopWaiter
+	stopwaiter.StopWaiter
 
 	// Only in run thread
 	caughtUp          bool

--- a/arbnode/l1reader.go
+++ b/arbnode/l1reader.go
@@ -12,13 +12,13 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/util"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 )
 
 type L1Reader struct {
-	util.StopWaiter
+	stopwaiter.StopWaiter
 	config L1ReaderConfig
 	client arbutil.L1Interface
 

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/util"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
 const CHOSENSEQ_KEY string = "coordinator.chosen"              // Never overwritten. Expires or released only
@@ -38,7 +38,7 @@ const LIVELINESS_VAL string = "OK"
 const INVALID_VAL string = "INVALID"
 
 type SeqCoordinator struct {
-	util.StopWaiter
+	stopwaiter.StopWaiter
 
 	streamer                *TransactionStreamer
 	sequencer               *Sequencer

--- a/arbnode/sequencer.go
+++ b/arbnode/sequencer.go
@@ -19,7 +19,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/l1pricing"
-	"github.com/offchainlabs/nitro/util"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 	"github.com/pkg/errors"
 )
 
@@ -38,7 +38,7 @@ func (i *txQueueItem) returnResult(err error) {
 }
 
 type Sequencer struct {
-	util.StopWaiter
+	stopwaiter.StopWaiter
 
 	txStreamer *TransactionStreamer
 	txQueue    chan txQueueItem

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -24,14 +24,14 @@ import (
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/broadcaster"
-	"github.com/offchainlabs/nitro/util"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 	"github.com/offchainlabs/nitro/validator"
 )
 
 // Produces blocks from a node's L1 messages, storing the results in the blockchain and recording their positions
 // The streamer is notified when there's new batches to process
 type TransactionStreamer struct {
-	util.StopWaiter
+	stopwaiter.StopWaiter
 
 	db ethdb.Database
 	bc *core.BlockChain

--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -23,7 +23,7 @@ import (
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/broadcaster"
-	"github.com/offchainlabs/nitro/util"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 	"github.com/offchainlabs/nitro/wsbroadcastserver"
 )
 
@@ -70,7 +70,7 @@ type TransactionStreamerInterface interface {
 }
 
 type BroadcastClient struct {
-	util.StopWaiter
+	stopwaiter.StopWaiter
 
 	websocketUrl    string
 	lastInboxSeqNum *big.Int

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -13,12 +13,12 @@ import (
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/broadcastclient"
 	"github.com/offchainlabs/nitro/broadcaster"
-	"github.com/offchainlabs/nitro/util"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 	"github.com/offchainlabs/nitro/wsbroadcastserver"
 )
 
 type Relay struct {
-	util.StopWaiter
+	stopwaiter.StopWaiter
 	broadcastClients            []*broadcastclient.BroadcastClient
 	broadcaster                 *broadcaster.Broadcaster
 	confirmedSequenceNumberChan chan arbutil.MessageIndex

--- a/util/stopwaiter/stopwaiter.go
+++ b/util/stopwaiter/stopwaiter.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2022, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-package util
+package stopwaiter
 
 import (
 	"context"

--- a/validator/block_validator.go
+++ b/validator/block_validator.go
@@ -26,11 +26,11 @@ import (
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/das"
-	"github.com/offchainlabs/nitro/util"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
 type BlockValidator struct {
-	util.StopWaiter
+	stopwaiter.StopWaiter
 	*StatelessBlockValidator
 
 	validationEntries sync.Map

--- a/validator/staker.go
+++ b/validator/staker.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 
-	"github.com/offchainlabs/nitro/util"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
 type StakerStrategy uint8
@@ -104,7 +104,7 @@ type nodeAndHash struct {
 
 type Staker struct {
 	*L1Validator
-	util.StopWaiter
+	stopwaiter.StopWaiter
 	l1Reader                L1ReaderInterface
 	activeChallenge         *ChallengeManager
 	strategy                StakerStrategy

--- a/wsbroadcastserver/clientconnection.go
+++ b/wsbroadcastserver/clientconnection.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gobwas/ws"
 	"github.com/gobwas/ws/wsutil"
 	"github.com/mailru/easygo/netpoll"
-	"github.com/offchainlabs/nitro/util"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
 // MaxSendQueue is the maximum number of items in a clients out channel before client gets disconnected.
@@ -26,7 +26,7 @@ const MaxSendQueue = 1000
 
 // ClientConnection represents client connection.
 type ClientConnection struct {
-	util.StopWaiter
+	stopwaiter.StopWaiter
 
 	ioMutex sync.Mutex
 	conn    net.Conn

--- a/wsbroadcastserver/clientmanager.go
+++ b/wsbroadcastserver/clientmanager.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/offchainlabs/nitro/util"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
 	"github.com/pkg/errors"
 
 	"github.com/gobwas/ws"
@@ -30,7 +30,7 @@ type CatchupBuffer interface {
 
 // ClientManager manages client connections
 type ClientManager struct {
-	util.StopWaiter
+	stopwaiter.StopWaiter
 
 	clientPtrMap  map[*ClientConnection]bool
 	clientCount   int32


### PR DESCRIPTION
Tested by `go get`ting this branch by revision into another project and importing the `stopwaiter` package.