### PR TITLE
Enable parallel tests

### DIFF
--- a/broadcastclient/broadcastclient_test.go
+++ b/broadcastclient/broadcastclient_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestReceiveMessages(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -109,6 +110,7 @@ func startMakeBroadcastClient(ctx context.Context, t *testing.T, addr net.Addr, 
 }
 
 func TestServerClientDisconnect(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -158,6 +160,7 @@ func TestServerClientDisconnect(t *testing.T) {
 }
 
 func TestBroadcastClientReconnectsOnServerDisconnect(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -187,6 +190,7 @@ func TestBroadcastClientReconnectsOnServerDisconnect(t *testing.T) {
 }
 
 func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
+	t.Parallel()
 	/* Uncomment to enable logging
 	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
 	glogger.Verbosity(log.LvlTrace)

--- a/das/aggregator_test.go
+++ b/das/aggregator_test.go
@@ -264,6 +264,7 @@ func testConfigurableStorageFailures(t *testing.T, shouldFailAggregation bool) {
 }
 
 func initTest(t *testing.T) int {
+	t.Parallel()
 	seed := time.Now().UnixNano()
 	seedStr := os.Getenv("SEED")
 	if len(seedStr) > 0 {

--- a/das/restful_server.go
+++ b/das/restful_server.go
@@ -32,22 +32,6 @@ func NewRestfulDasServer(address string, port uint64, storageService arbstate.Da
 	return NewRestfulDasServerOnListener(listener, storageService)
 }
 
-func NewRestfulDasServerOnRandomPort(address string, storageService arbstate.DataAvailabilityReader) (*RestfulDasServer, int, error) {
-	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", address))
-	if err != nil {
-		return nil, 0, err
-	}
-	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
-	if !ok {
-		return nil, 0, errors.New("attempt to listen on TCP returned non-TCP address")
-	}
-	rds, err := NewRestfulDasServerOnListener(listener, storageService)
-	if err != nil {
-		return nil, 0, err
-	}
-	return rds, tcpAddr.Port, nil
-}
-
 func NewRestfulDasServerOnListener(listener net.Listener, storageService arbstate.DataAvailabilityReader) (*RestfulDasServer, error) {
 
 	ret := &RestfulDasServer{

--- a/das/restful_server.go
+++ b/das/restful_server.go
@@ -32,6 +32,22 @@ func NewRestfulDasServer(address string, port uint64, storageService arbstate.Da
 	return NewRestfulDasServerOnListener(listener, storageService)
 }
 
+func NewRestfulDasServerOnRandomPort(address string, storageService arbstate.DataAvailabilityReader) (*RestfulDasServer, int, error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", address))
+	if err != nil {
+		return nil, 0, err
+	}
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return nil, 0, errors.New("attempt to listen on TCP returned non-TCP address")
+	}
+	rds, err := NewRestfulDasServerOnListener(listener, storageService)
+	if err != nil {
+		return nil, 0, err
+	}
+	return rds, tcpAddr.Port, nil
+}
+
 func NewRestfulDasServerOnListener(listener net.Listener, storageService arbstate.DataAvailabilityReader) (*RestfulDasServer, error) {
 
 	ret := &RestfulDasServer{

--- a/das/restful_server_list_test.go
+++ b/das/restful_server_list_test.go
@@ -77,7 +77,7 @@ func newListHttpServerForTest(t *testing.T, contents string) (int, *http.Server)
 	server := &http.Server{
 		Handler: &testHandler{contents},
 	}
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "localhost:0")
 	Require(t, err)
 	go func() {
 		_ = server.Serve(listener)

--- a/das/restful_server_test.go
+++ b/das/restful_server_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 const LocalServerAddressForTest = "localhost"
-const LocalServerPortForTest = 9877
 
 func TestRestfulClientServer(t *testing.T) { //nolint
 	initTest(t)
@@ -27,7 +26,7 @@ func TestRestfulClientServer(t *testing.T) { //nolint
 	data := []byte("Testing a restful server now.")
 	dataHash := crypto.Keccak256(data)
 
-	server, err := NewRestfulDasServer(LocalServerAddressForTest, LocalServerPortForTest, storage)
+	server, port, err := NewRestfulDasServerOnRandomPort(LocalServerAddressForTest, storage)
 	Require(t, err)
 
 	err = storage.Put(ctx, data, uint64(time.Now().Add(time.Hour).Unix()))
@@ -35,7 +34,7 @@ func TestRestfulClientServer(t *testing.T) { //nolint
 
 	time.Sleep(100 * time.Millisecond)
 
-	client := NewRestfulDasClient("http", LocalServerAddressForTest, LocalServerPortForTest)
+	client := NewRestfulDasClient("http", LocalServerAddressForTest, port)
 	returnedData, err := client.GetByHash(ctx, dataHash)
 	Require(t, err)
 	if !bytes.Equal(data, returnedData) {

--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func testBlockValidatorSimple(t *testing.T, dasModeString string, expensiveTx bool) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/system_tests/bloom_test.go
+++ b/system_tests/bloom_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestBloom(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	nodeconfig := arbnode.ConfigDefaultL2Test()

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -406,6 +406,7 @@ func enableLogging(logLvl int) {
 }
 
 func initTest(t *testing.T) {
+	t.Parallel()
 	loggingStr := os.Getenv("LOGGING")
 	if len(loggingStr) > 0 {
 		var err error

--- a/system_tests/delayedinboxlong_test.go
+++ b/system_tests/delayedinboxlong_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestDelayInboxLong(t *testing.T) {
+	t.Parallel()
 	addLocalLoops := 3
 	messagesPerAddLocal := 1000
 	messagesPerDelayed := 10

--- a/system_tests/fees_test.go
+++ b/system_tests/fees_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestTips(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	l2info, _, l2client, l1info, _, l1client, stack := CreateTestNodeOnL1(t, ctx, true)
@@ -105,6 +106,7 @@ func TestSequencerWontPostWhenNotPreferred(t *testing.T) {
 }
 
 func TestSequencerFeePaid(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	l2info, _, l2client, _, _, _, stack := CreateTestNodeOnL1(t, ctx, true)

--- a/system_tests/initialization_test.go
+++ b/system_tests/initialization_test.go
@@ -45,6 +45,7 @@ func InitOneContract(prand *testhelpers.PseudoRandomDataSource) (*statetransfer.
 }
 
 func TestInitContract(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	expectedSums := make(map[common.Address]*big.Int)

--- a/system_tests/outbox_test.go
+++ b/system_tests/outbox_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestOutboxProofs(t *testing.T) {
+	t.Parallel()
 	arbstate.RequireHookedGeth()
 	rand.Seed(time.Now().UTC().UnixNano())
 	ctx, cancel := context.WithCancel(context.Background())

--- a/system_tests/retryable_test.go
+++ b/system_tests/retryable_test.go
@@ -99,6 +99,7 @@ func TestRetryableNoExist(t *testing.T) {
 }
 
 func TestSubmitRetryableImmediateSuccess(t *testing.T) {
+	t.Parallel()
 	l2info, l1info, l2client, l1client, delayedInbox, lookupSubmitRetryableL2TxHash, ctx, teardown := retryableSetup(t)
 	defer teardown()
 
@@ -168,6 +169,7 @@ func TestSubmitRetryableImmediateSuccess(t *testing.T) {
 }
 
 func TestSubmitRetryableFailThenRetry(t *testing.T) {
+	t.Parallel()
 	l2info, l1info, l2client, l1client, delayedInbox, lookupSubmitRetryableL2TxHash, ctx, teardown := retryableSetup(t)
 	defer teardown()
 
@@ -247,6 +249,7 @@ func TestSubmitRetryableFailThenRetry(t *testing.T) {
 }
 
 func TestSubmissionGasCosts(t *testing.T) {
+	t.Parallel()
 	l2info, l1info, l2client, l1client, delayedInbox, _, ctx, teardown := retryableSetup(t)
 	defer teardown()
 

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -32,6 +32,7 @@ func newBroadcastClientConfigTest(port int) *broadcastclient.BroadcastClientConf
 }
 
 func TestSequencerFeed(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -67,6 +68,7 @@ func TestSequencerFeed(t *testing.T) {
 }
 
 func TestRelayedSequencerFeed(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -111,6 +113,7 @@ func TestRelayedSequencerFeed(t *testing.T) {
 }
 
 func testLyingSequencer(t *testing.T, dasModeStr string) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/system_tests/seqinbox_test.go
+++ b/system_tests/seqinbox_test.go
@@ -39,6 +39,7 @@ type blockTestState struct {
 const seqInboxTestIters = 40
 
 func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	conf := arbnode.ConfigDefaultL1Test()

--- a/system_tests/staker_test.go
+++ b/system_tests/staker_test.go
@@ -53,6 +53,7 @@ func makeBackgroundTxs(ctx context.Context, l2info *BlockchainTestInfo, l2client
 }
 
 func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) {
+	t.Parallel()
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
 	l2info, l2nodeA, l2clientA, l1info, _, l1client, l1stack := CreateTestNodeOnL1(t, ctx, true)

--- a/system_tests/twonodes_test.go
+++ b/system_tests/twonodes_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func testTwoNodesSimple(t *testing.T, dasModeStr string) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/system_tests/twonodeslong_test.go
+++ b/system_tests/twonodeslong_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func testTwoNodesLong(t *testing.T, dasModeStr string) {
+	t.Parallel()
 	largeLoops := 8
 	avgL2MsgsPerLoop := 30
 	avgDelayedMessagesPerLoop := 10


### PR DESCRIPTION
- Calls `t.Parallel()` in any test that takes over a second
- Uses a random port for the DAS tests (the lack of this was causing random failures even before this change)
- Shrinks the runtime on my system from 173s to 38s (78%!)