### PR TITLE
Exponential pricing model rpc & automatic blockscout abis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-#
-# Copyright 2020, Offchain Labs, Inc. All rights reserved.
-#
+# Copyright 2021-2022, Offchain Labs, Inc.
+# For license information, see https://github.com/nitro/blob/master/LICENSE
 
 # Docker builds mess up file timestamps. Then again, in docker builds we never
 # have to update an existing file. So - for docker, convert all dependencies

--- a/arbnode/api.go
+++ b/arbnode/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
+	"github.com/offchainlabs/nitro/arbos/l2pricing"
 	"github.com/offchainlabs/nitro/arbos/retryables"
 	"github.com/offchainlabs/nitro/validator"
 	"github.com/pkg/errors"
@@ -56,7 +57,7 @@ type ArbDebugAPI struct {
 	blockchain *core.BlockChain
 }
 
-type PricingModelHistory struct {
+type PricingModelHistoryPreExp struct {
 	First                    uint64     `json:"first"`
 	Timestamp                []uint64   `json:"timestamp"`
 	BaseFee                  []*big.Int `json:"baseFee"`
@@ -73,16 +74,16 @@ type PricingModelHistory struct {
 	L1BaseFeeEstimateInertia uint64     `json:"l1BaseFeeEstimateInertia"`
 }
 
-func (api *ArbDebugAPI) PricingModel(ctx context.Context, start, end rpc.BlockNumber) (PricingModelHistory, error) {
+func (api *ArbDebugAPI) PricingModelPreExp(ctx context.Context, start, end rpc.BlockNumber) (PricingModelHistoryPreExp, error) {
 	start, _ = arbitrum.ClipToPostNitroGenesis(api.blockchain, start)
 	end, _ = arbitrum.ClipToPostNitroGenesis(api.blockchain, end)
 
 	blocks := end.Int64() - start.Int64()
 	if blocks <= 0 {
-		return PricingModelHistory{}, fmt.Errorf("invalid block range: %v to %v", start.Int64(), end.Int64())
+		return PricingModelHistoryPreExp{}, fmt.Errorf("invalid block range: %v to %v", start.Int64(), end.Int64())
 	}
 
-	history := PricingModelHistory{
+	history := PricingModelHistoryPreExp{
 		First:               uint64(start),
 		Timestamp:           make([]uint64, blocks),
 		BaseFee:             make([]*big.Int, blocks),
@@ -112,6 +113,11 @@ func (api *ArbDebugAPI) PricingModel(ctx context.Context, start, end rpc.BlockNu
 		}
 		l1Pricing := state.L1PricingState()
 		l2Pricing := state.L2PricingState()
+
+		if state.FormatVersion() >= l2pricing.FirstExponentialPricingVersion {
+			// blocks from here on use the new model so we'll zero-fill the remaining values
+			break
+		}
 
 		rateEstimate, _ := l2Pricing.RateEstimate()
 		gasPool, _ := l2Pricing.GasPool_preExp()
@@ -145,6 +151,103 @@ func (api *ArbDebugAPI) PricingModel(ctx context.Context, start, end rpc.BlockNu
 			history.GasPoolWeight = uint64(gasPoolWeight)
 			history.MaxPerBlockGasLimit = maxPerBlockGasLimit
 			history.L1BaseFeeEstimateInertia = l1BaseFeeEstimateInertia
+		}
+	}
+
+	return history, nil
+}
+
+type PricingModelHistory struct {
+	First                    uint64     `json:"first"`
+	Timestamp                []uint64   `json:"timestamp"`
+	BaseFee                  []*big.Int `json:"baseFee"`
+	GasBacklog               []uint64   `json:"gasBacklog"`
+	GasUsed                  []uint64   `json:"gasUsed"`
+	L1BaseFeeEstimate        []*big.Int `json:"l1BaseFeeEstimate"`
+	L1BaseFeeUpdateTime      []uint64   `json:"l1BaseFeeUpdateTime"`
+	MinBaseFee               *big.Int   `json:"minBaseFee"`
+	SpeedLimit               uint64     `json:"speedLimit"`
+	MaxPerBlockGasLimit      uint64     `json:"maxPerBlockGasLimit"`
+	L1BaseFeeEstimateInertia uint64     `json:"l1BaseFeeEstimateInertia"`
+	PricingInertia           uint64     `json:"pricingInertia"`
+	BacklogTolerance         uint64     `json:"backlogTolerance"`
+}
+
+func (api *ArbDebugAPI) PricingModel(ctx context.Context, start, end rpc.BlockNumber) (PricingModelHistory, error) {
+	start, _ = arbitrum.ClipToPostNitroGenesis(api.blockchain, start)
+	end, _ = arbitrum.ClipToPostNitroGenesis(api.blockchain, end)
+
+	blocks := end.Int64() - start.Int64()
+	if blocks <= 0 {
+		return PricingModelHistory{}, fmt.Errorf("invalid block range: %v to %v", start.Int64(), end.Int64())
+	}
+
+	history := PricingModelHistory{
+		First:               uint64(start),
+		Timestamp:           make([]uint64, blocks),
+		BaseFee:             make([]*big.Int, blocks),
+		GasBacklog:          make([]uint64, blocks),
+		GasUsed:             make([]uint64, blocks),
+		L1BaseFeeEstimate:   make([]*big.Int, blocks),
+		L1BaseFeeUpdateTime: make([]uint64, blocks+1),
+	}
+
+	if start > core.NitroGenesisBlock {
+		state, _, err := stateAndHeader(api.blockchain, uint64(start)-1)
+		if err != nil {
+			return history, err
+		}
+		l1BaseFeeUpdateTime, err := state.L1PricingState().LastL1BaseFeeUpdateTime()
+		if err != nil {
+			return history, err
+		}
+		history.L1BaseFeeUpdateTime[0] = l1BaseFeeUpdateTime
+	}
+
+	for i := uint64(0); i < uint64(blocks); i++ {
+		state, header, err := stateAndHeader(api.blockchain, i+uint64(start))
+		if err != nil {
+			return history, err
+		}
+		l1Pricing := state.L1PricingState()
+		l2Pricing := state.L2PricingState()
+
+		history.Timestamp[i] = header.Time
+		history.BaseFee[i] = header.BaseFee
+
+		if state.FormatVersion() < l2pricing.FirstExponentialPricingVersion {
+			// this block doesn't use the exponential pricing model, so we'll zero-fill it
+			continue
+		}
+
+		gasBacklog, _ := l2Pricing.GasBacklog()
+		l1BaseFeeEstimate, _ := l1Pricing.L1BaseFeeEstimateWei()
+		l1BaseFeeUpdateTime, err := l1Pricing.LastL1BaseFeeUpdateTime()
+		if err != nil {
+			return history, err
+		}
+
+		history.GasBacklog[i] = gasBacklog
+		history.GasUsed[i] = header.GasUsed
+		history.L1BaseFeeEstimate[i] = l1BaseFeeEstimate
+		history.L1BaseFeeUpdateTime[i+1] = l1BaseFeeUpdateTime
+
+		if i == uint64(blocks)-1 {
+			speedLimit, _ := l2Pricing.SpeedLimitPerSecond()
+			maxPerBlockGasLimit, _ := l2Pricing.MaxPerBlockGasLimit()
+			l1BaseFeeEstimateInertia, err := l1Pricing.L1BaseFeeEstimateInertia()
+			minBaseFee, _ := l2Pricing.MinBaseFeeWei()
+			pricingInertia, _ := l2Pricing.PricingInertia()
+			backlogTolerance, _ := l2Pricing.BacklogTolerance()
+			if err != nil {
+				return history, err
+			}
+			history.MinBaseFee = minBaseFee
+			history.SpeedLimit = speedLimit
+			history.MaxPerBlockGasLimit = maxPerBlockGasLimit
+			history.L1BaseFeeEstimateInertia = l1BaseFeeEstimateInertia
+			history.PricingInertia = pricingInertia
+			history.BacklogTolerance = backlogTolerance
 		}
 	}
 

--- a/solgen/gen.go
+++ b/solgen/gen.go
@@ -1,6 +1,5 @@
-//
-// Copyright 2021-2022, Offchain Labs, Inc. All rights reserved.
-//
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
 
 package main
 
@@ -131,9 +130,14 @@ func main() {
 		}
 	}
 
-	blockscout := filepath.Join(parent, "blockscout", "init", "data")
-	modules["precompilesgen"].exportABIs(blockscout)
-	modules["node_interfacegen"].exportABIs(blockscout)
-
 	fmt.Println("successfully generated go abi files")
+
+	blockscout := filepath.Join(parent, "blockscout", "init", "data")
+	if _, err := os.Stat(blockscout); err != nil {
+		fmt.Println("skipping abi export since blockscout is not present")
+	} else {
+		modules["precompilesgen"].exportABIs(blockscout)
+		modules["node_interfacegen"].exportABIs(blockscout)
+		fmt.Println("successfully exported abi files")
+	}
 }


### PR DESCRIPTION
Updates and versions the `PricingModel` RPC as a new pair of methods -- one for blocks before the exponential model upgrade, and one for those after

Additionally, this PR updates blockscout so that it's abi-compatible with the exponential model's precompile methods, and so that it'll automatically change should further changes be made.

Associated PRs
- https://github.com/OffchainLabs/blockscout/pull/12