### PR TITLE
Allow DAS priv key to be specified inline on CLI

### DIFF
--- a/cmd/datool/datool.go
+++ b/cmd/datool/datool.go
@@ -61,7 +61,7 @@ type ClientStoreConfig struct {
 }
 
 func parseClientStoreConfig(args []string) (*ClientStoreConfig, error) {
-	f := flag.NewFlagSet("client", flag.ContinueOnError)
+	f := flag.NewFlagSet("datool client store", flag.ContinueOnError)
 	f.String("url", "", "URL of DAS server to connect to.")
 	f.String("message", "", "Message to send.")
 	f.Duration("das-retention-period", 24*time.Hour, "The period which DASes are requested to retain the stored batches.")
@@ -114,7 +114,7 @@ type ClientRetrieveConfig struct {
 }
 
 func parseClientRetrieveConfig(args []string) (*ClientRetrieveConfig, error) {
-	f := flag.NewFlagSet("client", flag.ContinueOnError)
+	f := flag.NewFlagSet("datool client retrieve", flag.ContinueOnError)
 	f.String("url", "", "URL of DAS server to connect to.")
 	f.String("cert", "", "Base64 encodeded DAS certificate of message to retrieve.")
 	conf.ConfConfigAddOptions("conf", f)
@@ -164,7 +164,7 @@ type KeyGenConfig struct {
 }
 
 func parseKeyGenConfig(args []string) (*KeyGenConfig, error) {
-	f := flag.NewFlagSet("client", flag.ContinueOnError)
+	f := flag.NewFlagSet("datool keygen", flag.ContinueOnError)
 	f.String("dir", "", "The directory to generate the keys in")
 	conf.ConfConfigAddOptions("conf", f)
 

--- a/das/aggregator_test.go
+++ b/das/aggregator_test.go
@@ -35,8 +35,10 @@ func TestDAS_BasicAggregationLocal(t *testing.T) {
 		}
 		das, err := NewLocalDiskDAS(config)
 		Require(t, err)
+		pubKey, _, err := ReadKeysFromFile(dbPath)
+		Require(t, err)
 		signerMask := uint64(1 << i)
-		details, err := NewServiceDetails(das, *das.pubKey, signerMask)
+		details, err := NewServiceDetails(das, *pubKey, signerMask)
 		Require(t, err)
 		backends = append(backends, *details)
 	}
@@ -207,9 +209,10 @@ func testConfigurableStorageFailures(t *testing.T, shouldFailAggregation bool) {
 		}
 		das, err := NewLocalDiskDAS(config)
 		Require(t, err)
-
+		pubKey, _, err := ReadKeysFromFile(dbPath)
+		Require(t, err)
 		signerMask := uint64(1 << i)
-		details, err := NewServiceDetails(&WrapStore{t, injectedFailures, das}, *das.pubKey, signerMask)
+		details, err := NewServiceDetails(&WrapStore{t, injectedFailures, das}, *pubKey, signerMask)
 		Require(t, err)
 		backends = append(backends, *details)
 	}
@@ -308,9 +311,10 @@ func testConfigurableRetrieveFailures(t *testing.T, shouldFail bool) {
 
 		das, err := NewLocalDiskDAS(config)
 		Require(t, err)
-
+		pubKey, _, err := ReadKeysFromFile(dbPath)
+		Require(t, err)
 		signerMask := uint64(1 << i)
-		details := ServiceDetails{&WrapRetrieve{t, injectedFailures, das}, *das.pubKey, signerMask}
+		details := ServiceDetails{&WrapRetrieve{t, injectedFailures, das}, *pubKey, signerMask}
 
 		backends = append(backends, details)
 	}

--- a/das/das.go
+++ b/das/das.go
@@ -56,7 +56,7 @@ func (c *DataAvailabilityConfig) Mode() (DataAvailabilityMode, error) {
 	}
 
 	if c.ModeImpl == "local" {
-		if c.LocalDiskDASConfig.DataDir == "" || c.LocalDiskDASConfig.KeyDir == "" {
+		if c.LocalDiskDASConfig.DataDir == "" || (c.LocalDiskDASConfig.KeyDir == "" && c.LocalDiskDASConfig.PrivKey == "") {
 			flag.Usage()
 			return 0, errors.New("--data-availability.local-disk.data-dir and .key-dir must be specified if mode is set to local")
 		}

--- a/das/key_utils.go
+++ b/das/key_utils.go
@@ -45,7 +45,7 @@ func DecodeBase64BLSPrivateKey(privKeyEncodedBytes []byte) (*blsSignatures.Priva
 const DefaultPubKeyFilename = "das_bls.pub"
 const DefaultPrivKeyFilename = "das_bls"
 
-func GenerateAndStoreKeys(keyDir string) (*blsSignatures.PublicKey, blsSignatures.PrivateKey, error) {
+func GenerateAndStoreKeys(keyDir string) (*blsSignatures.PublicKey, *blsSignatures.PrivateKey, error) {
 	pubKey, privKey, err := blsSignatures.GenerateKeys()
 	if err != nil {
 		return nil, nil, err
@@ -67,10 +67,10 @@ func GenerateAndStoreKeys(keyDir string) (*blsSignatures.PublicKey, blsSignature
 	if err != nil {
 		return nil, nil, err
 	}
-	return &pubKey, privKey, nil
+	return &pubKey, &privKey, nil
 }
 
-func ReadKeysFromFile(keyDir string) (*blsSignatures.PublicKey, blsSignatures.PrivateKey, error) {
+func ReadKeysFromFile(keyDir string) (*blsSignatures.PublicKey, *blsSignatures.PrivateKey, error) {
 	pubKey, err := ReadPubKeyFromFile(keyDir + "/" + DefaultPubKeyFilename)
 	if err != nil {
 		return nil, nil, err
@@ -80,7 +80,7 @@ func ReadKeysFromFile(keyDir string) (*blsSignatures.PublicKey, blsSignatures.Pr
 	if err != nil {
 		return nil, nil, err
 	}
-	return pubKey, *privKey, nil
+	return pubKey, privKey, nil
 }
 
 func ReadPubKeyFromFile(pubKeyPath string) (*blsSignatures.PublicKey, error) {

--- a/das/local_disk_das.go
+++ b/das/local_disk_das.go
@@ -43,7 +43,7 @@ func NewLocalDiskDAS(config LocalDiskDASConfig) (*LocalDiskDAS, error) {
 	if len(config.PrivKey) != 0 {
 		privKey, err = DecodeBase64BLSPrivateKey([]byte(config.PrivKey))
 		if err != nil {
-			return nil, fmt.Errorf("'priv-key' was invalid: %v", err)
+			return nil, fmt.Errorf("'priv-key' was invalid: %w", err)
 		}
 	} else {
 		_, privKey, err = ReadKeysFromFile(config.KeyDir)


### PR DESCRIPTION
Now you can specify the private local DAS key on the command line directly, as a base64 encoded string.

# Testing done
Started a DAS behind the aggregator with the following config
```
{"conf":{"dump":false,"env-prefix":"","file":[],"s3":{"access-key":"","bucket":"","object-key":"","region":"","secret-key":""},"string":""},"data-availability":{"aggregator":{"assumed-honest":0,"backends":""},"local-disk":{"allow-generate-keys":false,"data-dir":"/tmp/dacommittee/2_inline","priv-key":"UAFJd7VH2sg5z1aEpDTL0dnKeo+ihdxFmQ135RNkKxQ="},"mode":"local"},"log-level":5,"port":"12342"}
```

Store and Retrieve from this DAS
```
tristan@ramona ~/offchain/nitro 0                                                                                                                                                                 
Mon May 09 19:59:40                                                                                                                                                                               
$ ./target/bin/datool client store --url localhost:9876 --message "Hello aggregator world - inline test"                                                                                          
Base64 Encoded Cert: gKdOgdtytVhwS28PB9k+J9/aKnrUMyDou5UlTRpGUI2CAAAAAGJ7JqAAAAAAAAAAAwgB7pUcZK3nqbR7ntrymCRrpVaXQh8JDSAURz0l+BY9ZEskpCVtOcc7bAlWaeXjtQahCtw2UiyOOOY85RTWv3EEhxUHGEiIrKct6FZ+xFx/U
Qc7qS0FCdFkxQL0flKd1g==                                                                                                                                                                           
tristan@ramona ~/offchain/nitro 0                                                                                                                                                                                                                                                                                                                   
Mon May 09 19:59:50                                                                                                                                                                               
$ ./target/bin/datool client retrieve --url localhost:9876 --cert "gKdOgdtytVhwS28PB9k+J9/aKnrUMyDou5UlTRpGUI2CAAAAAGJ7JqAAAAAAAAAAAwgB7pUcZK3nqbR7ntrymCRrpVaXQh8JDSAURz0l+BY9ZEskpCVtOcc7bAlWaeX
jtQahCtw2UiyOOOY85RTWv3EEhxUHGEiIrKct6FZ+xFx/UQc7qS0FCdFkxQL0flKd1g=="                                                                                                                            
Message: Hello aggregator world - inline test
```