### PR TITLE
Enable/Disable data deletion and Expiration Policy API

### DIFF
--- a/das/archiving_storage_service.go
+++ b/das/archiving_storage_service.go
@@ -126,6 +126,10 @@ func (serv *ArchivingStorageService) Close(ctx context.Context) error {
 	}
 }
 
+func (serv *ArchivingStorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
+	return KeptInArchive
+}
+
 func (serv *ArchivingStorageService) GetArchiverErrorSignalChan() <-chan interface{} {
 	return serv.archiverErrorSignal
 }
@@ -185,6 +189,10 @@ func (lss *limitedStorageService) Sync(ctx context.Context) error {
 
 func (lss *limitedStorageService) Close(ctx context.Context) error {
 	return errors.New("invalid operation")
+}
+
+func (lss *limitedStorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
+	return -1
 }
 
 func (lss *limitedStorageService) String() string {

--- a/das/archiving_storage_service.go
+++ b/das/archiving_storage_service.go
@@ -127,7 +127,7 @@ func (serv *ArchivingStorageService) Close(ctx context.Context) error {
 }
 
 func (serv *ArchivingStorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
-	return KeptInArchive
+	return DiscardAfterArchiveTimeout
 }
 
 func (serv *ArchivingStorageService) GetArchiverErrorSignalChan() <-chan interface{} {

--- a/das/bigcache_storage_service.go
+++ b/das/bigcache_storage_service.go
@@ -84,6 +84,10 @@ func (bcs *BigCacheStorageService) Close(ctx context.Context) error {
 	return bcs.baseStorageService.Close(ctx)
 }
 
+func (bcs *BigCacheStorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
+	return bcs.baseStorageService.ExpirationPolicy(ctx)
+}
+
 func (bcs *BigCacheStorageService) String() string {
 	return fmt.Sprintf("BigCahceStorageService(:%v)", bcs.bigCacheConfig)
 }

--- a/das/db_storage_service.go
+++ b/das/db_storage_service.go
@@ -94,6 +94,14 @@ func (dbs *DBStorageService) Close(ctx context.Context) error {
 	return nil
 }
 
+func (dbs *DBStorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
+	if dbs.discardAfterTimeout {
+		return DiscardAfterTimeout
+	} else {
+		return KeepAfterTimeout
+	}
+}
+
 func (dbs *DBStorageService) String() string {
 	return "BadgerDB(" + dbs.dirPath + ")"
 }

--- a/das/db_storage_service.go
+++ b/das/db_storage_service.go
@@ -96,9 +96,9 @@ func (dbs *DBStorageService) Close(ctx context.Context) error {
 
 func (dbs *DBStorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
 	if dbs.discardAfterTimeout {
-		return DiscardAfterTimeout
+		return DiscardAfterDataTimeout
 	} else {
-		return KeepAfterTimeout
+		return KeepForever
 	}
 }
 

--- a/das/local_disk_das.go
+++ b/das/local_disk_das.go
@@ -29,7 +29,7 @@ type ExpirationPolicy int64
 
 const (
 	KeepForever                ExpirationPolicy = iota // Data is kept forever
-	DiscardAfterArchiveTimeout                         // Data is kept till Archive timeout (Archive Timeout is defined by archiving node)
+	DiscardAfterArchiveTimeout                         // Data is kept till Archive timeout (Archive Timeout is defined by archiving node, assumed to be as long as minimum data timeout)
 	DiscardAfterDataTimeout                            // Data is kept till aggregator provided timeout (Aggregator provides a timeout for data while making the put call)
 	// Add more type of expiration policy.
 )

--- a/das/local_disk_das.go
+++ b/das/local_disk_das.go
@@ -52,7 +52,7 @@ func LocalDiskDASConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".key-dir", "", fmt.Sprintf("The directory to read the bls keypair ('%s' and '%s') from", DefaultPubKeyFilename, DefaultPrivKeyFilename))
 	f.String(prefix+".priv-key", "", "The base64 BLS private key to use for signing DAS certificates")
 	f.String(prefix+".data-dir", "", "The directory to use as the DAS file-based database")
-	f.Bool(prefix+"discard-after-timeout", false, "Discard data after timeout in DAS")
+	f.Bool(prefix+".discard-after-timeout", false, "Discard data after timeout in DAS")
 	genericconf.S3ConfigAddOptions(prefix+".s3", f)
 	RedisConfigAddOptions(prefix+".redis", f)
 	BigCacheConfigAddOptions(prefix+".big-cache", f)

--- a/das/local_disk_das.go
+++ b/das/local_disk_das.go
@@ -28,9 +28,9 @@ var ErrDasKeysetNotFound = errors.New("no such keyset")
 type ExpirationPolicy int64
 
 const (
-	KeepAfterTimeout ExpirationPolicy = iota
-	KeptInArchive
-	DiscardAfterTimeout
+	KeepForever                ExpirationPolicy = iota // Data is kept forever
+	DiscardAfterArchiveTimeout                         // Data is kept till Archive timeout (Archive Timeout is defined by archiving node)
+	DiscardAfterDataTimeout                            // Data is kept till aggregator provided timeout (Aggregator provides a timeout for data while making the put call)
 	// Add more type of expiration policy.
 )
 

--- a/das/memory_backed_storage_service.go
+++ b/das/memory_backed_storage_service.go
@@ -68,6 +68,10 @@ func (m *MemoryBackedStorageService) Close(ctx context.Context) error {
 	return nil
 }
 
+func (m *MemoryBackedStorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
+	return KeepAfterTimeout
+}
+
 func (m *MemoryBackedStorageService) String() string {
 	return "MemoryBackedStorageService"
 }

--- a/das/memory_backed_storage_service.go
+++ b/das/memory_backed_storage_service.go
@@ -69,7 +69,7 @@ func (m *MemoryBackedStorageService) Close(ctx context.Context) error {
 }
 
 func (m *MemoryBackedStorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
-	return KeepAfterTimeout
+	return KeepForever
 }
 
 func (m *MemoryBackedStorageService) String() string {

--- a/das/redis_storage_service.go
+++ b/das/redis_storage_service.go
@@ -138,6 +138,10 @@ func (rs *RedisStorageService) Close(ctx context.Context) error {
 	return rs.baseStorageService.Close(ctx)
 }
 
+func (rs *RedisStorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
+	return rs.baseStorageService.ExpirationPolicy(ctx)
+}
+
 func (rs *RedisStorageService) String() string {
 	return fmt.Sprintf("RedisStorageService(:%v)", rs.redisConfig)
 }

--- a/das/redundant_storage_service.go
+++ b/das/redundant_storage_service.go
@@ -114,24 +114,24 @@ func (r *RedundantStorageService) Close(ctx context.Context) error {
 }
 
 func (r *RedundantStorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
-	// If at least one inner service has KeepAfterTimeout,
+	// If at least one inner service has KeepForever,
 	// then whole redundant service can serve after timeout.
 	for _, serv := range r.innerServices {
-		if serv.ExpirationPolicy(ctx) == KeepAfterTimeout {
-			return KeepAfterTimeout
+		if serv.ExpirationPolicy(ctx) == KeepForever {
+			return KeepForever
 		}
 	}
-	// If no inner service has KeepAfterTimeout,
-	// but at least one inner service has KeptInArchive,
+	// If no inner service has KeepForever,
+	// but at least one inner service has DiscardAfterArchiveTimeout,
 	// then whole redundant service can serve till archive timeout.
 	for _, serv := range r.innerServices {
-		if serv.ExpirationPolicy(ctx) == KeptInArchive {
-			return KeptInArchive
+		if serv.ExpirationPolicy(ctx) == DiscardAfterArchiveTimeout {
+			return DiscardAfterArchiveTimeout
 		}
 	}
-	// If no inner service has KeepAfterTimeout and KeptInArchive,
+	// If no inner service has KeepForever and DiscardAfterArchiveTimeout,
 	// then whole redundant service will serve only till timeout.
-	return DiscardAfterTimeout
+	return DiscardAfterDataTimeout
 }
 
 func (r *RedundantStorageService) String() string {

--- a/das/s3_storage_service.go
+++ b/das/s3_storage_service.go
@@ -81,9 +81,9 @@ func (s3s *S3StorageService) Close(ctx context.Context) error {
 
 func (s3s *S3StorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
 	if s3s.discardAfterTimeout {
-		return DiscardAfterTimeout
+		return DiscardAfterDataTimeout
 	} else {
-		return KeepAfterTimeout
+		return KeepForever
 	}
 }
 

--- a/das/storage_service.go
+++ b/das/storage_service.go
@@ -20,6 +20,7 @@ type StorageService interface {
 	Put(ctx context.Context, data []byte, expirationTime uint64) error
 	Sync(ctx context.Context) error
 	Close(ctx context.Context) error
+	ExpirationPolicy(ctx context.Context) ExpirationPolicy
 	String() string
 }
 
@@ -52,6 +53,10 @@ func (s *LocalDiskStorageService) Sync(ctx context.Context) error {
 
 func (s *LocalDiskStorageService) Close(ctx context.Context) error {
 	return nil
+}
+
+func (s *LocalDiskStorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
+	return KeepAfterTimeout
 }
 
 func (s *LocalDiskStorageService) String() string {

--- a/das/storage_service.go
+++ b/das/storage_service.go
@@ -56,7 +56,7 @@ func (s *LocalDiskStorageService) Close(ctx context.Context) error {
 }
 
 func (s *LocalDiskStorageService) ExpirationPolicy(ctx context.Context) ExpirationPolicy {
-	return KeepAfterTimeout
+	return KeepForever
 }
 
 func (s *LocalDiskStorageService) String() string {


### PR DESCRIPTION
Added option in config to enable/disable data deletion based on timeout in persistent data stores.
Added Expiration Policy API to check what kind of policy the DAS is using. 