### PR TITLE
Remove top clamp on L2 price adjustment

### DIFF
--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -83,7 +83,7 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 	_ = state.RetryableState().TryToReapOneRetryable(currentTime, evm, util.TracingDuringEVM)
 	_ = state.RetryableState().TryToReapOneRetryable(currentTime, evm, util.TracingDuringEVM)
 
-	state.L2PricingState().UpdatePricingModel(l2BaseFee, timePassed, false)
+	state.L2PricingState().UpdatePricingModel(l2BaseFee, timePassed, state.FormatVersion(), false)
 	state.L1PricingState().UpdatePricingModel(l1BaseFee, currentTime)
 
 	state.UpgradeArbosVersionIfNecessary(currentTime, evm.ChainConfig())

--- a/arbos/l2pricing/l2pricing_test.go
+++ b/arbos/l2pricing/l2pricing_test.go
@@ -23,7 +23,7 @@ func PricingForTest(t *testing.T) *L2PricingState {
 func fakeBlockUpdate(t *testing.T, pricing *L2PricingState, gasUsed int64, timePassed uint64) {
 	basefee := getPrice(t, pricing)
 	pricing.storage.Burner().Restrict(pricing.AddToGasPool(-gasUsed))
-	pricing.UpdatePricingModel(arbmath.UintToBig(basefee), timePassed, true)
+	pricing.UpdatePricingModel(arbmath.UintToBig(basefee), timePassed, 3, true)
 }
 
 func TestPricingModel(t *testing.T) {

--- a/arbos/l2pricing/model.go
+++ b/arbos/l2pricing/model.go
@@ -31,7 +31,7 @@ func (ps *L2PricingState) AddToGasPool(gas int64) error {
 }
 
 // Update the pricing model with info from the last block
-func (ps *L2PricingState) UpdatePricingModel(l2BaseFee *big.Int, timePassed uint64, debug bool) {
+func (ps *L2PricingState) UpdatePricingModel(l2BaseFee *big.Int, timePassed uint64, arbosVersion uint64, debug bool) {
 
 	// update the rate estimate, which is the weighted average of the past and present
 	//     rate' = weighted average of the historical rate and the current
@@ -87,6 +87,10 @@ func (ps *L2PricingState) UpdatePricingModel(l2BaseFee *big.Int, timePassed uint
 		arbmath.BigFloatMulByUint(rateRatio, uint64(oneInBips-poolWeight)),
 	).Uint64()
 	averageOfRatios := arbmath.Bips(averageOfRatiosRaw)
+	averageOfRatiosUnbounded := averageOfRatios
+	if arbosVersion < 3 && averageOfRatios > arbmath.PercentToBips(200) {
+		averageOfRatios = arbmath.PercentToBips(200)
+	}
 
 	// update the gas price, adjusting each second by the max allowed by EIP 1559
 	//      price' = price * exp(seconds at intensity) / 2 mins
@@ -103,7 +107,7 @@ func (ps *L2PricingState) UpdatePricingModel(l2BaseFee *big.Int, timePassed uint
 	}
 	p("\nused\t", gasUsed, " in ", timePassed, "s = ", rate, "/s vs limit ", speedLimit, "/s for ", rateRatio)
 	p("pool\t", gasPool, "/", poolMax, " ➤ ", averagePool, " ➤ ", newGasPool, " ", poolRatio)
-	p("ratio\t", poolRatio, rateRatio, " ➤ ", averageOfRatios, "‱  ")
+	p("ratio\t", poolRatio, rateRatio, " ➤ ", averageOfRatiosUnbounded, "‱  ")
 	p("exp()\t", exp, " ➤ ", arbmath.ApproxExpBasisPoints(exp), "‱  ")
 	p("price\t", l2BaseFee, " ➤ ", price, " bound to [", minPrice, ", ", maxPrice, "]\n")
 

--- a/arbos/l2pricing/model.go
+++ b/arbos/l2pricing/model.go
@@ -87,10 +87,6 @@ func (ps *L2PricingState) UpdatePricingModel(l2BaseFee *big.Int, timePassed uint
 		arbmath.BigFloatMulByUint(rateRatio, uint64(oneInBips-poolWeight)),
 	).Uint64()
 	averageOfRatios := arbmath.Bips(averageOfRatiosRaw)
-	averageOfRatiosUnbounded := averageOfRatios
-	if averageOfRatios > arbmath.PercentToBips(200) {
-		averageOfRatios = arbmath.PercentToBips(200)
-	}
 
 	// update the gas price, adjusting each second by the max allowed by EIP 1559
 	//      price' = price * exp(seconds at intensity) / 2 mins
@@ -107,7 +103,7 @@ func (ps *L2PricingState) UpdatePricingModel(l2BaseFee *big.Int, timePassed uint
 	}
 	p("\nused\t", gasUsed, " in ", timePassed, "s = ", rate, "/s vs limit ", speedLimit, "/s for ", rateRatio)
 	p("pool\t", gasPool, "/", poolMax, " ➤ ", averagePool, " ➤ ", newGasPool, " ", poolRatio)
-	p("ratio\t", poolRatio, rateRatio, " ➤ ", averageOfRatiosUnbounded, "‱   bound to [0, 20000]")
+	p("ratio\t", poolRatio, rateRatio, " ➤ ", averageOfRatios, "‱  ")
 	p("exp()\t", exp, " ➤ ", arbmath.ApproxExpBasisPoints(exp), "‱  ")
 	p("price\t", l2BaseFee, " ➤ ", price, " bound to [", minPrice, ", ", maxPrice, "]\n")
 


### PR DESCRIPTION
This will allow the system to respond more quickly to large surges in transaction traffic.