### PR TITLE
Das reader for non sequencers

### DIFF
--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -26,10 +26,10 @@ type InboxTracker struct {
 	txStreamer *TransactionStreamer
 	mutex      sync.Mutex
 	validator  *validator.BlockValidator
-	das        arbstate.DataAvailabilityServiceReader
+	das        arbstate.SimpleDASReader
 }
 
-func NewInboxTracker(raw ethdb.Database, txStreamer *TransactionStreamer, das arbstate.DataAvailabilityServiceReader) (*InboxTracker, error) {
+func NewInboxTracker(raw ethdb.Database, txStreamer *TransactionStreamer, das arbstate.SimpleDASReader) (*InboxTracker, error) {
 	db := &InboxTracker{
 		db:         rawdb.NewTable(raw, arbitrumPrefix),
 		txStreamer: txStreamer,

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -823,6 +823,12 @@ func setUpDataAvailabilityReader(
 		return nil, fmt.Errorf("Unknown data availability mode %v", dataAvailabilityMode)
 	}
 
+	if daReader != nil {
+		daReader, err = das.NewChainFetchSimpleDASReader(daReader, l1client, deployInfo.SequencerInbox)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return daReader, nil
 }
 

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -557,6 +557,7 @@ type Node struct {
 	BroadcastClients []*broadcastclient.BroadcastClient
 	SeqCoordinator   *SeqCoordinator
 	DataAvailService das.DataAvailabilityService
+	DataAvailReader  arbstate.SimpleDASReader
 }
 
 func createNodeImpl(
@@ -638,11 +639,11 @@ func createNodeImpl(
 		}
 	}
 	if !config.L1Reader.Enable {
-		dataAvailabilityService, err := setUpDataAvailabilityService(ctx, config, nil, nil, daSigner)
+		daReader, err := setUpDataAvailabilityReader(ctx, config, nil, nil)
 		if err != nil {
 			return nil, err
 		}
-		return &Node{backend, arbInterface, nil, txStreamer, txPublisher, nil, nil, nil, nil, nil, nil, nil, broadcastServer, broadcastClients, coordinator, dataAvailabilityService}, nil
+		return &Node{backend, arbInterface, nil, txStreamer, txPublisher, nil, nil, nil, nil, nil, nil, nil, broadcastServer, broadcastClients, coordinator, nil, daReader}, nil
 	}
 
 	if deployInfo == nil {
@@ -660,7 +661,8 @@ func createNodeImpl(
 	if err != nil {
 		return nil, err
 	}
-	inboxTracker, err := NewInboxTracker(chainDb, txStreamer, dataAvailabilityService)
+	var dataAvailabilityReader arbstate.SimpleDASReader = dataAvailabilityService
+	inboxTracker, err := NewInboxTracker(chainDb, txStreamer, dataAvailabilityReader)
 	if err != nil {
 		return nil, err
 	}
@@ -684,7 +686,7 @@ func createNodeImpl(
 
 	var blockValidator *validator.BlockValidator
 	if config.BlockValidator.Enable {
-		blockValidator, err = validator.NewBlockValidator(inboxReader, inboxTracker, txStreamer, l2BlockChain, rawdb.NewTable(chainDb, blockValidatorPrefix), &config.BlockValidator, nitroMachineLoader, dataAvailabilityService)
+		blockValidator, err = validator.NewBlockValidator(inboxReader, inboxTracker, txStreamer, l2BlockChain, rawdb.NewTable(chainDb, blockValidatorPrefix), &config.BlockValidator, nitroMachineLoader, dataAvailabilityReader)
 		if err != nil {
 			return nil, err
 		}
@@ -697,7 +699,7 @@ func createNodeImpl(
 		if err != nil {
 			return nil, err
 		}
-		staker, err = validator.NewStaker(l1Reader, wallet, bind.CallOpts{}, config.Validator, l2BlockChain, dataAvailabilityService, inboxReader, inboxTracker, txStreamer, blockValidator, nitroMachineLoader, deployInfo.ValidatorUtils)
+		staker, err = validator.NewStaker(l1Reader, wallet, bind.CallOpts{}, config.Validator, l2BlockChain, dataAvailabilityReader, inboxReader, inboxTracker, txStreamer, blockValidator, nitroMachineLoader, deployInfo.ValidatorUtils)
 		if err != nil {
 			return nil, err
 		}
@@ -723,7 +725,10 @@ func createNodeImpl(
 		return nil, errors.New("sequencer and l1 reader, without delayed sequencer")
 	}
 
-	return &Node{backend, arbInterface, l1Reader, txStreamer, txPublisher, deployInfo, inboxReader, inboxTracker, delayedSequencer, batchPoster, blockValidator, staker, broadcastServer, broadcastClients, coordinator, dataAvailabilityService}, nil
+	if batchPoster != nil {
+		dataAvailabilityService = nil
+	}
+	return &Node{backend, arbInterface, l1Reader, txStreamer, txPublisher, deployInfo, inboxReader, inboxTracker, delayedSequencer, batchPoster, blockValidator, staker, broadcastServer, broadcastClients, coordinator, dataAvailabilityService, dataAvailabilityReader}, nil
 }
 
 func setUpDataAvailabilityService(
@@ -778,6 +783,47 @@ func setUpDataAvailabilityService(
 		}
 	}
 	return dataAvailabilityService, nil
+}
+
+func setUpDataAvailabilityReader(
+	ctx context.Context,
+	config *Config,
+	l1client arbutil.L1Interface,
+	deployInfo *RollupAddresses,
+) (arbstate.SimpleDASReader, error) {
+	dataAvailabilityMode, err := config.DataAvailability.Mode()
+	if err != nil {
+		return nil, err
+	}
+	var daReader arbstate.SimpleDASReader
+	switch dataAvailabilityMode {
+	case das.LocalDiskDataAvailability:
+		storageService, err := das.NewStorageServiceFromLocalConfig(ctx, config.DataAvailability.LocalDiskDASConfig)
+		if err != nil {
+			return nil, err
+		}
+		daReader, err = das.NewLocalDiskDASWithL1Info(
+			ctx,
+			config.DataAvailability.LocalDiskDASConfig,
+			l1client,
+			deployInfo.SequencerInbox,
+			storageService,
+		)
+		if err != nil {
+			return nil, err
+		}
+	case das.AggregatorDataAvailability:
+		daReader, err = dasrpc.NewRPCAggregatorWithL1Info(config.DataAvailability.AggregatorConfig, l1client, deployInfo.SequencerInbox)
+		if err != nil {
+			return nil, err
+		}
+	case das.OnchainDataAvailability:
+		// Batches stored onchain, don't create a DAS.
+	default:
+		return nil, fmt.Errorf("Unknown data availability mode %v", dataAvailabilityMode)
+	}
+
+	return daReader, nil
 }
 
 type arbNodeLifecycle struct {

--- a/das/chain_fetch_das.go
+++ b/das/chain_fetch_das.go
@@ -7,10 +7,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 )
@@ -76,6 +76,75 @@ func (das *ChainFetchDAS) KeysetFromHash(ctx context.Context, ksHash []byte) ([]
 	for iter.Next() {
 		if bytes.Equal(ksHash, crypto.Keccak256(iter.Event.KeysetBytes)) {
 			das.keysetCache[ksHash32] = iter.Event.KeysetBytes
+			return iter.Event.KeysetBytes, nil
+		}
+	}
+	if iter.Error() != nil {
+		return nil, iter.Error()
+	}
+
+	return nil, errors.New("Keyset not found")
+}
+
+type ChainFetchSimpleDASReader struct {
+	arbstate.SimpleDASReader
+	seqInboxCaller   *bridgegen.SequencerInboxCaller
+	seqInboxFilterer *bridgegen.SequencerInboxFilterer
+	keysetCache      map[[32]byte][]byte
+}
+
+func NewChainFetchSimpleDASReader(inner arbstate.SimpleDASReader, l1client arbutil.L1Interface, seqInboxAddr common.Address) (*ChainFetchSimpleDASReader, error) {
+	seqInbox, err := bridgegen.NewSequencerInbox(seqInboxAddr, l1client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ChainFetchSimpleDASReader{
+		inner,
+		&seqInbox.SequencerInboxCaller,
+		&seqInbox.SequencerInboxFilterer,
+		make(map[[32]byte][]byte),
+	}, nil
+}
+
+func (daReader *ChainFetchSimpleDASReader) GetByHash(ctx context.Context, hash []byte) ([]byte, error) {
+	// try to fetch from the cache
+	var hash32 [32]byte
+	copy(hash32[:], hash)
+	res, ok := daReader.keysetCache[hash32]
+	if ok {
+		return res, nil
+	}
+
+	// try to fetch from the inner DAS
+	innerRes, err := daReader.SimpleDASReader.GetByHash(ctx, hash)
+	if err == nil && bytes.Equal(hash, crypto.Keccak256(innerRes)) {
+		return innerRes, nil
+	}
+
+	// try to fetch from the L1 chain
+	blockNumBig, err := daReader.seqInboxCaller.GetKeysetCreationBlock(&bind.CallOpts{Context: ctx}, hash32)
+	if err != nil {
+		return nil, err
+	}
+	if !blockNumBig.IsUint64() {
+		return nil, errors.New("block number too large")
+	}
+	blockNum := blockNumBig.Uint64()
+	blockNumPlus1 := blockNum + 1
+
+	filterOpts := &bind.FilterOpts{
+		Start:   blockNum,
+		End:     &blockNumPlus1,
+		Context: ctx,
+	}
+	iter, err := daReader.seqInboxFilterer.FilterSetValidKeyset(filterOpts, [][32]byte{hash32})
+	if err != nil {
+		return nil, err
+	}
+	for iter.Next() {
+		if bytes.Equal(hash, crypto.Keccak256(iter.Event.KeysetBytes)) {
+			daReader.keysetCache[hash32] = iter.Event.KeysetBytes
 			return iter.Event.KeysetBytes, nil
 		}
 	}

--- a/validator/block_validator.go
+++ b/validator/block_validator.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/das"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
@@ -108,7 +107,7 @@ type validationStatus struct {
 	ModuleRoots []common.Hash    // non-atomic: present from the start
 }
 
-func NewBlockValidator(inboxReader InboxReaderInterface, inbox InboxTrackerInterface, streamer TransactionStreamerInterface, blockchain *core.BlockChain, db ethdb.Database, config *BlockValidatorConfig, machineLoader *NitroMachineLoader, das das.DataAvailabilityService) (*BlockValidator, error) {
+func NewBlockValidator(inboxReader InboxReaderInterface, inbox InboxTrackerInterface, streamer TransactionStreamerInterface, blockchain *core.BlockChain, db ethdb.Database, config *BlockValidatorConfig, machineLoader *NitroMachineLoader, das arbstate.SimpleDASReader) (*BlockValidator, error) {
 	concurrent := config.ConcurrentRunsLimit
 	if concurrent == 0 {
 		concurrent = runtime.NumCPU()

--- a/validator/challenge_manager.go
+++ b/validator/challenge_manager.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"github.com/offchainlabs/nitro/arbstate"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -17,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/das"
 	"github.com/offchainlabs/nitro/solgen/go/challengegen"
 	"github.com/pkg/errors"
 )
@@ -68,7 +68,7 @@ type ChallengeManager struct {
 	inboxTracker      InboxTrackerInterface
 	txStreamer        TransactionStreamerInterface
 	blockchain        *core.BlockChain
-	das               das.DataAvailabilityService
+	das               arbstate.SimpleDASReader
 	machineLoader     *NitroMachineLoader
 	targetNumMachines int
 	wasmModuleRoot    common.Hash
@@ -89,7 +89,7 @@ func NewChallengeManager(
 	challengeManagerAddr common.Address,
 	challengeIndex uint64,
 	l2blockChain *core.BlockChain,
-	das das.DataAvailabilityService,
+	das arbstate.SimpleDASReader,
 	inboxReader InboxReaderInterface,
 	inboxTracker InboxTrackerInterface,
 	txStreamer TransactionStreamerInterface,

--- a/validator/l1_validator.go
+++ b/validator/l1_validator.go
@@ -6,6 +6,7 @@ package validator
 import (
 	"context"
 	"fmt"
+	"github.com/offchainlabs/nitro/arbstate"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -15,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/das"
 	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
 	"github.com/pkg/errors"
 )
@@ -49,7 +49,7 @@ type L1Validator struct {
 	genesisBlockNumber      uint64
 
 	l2Blockchain       *core.BlockChain
-	das                das.DataAvailabilityService
+	das                arbstate.SimpleDASReader
 	inboxTracker       InboxTrackerInterface
 	txStreamer         TransactionStreamerInterface
 	blockValidator     *BlockValidator
@@ -62,7 +62,7 @@ func NewL1Validator(
 	validatorUtilsAddress common.Address,
 	callOpts bind.CallOpts,
 	l2Blockchain *core.BlockChain,
-	das das.DataAvailabilityService,
+	das arbstate.SimpleDASReader,
 	inboxTracker InboxTrackerInterface,
 	txStreamer TransactionStreamerInterface,
 	blockValidator *BlockValidator,

--- a/validator/staker.go
+++ b/validator/staker.go
@@ -6,6 +6,7 @@ package validator
 import (
 	"context"
 	"fmt"
+	"github.com/offchainlabs/nitro/arbstate"
 	"math/big"
 	"strings"
 	"time"
@@ -18,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 
-	"github.com/offchainlabs/nitro/das"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
@@ -140,7 +140,7 @@ func NewStaker(
 	callOpts bind.CallOpts,
 	config L1ValidatorConfig,
 	l2Blockchain *core.BlockChain,
-	das das.DataAvailabilityService,
+	das arbstate.SimpleDASReader,
 	inboxReader InboxReaderInterface,
 	inboxTracker InboxTrackerInterface,
 	txStreamer TransactionStreamerInterface,

--- a/validator/stateless_block_validator.go
+++ b/validator/stateless_block_validator.go
@@ -19,7 +19,6 @@ import (
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbstate"
-	"github.com/offchainlabs/nitro/das"
 	"github.com/pkg/errors"
 )
 
@@ -30,7 +29,7 @@ type StatelessBlockValidator struct {
 	streamer        TransactionStreamerInterface
 	blockchain      *core.BlockChain
 	db              ethdb.Database
-	daService       das.DataAvailabilityService
+	daService       arbstate.SimpleDASReader
 	genesisBlockNum uint64
 }
 
@@ -194,7 +193,7 @@ func NewStatelessBlockValidator(
 	streamer TransactionStreamerInterface,
 	blockchain *core.BlockChain,
 	db ethdb.Database,
-	das das.DataAvailabilityService,
+	das arbstate.SimpleDASReader,
 ) (*StatelessBlockValidator, error) {
 	genesisBlockNum, err := streamer.GetGenesisBlockNumber()
 	if err != nil {
@@ -288,7 +287,7 @@ func BlockDataForValidation(blockchain *core.BlockChain, header, prevHeader *typ
 	return
 }
 
-func SetMachinePreimageResolver(ctx context.Context, mach *ArbitratorMachine, preimages map[common.Hash][]byte, seqMsg []byte, bc *core.BlockChain, das das.DataAvailabilityService) error {
+func SetMachinePreimageResolver(ctx context.Context, mach *ArbitratorMachine, preimages map[common.Hash][]byte, seqMsg []byte, bc *core.BlockChain, das arbstate.SimpleDASReader) error {
 	recordNewPreimages := true
 	if preimages == nil {
 		preimages = make(map[common.Hash][]byte)


### PR DESCRIPTION
This switches all nodes, other than sequencers, to use a `SimpleDASReader` rather than a full-on DAS.  This should be safer and should give us more flexibility to separate read-only servers from DAS committee members.