### PR TITLE
Quiet inbox reader header not found errors

### DIFF
--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"sync"
 	"time"
 
@@ -82,8 +83,8 @@ func (r *InboxReader) Start(ctxIn context.Context) error {
 	r.StopWaiter.Start(ctxIn)
 	r.CallIteratively(func(ctx context.Context) time.Duration {
 		err := r.run(ctx)
-		if err != nil && !errors.Is(err, context.Canceled) {
-			log.Error("error reading inbox", "err", err)
+		if err != nil && !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "header not found") {
+			log.Warn("error reading inbox", "err", err)
 		}
 		return time.Second
 	})


### PR DESCRIPTION
One side effect of #540 is that we're now exposed to L1 node inconsistencies. This quiets a common one of the latest block not being available, and reduces the log level to warn.