### PR TITLE
Verify store signer on l1

### DIFF
--- a/das/aggregator_test.go
+++ b/das/aggregator_test.go
@@ -29,10 +29,10 @@ func TestDAS_BasicAggregationLocal(t *testing.T) {
 		defer os.RemoveAll(dbPath)
 
 		config := LocalDiskDASConfig{
-			KeyDir:             dbPath,
-			DataDir:            dbPath,
-			AllowGenerateKeys:  true,
-			StoreSignerAddress: "none",
+			KeyDir:            dbPath,
+			DataDir:           dbPath,
+			AllowGenerateKeys: true,
+			L1NodeURL:         "none",
 		}
 		das, err := NewLocalDiskDAS(config)
 		Require(t, err)
@@ -44,7 +44,7 @@ func TestDAS_BasicAggregationLocal(t *testing.T) {
 		backends = append(backends, *details)
 	}
 
-	aggregator, err := NewAggregator(AggregatorConfig{AssumedHonest: 1, StoreSignerAddress: "none"}, backends)
+	aggregator, err := NewAggregator(AggregatorConfig{AssumedHonest: 1, L1NodeURL: "none"}, backends)
 	Require(t, err)
 	ctx := context.Background()
 
@@ -204,10 +204,10 @@ func testConfigurableStorageFailures(t *testing.T, shouldFailAggregation bool) {
 		defer os.RemoveAll(dbPath)
 
 		config := LocalDiskDASConfig{
-			KeyDir:             dbPath,
-			DataDir:            dbPath,
-			AllowGenerateKeys:  true,
-			StoreSignerAddress: "none",
+			KeyDir:            dbPath,
+			DataDir:           dbPath,
+			AllowGenerateKeys: true,
+			L1NodeURL:         "none",
 		}
 		das, err := NewLocalDiskDAS(config)
 		Require(t, err)
@@ -219,7 +219,7 @@ func testConfigurableStorageFailures(t *testing.T, shouldFailAggregation bool) {
 		backends = append(backends, *details)
 	}
 
-	unwrappedAggregator, err := NewAggregator(AggregatorConfig{AssumedHonest: assumedHonest, StoreSignerAddress: "none"}, backends)
+	unwrappedAggregator, err := NewAggregator(AggregatorConfig{AssumedHonest: assumedHonest, L1NodeURL: "none"}, backends)
 	Require(t, err)
 	aggregator := TimeoutWrapper{time.Millisecond * 2000, unwrappedAggregator}
 	ctx := context.Background()
@@ -306,10 +306,10 @@ func testConfigurableRetrieveFailures(t *testing.T, shouldFail bool) {
 		defer os.RemoveAll(dbPath)
 
 		config := LocalDiskDASConfig{
-			KeyDir:             dbPath,
-			DataDir:            dbPath,
-			AllowGenerateKeys:  true,
-			StoreSignerAddress: "none",
+			KeyDir:            dbPath,
+			DataDir:           dbPath,
+			AllowGenerateKeys: true,
+			L1NodeURL:         "none",
 		}
 
 		das, err := NewLocalDiskDAS(config)
@@ -325,7 +325,7 @@ func testConfigurableRetrieveFailures(t *testing.T, shouldFail bool) {
 	// All honest -> at least 1 store succeeds.
 	// Aggregator should collect responses up until end of deadline, so
 	// it should get all successes.
-	unwrappedAggregator, err := NewAggregator(AggregatorConfig{AssumedHonest: numBackendDAS, StoreSignerAddress: "none"}, backends)
+	unwrappedAggregator, err := NewAggregator(AggregatorConfig{AssumedHonest: numBackendDAS, L1NodeURL: "none"}, backends)
 	Require(t, err)
 	aggregator := TimeoutWrapper{time.Millisecond * 2000, unwrappedAggregator}
 	ctx := context.Background()

--- a/das/batch_poster_verifier.go
+++ b/das/batch_poster_verifier.go
@@ -1,0 +1,42 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package das
+
+import (
+	"context"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
+	"time"
+)
+
+type BatchPosterVerifier struct {
+	seqInboxCaller *bridgegen.SequencerInboxCaller
+	cache          map[common.Address]bool
+	cacheExpiry    time.Time
+}
+
+var batchPosterVerifierLifetime = time.Hour
+
+func NewBatchPosterVerifier(seqInboxCaller *bridgegen.SequencerInboxCaller) *BatchPosterVerifier {
+	return &BatchPosterVerifier{seqInboxCaller, make(map[common.Address]bool), time.Now()}
+}
+
+func (bpv *BatchPosterVerifier) IsBatchPoster(ctx context.Context, addr common.Address) (bool, error) {
+	if time.Now().After(bpv.cacheExpiry) {
+		bpv.cache = make(map[common.Address]bool)
+		bpv.cacheExpiry = time.Now().Add(batchPosterVerifierLifetime)
+	}
+	if bpv.cache[addr] {
+		return true, nil
+	}
+	isBatchPoster, err := bpv.seqInboxCaller.IsBatchPoster(&bind.CallOpts{Context: ctx}, addr)
+	if err != nil {
+		return false, err
+	}
+	if isBatchPoster {
+		bpv.cache[addr] = true
+	}
+	return isBatchPoster, nil
+}

--- a/das/das_test.go
+++ b/das/das_test.go
@@ -21,10 +21,10 @@ func TestDASStoreRetrieveMultipleInstances(t *testing.T) {
 	Require(t, err)
 
 	config := LocalDiskDASConfig{
-		KeyDir:             dbPath,
-		DataDir:            dbPath,
-		AllowGenerateKeys:  true,
-		StoreSignerAddress: "none",
+		KeyDir:            dbPath,
+		DataDir:           dbPath,
+		AllowGenerateKeys: true,
+		L1NodeURL:         "none",
 	}
 	das, err := NewLocalDiskDAS(config)
 	Require(t, err, "no das")
@@ -62,10 +62,10 @@ func TestDASMissingMessage(t *testing.T) {
 	Require(t, err)
 
 	config := LocalDiskDASConfig{
-		KeyDir:             dbPath,
-		DataDir:            dbPath,
-		AllowGenerateKeys:  true,
-		StoreSignerAddress: "none",
+		KeyDir:            dbPath,
+		DataDir:           dbPath,
+		AllowGenerateKeys: true,
+		L1NodeURL:         "none",
 	}
 	das, err := NewLocalDiskDAS(config)
 	Require(t, err, "no das")

--- a/das/local_disk_das.go
+++ b/das/local_disk_das.go
@@ -9,7 +9,9 @@ import (
 	"encoding/base32"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"os"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -22,11 +24,12 @@ import (
 var ErrDasKeysetNotFound = errors.New("no such keyset")
 
 type LocalDiskDASConfig struct {
-	KeyDir             string `koanf:"key-dir"`
-	PrivKey            string `koanf:"priv-key"`
-	DataDir            string `koanf:"data-dir"`
-	AllowGenerateKeys  bool   `koanf:"allow-generate-keys"`
-	StoreSignerAddress string `koanf:"store-signer-address"`
+	KeyDir                string `koanf:"key-dir"`
+	PrivKey               string `koanf:"priv-key"`
+	DataDir               string `koanf:"data-dir"`
+	AllowGenerateKeys     bool   `koanf:"allow-generate-keys"`
+	L1NodeURL             string `koanf:"l1-node-url"`
+	SequencerInboxAddress string `koanf:"sequencer-inbox-address"`
 }
 
 func LocalDiskDASConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -34,15 +37,16 @@ func LocalDiskDASConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".priv-key", "", "The base64 BLS private key to use for signing DAS certificates")
 	f.String(prefix+".data-dir", "", "The directory to use as the DAS file-based database")
 	f.Bool(prefix+".allow-generate-keys", false, "Allow the local disk DAS to generate its own keys in key-dir if they don't already exist")
-	f.String(prefix+".store-signer-address", "", "Address required to sign stores, or empty if anyone can store")
+	f.String(prefix+".l1-node-url", "", "URL of L1 Ethereum node")
+	f.String(prefix+".sequencer-inbox-address", "", "L1 address of SequencerInbox contract")
 }
 
 type LocalDiskDAS struct {
-	config          LocalDiskDASConfig
-	privKey         *blsSignatures.PrivateKey
-	keysetHash      [32]byte
-	keysetBytes     []byte
-	storeSignerAddr *common.Address
+	config         LocalDiskDASConfig
+	privKey        *blsSignatures.PrivateKey
+	keysetHash     [32]byte
+	keysetBytes    []byte
+	seqInboxCaller *bridgegen.SequencerInboxCaller
 }
 
 func NewLocalDiskDAS(config LocalDiskDASConfig) (*LocalDiskDAS, error) {
@@ -91,27 +95,42 @@ func NewLocalDiskDAS(config LocalDiskDASConfig) (*LocalDiskDAS, error) {
 	var ksHash [32]byte
 	copy(ksHash[:], ksHashBuf)
 
-	storeSignerAddr, err := StoreSignerAddressFromString(config.StoreSignerAddress)
-	if err != nil {
-		return nil, err
+	var seqInboxCaller *bridgegen.SequencerInboxCaller
+	if config.L1NodeURL != "none" {
+		l1client, err := ethclient.Dial(config.L1NodeURL)
+		if err != nil {
+			return nil, err
+		}
+		seqInboxAddress, err := StoreSignerAddressFromString(config.SequencerInboxAddress)
+		if err != nil {
+			return nil, err
+		}
+		seqInboxCaller, err = bridgegen.NewSequencerInboxCaller(*seqInboxAddress, l1client)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &LocalDiskDAS{
-		config:          config,
-		privKey:         privKey,
-		keysetHash:      ksHash,
-		keysetBytes:     ksBuf.Bytes(),
-		storeSignerAddr: storeSignerAddr,
+		config:         config,
+		privKey:        privKey,
+		keysetHash:     ksHash,
+		keysetBytes:    ksBuf.Bytes(),
+		seqInboxCaller: seqInboxCaller,
 	}, nil
 }
 
 func (das *LocalDiskDAS) Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (c *arbstate.DataAvailabilityCertificate, err error) {
-	if das.storeSignerAddr != nil {
+	if das.seqInboxCaller != nil {
 		actualSigner, err := DasRecoverSigner(message, timeout, sig)
 		if err != nil {
 			return nil, err
 		}
-		if actualSigner != *das.storeSignerAddr {
+		isBatchPoster, err := das.seqInboxCaller.IsBatchPoster(&bind.CallOpts{Context: ctx}, actualSigner)
+		if err != nil {
+			return nil, err
+		}
+		if !isBatchPoster {
 			return nil, errors.New("store request not properly signed")
 		}
 	}

--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -36,10 +36,9 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, expensiveTx bo
 	l1NodeConfigB.BlockValidator.Enable = true
 	l1NodeConfigB.DataAvailability.ModeImpl = dasModeString
 	dasConfig := das.LocalDiskDASConfig{
-		KeyDir:             dbPath,
-		DataDir:            dbPath,
-		AllowGenerateKeys:  true,
-		StoreSignerAddress: "none",
+		KeyDir:            dbPath,
+		DataDir:           dbPath,
+		AllowGenerateKeys: true,
 	}
 	l1NodeConfigB.DataAvailability.LocalDiskDASConfig = dasConfig
 	l2clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, &l2info.ArbInitData, l1NodeConfigB)

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -338,10 +338,9 @@ func setupConfigWithDAS(t *testing.T, dasModeString string) (*params.ChainConfig
 		dasSignerKey, _, err = das.GenerateAndStoreKeys(dbPath)
 		Require(t, err)
 		dasConfig := das.LocalDiskDASConfig{
-			KeyDir:             dbPath,
-			DataDir:            dbPath,
-			AllowGenerateKeys:  true,
-			StoreSignerAddress: "none",
+			KeyDir:            dbPath,
+			DataDir:           dbPath,
+			AllowGenerateKeys: true,
 		}
 		l1NodeConfigA.DataAvailability.LocalDiskDASConfig = dasConfig
 		chainConfig = params.ArbitrumDevTestDASChainConfig()

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/offchainlabs/nitro/arbutil"
 	"math/big"
 	"net"
 	"testing"
@@ -22,18 +24,23 @@ import (
 	"github.com/offchainlabs/nitro/das"
 )
 
-func startLocalDASServer(t *testing.T, ctx context.Context, dataDir string) (*dasrpc.DASRPCServer, *blsSignatures.PublicKey, dasrpc.BackendConfig) {
+func startLocalDASServer(
+	t *testing.T,
+	ctx context.Context,
+	dataDir string,
+	l1client arbutil.L1Interface,
+	seqInboxAddress common.Address,
+) (*dasrpc.DASRPCServer, *blsSignatures.PublicKey, dasrpc.BackendConfig) {
 	lis, err := net.Listen("tcp", "localhost:0")
 	Require(t, err)
 	keyDir := t.TempDir()
 	pubkey, _, err := das.GenerateAndStoreKeys(keyDir)
 	Require(t, err)
 	dasConfig := das.LocalDiskDASConfig{
-		KeyDir:             keyDir,
-		DataDir:            dataDir,
-		StoreSignerAddress: "none",
+		KeyDir:  keyDir,
+		DataDir: dataDir,
 	}
-	localDas, err := das.NewLocalDiskDAS(dasConfig)
+	localDas, err := das.NewLocalDiskDASWithL1Info(dasConfig, l1client, seqInboxAddress)
 	Require(t, err)
 	dasServer, err := dasrpc.StartDASRPCServerOnListener(ctx, lis, localDas)
 	Require(t, err)
@@ -56,9 +63,9 @@ func aggConfigForBackend(t *testing.T, backendConfig dasrpc.BackendConfig) das.A
 	backendsJsonByte, err := json.Marshal([]dasrpc.BackendConfig{backendConfig})
 	Require(t, err)
 	return das.AggregatorConfig{
-		AssumedHonest:      1,
-		Backends:           string(backendsJsonByte),
-		StoreSignerAddress: "none",
+		AssumedHonest: 1,
+		Backends:      string(backendsJsonByte),
+		L1NodeURL:     "none",
 	}
 }
 
@@ -74,7 +81,7 @@ func TestDASRekey(t *testing.T) {
 
 	// Setup DAS servers
 	dasDataDir := t.TempDir()
-	dasServerA, pubkeyA, backendConfigA := startLocalDASServer(t, ctx, dasDataDir)
+	dasServerA, pubkeyA, backendConfigA := startLocalDASServer(t, ctx, dasDataDir, l1client, addresses.SequencerInbox)
 	authorizeDASKeyset(t, ctx, pubkeyA, l1info, l1client)
 
 	// Setup L2 chain
@@ -104,7 +111,7 @@ func TestDASRekey(t *testing.T) {
 	nodeB.StopAndWait()
 
 	dasServerA.Stop()
-	dasServerB, pubkeyB, backendConfigB := startLocalDASServer(t, ctx, dasDataDir)
+	dasServerB, pubkeyB, backendConfigB := startLocalDASServer(t, ctx, dasDataDir, l1client, addresses.SequencerInbox)
 	defer dasServerB.Stop()
 	authorizeDASKeyset(t, ctx, pubkeyB, l1info, l1client)
 

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -136,10 +136,9 @@ func testLyingSequencer(t *testing.T, dasModeStr string) {
 	nodeConfigC.BatchPoster.Enable = false
 	nodeConfigC.DataAvailability.ModeImpl = dasModeStr
 	dasConfig := das.LocalDiskDASConfig{
-		KeyDir:             dbPath,
-		DataDir:            dbPath,
-		AllowGenerateKeys:  true,
-		StoreSignerAddress: "none",
+		KeyDir:            dbPath,
+		DataDir:           dbPath,
+		AllowGenerateKeys: true,
 	}
 	nodeConfigC.DataAvailability.LocalDiskDASConfig = dasConfig
 	nodeConfigC.Feed.Output = *newBroadcasterConfigTest(0)
@@ -154,10 +153,9 @@ func testLyingSequencer(t *testing.T, dasModeStr string) {
 	nodeConfigB.Feed.Input = *newBroadcastClientConfigTest(port)
 	nodeConfigB.DataAvailability.ModeImpl = dasModeStr
 	dasConfigB := das.LocalDiskDASConfig{
-		KeyDir:             dbPath,
-		DataDir:            dbPath,
-		AllowGenerateKeys:  true,
-		StoreSignerAddress: "none",
+		KeyDir:            dbPath,
+		DataDir:           dbPath,
+		AllowGenerateKeys: true,
 	}
 	nodeConfigB.DataAvailability.LocalDiskDASConfig = dasConfigB
 	l2clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, &l2infoA.ArbInitData, nodeConfigB)

--- a/system_tests/twonodes_test.go
+++ b/system_tests/twonodes_test.go
@@ -30,10 +30,9 @@ func testTwoNodesSimple(t *testing.T, dasModeStr string) {
 	l1NodeConfigB.BlockValidator.Enable = false
 	l1NodeConfigB.DataAvailability.ModeImpl = dasModeStr
 	dasConfig := das.LocalDiskDASConfig{
-		KeyDir:             dbPath,
-		DataDir:            dbPath,
-		AllowGenerateKeys:  true,
-		StoreSignerAddress: "none",
+		KeyDir:            dbPath,
+		DataDir:           dbPath,
+		AllowGenerateKeys: true,
 	}
 	l1NodeConfigB.DataAvailability.LocalDiskDASConfig = dasConfig
 	l2clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, &l2info.ArbInitData, l1NodeConfigB)

--- a/system_tests/twonodeslong_test.go
+++ b/system_tests/twonodeslong_test.go
@@ -51,10 +51,9 @@ func testTwoNodesLong(t *testing.T, dasModeStr string) {
 	l1NodeConfigB.BlockValidator.Enable = false
 	l1NodeConfigB.DataAvailability.ModeImpl = dasModeStr
 	dasConfig := das.LocalDiskDASConfig{
-		KeyDir:             dbPath,
-		DataDir:            dbPath,
-		AllowGenerateKeys:  true,
-		StoreSignerAddress: "none",
+		KeyDir:            dbPath,
+		DataDir:           dbPath,
+		AllowGenerateKeys: true,
 	}
 	l1NodeConfigB.DataAvailability.LocalDiskDASConfig = dasConfig
 	l2clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, &l2info.ArbInitData, l1NodeConfigB)


### PR DESCRIPTION
This uses the L1 chain's `SequencerInbox` contract to verify that signers of DAS Store operations are batch posters.  This facility is set up automatically for DASes that are built into Nitro nodes. Other DASes use config options to provide the URL for an L1 node, plus the L1 address of the SequencerInbox.

Results of these lookups are cached (if positive) for up to an hour, managed by a new `BatchPosterVerifier` facility.