### PR TITLE
coordinator: myurl invalid by default

### DIFF
--- a/arbnode/forwarder.go
+++ b/arbnode/forwarder.go
@@ -23,10 +23,17 @@ func NewForwarder(target string) *TxForwarder {
 }
 
 func (f *TxForwarder) PublishTransaction(ctx context.Context, tx *types.Transaction) error {
+	if f.client == nil {
+		return errors.New("sequencer temporarily unavailable")
+	}
 	return f.client.SendTransaction(ctx, tx)
 }
 
 func (f *TxForwarder) Initialize(ctx context.Context) error {
+	if f.target == "" {
+		f.client = nil
+		return nil
+	}
 	client, err := ethclient.DialContext(ctx, f.target)
 	if err != nil {
 		return err

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -36,6 +36,7 @@ const LIVELINESS_KEY_PREFIX string = "coordinator.liveliness." // Per server. On
 const MESSAGE_KEY_PREFIX string = "coordinator.msg."           // Per Message. Only written by sequencer holding CHOSEN
 const LIVELINESS_VAL string = "OK"
 const INVALID_VAL string = "INVALID"
+const INVALID_URL string = "<?INVALID-URL?>"
 
 type SeqCoordinator struct {
 	stopwaiter.StopWaiter
@@ -107,7 +108,7 @@ var DefaultSeqCoordinatorConfig = SeqCoordinatorConfig{
 	RetryInterval:         time.Second,
 	AllowedMsgLag:         200,
 	MaxMsgPerPoll:         2000,
-	MyUrl:                 "",
+	MyUrl:                 INVALID_URL,
 	SigningKey:            "",
 	Dangerous:             DefaultSeqCoordinatorDangerousConfig,
 }
@@ -126,7 +127,7 @@ var TestSeqCoordinatorConfig = SeqCoordinatorConfig{
 	RetryInterval:   time.Millisecond * 3,
 	AllowedMsgLag:   5,
 	MaxMsgPerPoll:   20,
-	MyUrl:           "",
+	MyUrl:           INVALID_URL,
 	SigningKey:      "b561f5d5d98debc783aa8a1472d67ec3bcd532a1c8d95e5cb23caa70c649f7c9",
 	Dangerous: SeqCoordinatorDangerousConfig{
 		DisableSignatureVerification: false,
@@ -174,6 +175,9 @@ func NewSeqCoordinator(streamer *TransactionStreamer, sequencer *Sequencer, conf
 	fallbackVerificationKey, err := loadSigningKey(config.FallbackVerificationKey)
 	if err != nil {
 		return nil, err
+	}
+	if config.MyUrl == "" {
+		config.MyUrl = INVALID_URL
 	}
 	coordinator := &SeqCoordinator{
 		streamer:                streamer,

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -504,7 +504,7 @@ func (c *SeqCoordinator) updatePrevKnownChosen(ctx context.Context, nextChosen s
 	}
 	localMsgCount, err := c.streamer.GetMessageCount()
 	if err != nil {
-		log.Crit("coordinator cannot read message count", "err", err)
+		log.Error("coordinator cannot read message count", "err", err)
 		return c.config.UpdateInterval
 	}
 	err = c.chosenOneUpdate(ctx, localMsgCount, localMsgCount, nil)
@@ -536,7 +536,7 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 	// read messages from redis
 	localMsgCount, err := c.streamer.GetMessageCount()
 	if err != nil {
-		log.Crit("cannot read message count", "err", err)
+		log.Error("cannot read message count", "err", err)
 		return c.config.UpdateInterval
 	}
 	remoteMsgCount, err := c.GetRemoteMsgCount(ctx)
@@ -600,10 +600,14 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 		}
 	}
 
+	if c.config.MyUrl == INVALID_URL {
+		return c.noRedisError()
+	}
+
 	// can take over as main sequencer?
 	if localMsgCount >= remoteMsgCount && chosenSeq == c.config.MyUrl {
 		if c.sequencer == nil {
-			log.Crit("myurl main sequencer, but no sequencer exists")
+			log.Error("myurl main sequencer, but no sequencer exists")
 			return c.noRedisError()
 		}
 		err := c.chosenOneUpdate(ctx, localMsgCount, localMsgCount, nil)


### PR DESCRIPTION
this avoids the bug where nodes with no url configured think they were selected when the chosenUrl is nil (because choosing a sequncer failed)