### PR TITLE
Apply base fee updates immediately by computing gas model twice

### DIFF
--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -72,7 +72,7 @@ func OpenArbosState(stateDB vm.StateDB, burner burn.Burner) (*ArbosState, error)
 		backingStorage.OpenStorageBackedUint64(uint64(upgradeTimestampOffset)),
 		backingStorage.OpenStorageBackedAddress(uint64(networkFeeAccountOffset)),
 		l1pricing.OpenL1PricingState(backingStorage.OpenSubStorage(l1PricingSubspace)),
-		l2pricing.OpenL2PricingState(backingStorage.OpenSubStorage(l2PricingSubspace)),
+		l2pricing.OpenL2PricingState(backingStorage.OpenSubStorage(l2PricingSubspace), arbosVersion),
 		retryables.OpenRetryableState(backingStorage.OpenSubStorage(retryablesSubspace), stateDB),
 		addressTable.Open(backingStorage.OpenSubStorage(addressTableSubspace)),
 		blsTable.Open(backingStorage.OpenSubStorage(blsTableSubspace)),
@@ -234,7 +234,8 @@ func (state *ArbosState) UpgradeArbosVersionIfNecessary(currentTimestamp uint64,
 					state.Restrict(state.chainOwners.Add(TestnetUpgrade2Owner))
 				}
 			} else if state.arbosVersion == 2 {
-				// Upgrade version 2->3 has no state changes
+				// Upgrade version 2->3 removes the base fee from state
+				state.Restrict(state.L2PricingState().SetBaseFeeWei(common.Big0))
 			} else {
 				// code to upgrade to future versions will be put here
 				panic("Unable to perform requested ArbOS upgrade")

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -35,10 +35,6 @@ var EmitReedeemScheduledEvent func(*vm.EVM, uint64, uint64, [32]byte, [32]byte, 
 var EmitTicketCreatedEvent func(*vm.EVM, [32]byte) error
 
 func createNewHeader(prevHeader *types.Header, l1info *L1Info, state *arbosState.ArbosState, chainConfig *params.ChainConfig) *types.Header {
-	l2Pricing := state.L2PricingState()
-	baseFee, err := l2Pricing.BaseFeeWei()
-	state.Restrict(err)
-
 	var lastBlockHash common.Hash
 	blockNumber := big.NewInt(0)
 	timestamp := uint64(0)
@@ -54,6 +50,10 @@ func createNewHeader(prevHeader *types.Header, l1info *L1Info, state *arbosState
 			timestamp = prevHeader.Time
 		}
 	}
+
+	timePassed := timestamp - prevHeader.Time
+	baseFee := state.L2PricingState().UpdatePricingModel(prevHeader.BaseFee, timePassed, false, false)
+
 	return &types.Header{
 		ParentHash:  lastBlockHash,
 		UncleHash:   types.EmptyUncleHash, // Post-merge Ethereum will require this to be types.EmptyUncleHash

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -59,16 +59,6 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 	nextL1BlockNumber, err := state.Blockhashes().NextBlockNumber()
 	state.Restrict(err)
 
-	if state.FormatVersion() >= 3 {
-		// The `l2BaseFee` in the tx data is indeed the last block's base fee,
-		// however, for the purposes of this function, we need the previous computed base fee.
-		// Since the computed base fee takes one block to apply, the last block's base fee
-		// is actually two calculations ago. Instead, as of ArbOS format version 3,
-		// we use the current state's base fee, which is the result of the last calculation.
-		l2BaseFee, err = state.L2PricingState().BaseFeeWei()
-		state.Restrict(err)
-	}
-
 	if l1BlockNumber >= nextL1BlockNumber {
 		var prevHash common.Hash
 		if evm.Context.BlockNumber.Sign() > 0 {
@@ -83,7 +73,7 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 	_ = state.RetryableState().TryToReapOneRetryable(currentTime, evm, util.TracingDuringEVM)
 	_ = state.RetryableState().TryToReapOneRetryable(currentTime, evm, util.TracingDuringEVM)
 
-	state.L2PricingState().UpdatePricingModel(l2BaseFee, timePassed, false)
+	state.L2PricingState().UpdatePricingModel(l2BaseFee, timePassed, true, false)
 	state.L1PricingState().UpdatePricingModel(l1BaseFee, currentTime)
 
 	state.UpgradeArbosVersionIfNecessary(currentTime, evm.ChainConfig())

--- a/arbos/l2pricing/l2pricing_test.go
+++ b/arbos/l2pricing/l2pricing_test.go
@@ -17,13 +17,13 @@ func PricingForTest(t *testing.T) *L2PricingState {
 	storage := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	err := InitializeL2PricingState(storage)
 	Require(t, err)
-	return OpenL2PricingState(storage)
+	return OpenL2PricingState(storage, 2)
 }
 
 func fakeBlockUpdate(t *testing.T, pricing *L2PricingState, gasUsed int64, timePassed uint64) {
 	basefee := getPrice(t, pricing)
 	pricing.storage.Burner().Restrict(pricing.AddToGasPool(-gasUsed))
-	pricing.UpdatePricingModel(arbmath.UintToBig(basefee), timePassed, true)
+	pricing.UpdatePricingModel(arbmath.UintToBig(basefee), timePassed, true, true)
 }
 
 func TestPricingModel(t *testing.T) {


### PR DESCRIPTION
This removes the delay in applying a base fee by separately computing the gas model in block production (without writing it to state). Unfortunately, this does mean that the gas model is computed twice.