### PR TITLE
Fallback StorageService

### DIFF
--- a/das/fallback_storage_service.go
+++ b/das/fallback_storage_service.go
@@ -1,0 +1,54 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package das
+
+import (
+	"context"
+	"errors"
+	"github.com/offchainlabs/nitro/arbstate"
+	"github.com/offchainlabs/nitro/util/arbmath"
+	"time"
+)
+
+type FallbackStorageService struct {
+	StorageService
+	backup                     arbstate.SimpleDASReader
+	backupRetentionSeconds     uint64
+	ignoreRetentionWriteErrors bool
+}
+
+func NewFallbackStorageService(
+	primary StorageService,
+	backup arbstate.SimpleDASReader,
+	backupRetentionSeconds uint64, // how long to retain data that we copy in from the backup (MaxUint64 means forever)
+	ignoreRetentionWriteErrors bool, // if true, don't return error if write of retention data to primary fails
+) *FallbackStorageService {
+	return &FallbackStorageService{
+		primary,
+		backup,
+		backupRetentionSeconds,
+		ignoreRetentionWriteErrors,
+	}
+}
+
+func (f *FallbackStorageService) GetByHash(ctx context.Context, key []byte) ([]byte, error) {
+	data, err := f.StorageService.GetByHash(ctx, key)
+	if errors.Is(err, ErrNotFound) {
+		data, err = f.backup.GetByHash(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+
+		// write data to the primary, ignore errors because nothing breaks if this doesn't succeed
+		putErr := f.StorageService.Put(ctx, data, arbmath.SaturatingUAdd(uint64(time.Now().Unix()), f.backupRetentionSeconds))
+		if putErr != nil && !f.ignoreRetentionWriteErrors {
+			return nil, err
+		}
+	}
+	return data, err
+}
+
+func (f *FallbackStorageService) String() string {
+	return "FallbackStorageService(" + f.StorageService.String() + ")"
+}

--- a/das/fallback_storage_service.go
+++ b/das/fallback_storage_service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/util/arbmath"
+	"sync"
 	"time"
 )
 
@@ -18,6 +19,8 @@ type FallbackStorageService struct {
 	backup                     arbstate.SimpleDASReader
 	backupRetentionSeconds     uint64
 	ignoreRetentionWriteErrors bool
+	currentlyFetching          map[[32]byte]bool
+	currentlyFetchingMutex     sync.RWMutex
 }
 
 // This is a StorageService that relies on a "primary" StorageService and a "backup". Puts go to the primary.
@@ -34,13 +37,31 @@ func NewFallbackStorageService(
 		backup,
 		backupRetentionSeconds,
 		ignoreRetentionWriteErrors,
+		make(map[[32]byte]bool),
+		sync.RWMutex{},
 	}
 }
 
 func (f *FallbackStorageService) GetByHash(ctx context.Context, key []byte) ([]byte, error) {
+	f.currentlyFetchingMutex.RLock()
+	var key32 [32]byte
+	copy(key32[:], key)
+	if f.currentlyFetching[key32] {
+		// This is a recursive call, so return not-found
+		f.currentlyFetchingMutex.RUnlock()
+		return nil, ErrNotFound
+	}
+	f.currentlyFetchingMutex.RUnlock()
+
 	data, err := f.StorageService.GetByHash(ctx, key)
 	if errors.Is(err, ErrNotFound) {
+		f.currentlyFetchingMutex.Lock()
+		f.currentlyFetching[key32] = true
+		f.currentlyFetchingMutex.Unlock()
 		data, err = f.backup.GetByHash(ctx, key)
+		f.currentlyFetchingMutex.Lock()
+		delete(f.currentlyFetching, key32)
+		f.currentlyFetchingMutex.Unlock()
 		if err != nil {
 			return nil, err
 		}

--- a/das/fallback_storage_service_test.go
+++ b/das/fallback_storage_service_test.go
@@ -28,7 +28,7 @@ func TestFallbackStorageService(t *testing.T) {
 	err = fallback.Put(ctx, val2, math.MaxUint64)
 	Require(t, err)
 
-	fss := NewFallbackStorageService(primary, fallback, 60*60, true)
+	fss := NewFallbackStorageService(primary, fallback, 60*60, true, true)
 
 	res1, err := fss.GetByHash(ctx, hash1)
 	Require(t, err)
@@ -56,7 +56,7 @@ func TestFallbackStorageServiceRecursive(t *testing.T) {
 	hash1 := crypto.Keccak256(val1)
 
 	ss := NewMemoryBackedStorageService(ctx)
-	fss := NewFallbackStorageService(ss, ss, 60*60, true)
+	fss := NewFallbackStorageService(ss, ss, 60*60, true, true)
 
 	// artificially make fss recursive
 	fss.backup = fss

--- a/util/arbmath/math_test.go
+++ b/util/arbmath/math_test.go
@@ -29,7 +29,7 @@ func TestMath(t *testing.T) {
 
 	// try large random sqrts
 	for i := 0; i < 100000; i++ {
-		input := rand.Uint64() / 2
+		input := rand.Uint64() / 256
 		approx := ApproxSquareRoot(input)
 		correct := math.Sqrt(float64(input))
 		diff := int(approx) - int(correct)


### PR DESCRIPTION
This adds a `FallbackStorageService` class, which uses a primary `StorageService` but `GetByHash` operations that fail in the primary are tried against a backup `SimpleDASReader`. Successful `GetByHash`es from the backup are `Put` into the primary before being returned to the caller.

This is useful for a `StorageService` that doesn't have a full set of historic data. Such a service can use as a backup a remote server (or aggregated set of servers) that has more data, and that data will be populated into the primary as it is encountered.