### PR TITLE
Use 4-byte selector for Internal Transactions

### DIFF
--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -31,6 +31,8 @@ import (
 // set by the precompile module, to avoid a package dependence cycle
 var ArbRetryableTxAddress common.Address
 var ArbSysAddress common.Address
+var InternalTxStartBlockMethodID [4]byte
+var InternalTxBatchPostingReportMethodID [4]byte
 var RedeemScheduledEventID common.Hash
 var L2ToL1TransactionEventID common.Hash
 var L2ToL1TxEventID common.Hash

--- a/arbos/incomingmessage.go
+++ b/arbos/incomingmessage.go
@@ -540,7 +540,6 @@ func parseBatchPostingReportMessage(rd io.Reader, chainId *big.Int, batchFetcher
 	}
 	return types.NewTx(&types.ArbitrumInternalTx{
 		ChainId: chainId,
-		SubType: arbInternalTxBatchPostReport,
 		Data:    data,
 		// don't need to fill in the other fields, since they exist only to ensure uniqueness, and batchNum is already unique
 	}), nil

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -96,7 +96,7 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 		batchDataGas, _ := inputs[3].(uint64)
 		l1BaseFeeWei, _ := inputs[4].(*big.Int)
 
-		weiSpent := new(big.Int).Mul(l1BaseFeeWei, new(big.Int).SetUint64(batchDataGas))
+		weiSpent := arbmath.BigMulByUint(l1BaseFeeWei, batchDataGas)
 		err = state.L1PricingState().UpdateForBatchPosterSpending(evm.StateDB, evm, batchTimestamp.Uint64(), evm.Context.Time.Uint64(), batchPosterAddress, weiSpent)
 		if err != nil {
 			log.Warn("L1Pricing UpdateForSequencerSpending failed", "err", err)

--- a/arbos/util/util.go
+++ b/arbos/util/util.go
@@ -20,8 +20,6 @@ import (
 
 var AddressAliasOffset *big.Int
 var InverseAddressAliasOffset *big.Int
-var InternalTxStartBlockMethodID [4]byte
-var InternalTxBatchPostReportMethodID [4]byte
 var ParseRedeemScheduledLog func(interface{}, *types.Log) error
 var ParseL2ToL1TransactionLog func(interface{}, *types.Log) error
 var ParseL2ToL1TxLog func(interface{}, *types.Log) error

--- a/arbos/util/util.go
+++ b/arbos/util/util.go
@@ -15,10 +15,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
+	"github.com/offchainlabs/nitro/util/arbmath"
 )
 
 var AddressAliasOffset *big.Int
 var InverseAddressAliasOffset *big.Int
+var InternalTxStartBlockMethodID [4]byte
+var InternalTxBatchPostReportMethodID [4]byte
 var ParseRedeemScheduledLog func(interface{}, *types.Log) error
 var ParseL2ToL1TransactionLog func(interface{}, *types.Log) error
 var ParseL2ToL1TxLog func(interface{}, *types.Log) error
@@ -34,7 +37,7 @@ func init() {
 		panic("Error initializing AddressAliasOffset")
 	}
 	AddressAliasOffset = offset
-	InverseAddressAliasOffset = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 160), AddressAliasOffset)
+	InverseAddressAliasOffset = arbmath.BigSub(new(big.Int).Lsh(big.NewInt(1), 160), AddressAliasOffset)
 
 	// Create a mechanism for parsing event logs
 	logParser := func(source string, name string) func(interface{}, *types.Log) error {


### PR DESCRIPTION
Uses the 4-byte method selector now that we've decided `ArbitrumInternalTx`'s always have abi-encoded data

Associated PRs
- https://github.com/OffchainLabs/go-ethereum/pull/107