### PR TITLE
Pricing time delta fix

### DIFF
--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -87,7 +87,7 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 		l1BaseFeeWei, _ := inputs[4].(*big.Int)
 
 		weiSpent := arbmath.BigMulByUint(l1BaseFeeWei, batchDataGas)
-		err = state.L1PricingState().UpdateForBatchPosterSpending(evm.StateDB, evm, batchTimestamp.Uint64(), evm.Context.Time.Uint64(), batchPosterAddress, weiSpent)
+		err = state.L1PricingState().UpdateForBatchPosterSpending(evm.StateDB, evm, state.FormatVersion(), batchTimestamp.Uint64(), evm.Context.Time.Uint64(), batchPosterAddress, weiSpent)
 		if err != nil {
 			log.Warn("L1Pricing UpdateForSequencerSpending failed", "err", err)
 		}

--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -229,15 +229,15 @@ func (ps *L1PricingState) UpdateForBatchPosterSpending(statedb vm.StateDB, evm *
 	if updateTime >= currentTime || updateTime < lastUpdateTime {
 		return ErrInvalidTime
 	}
-	updateTimeDelta := updateTime - lastUpdateTime
-	timeDelta := currentTime - lastUpdateTime
+	allocationNumerator := updateTime - lastUpdateTime
+	allocationDenominator := currentTime - lastUpdateTime
 
 	// allocate units to this update
 	unitsSinceUpdate, err := ps.UnitsSinceUpdate()
 	if err != nil {
 		return err
 	}
-	unitsAllocated := unitsSinceUpdate * updateTimeDelta / timeDelta
+	unitsAllocated := unitsSinceUpdate * allocationNumerator / allocationDenominator
 	unitsSinceUpdate -= unitsAllocated
 	if err := ps.SetUnitsSinceUpdate(unitsSinceUpdate); err != nil {
 		return err
@@ -262,7 +262,7 @@ func (ps *L1PricingState) UpdateForBatchPosterSpending(statedb vm.StateDB, evm *
 
 	// allocate funds to this update
 	collectedSinceUpdate := statedb.GetBalance(L1PricerFundsPoolAddress)
-	availableFunds := am.BigDivByUint(am.BigMulByUint(collectedSinceUpdate, updateTimeDelta), timeDelta)
+	availableFunds := am.BigDivByUint(am.BigMulByUint(collectedSinceUpdate, allocationNumerator), allocationDenominator)
 
 	// pay rewards, as much as possible
 	paymentForRewards := am.BigMulByUint(am.UintToBig(perUnitReward), unitsAllocated)


### PR DESCRIPTION
If a batch posting report arrives with update time equal to the current (L2) time, this handles it gracefully rather than returning an error.

This is a consensus change, which takes effect at ArbOS version 2.