### PR TITLE
refactor: sequencer inbox DAS changes

### DIFF
--- a/contracts/src/bridge/ISequencerInbox.sol
+++ b/contracts/src/bridge/ISequencerInbox.sol
@@ -56,8 +56,8 @@ interface ISequencerInbox is IDelayedMessageProvider {
     /// @dev Thrown when someone attempts to read more messages than exist
     error DelayedTooFar();
 
-    /// @dev Thrown if the length of the batch isn't long enough
-    error DataLengthOverflow();
+    /// @dev Thrown if the length of the batch isn't long enough to be valid
+    error DataLengthUnderflow();
 
     /// @dev Force include can only read messages more blocks old than the delay period
     error ForceIncludeBlockTooSoon();

--- a/contracts/src/bridge/ISequencerInbox.sol
+++ b/contracts/src/bridge/ISequencerInbox.sol
@@ -56,9 +56,6 @@ interface ISequencerInbox is IDelayedMessageProvider {
     /// @dev Thrown when someone attempts to read more messages than exist
     error DelayedTooFar();
 
-    /// @dev Thrown if the length of the batch isn't long enough to be valid
-    error DataLengthUnderflow();
-
     /// @dev Force include can only read messages more blocks old than the delay period
     error ForceIncludeBlockTooSoon();
 

--- a/contracts/src/bridge/ISequencerInbox.sol
+++ b/contracts/src/bridge/ISequencerInbox.sol
@@ -56,7 +56,7 @@ interface ISequencerInbox is IDelayedMessageProvider {
     /// @dev Thrown when someone attempts to read more messages than exist
     error DelayedTooFar();
 
-    /// @dev Thrown if the length of the header plus the length of the batch overflows
+    /// @dev Thrown if the length of the batch isn't long enough
     error DataLengthOverflow();
 
     /// @dev Force include can only read messages more blocks old than the delay period

--- a/contracts/src/bridge/SequencerInbox.sol
+++ b/contracts/src/bridge/SequencerInbox.sol
@@ -204,7 +204,6 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
 
     modifier validateBatchData(bytes calldata data) {
         uint256 fullDataLen = HEADER_LENGTH + data.length;
-        if (fullDataLen < HEADER_LENGTH) revert DataLengthOverflow();
         if (fullDataLen > MAX_DATA_SIZE) revert DataTooLarge(fullDataLen, MAX_DATA_SIZE);
         if (data.length > 0 && (data[0] & DATA_AUTHENTICATED_FLAG) == DATA_AUTHENTICATED_FLAG) {
             revert DataNotAuthenticated();

--- a/contracts/src/bridge/SequencerInbox.sol
+++ b/contracts/src/bridge/SequencerInbox.sol
@@ -213,7 +213,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
             // not a DAS batch, so we don't need keyset validation
             _;
         } else {
-            if(data.length < 33) revert DataLengthUnderflow();
+            if (data.length < 33) revert DataLengthUnderflow();
             bytes32 dasKeysetHash = bytes32(data[1:33]);
             if (!dasKeySetInfo[dasKeysetHash].isValidKeyset) revert NoSuchKeyset(dasKeysetHash);
             _;
@@ -362,7 +362,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
      */
     function invalidateKeysetHash(bytes32 ksHash) external onlyRollupOwner {
         if (!dasKeySetInfo[ksHash].isValidKeyset) revert NoSuchKeyset(ksHash);
-        dasKeySetInfo[ksHash].isValidKeyset = false;
+        dasKeySetInfo[ksHash] = DasKeySetInfo({isValidKeyset: false, creationBlock: uint64(0)});
         emit InvalidateKeyset(ksHash);
         emit OwnerFunctionCalled(3);
     }
@@ -372,8 +372,8 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     }
 
     function getKeysetCreationBlock(bytes32 ksHash) external view returns (uint256) {
-        DasKeySetInfo memory ksInfo = dasKeySetInfo[ksHash];
-        if (ksInfo.creationBlock == 0 || !ksInfo.isValidKeyset) revert NoSuchKeyset(ksHash);
-        return uint256(ksInfo.creationBlock);
+        uint64 bnum = dasKeySetInfo[ksHash].creationBlock;
+        if (bnum == 0) revert NoSuchKeyset(ksHash);
+        return uint256(bnum);
     }
 }

--- a/contracts/src/bridge/SequencerInbox.sol
+++ b/contracts/src/bridge/SequencerInbox.sol
@@ -363,6 +363,8 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
      */
     function invalidateKeysetHash(bytes32 ksHash) external onlyRollupOwner {
         if (!dasKeySetInfo[ksHash].isValidKeyset) revert NoSuchKeyset(ksHash);
+        // this is used to fetch the hash preimage in the SetValidKeyset event  
+        // which is emitted when the key is initially created.
         dasKeySetInfo[ksHash].isValidKeyset = false;
         emit InvalidateKeyset(ksHash);
         emit OwnerFunctionCalled(3);
@@ -372,9 +374,10 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         return dasKeySetInfo[ksHash].isValidKeyset;
     }
 
+    /// @notice the creation block is intended to still be available after a keyset is deleted
     function getKeysetCreationBlock(bytes32 ksHash) external view returns (uint256) {
         DasKeySetInfo memory ksInfo = dasKeySetInfo[ksHash];
-        if (ksInfo.creationBlock == 0 || !ksInfo.isValidKeyset) revert NoSuchKeyset(ksHash);
+        if (ksInfo.creationBlock == 0) revert NoSuchKeyset(ksHash);
         return uint256(ksInfo.creationBlock);
     }
 }

--- a/contracts/src/bridge/SequencerInbox.sol
+++ b/contracts/src/bridge/SequencerInbox.sol
@@ -213,7 +213,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
             // not a DAS batch, so we don't need keyset validation
             _;
         } else {
-            if(data.length < 33) revert DataLengthOverflow();
+            if(data.length < 33) revert DataLengthUnderflow();
             bytes32 dasKeysetHash = bytes32(data[1:33]);
             if (!dasKeySetInfo[dasKeysetHash].isValidKeyset) revert NoSuchKeyset(dasKeysetHash);
             _;

--- a/contracts/src/bridge/SequencerInbox.sol
+++ b/contracts/src/bridge/SequencerInbox.sol
@@ -353,8 +353,9 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
      */
     function invalidateKeysetHash(bytes32 ksHash) external onlyRollupOwner {
         if (!dasKeySetInfo[ksHash].isValidKeyset) revert NoSuchKeyset(ksHash);
-        // this is used to fetch the hash preimage in the SetValidKeyset event
-        // which is emitted when the key is initially created.
+        // we don't delete the block creation value since its used to fetch the SetValidKeyset
+        // event efficiently. The event provides the hash preimage of the key.
+        // this is still needed when syncing the chain after a keyset is invalidated.
         dasKeySetInfo[ksHash].isValidKeyset = false;
         emit InvalidateKeyset(ksHash);
         emit OwnerFunctionCalled(3);

--- a/contracts/src/bridge/SequencerInbox.sol
+++ b/contracts/src/bridge/SequencerInbox.sol
@@ -209,11 +209,10 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
             revert DataNotAuthenticated();
         }
         // the first byte is used to identify the type of batch data
-        if (data[0] & 0x80 == 0) {
+        if (data.length < 33 || data[0] & 0x80 == 0) {
             // not a DAS batch, so we don't need keyset validation
             _;
         } else {
-            if (data.length < 33) revert DataLengthUnderflow();
             bytes32 dasKeysetHash = bytes32(data[1:33]);
             if (!dasKeySetInfo[dasKeysetHash].isValidKeyset) revert NoSuchKeyset(dasKeysetHash);
             _;

--- a/contracts/src/bridge/SequencerInbox.sol
+++ b/contracts/src/bridge/SequencerInbox.sol
@@ -363,7 +363,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
      */
     function invalidateKeysetHash(bytes32 ksHash) external onlyRollupOwner {
         if (!dasKeySetInfo[ksHash].isValidKeyset) revert NoSuchKeyset(ksHash);
-        dasKeySetInfo[ksHash] = DasKeySetInfo({isValidKeyset: false, creationBlock: uint64(0)});
+        dasKeySetInfo[ksHash].isValidKeyset = false;
         emit InvalidateKeyset(ksHash);
         emit OwnerFunctionCalled(3);
     }
@@ -373,8 +373,8 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     }
 
     function getKeysetCreationBlock(bytes32 ksHash) external view returns (uint256) {
-        uint64 bnum = dasKeySetInfo[ksHash].creationBlock;
-        if (bnum == 0) revert NoSuchKeyset(ksHash);
-        return uint256(bnum);
+        DasKeySetInfo memory ksInfo = dasKeySetInfo[ksHash];
+        if (ksInfo.creationBlock == 0 || !ksInfo.isValidKeyset) revert NoSuchKeyset(ksHash);
+        return uint256(ksInfo.creationBlock);
     }
 }

--- a/contracts/src/bridge/SequencerInbox.sol
+++ b/contracts/src/bridge/SequencerInbox.sol
@@ -209,10 +209,12 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
             revert DataNotAuthenticated();
         }
         // the first byte is used to identify the type of batch data
+        // das batches expect to have the type byte set, followed by the keyset (so they should have at least 33 bytes)
         if (data.length < 33 || data[0] & 0x80 == 0) {
             // not a DAS batch, so we don't need keyset validation
             _;
         } else {
+            // we skip the first byte, then read the next 32 bytes for the keyset
             bytes32 dasKeysetHash = bytes32(data[1:33]);
             if (!dasKeySetInfo[dasKeysetHash].isValidKeyset) revert NoSuchKeyset(dasKeysetHash);
             _;

--- a/contracts/src/bridge/SequencerInbox.sol
+++ b/contracts/src/bridge/SequencerInbox.sol
@@ -39,7 +39,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
 
     struct DasKeySetInfo {
         bool isValidKeyset;
-        uint64 creationBlock;
+        uint64[] blocksValueUpdated;
     }
     mapping(bytes32 => DasKeySetInfo) public dasKeySetInfo;
 
@@ -346,11 +346,12 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
      */
     function setValidKeyset(bytes calldata keysetBytes) external onlyRollupOwner {
         bytes32 ksHash = keccak256(keysetBytes);
-        if (dasKeySetInfo[ksHash].isValidKeyset) revert AlreadyValidDASKeyset(ksHash);
-        dasKeySetInfo[ksHash] = DasKeySetInfo({
-            isValidKeyset: true,
-            creationBlock: uint64(block.number)
-        });
+        DasKeySetInfo storage dkInfo = dasKeySetInfo[ksHash];
+        if (dkInfo.isValidKeyset) revert AlreadyValidDASKeyset(ksHash);
+
+        dkInfo.isValidKeyset = true;
+        dkInfo.blocksValueUpdated.push(uint64(block.number));
+
         emit SetValidKeyset(ksHash, keysetBytes);
         emit OwnerFunctionCalled(2);
     }
@@ -360,8 +361,12 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
      * @param ksHash hash of the keyset
      */
     function invalidateKeysetHash(bytes32 ksHash) external onlyRollupOwner {
-        if (!dasKeySetInfo[ksHash].isValidKeyset) revert NoSuchKeyset(ksHash);
-        dasKeySetInfo[ksHash] = DasKeySetInfo({isValidKeyset: false, creationBlock: uint64(0)});
+        DasKeySetInfo storage dkInfo = dasKeySetInfo[ksHash];
+        if (!dkInfo.isValidKeyset) revert NoSuchKeyset(ksHash);
+
+        dkInfo.isValidKeyset = false;
+        dkInfo.blocksValueUpdated.push(uint64(block.number));
+
         emit InvalidateKeyset(ksHash);
         emit OwnerFunctionCalled(3);
     }
@@ -371,8 +376,23 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     }
 
     function getKeysetCreationBlock(bytes32 ksHash) external view returns (uint256) {
-        uint64 bnum = dasKeySetInfo[ksHash].creationBlock;
-        if (bnum == 0) revert NoSuchKeyset(ksHash);
+        DasKeySetInfo storage dkInfo = dasKeySetInfo[ksHash];
+        uint256 length = dkInfo.blocksValueUpdated.length;
+        if (length == 0) revert NoSuchKeyset(ksHash);
+        uint64 bnum = dkInfo.blocksValueUpdated[0];
         return uint256(bnum);
+    }
+
+    function getKeysetLatestBlock(bytes32 ksHash) external view returns (uint256) {
+        DasKeySetInfo storage dkInfo = dasKeySetInfo[ksHash];
+        uint256 length = dkInfo.blocksValueUpdated.length;
+        if (length == 0) revert NoSuchKeyset(ksHash);
+        uint64 bnum = dkInfo.blocksValueUpdated[length - 1];
+        return uint256(bnum);
+    }
+
+    function getKeysetBlocksLength(bytes32 ksHash) external view returns (uint256) {
+        DasKeySetInfo storage dkInfo = dasKeySetInfo[ksHash];
+        return dkInfo.blocksValueUpdated.length;
     }
 }

--- a/contracts/src/bridge/SequencerInbox.sol
+++ b/contracts/src/bridge/SequencerInbox.sol
@@ -214,7 +214,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
             // not a DAS batch, so we don't need keyset validation
             _;
         } else {
-            // the data length should always be > 33 here due to the HEADER_LENGTH check above
+            if(data.length < 33) revert DataLengthOverflow();
             bytes32 dasKeysetHash = bytes32(data[1:33]);
             if (!dasKeySetInfo[dasKeysetHash].isValidKeyset) revert NoSuchKeyset(dasKeysetHash);
             _;


### PR DESCRIPTION
Refactored a couple things:
 - removed a calldata to memory copy when processing batches
 - removed low level assembly syntax
 - refactored batch data validation into a single modifier
 - removed overflow validation step which isn't needed in solidity >= 0.8
 - added a struct to track DAS keysets