### PR TITLE
Optional signing of DAS stores

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -373,7 +373,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context, timeSinceBatc
 	}
 
 	if b.das != nil {
-		cert, err := b.das.Store(ctx, sequencerMsg, uint64(time.Now().Add(b.config.DASRetentionPeriod).Unix()))
+		cert, err := b.das.Store(ctx, sequencerMsg, uint64(time.Now().Add(b.config.DASRetentionPeriod).Unix()), []byte{}) // BUGBUG
 		if err != nil {
 			log.Warn("Unable to batch to DAS, falling back to storing data on chain", "err", err)
 		} else {

--- a/cmd/datool/datool.go
+++ b/cmd/datool/datool.go
@@ -93,7 +93,7 @@ func startClientStore(args []string) error {
 	}
 
 	ctx := context.Background()
-	cert, err := client.Store(ctx, []byte(config.Message), uint64(time.Now().Add(config.DASRetentionPeriod).Unix()))
+	cert, err := client.Store(ctx, []byte(config.Message), uint64(time.Now().Add(config.DASRetentionPeriod).Unix()), []byte{})
 	if err != nil {
 		return err
 	}

--- a/das/aggregator.go
+++ b/das/aggregator.go
@@ -183,13 +183,13 @@ type storeResponse struct {
 //
 // If Store gets not enough successful responses by the time its context is canceled
 // (eg via TimeoutWrapper) then it also returns an error.
-func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64) (*arbstate.DataAvailabilityCertificate, error) {
+func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (*arbstate.DataAvailabilityCertificate, error) {
 	responses := make(chan storeResponse, len(a.services))
 
 	expectedHash := crypto.Keccak256(message)
 	for _, d := range a.services {
 		go func(ctx context.Context, d ServiceDetails) {
-			cert, err := d.service.Store(ctx, message, timeout)
+			cert, err := d.service.Store(ctx, message, timeout, sig)
 			if err != nil {
 				responses <- storeResponse{d, nil, err}
 				return

--- a/das/das.go
+++ b/das/das.go
@@ -18,7 +18,7 @@ import (
 
 type DataAvailabilityServiceWriter interface {
 	// Requests that the message be stored until timeout (UTC time in unix epoch seconds).
-	Store(ctx context.Context, message []byte, timeout uint64) (*arbstate.DataAvailabilityCertificate, error)
+	Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (*arbstate.DataAvailabilityCertificate, error)
 }
 
 type DataAvailabilityService interface {

--- a/das/das_test.go
+++ b/das/das_test.go
@@ -32,7 +32,7 @@ func TestDASStoreRetrieveMultipleInstances(t *testing.T) {
 
 	timeout := uint64(time.Now().Add(time.Hour * 24).Unix())
 	messageSaved := []byte("hello world")
-	cert, err := das.Store(ctx, messageSaved, timeout)
+	cert, err := das.Store(ctx, messageSaved, timeout, []byte{})
 	Require(t, err, "Error storing message")
 	if cert.Timeout != timeout {
 		Fail(t, fmt.Sprintf("Expected timeout of %d in cert, was %d", timeout, cert.Timeout))
@@ -72,7 +72,7 @@ func TestDASMissingMessage(t *testing.T) {
 
 	messageSaved := []byte("hello world")
 	timeout := uint64(time.Now().Add(time.Hour * 24).Unix())
-	cert, err := das.Store(ctx, messageSaved, timeout)
+	cert, err := das.Store(ctx, messageSaved, timeout, []byte{})
 	Require(t, err, "Error storing message")
 	if cert.Timeout != timeout {
 		Fail(t, fmt.Sprintf("Expected timeout of %d in cert, was %d", timeout, cert.Timeout))

--- a/das/dasrpc/dasRpcClient.go
+++ b/das/dasrpc/dasRpcClient.go
@@ -37,8 +37,8 @@ func (clnt *DASRPCClient) Retrieve(ctx context.Context, cert *arbstate.DataAvail
 	return response.Result, nil
 }
 
-func (clnt *DASRPCClient) Store(ctx context.Context, message []byte, timeout uint64) (*arbstate.DataAvailabilityCertificate, error) {
-	response, err := clnt.clnt.Store(ctx, &StoreRequest{Message: message, Timeout: timeout})
+func (clnt *DASRPCClient) Store(ctx context.Context, message []byte, timeout uint64, reqSig []byte) (*arbstate.DataAvailabilityCertificate, error) {
+	response, err := clnt.clnt.Store(ctx, &StoreRequest{Message: message, Timeout: timeout, Sig: reqSig})
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (clnt *DASRPCClient) Store(ctx context.Context, message []byte, timeout uin
 	copy(keysetHash[:], response.KeysetHash)
 	var dataHash [32]byte
 	copy(dataHash[:], response.DataHash)
-	sig, err := blsSignatures.SignatureFromBytes(response.Sig)
+	respSig, err := blsSignatures.SignatureFromBytes(response.Sig)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (clnt *DASRPCClient) Store(ctx context.Context, message []byte, timeout uin
 		DataHash:    dataHash,
 		Timeout:     response.Timeout,
 		SignersMask: response.SignersMask,
-		Sig:         sig,
+		Sig:         respSig,
 		KeysetHash:  keysetHash,
 	}, nil
 }

--- a/das/dasrpc/dasRpcServer.go
+++ b/das/dasrpc/dasRpcServer.go
@@ -46,7 +46,7 @@ func (serv *DASRPCServer) Stop() {
 }
 
 func (serv *DASRPCServer) Store(ctx context.Context, req *StoreRequest) (*StoreResponse, error) {
-	cert, err := serv.localDAS.Store(ctx, req.Message, req.Timeout)
+	cert, err := serv.localDAS.Store(ctx, req.Message, req.Timeout, req.Sig)
 	if err != nil {
 		return nil, err
 	}

--- a/das/local_disk_das.go
+++ b/das/local_disk_das.go
@@ -95,7 +95,7 @@ func NewLocalDiskDAS(config LocalDiskDASConfig) (*LocalDiskDAS, error) {
 	}, nil
 }
 
-func (das *LocalDiskDAS) Store(ctx context.Context, message []byte, timeout uint64) (c *arbstate.DataAvailabilityCertificate, err error) {
+func (das *LocalDiskDAS) Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (c *arbstate.DataAvailabilityCertificate, err error) {
 	c = &arbstate.DataAvailabilityCertificate{}
 	copy(c.DataHash[:], crypto.Keccak256(message))
 

--- a/das/local_disk_das.go
+++ b/das/local_disk_das.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base32"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/common"
 	"os"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -21,10 +22,11 @@ import (
 var ErrDasKeysetNotFound = errors.New("no such keyset")
 
 type LocalDiskDASConfig struct {
-	KeyDir            string `koanf:"key-dir"`
-	PrivKey           string `koanf:"priv-key"`
-	DataDir           string `koanf:"data-dir"`
-	AllowGenerateKeys bool   `koanf:"allow-generate-keys"`
+	KeyDir             string `koanf:"key-dir"`
+	PrivKey            string `koanf:"priv-key"`
+	DataDir            string `koanf:"data-dir"`
+	AllowGenerateKeys  bool   `koanf:"allow-generate-keys"`
+	StoreSignerAddress string `koanf:"store-signer-address"`
 }
 
 func LocalDiskDASConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -32,13 +34,15 @@ func LocalDiskDASConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".priv-key", "", "The base64 BLS private key to use for signing DAS certificates")
 	f.String(prefix+".data-dir", "", "The directory to use as the DAS file-based database")
 	f.Bool(prefix+".allow-generate-keys", false, "Allow the local disk DAS to generate its own keys in key-dir if they don't already exist")
+	f.String(prefix+".store-signer-address", "", "Address required to sign stores, or empty if anyone can store")
 }
 
 type LocalDiskDAS struct {
-	config      LocalDiskDASConfig
-	privKey     *blsSignatures.PrivateKey
-	keysetHash  [32]byte
-	keysetBytes []byte
+	config          LocalDiskDASConfig
+	privKey         *blsSignatures.PrivateKey
+	keysetHash      [32]byte
+	keysetBytes     []byte
+	storeSignerAddr *common.Address
 }
 
 func NewLocalDiskDAS(config LocalDiskDASConfig) (*LocalDiskDAS, error) {
@@ -88,14 +92,25 @@ func NewLocalDiskDAS(config LocalDiskDASConfig) (*LocalDiskDAS, error) {
 	copy(ksHash[:], ksHashBuf)
 
 	return &LocalDiskDAS{
-		config:      config,
-		privKey:     privKey,
-		keysetHash:  ksHash,
-		keysetBytes: ksBuf.Bytes(),
+		config:          config,
+		privKey:         privKey,
+		keysetHash:      ksHash,
+		keysetBytes:     ksBuf.Bytes(),
+		storeSignerAddr: StoreSignerAddressFromString(config.StoreSignerAddress),
 	}, nil
 }
 
 func (das *LocalDiskDAS) Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (c *arbstate.DataAvailabilityCertificate, err error) {
+	if das.storeSignerAddr != nil {
+		actualSigner, err := DasRecoverSigner(message, timeout, sig)
+		if err != nil {
+			return nil, err
+		}
+		if actualSigner != *das.storeSignerAddr {
+			return nil, errors.New("store request not properly signed")
+		}
+	}
+
 	c = &arbstate.DataAvailabilityCertificate{}
 	copy(c.DataHash[:], crypto.Keccak256(message))
 

--- a/das/store_signing.go
+++ b/das/store_signing.go
@@ -4,23 +4,68 @@
 package das
 
 import (
+	"context"
 	"crypto/ecdsa"
+	"encoding/binary"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/offchainlabs/nitro/arbstate"
 )
 
-func DasSignStore(message []byte, timeout uint64, privateKey *ecdsa.PrivateKey) ([]byte, error) {
-	return crypto.Sign(dasStoreHash(message, timeout), privateKey)
+var uniquifyingPrefix = []byte("Arbitrum Nitro DAS API Store:")
+
+func DasSignStore(data []byte, timeout uint64, privateKey *ecdsa.PrivateKey) ([]byte, error) {
+	return crypto.Sign(dasStoreHash(data, timeout), privateKey)
 }
 
-func DasRecoverSigner(message []byte, timeout uint64, sig []byte) (common.Address, error) {
-	pk, err := crypto.SigToPub(dasStoreHash(message, timeout), sig)
+func DasRecoverSigner(data []byte, timeout uint64, sig []byte) (common.Address, error) {
+	pk, err := crypto.SigToPub(dasStoreHash(data, timeout), sig)
 	if err != nil {
 		return common.Address{}, err
 	}
 	return crypto.PubkeyToAddress(*pk), nil
 }
 
-func dasStoreHash(message []byte, timeout uint64) []byte {
-	return []byte{}
+func dasStoreHash(data []byte, timeout uint64) []byte {
+	var buf8 [8]byte
+	binary.BigEndian.PutUint64(buf8[:], timeout)
+	return crypto.Keccak256(uniquifyingPrefix, buf8[:], data)
+}
+
+type StoreSigningDAS struct {
+	inner      DataAvailabilityService
+	privateKey *ecdsa.PrivateKey
+}
+
+func NewStoreSigningDAS(inner DataAvailabilityService, privateKey *ecdsa.PrivateKey) DataAvailabilityService {
+	return &StoreSigningDAS{inner, privateKey}
+}
+
+func (s *StoreSigningDAS) Retrieve(ctx context.Context, cert *arbstate.DataAvailabilityCertificate) ([]byte, error) {
+	return s.inner.Retrieve(ctx, cert)
+}
+
+func (s *StoreSigningDAS) KeysetFromHash(ctx context.Context, ksHash []byte) ([]byte, error) {
+	return s.inner.KeysetFromHash(ctx, ksHash)
+}
+
+func (s *StoreSigningDAS) CurrentKeysetBytes(ctx context.Context) ([]byte, error) {
+	return s.inner.CurrentKeysetBytes(ctx)
+}
+
+func (s *StoreSigningDAS) Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (*arbstate.DataAvailabilityCertificate, error) {
+	mySig, err := DasSignStore(message, timeout, s.privateKey)
+	if err != nil {
+		return nil, err
+	}
+	return s.inner.Store(ctx, message, timeout, mySig)
+}
+
+func (s *StoreSigningDAS) String() string {
+	return "StoreSigningDAS (" + s.SignerAddress().Hex() + " ," + s.inner.String() + ")"
+}
+
+func (s *StoreSigningDAS) SignerAddress() common.Address {
+	publicKey := s.privateKey.Public()
+	return crypto.PubkeyToAddress(*publicKey.(*ecdsa.PublicKey))
 }

--- a/das/store_signing.go
+++ b/das/store_signing.go
@@ -1,0 +1,26 @@
+// Copyright 2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package das
+
+import (
+	"crypto/ecdsa"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func DasSignStore(message []byte, timeout uint64, privateKey *ecdsa.PrivateKey) ([]byte, error) {
+	return crypto.Sign(dasStoreHash(message, timeout), privateKey)
+}
+
+func DasRecoverSigner(message []byte, timeout uint64, sig []byte) (common.Address, error) {
+	pk, err := crypto.SigToPub(dasStoreHash(message, timeout), sig)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return crypto.PubkeyToAddress(*pk), nil
+}
+
+func dasStoreHash(message []byte, timeout uint64) []byte {
+	return []byte{}
+}

--- a/das/store_signing_test.go
+++ b/das/store_signing_test.go
@@ -1,0 +1,32 @@
+// Copyright 2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package das
+
+import (
+	"crypto/ecdsa"
+	"github.com/ethereum/go-ethereum/crypto"
+	"testing"
+	"time"
+)
+
+func TestStoreSigning(t *testing.T) {
+	privateKey, err := crypto.GenerateKey()
+	Require(t, err)
+
+	publicKey := privateKey.Public()
+	addr := crypto.PubkeyToAddress(*publicKey.(*ecdsa.PublicKey))
+
+	weirdMessage := []byte("The quick brown fox jumped over the lazy dog.")
+	timeout := uint64(time.Now().Unix())
+
+	sig, err := DasSignStore(weirdMessage, timeout, privateKey)
+	Require(t, err)
+
+	recoveredAddr, err := DasRecoverSigner(weirdMessage, timeout, sig)
+	Require(t, err)
+
+	if recoveredAddr != addr {
+		t.Fatal()
+	}
+}

--- a/das/timeout_wrapper.go
+++ b/das/timeout_wrapper.go
@@ -24,7 +24,7 @@ func (w *TimeoutWrapper) Retrieve(ctx context.Context, cert *arbstate.DataAvaila
 	return w.DataAvailabilityService.Retrieve(deadlineCtx, cert)
 }
 
-func (w *TimeoutWrapper) Store(ctx context.Context, message []byte, timeout uint64) (*arbstate.DataAvailabilityCertificate, error) {
+func (w *TimeoutWrapper) Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (*arbstate.DataAvailabilityCertificate, error) {
 	deadlineCtx, cancel := context.WithDeadline(ctx, time.Now().Add(w.t))
 	// In the case of the aggregator, allow goroutines started by Store(...)
 	// to continue until the end of the deadline even after a result
@@ -33,7 +33,7 @@ func (w *TimeoutWrapper) Store(ctx context.Context, message []byte, timeout uint
 		<-deadlineCtx.Done()
 		cancel()
 	}()
-	return w.DataAvailabilityService.Store(deadlineCtx, message, timeout)
+	return w.DataAvailabilityService.Store(deadlineCtx, message, timeout, sig)
 }
 
 func (w *TimeoutWrapper) String() string {

--- a/das/wireFormat.proto
+++ b/das/wireFormat.proto
@@ -16,6 +16,7 @@ service DASServiceImpl {
 message StoreRequest {
   bytes message = 1;
   uint64 timeout = 2;
+  bytes  sig = 3;
 }
 
 message StoreResponse {


### PR DESCRIPTION
Add the option of having DAS Stores signed by the submitter.  
* Local DAS and Aggregator DAS include options to require stores be signed by some Ethereum address
* New DAS type that wraps an inner DAS and adds signatures with a private key to all Stores it passes through