### PR TITLE
feat: expose isSpent in Outbox

### DIFF
--- a/contracts/src/bridge/Outbox.sol
+++ b/contracts/src/bridge/Outbox.sol
@@ -226,7 +226,7 @@ contract Outbox is DelegateCallAware, IOutbox {
         return ((replay >> bitOffset) & bytes32(uint256(1))) != bytes32(0);
     }
 
-    function isSpent(uint256 index) public view returns (bool) {
+    function isSpent(uint256 index) external view returns (bool) {
         (, uint256 bitOffset, bytes32 replay) = _calcSpentIndexOffset(index);
         return _isSpent(bitOffset, replay);
     }


### PR DESCRIPTION
Since https://github.com/OffchainLabs/nitro/pull/623 there are no easy way to see if a certain outbox entry is spent, this PR expose a helper function isSpent to solve that.