### PR TITLE
Port broadcaster fixes from classic

### DIFF
--- a/broadcastclient/broadcastclient_test.go
+++ b/broadcastclient/broadcastclient_test.go
@@ -21,15 +21,7 @@ func TestReceiveMessages(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	settings := wsbroadcastserver.BroadcasterConfig{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "0",
-		Ping:          5 * time.Second,
-		ClientTimeout: 20 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	settings := wsbroadcastserver.DefaultTestBroadcasterConfig
 
 	messageCount := 1000
 	clientCount := 2
@@ -120,15 +112,8 @@ func TestServerClientDisconnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	settings := wsbroadcastserver.BroadcasterConfig{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "0",
-		Ping:          1 * time.Second,
-		ClientTimeout: 2 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	settings := wsbroadcastserver.DefaultTestBroadcasterConfig
+	settings.Ping = 1 * time.Second
 
 	b := broadcaster.NewBroadcaster(settings)
 
@@ -176,15 +161,9 @@ func TestBroadcastClientReconnectsOnServerDisconnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	settings := wsbroadcastserver.BroadcasterConfig{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "0",
-		Ping:          50 * time.Second,
-		ClientTimeout: 150 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	settings := wsbroadcastserver.DefaultTestBroadcasterConfig
+	settings.Ping = 50 * time.Second
+	settings.ClientTimeout = 150 * time.Second
 
 	b1 := broadcaster.NewBroadcaster(settings)
 
@@ -215,15 +194,7 @@ func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
 	*/
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	settings := wsbroadcastserver.BroadcasterConfig{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "0",
-		Ping:          5 * time.Second,
-		ClientTimeout: 15 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	settings := wsbroadcastserver.DefaultTestBroadcasterConfig
 
 	b := broadcaster.NewBroadcaster(settings)
 

--- a/broadcaster/broadcaster_test.go
+++ b/broadcaster/broadcaster_test.go
@@ -55,15 +55,7 @@ func TestBroadcasterMessagesRemovedOnConfirmation(t *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 
-	broadcasterSettings := wsbroadcastserver.BroadcasterConfig{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "0",
-		Ping:          5 * time.Second,
-		ClientTimeout: 30 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	broadcasterSettings := wsbroadcastserver.DefaultTestBroadcasterConfig
 
 	b := NewBroadcaster(broadcasterSettings)
 	Require(t, b.Start(ctx))

--- a/wsbroadcastserver/utils.go
+++ b/wsbroadcastserver/utils.go
@@ -21,6 +21,12 @@ type chainedReader struct {
 	readers []io.Reader
 }
 
+func logError(err error, msg string) {
+	if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+		log.Error(msg, "err", err)
+	}
+}
+
 func (cr *chainedReader) Read(b []byte) (n int, err error) {
 	for len(cr.readers) > 0 {
 		n, err = cr.readers[0].Read(b)
@@ -65,9 +71,7 @@ func ReadData(ctx context.Context, conn net.Conn, earlyFrameData io.Reader, idle
 	// Remove timeout when leaving this function
 	defer func(conn net.Conn) {
 		err := conn.SetReadDeadline(time.Time{})
-		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-			log.Error("error removing read deadline", "err", err)
-		}
+		logError(err, "error removing read deadline")
 	}(conn)
 
 	for {

--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -91,7 +91,7 @@ func (s *WSBroadcastServer) Start(ctx context.Context) error {
 	s.startMutex.Lock()
 	defer s.startMutex.Unlock()
 	if s.started {
-		return nil
+		return errors.New("broadcast server already started")
 	}
 
 	var err error
@@ -180,7 +180,7 @@ func (s *WSBroadcastServer) Start(ctx context.Context) error {
 	log.Info("arbitrum websocket broadcast server is listening", "address", ln.Addr().String())
 
 	// Create netpoll descriptor for the listener.
-	// We use OneShot here to manually resume events stream when we want to.
+	// We use OneShot here to synchronously manage the rate that new connections are accepted
 	acceptDesc, err := netpoll.HandleListener(ln, netpoll.EventRead|netpoll.EventOneShot)
 	if err != nil {
 		log.Error("error calling HandleListener", "err", err)
@@ -188,12 +188,16 @@ func (s *WSBroadcastServer) Start(ctx context.Context) error {
 	}
 	s.acceptDesc = acceptDesc
 
-	// accept is a channel to signal about next incoming connection Accept()
-	// results.
-	accept := make(chan error, 1)
+	// acceptErrChan blocks until connection accepted or error occurred
+	acceptErrChan := make(chan error, 1)
 
 	// Subscribe to events about listener.
 	err = s.poller.Start(acceptDesc, func(e netpoll.Event) {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		// We do not want to accept incoming connection when goroutine pool is
 		// busy. So if there are no free goroutines during 1ms we want to
 		// cooldown the server and do not receive connection for some short
@@ -201,27 +205,24 @@ func (s *WSBroadcastServer) Start(ctx context.Context) error {
 		err := clientManager.pool.ScheduleTimeout(time.Millisecond, func() {
 			conn, err := ln.Accept()
 			if err != nil {
-				accept <- err
+				acceptErrChan <- err
 				return
 			}
 
-			accept <- nil
+			acceptErrChan <- nil
 			handle(conn)
 		})
 		if err == nil {
-			err = <-accept
+			err = <-acceptErrChan
 		}
 		if err != nil {
 			if errors.Is(err, gopool.ErrScheduleTimeout) {
 				var netError net.Error
-				success := errors.As(err, &netError)
-				if !success || !netError.Timeout() {
-					log.Error("error in poller.Start", "err", err)
-					return
-				}
+				isNetError := errors.As(err, &netError)
 				if strings.Contains(err.Error(), "file descriptor was not registered") {
-					log.Info("poller exiting", "err", err)
-					return
+					log.Error("broadcast poller unable to register file descriptor", "err", err)
+				} else if !isNetError || !netError.Timeout() {
+					log.Error("broadcast poller error", "err", err)
 				}
 			}
 
@@ -234,10 +235,12 @@ func (s *WSBroadcastServer) Start(ctx context.Context) error {
 		err = s.poller.Resume(acceptDesc)
 		if err != nil {
 			log.Warn("error in poller.Resume", "err", err)
+			panic("error resuming broadcaster poller")
 		}
 	})
 	if err != nil {
-		log.Warn("error in poller.Start", "err", err)
+		log.Warn("error in starting broadcaster poller", "err", err)
+		return err
 	}
 
 	s.started = true

--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -28,6 +28,7 @@ type BroadcasterConfig struct {
 	ClientTimeout time.Duration `koanf:"client-timeout"`
 	Queue         int           `koanf:"queue"`
 	Workers       int           `koanf:"workers"`
+	MaxSendQueue  int           `koanf:"max-send-queue"`
 }
 
 func BroadcasterConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -39,6 +40,7 @@ func BroadcasterConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Duration(prefix+".client-timeout", DefaultBroadcasterConfig.ClientTimeout, "duration to wait before timing out connections to client")
 	f.Int(prefix+".queue", DefaultBroadcasterConfig.Queue, "queue size")
 	f.Int(prefix+".workers", DefaultBroadcasterConfig.Workers, "number of threads to reserve for HTTP to WS upgrade")
+	f.Int(prefix+".max-send-queue", DefaultBroadcasterConfig.MaxSendQueue, "maximum number of messages allowed to accumulate before client is disconnected")
 }
 
 var DefaultBroadcasterConfig = BroadcasterConfig{
@@ -50,6 +52,19 @@ var DefaultBroadcasterConfig = BroadcasterConfig{
 	ClientTimeout: 15 * time.Second,
 	Queue:         100,
 	Workers:       100,
+	MaxSendQueue:  4096,
+}
+
+var DefaultTestBroadcasterConfig = BroadcasterConfig{
+	Enable:        false,
+	Addr:          "0.0.0.0",
+	IOTimeout:     2 * time.Second,
+	Port:          "0",
+	Ping:          5 * time.Second,
+	ClientTimeout: 15 * time.Second,
+	Queue:         1,
+	Workers:       100,
+	MaxSendQueue:  4096,
 }
 
 type WSBroadcastServer struct {


### PR DESCRIPTION
* Fix broadcaster deadlock when channel fills up with client connections to delete
* Increase default MaxSendQueue and make it a configurable option
* More robust error handling for broadcaster server