### PR TITLE
Arbitrator: Fix stack pollution when branching out of block

### DIFF
--- a/arbitrator/prover/test-cases/block.wat
+++ b/arbitrator/prover/test-cases/block.wat
@@ -27,6 +27,32 @@
 		)
 		(unreachable)
 	)
+
+	(i32.const 1)
+	(block
+		(i64.const -64)
+		(i64.const -64)
+		(br 0)
+		(unreachable)
+	)
+	(block
+		(i64.const -64)
+		(i32.const 1)
+		(br_if 0)
+		(unreachable)
+	)
+	(block (param i32)
+		(br_if 0)
+		(unreachable)
+	)
+	(i32.const 1)
+	(block
+		(i32.const 1)
+		(i64.const -64)
+		(br 0)
+		(unreachable)
+	)
+	(br_if 0)
 )
 
 (start 0)

--- a/arbitrator/prover/test-cases/loop.wat
+++ b/arbitrator/prover/test-cases/loop.wat
@@ -1,10 +1,22 @@
-(func
+(func (local i32)
+	(i32.const 0)
+	(loop
+		(i64.const 123)
+		(local.get 0)
+		(i32.add (i32.const 1))
+		(local.tee 0)
+		(i32.ne (i32.const 10))
+		(br_if 0)
+		(drop)
+	)
+	(br_if 0)
+
 	(i32.const 1)
 	(loop
 		(br 0)
 		(unreachable)
 	)
-	(drop)
+	(unreachable)
 )
 
 (start 0)


### PR DESCRIPTION
I've confirmed Rust and Go don't seem to codegen this, but theoretically a branch can implicitly drop items off the stack. This PR uses the infrastructure introduced in the return code optimization to fix this, and adds test cases for it.