### PR TITLE
Downloader for RESTful DAS list

### DIFF
--- a/das/rest_server_list.go
+++ b/das/rest_server_list.go
@@ -1,0 +1,98 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package das
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const initialMaxRecurseDepth uint16 = 8
+
+// RestfulServerURLsFromList reads a list of Restful server URLs from a remote URL.
+// The contents at the remote URL are parsed into a series of whitespace-separated words.
+// Each word is interpreted as the URL of a Restful server, except that if a word is "LIST"
+//    (case-insensitive) then the following word is interpreted as the URL of another list,
+//    which is recursively fetched. The depth of recursion is limited to initialMaxRecurseDepth.
+func RestfulServerURLsFromList(ctx context.Context, listUrl string) ([]string, error) {
+	client := &http.Client{}
+	urls, err := restfulServerURLsFromList(ctx, client, listUrl, initialMaxRecurseDepth)
+	if err != nil {
+		return nil, err
+	}
+
+	// deduplicate the list of URL strings
+	seen := make(map[string]bool)
+	dedupedUrls := []string{}
+	for _, url := range urls {
+		if !seen[url] {
+			seen[url] = true
+			dedupedUrls = append(dedupedUrls, url)
+		}
+	}
+
+	return dedupedUrls, nil
+}
+
+func restfulServerURLsFromList(ctx context.Context, client *http.Client, listUrl string, maxRecurseDepth uint16) ([]string, error) {
+	urls := []string{}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, listUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Split(bufio.ScanWords)
+	for scanner.Scan() {
+		word := scanner.Text()
+		if strings.ToLower(word) == "list" {
+			if maxRecurseDepth > 0 && scanner.Scan() {
+				word = scanner.Text()
+				subUrls, err := restfulServerURLsFromList(ctx, client, word, maxRecurseDepth-1)
+				if err != nil {
+					urls = append(urls, subUrls...)
+				}
+			}
+		} else {
+			urls = append(urls, word)
+		}
+	}
+	return urls, nil
+}
+
+const maxListFetchTime = time.Minute
+
+func StartRestfulServerListFetchDaemon(ctx context.Context, listUrl string, updatePeriod time.Duration) <-chan []string {
+	updateChan := make(chan []string)
+	go func() {
+		ticker := time.NewTicker(updatePeriod)
+		defer ticker.Stop()
+		defer close(updateChan)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				subCtx, subCtxCancel := context.WithTimeout(ctx, maxListFetchTime)
+				urls, err := RestfulServerURLsFromList(subCtx, listUrl)
+				subCtxCancel()
+				if err != nil {
+					return
+				}
+				select {
+				case updateChan <- urls:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return updateChan
+}

--- a/das/restful_server_list_test.go
+++ b/das/restful_server_list_test.go
@@ -1,0 +1,52 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package das
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestRestfulServerList(t *testing.T) {
+	initTest(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	urlsIn := []string{"https://supersecret.nowhere.com:9871", "http://www.google.com"}
+	listContents := urlsIn[0] + " \t" + urlsIn[1]
+	server := newListHttpServerForTest(LocalServerPortForTest, listContents)
+
+	listUrl := "http://localhost:" + strconv.FormatInt(LocalServerPortForTest, 10) //nolint
+	urls, err := RestfulServerURLsFromList(ctx, listUrl)
+	Require(t, err)
+	if len(urls) != 2 || (urls[0] != urlsIn[0] && urls[0] != urlsIn[1]) || (urls[1] != urlsIn[0] && urls[1] != urlsIn[1]) {
+		t.Fatal()
+	}
+
+	err = server.Shutdown(ctx)
+	Require(t, err)
+}
+
+func newListHttpServerForTest(port int64, contents string) *http.Server {
+	server := &http.Server{
+		Addr:    ":" + strconv.FormatInt(port, 10),
+		Handler: &testHandler{contents},
+	}
+	go func() {
+		_ = server.ListenAndServe()
+	}()
+	return server
+}
+
+type testHandler struct {
+	contents string
+}
+
+func (th *testHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	_, _ = w.Write([]byte(th.contents))
+}


### PR DESCRIPTION
This adds `RestfulServerURLsFromList`, which downloads and parses online lists of RESTful DAS servers.  Given the URL of a list file, it downloads the file, parses it, and returns a list of URLs from the list.

The list format is a simple list of whitespace-separated URLs.

If a "URL" in the list is "list" (case insensitive) then the following URL is interpreted as the URL of another list which is recursively downloaded, parsed, and added to the set of URLs. (Recursion depth is limited.)

This also adds`StartResfulServerListFetchDaemon` which starts a goroutine that periodically calls`RestfulServerURLsFromList` and sends the result on a channel.