### PR TITLE
Get Store signer from batch poster wallet

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -7,9 +7,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/offchainlabs/nitro/cmd/genericconf"
+	"golang.org/x/term"
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"time"
 
 	"github.com/offchainlabs/nitro/util/headerreader"
@@ -1087,4 +1093,93 @@ func WriteOrTestBlockChain(chainDb ethdb.Database, cacheConfig *core.CacheConfig
 // Don't preserve reorg'd out blocks
 func shouldPreserveFalse(header *types.Header) bool {
 	return false
+}
+
+func GetSignerFromWallet(
+	walletConfig *genericconf.WalletConfig,
+) (func([]byte) ([]byte, error), error) {
+	var signer func(data []byte) ([]byte, error)
+
+	if len(walletConfig.PrivateKey) != 0 {
+		privateKey, err := crypto.HexToECDSA(walletConfig.PrivateKey)
+		if err != nil {
+			return nil, err
+		}
+		signer = func(data []byte) ([]byte, error) {
+			return crypto.Sign(data, privateKey)
+		}
+	} else {
+		ks, account, newKeystoreCreated, err := openKeystore("account", walletConfig.Pathname, walletConfig.Password())
+		if err != nil {
+			return nil, err
+		}
+
+		if newKeystoreCreated {
+			return nil, errors.New("wallet key created, backup key (" + walletConfig.Pathname + ") and remove --wallet.local.only-create-key to start normally")
+		}
+
+		signer = func(data []byte) ([]byte, error) {
+			return ks.SignHash(*account, data)
+		}
+	}
+
+	return signer, nil
+}
+
+func openKeystore(description string, walletPath string, walletPassword *string) (*keystore.KeyStore, *accounts.Account, bool, error) {
+	ks := keystore.NewKeyStore(
+		walletPath,
+		keystore.StandardScryptN,
+		keystore.StandardScryptP,
+	)
+
+	creatingNew := len(ks.Accounts()) == 0
+	if creatingNew {
+		return nil, nil, false, errors.New("No wallet exists, re-run with --wallet.local.only-create-key to create a wallet")
+	}
+	passOpt := walletPassword
+	var password string
+	if passOpt != nil {
+		password = *passOpt
+	} else {
+		if creatingNew {
+			fmt.Print("Enter new account password: ")
+		} else {
+			fmt.Print("Enter account password: ")
+		}
+		var err error
+		password, err = readPass()
+		if err != nil {
+			return nil, nil, false, err
+		}
+	}
+
+	var account accounts.Account
+	if creatingNew {
+		var err error
+		account, err = ks.NewAccount(password)
+		if err != nil {
+			return nil, &accounts.Account{}, false, err
+		}
+
+	} else {
+		account = ks.Accounts()[0]
+	}
+
+	err := ks.Unlock(account, password)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	return ks, &account, creatingNew, nil
+}
+
+func readPass() (string, error) {
+	bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return "", err
+	}
+	passphrase := string(bytePassword)
+	passphrase = strings.TrimSpace(passphrase)
+	return passphrase, nil
 }

--- a/cmd/genericconf/wallet.go
+++ b/cmd/genericconf/wallet.go
@@ -13,10 +13,11 @@ import (
 const PASSWORD_NOT_SET = "PASSWORD_NOT_SET"
 
 type WalletConfig struct {
-	Pathname     string `koanf:"pathname"`
-	PasswordImpl string `koanf:"password"`
-	PrivateKey   string `koanf:"private-key"`
-	Account      string `koanf:"account"`
+	Pathname      string `koanf:"pathname"`
+	PasswordImpl  string `koanf:"password"`
+	PrivateKey    string `koanf:"private-key"`
+	Account       string `koanf:"account"`
+	OnlyCreateKey bool   `koanf:"only-create-key"`
 }
 
 func (w *WalletConfig) Password() *string {
@@ -27,10 +28,11 @@ func (w *WalletConfig) Password() *string {
 }
 
 var WalletConfigDefault = WalletConfig{
-	Pathname:     "",
-	PasswordImpl: "",
-	PrivateKey:   "",
-	Account:      "",
+	Pathname:      "",
+	PasswordImpl:  "",
+	PrivateKey:    "",
+	Account:       "",
+	OnlyCreateKey: false,
 }
 
 func WalletConfigAddOptions(prefix string, f *flag.FlagSet, defaultPathname string) {
@@ -38,6 +40,7 @@ func WalletConfigAddOptions(prefix string, f *flag.FlagSet, defaultPathname stri
 	f.String(prefix+".password", WalletConfigDefault.PasswordImpl, "wallet passphrase")
 	f.String(prefix+".private-key", WalletConfigDefault.PasswordImpl, "private key for wallet")
 	f.String(prefix+".account", WalletConfigDefault.Account, "account to use (default is first account in keystore)")
+	f.Bool(prefix+".only-create-key", WalletConfigDefault.OnlyCreateKey, "if true, creates new key then exits")
 }
 
 func (w *WalletConfig) ResolveDirectoryNames(chain string) {

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/offchainlabs/nitro/das"
 	"math"
 	"math/big"
 	"os"
@@ -297,13 +296,9 @@ func main() {
 		}
 	}
 
-	var daSigner das.DasSigner
-	if l1Wallet.PrivateKey != "" {
-		privateKey, err := crypto.HexToECDSA(l1Wallet.PrivateKey)
-		if err != nil {
-			panic(err)
-		}
-		daSigner = das.DasSignerFromPrivateKey(privateKey)
+	daSigner, err := arbnode.GetSignerFromWallet(l1Wallet)
+	if err != nil {
+		panic(err)
 	}
 
 	currentNode, err := arbnode.CreateNode(stack, chainDb, &nodeConfig.Node, l2BlockChain, l1Client, &rollupAddrs, l1TransactionOpts, daSigner)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/knadh/koanf v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	google.golang.org/grpc v1.44.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -601,6 +601,7 @@ golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0 h1:xrCZDmdtoloIiooiA9q0OQb9r8HejIHYoHGhGCe1pGg=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This improves the method for getting a DasSigner that the batch poster can use to sign Stores.  This can either read a private key from the config, or get wallet info from the config and prompt for a password.