### PR TITLE
Fix no keys config

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -881,7 +881,7 @@ func SetUpDataAvailability(
 		}
 
 		topLevelDas = rpcAggregator
-	} else if hasPersistentStorage {
+	} else if hasPersistentStorage && (config.KeyConfig.KeyDir != "" || config.KeyConfig.PrivKey != "") {
 
 		// TODO rename StorageServiceDASAdapter
 		topLevelDas, err = das.NewSignAfterStoreDASWithSeqInboxCaller(

--- a/das/restful_server.go
+++ b/das/restful_server.go
@@ -151,7 +151,6 @@ func (rds *RestfulDasServer) GetByHashHandler(w http.ResponseWriter, r *http.Req
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
 	w.Header()[cacheControlKey] = []string{cacheControlValue}
 }
 


### PR DESCRIPTION
Fix error that we saw setting up the mirror DASes which are not supposed to have keys

```
ERROR[06-08|22:25:28.244] Error running DAServer                   err="Required BLS keypair did not exist at 
```

# manual testing done
Created a DAS with a keypair, stored some data in it. Restarted it without the key location configuration, was able to retrieve the data.

Created another DAS using the first DAS for lazy sync. Requested the same data from it, observed logs to see that it is retrieved from the first DAS. Requested again to confirm it is now stored in the second DAS.