### PR TITLE
Make poster cache tx cache atomic

### DIFF
--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -210,8 +210,8 @@ func ProduceBlockAdvanced(
 
 			if gasPrice.Sign() > 0 {
 				dataGas = math.MaxUint64
-				state.L1PricingState().AddPosterInfo(tx, sender, poster)
-				posterCostInL2Gas := arbmath.BigDiv(tx.PosterCost, gasPrice)
+				posterCost, _ := state.L1PricingState().GetPosterInfo(tx, sender, poster)
+				posterCostInL2Gas := arbmath.BigDiv(posterCost, gasPrice)
 
 				if posterCostInL2Gas.IsUint64() {
 					dataGas = posterCostInL2Gas.Uint64()


### PR DESCRIPTION
Unfortunately, geth master has become a reinit branch, so this includes a geth change that can't be merged: https://github.com/OffchainLabs/go-ethereum/pull/117

I'll handle merging this into the nitro reinit branch after it's merged into master.