### PR TITLE
Combined rpc rest da server

### DIFF
--- a/cmd/daserver/daserver.go
+++ b/cmd/daserver/daserver.go
@@ -110,8 +110,6 @@ func parseDAServer(args []string) (*DAServerConfig, error) {
 func startup() error {
 	// Some different defaults to DAS config in a node.
 	das.DefaultDataAvailabilityConfig.Enable = true
-	das.DefaultDataAvailabilityConfig.L1NodeURL = "none"
-	das.DefaultDataAvailabilityConfig.SequencerInboxAddress = "none"
 
 	vcsRevision, vcsTime := genericconf.GetVersion()
 	serverConfig, err := parseDAServer(os.Args[1:])

--- a/cmd/daserver/daserver.go
+++ b/cmd/daserver/daserver.go
@@ -74,7 +74,7 @@ func parseDAServer(args []string) (*DAServerConfig, error) {
 	f.String("rest-addr", DefaultDAServerConfig.RESTAddr, "REST server listening interface")
 	f.Uint64("rest-port", DefaultDAServerConfig.RESTPort, "REST server listening port")
 
-	f.Int("log-level", int(log.LvlInfo), "log level")
+	f.Int("log-level", int(log.LvlInfo), "log level; 1: ERROR, 2: WARN, 3: INFO, 4: DEBUG, 5: TRACE")
 	das.DataAvailabilityConfigAddOptions("data-availability", f)
 	genericconf.ConfConfigAddOptions("conf", f)
 

--- a/das/dasrpc/dasRpcClient.go
+++ b/das/dasrpc/dasRpcClient.go
@@ -36,6 +36,10 @@ func NewDASRPCClient(target string) (*DASRPCClient, error) {
 }
 
 func (c *DASRPCClient) GetByHash(ctx context.Context, hash []byte) ([]byte, error) {
+	if len(hash) < 32 {
+		return nil, fmt.Errorf("Hash was too short, should be 32, was %d", len(hash))
+	}
+	hash = hash[:32]
 	var ret hexutil.Bytes
 	if err := c.clnt.CallContext(ctx, &ret, "das_getByHash", hexutil.Bytes(hash)); err != nil {
 		return nil, err

--- a/das/dasrpc/dasRpcClient.go
+++ b/das/dasrpc/dasRpcClient.go
@@ -36,10 +36,9 @@ func NewDASRPCClient(target string) (*DASRPCClient, error) {
 }
 
 func (c *DASRPCClient) GetByHash(ctx context.Context, hash []byte) ([]byte, error) {
-	if len(hash) < 32 {
-		return nil, fmt.Errorf("Hash was too short, should be 32, was %d", len(hash))
+	if len(hash) != 32 {
+		return nil, fmt.Errorf("Hash must be 32 bytes long, was %d", len(hash))
 	}
-	hash = hash[:32]
 	var ret hexutil.Bytes
 	if err := c.clnt.CallContext(ctx, &ret, "das_getByHash", hexutil.Bytes(hash)); err != nil {
 		return nil, err

--- a/das/dasrpc/dasRpcServer.go
+++ b/das/dasrpc/dasRpcServer.go
@@ -65,7 +65,7 @@ type StoreResult struct {
 }
 
 func (serv *DASRPCServer) Store(ctx context.Context, message hexutil.Bytes, timeout hexutil.Uint64, sig hexutil.Bytes) (*StoreResult, error) {
-	log.Trace("dasRpc.DASRPCServer.Store", "message", pretty.FirstFewBytes(message), "timeout", time.Unix(int64(timeout), 0), "sig", pretty.FirstFewBytes(sig), "this", serv)
+	log.Trace("dasRpc.DASRPCServer.Store", "message", pretty.FirstFewBytes(message), "message length", len(message), "timeout", time.Unix(int64(timeout), 0), "sig", pretty.FirstFewBytes(sig), "this", serv)
 
 	cert, err := serv.localDAS.Store(ctx, message, uint64(timeout), sig)
 	if err != nil {

--- a/das/db_storage_service.go
+++ b/das/db_storage_service.go
@@ -5,6 +5,7 @@ package das
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	badger "github.com/dgraph-io/badger/v3"
@@ -92,6 +93,9 @@ func (dbs *DBStorageService) GetByHash(ctx context.Context, key []byte) ([]byte,
 			return nil
 		})
 	})
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return ret, ErrNotFound
+	}
 	return ret, err
 }
 

--- a/das/fallback_storage_service.go
+++ b/das/fallback_storage_service.go
@@ -6,7 +6,6 @@ package das
 import (
 	"bytes"
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -63,7 +62,7 @@ func (f *FallbackStorageService) GetByHash(ctx context.Context, key []byte) ([]b
 	}
 
 	data, err := f.StorageService.GetByHash(ctx, key)
-	if errors.Is(err, ErrNotFound) {
+	if err != nil {
 		doDelete := false
 		if f.preventRecursiveGets {
 			f.currentlyFetchingMutex.Lock()
@@ -73,6 +72,7 @@ func (f *FallbackStorageService) GetByHash(ctx context.Context, key []byte) ([]b
 			}
 			f.currentlyFetchingMutex.Unlock()
 		}
+		log.Trace("das.FallbackStorageService.GetByHash trying fallback")
 		data, err = f.backup.GetByHash(ctx, key)
 		if doDelete {
 			f.currentlyFetchingMutex.Lock()
@@ -93,5 +93,5 @@ func (f *FallbackStorageService) GetByHash(ctx context.Context, key []byte) ([]b
 }
 
 func (f *FallbackStorageService) String() string {
-	return "FallbackStorageService(" + f.StorageService.String() + ")"
+	return "FallbackStorageService(stoargeService:" + f.StorageService.String() + ")"
 }

--- a/das/local_file_storage_service.go
+++ b/das/local_file_storage_service.go
@@ -6,6 +6,7 @@ package das
 import (
 	"context"
 	"encoding/base32"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -45,7 +46,13 @@ func NewLocalFileStorageService(dataDir string) (StorageService, error) {
 func (s *LocalFileStorageService) GetByHash(ctx context.Context, key []byte) ([]byte, error) {
 	log.Trace("das.LocalFileStorageService.GetByHash", "key", pretty.FirstFewBytes(key), "this", s)
 	pathname := s.dataDir + "/" + base32.StdEncoding.EncodeToString(key)
-	return os.ReadFile(pathname)
+	data, err := os.ReadFile(pathname)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNotFound
+		}
+	}
+	return data, nil
 }
 
 func (s *LocalFileStorageService) Put(ctx context.Context, data []byte, timeout uint64) error {

--- a/das/restful_client.go
+++ b/das/restful_client.go
@@ -9,13 +9,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/offchainlabs/nitro/arbstate"
 	"io/ioutil"
 	"net/http"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/offchainlabs/nitro/arbstate"
 )
 
 // Implements DataAvailabilityReader
@@ -40,6 +40,10 @@ func NewRestfulDasClientFromURL(url string) (*RestfulDasClient, error) {
 }
 
 func (c *RestfulDasClient) GetByHash(ctx context.Context, hash []byte) ([]byte, error) {
+	if len(hash) < 32 {
+		return nil, fmt.Errorf("Hash was too short, should be 32, was %d", len(hash))
+	}
+	hash = hash[:32]
 	res, err := http.Get(c.url + hexutil.Encode(hash))
 	if err != nil {
 		return nil, err
@@ -64,7 +68,6 @@ func (c *RestfulDasClient) GetByHash(ctx context.Context, hash []byte) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
-
 	if !bytes.Equal(hash, crypto.Keccak256(decodedBytes)) {
 		return nil, arbstate.ErrHashMismatch
 	}

--- a/das/restful_client.go
+++ b/das/restful_client.go
@@ -40,10 +40,9 @@ func NewRestfulDasClientFromURL(url string) (*RestfulDasClient, error) {
 }
 
 func (c *RestfulDasClient) GetByHash(ctx context.Context, hash []byte) ([]byte, error) {
-	if len(hash) < 32 {
-		return nil, fmt.Errorf("Hash was too short, should be 32, was %d", len(hash))
+	if len(hash) != 32 {
+		return nil, fmt.Errorf("Hash must be 32 bytes long, was %d", len(hash))
 	}
-	hash = hash[:32]
 	res, err := http.Get(c.url + hexutil.Encode(hash))
 	if err != nil {
 		return nil, err

--- a/das/restful_server.go
+++ b/das/restful_server.go
@@ -24,7 +24,7 @@ type RestfulDasServer struct {
 	httpServerError      error
 }
 
-func NewRestfulDasServer(address string, port uint64, storageService StorageService) (*RestfulDasServer, error) {
+func NewRestfulDasServer(address string, port uint64, storageService arbstate.DataAvailabilityReader) (*RestfulDasServer, error) {
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", address, port))
 	if err != nil {
 		return nil, err

--- a/das/restful_server.go
+++ b/das/restful_server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/offchainlabs/nitro/arbstate"
+	"github.com/offchainlabs/nitro/util/pretty"
 )
 
 type RestfulDasServer struct {
@@ -84,6 +85,7 @@ func (rds *RestfulDasServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
+	log.Trace("RestfulDasServer.ServeHTTP returning", "message", pretty.FirstFewBytes(responseData), "message length", len(responseData))
 
 	encodedResponseData := make([]byte, base64.StdEncoding.EncodedLen(len(responseData)))
 	base64.StdEncoding.Encode(encodedResponseData, responseData)


### PR DESCRIPTION
# Testing Done

Manually tested running `daserver` in RPC either and both of REST modes with all local storage and cache types. 

Tested fallback: store data to one DAS, request from another (observe fallback logging), make another request to confirm that it doesn't fall back.

```
{
  "data-availability": {
    "enable": true,
    "key": {
      "key-dir": "/tmp/darest/2",
      "priv-key": ""
    },
    "local-cache": {
      "enable": true,
      "expiration": "1h0m0s"
    },
    "local-db-storage": {
      "data-dir": "/tmp/darest/2",
      "discard-after-timeout": false,
      "enable": true
    },
    "local-file-storage": {
      "data-dir": "/tmp/darest/2",
      "enable": true
    },
    "rest-aggregator": {
      "enable": true,
      "max-per-endpoint-stats": 20,
      "simple-explore-exploit-strategy": {
        "exploit-iterations": 20,
        "explore-iterations": 2
      },
      "strategy": "simple-explore-exploit",
      "strategy-update-interval": "2s",
      "urls": ["http://localhost:9817","http://localhost:9827","http://localhost:9837"],
      "wait-before-try-next": "2s"
    },
  	"l1-node-url": "none",
	"sequencer-inbox-address": "none"
  },
  "enable-rest": true,
  "enable-rpc": true,
  "log-level": 5,
  "rest-addr": "localhost",
  "rest-port": "9827",
  "rpc-addr": "localhost",
  "rpc-port": "9826"
}
```


Tested `daserver` can run as a REST aggregator standalone.
```
{
  "data-availability": {
    "enable": true,

    "rest-aggregator": {
      "enable": true,
      "max-per-endpoint-stats": 20,
      "simple-explore-exploit-strategy": {
        "exploit-iterations": 20,
        "explore-iterations": 2
      },
      "strategy": "simple-explore-exploit",
      "strategy-update-interval": "2s",
      "urls": ["http://localhost:9817","http://localhost:9827","http://localhost:9837"],
      "wait-before-try-next": "2s"
    },
	"l1-node-url": "none",
	"sequencer-inbox-address": "none"
  },
  "enable-rest": true,
  "enable-rpc": true,
  "log-level": 5,
  "rest-addr": "localhost",
  "rest-port": "9897",
  "rpc-addr": "localhost",
  "rpc-port": "9896"
}
```