### PR TITLE
use remote types

### DIFF
--- a/arbitrator/prover/src/binary.rs
+++ b/arbitrator/prover/src/binary.rs
@@ -234,9 +234,6 @@ pub struct Local {
 pub struct NameCustomSection {
     pub module: String,
     pub functions: HashMap<u32, String>,
-    // TODO: remove this when re-initializing the rollup
-    // this is kept around to deserialize old binaries
-    pub _locals_removed: HashMap<u32, HashMap<u32, String>>,
 }
 
 #[derive(Clone, Default)]

--- a/arbitrator/prover/src/machine.rs
+++ b/arbitrator/prover/src/machine.rs
@@ -8,7 +8,7 @@ use crate::{
     memory::Memory,
     merkle::{Merkle, MerkleType},
     reinterpret::{ReinterpretAsSigned, ReinterpretAsUnsigned},
-    utils::{file_bytes, Bytes32, CBytes, DeprecatedTableType},
+    utils::{file_bytes, Bytes32, CBytes, RemoteTableType},
     value::{ArbValueType, FunctionType, IntegerValType, ProgramCounter, Value},
     wavm::{
         pack_cross_module_call, unpack_cross_module_call, wasm_to_wavm, FloatingPointImpls,
@@ -21,7 +21,7 @@ use fnv::FnvHashMap as HashMap;
 use num::{traits::PrimInt, Zero};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, FromInto};
+use serde_with::serde_as;
 use sha3::Keccak256;
 use std::{
     borrow::Cow,
@@ -211,7 +211,7 @@ impl TableElement {
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct Table {
-    #[serde_as(as = "FromInto<DeprecatedTableType>")]
+    #[serde(with = "RemoteTableType")]
     ty: TableType,
     elems: Vec<TableElement>,
     #[serde(skip)]
@@ -1102,7 +1102,6 @@ impl Machine {
         let mut entrypoint_names = NameCustomSection {
             module: "entry".into(),
             functions: HashMap::default(),
-            _locals_removed: HashMap::default(),
         };
         entrypoint_names
             .functions

--- a/arbitrator/prover/src/utils.rs
+++ b/arbitrator/prover/src/utils.rs
@@ -102,19 +102,6 @@ impl fmt::Debug for Bytes32 {
     }
 }
 
-impl From<DeprecatedTableType> for TableType {
-    fn from(table: DeprecatedTableType) -> Self {
-        Self {
-            element_type: match table.ty {
-                DeprecatedRefType::FuncRef => Type::FuncRef,
-                DeprecatedRefType::ExternRef => Type::ExternRef,
-            },
-            initial: table.limits.minimum_size,
-            maximum: table.limits.maximum_size,
-        }
-    }
-}
-
 /// A Vec<u8> allocated with libc::malloc
 pub struct CBytes {
     ptr: *mut u8,
@@ -150,46 +137,6 @@ impl fmt::Debug for CBytes {
     }
 }
 
-// TODO: remove this when re-initializing the rollup
-// this is kept around to deserialize old binaries
-#[derive(Serialize, Deserialize)]
-pub enum DeprecatedRefType {
-    FuncRef,
-    ExternRef,
-}
-
-// TODO: remove this when re-initializing the rollup
-// this is kept around to deserialize old binaries
-#[derive(Serialize, Deserialize)]
-pub struct DeprecatedLimits {
-    pub minimum_size: u32,
-    pub maximum_size: Option<u32>,
-}
-
-// TODO: remove this when re-initializing the rollup
-// this is kept around to deserialize old binaries
-#[derive(Serialize, Deserialize)]
-pub struct DeprecatedTableType {
-    pub ty: DeprecatedRefType,
-    pub limits: DeprecatedLimits,
-}
-
-impl From<TableType> for DeprecatedTableType {
-    fn from(table: TableType) -> Self {
-        Self {
-            ty: match table.element_type {
-                Type::FuncRef => DeprecatedRefType::FuncRef,
-                Type::ExternRef => DeprecatedRefType::ExternRef,
-                x => panic!("impossible table type {:?}", x),
-            },
-            limits: DeprecatedLimits {
-                minimum_size: table.initial,
-                maximum_size: table.maximum,
-            },
-        }
-    }
-}
-
 impl From<&[u8]> for CBytes {
     fn from(slice: &[u8]) -> Self {
         if slice.is_empty() {
@@ -207,6 +154,27 @@ impl From<&[u8]> for CBytes {
             }
         }
     }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Type")]
+enum RemoteType {
+    I32,
+    I64,
+    F32,
+    F64,
+    V128,
+    FuncRef,
+    ExternRef,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "TableType")]
+pub struct RemoteTableType {
+    #[serde(with = "RemoteType")]
+    pub element_type: Type,
+    pub initial: u32,
+    pub maximum: Option<u32>,
 }
 
 impl Drop for CBytes {


### PR DESCRIPTION
Breaks compatibility with the old binary format to remove some technical debt around serialization