### PR TITLE
separate context from preimage_resolver

### DIFF
--- a/arbitrator/prover/src/main.rs
+++ b/arbitrator/prover/src/main.rs
@@ -178,7 +178,8 @@ fn main() -> Result<()> {
             })
             .collect();
     }
-    let preimage_resolver = Arc::new(move |hash| preimages.get(&hash).cloned()) as PreimageResolver;
+    let preimage_resolver =
+        Arc::new(move |_, hash| preimages.get(&hash).cloned()) as PreimageResolver;
 
     let last_block_hash = decode_hex_arg(&opts.last_block_hash, "--last-block-hash")?;
     let last_send_root = decode_hex_arg(&opts.last_send_root, "--last-send-root")?;

--- a/validator/machine.go
+++ b/validator/machine.go
@@ -59,6 +59,7 @@ func machineFromPointer(ptr *C.struct_Machine) *ArbitratorMachine {
 		return nil
 	}
 	mach := &ArbitratorMachine{ptr: ptr}
+	C.arbitrator_set_preimage_resolver(ptr, (*[0]byte)(C.preimageResolverC))
 	runtime.SetFinalizer(mach, freeMachine)
 	return mach
 }
@@ -323,6 +324,6 @@ func (m *ArbitratorMachine) SetPreimageResolver(resolver GoPreimageResolver) err
 	preimageResolvers.Store(id, resolver)
 	m.contextId = &id
 	runtime.SetFinalizer(m.contextId, freeContextId)
-	C.arbitrator_set_preimage_resolver(m.ptr, C.size_t(id), (*[0]byte)(C.preimageResolverC))
+	C.arbitrator_set_context(m.ptr, C.uint64_t(id))
 	return nil
 }


### PR DESCRIPTION
the easiest way that still maintains what seems like a good separation of the two..