### PR TITLE
Fix sequencer reorgs caused by delayed messages

### DIFF
--- a/arbnode/delayed_seq_reorg_test.go
+++ b/arbnode/delayed_seq_reorg_test.go
@@ -79,7 +79,21 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 		bridgeAddress:     [20]byte{},
 		serialized:        serializedUserMsgBatch,
 	}
-	err = tracker.AddSequencerBatches(ctx, nil, []*SequencerInboxBatch{initMsgBatch, userMsgBatch})
+	emptyBatch := &SequencerInboxBatch{
+		BlockHash:         [32]byte{},
+		BlockNumber:       0,
+		SequenceNumber:    2,
+		BeforeInboxAcc:    [32]byte{2},
+		AfterInboxAcc:     [32]byte{3},
+		AfterDelayedAcc:   userDelayed.AfterInboxAcc(),
+		AfterDelayedCount: 2,
+		TimeBounds:        bridgegen.ISequencerInboxTimeBounds{},
+		txIndexInBlock:    0,
+		dataLocation:      0,
+		bridgeAddress:     [20]byte{},
+		serialized:        serializedUserMsgBatch,
+	}
+	err = tracker.AddSequencerBatches(ctx, nil, []*SequencerInboxBatch{initMsgBatch, userMsgBatch, emptyBatch})
 	Require(t, err)
 
 	// Reorg out the user delayed message
@@ -104,7 +118,7 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 		Fail(t, "Unexpected tracker batch count", batchCount, "(expected 1)")
 	}
 
-	emptyBatch := &SequencerInboxBatch{
+	emptyBatch = &SequencerInboxBatch{
 		BlockHash:         [32]byte{},
 		BlockNumber:       0,
 		SequenceNumber:    1,

--- a/arbnode/delayed_seq_reorg_test.go
+++ b/arbnode/delayed_seq_reorg_test.go
@@ -1,0 +1,135 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package arbnode
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/offchainlabs/nitro/arbos"
+	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
+)
+
+func TestSequencerReorgFromDelayed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	streamer, db, _ := NewTransactionStreamerForTest(t, common.Address{})
+	tracker, err := NewInboxTracker(db, streamer, nil)
+	Require(t, err)
+
+	init, err := streamer.GetMessage(0)
+	Require(t, err)
+
+	initMsgDelayed := &DelayedInboxMessage{
+		BlockHash:      [32]byte{},
+		BeforeInboxAcc: [32]byte{},
+		Message:        init.Message,
+	}
+	delayedRequestId := common.BigToHash(common.Big1)
+	userDelayed := &DelayedInboxMessage{
+		BlockHash:      [32]byte{},
+		BeforeInboxAcc: initMsgDelayed.AfterInboxAcc(),
+		Message: &arbos.L1IncomingMessage{
+			Header: &arbos.L1IncomingMessageHeader{
+				Kind:        arbos.L1MessageType_EndOfBlock,
+				Poster:      [20]byte{},
+				BlockNumber: 0,
+				Timestamp:   0,
+				RequestId:   &delayedRequestId,
+				L1BaseFee:   common.Big0,
+			},
+		},
+	}
+	err = tracker.AddDelayedMessages([]*DelayedInboxMessage{initMsgDelayed, userDelayed})
+	Require(t, err)
+
+	serializedInitMsgBatch := make([]byte, 40)
+	binary.BigEndian.PutUint64(serializedInitMsgBatch[32:], 1)
+	initMsgBatch := &SequencerInboxBatch{
+		BlockHash:         [32]byte{},
+		BlockNumber:       0,
+		SequenceNumber:    0,
+		BeforeInboxAcc:    [32]byte{},
+		AfterInboxAcc:     [32]byte{1},
+		AfterDelayedAcc:   initMsgDelayed.AfterInboxAcc(),
+		AfterDelayedCount: 1,
+		TimeBounds:        bridgegen.ISequencerInboxTimeBounds{},
+		txIndexInBlock:    0,
+		dataLocation:      0,
+		bridgeAddress:     [20]byte{},
+		serialized:        serializedInitMsgBatch,
+	}
+	serializedUserMsgBatch := make([]byte, 40)
+	binary.BigEndian.PutUint64(serializedUserMsgBatch[32:], 2)
+	userMsgBatch := &SequencerInboxBatch{
+		BlockHash:         [32]byte{},
+		BlockNumber:       0,
+		SequenceNumber:    1,
+		BeforeInboxAcc:    [32]byte{1},
+		AfterInboxAcc:     [32]byte{2},
+		AfterDelayedAcc:   userDelayed.AfterInboxAcc(),
+		AfterDelayedCount: 2,
+		TimeBounds:        bridgegen.ISequencerInboxTimeBounds{},
+		txIndexInBlock:    0,
+		dataLocation:      0,
+		bridgeAddress:     [20]byte{},
+		serialized:        serializedUserMsgBatch,
+	}
+	err = tracker.AddSequencerBatches(ctx, nil, []*SequencerInboxBatch{initMsgBatch, userMsgBatch})
+	Require(t, err)
+
+	// Reorg out the user delayed message
+	err = tracker.ReorgDelayedTo(1)
+	Require(t, err)
+
+	msgCount, err := streamer.GetMessageCount()
+	Require(t, err)
+	if msgCount != 1 {
+		Fail(t, "Unexpected tx streamer message count", msgCount, "(expected 1)")
+	}
+
+	delayedCount, err := tracker.GetDelayedCount()
+	Require(t, err)
+	if delayedCount != 1 {
+		Fail(t, "Unexpected tracker delayed message count", delayedCount, "(expected 1)")
+	}
+
+	batchCount, err := tracker.GetBatchCount()
+	Require(t, err)
+	if batchCount != 1 {
+		Fail(t, "Unexpected tracker batch count", batchCount, "(expected 1)")
+	}
+
+	emptyBatch := &SequencerInboxBatch{
+		BlockHash:         [32]byte{},
+		BlockNumber:       0,
+		SequenceNumber:    1,
+		BeforeInboxAcc:    [32]byte{1},
+		AfterInboxAcc:     [32]byte{2},
+		AfterDelayedAcc:   initMsgDelayed.AfterInboxAcc(),
+		AfterDelayedCount: 1,
+		TimeBounds:        bridgegen.ISequencerInboxTimeBounds{},
+		txIndexInBlock:    0,
+		dataLocation:      0,
+		bridgeAddress:     [20]byte{},
+		serialized:        serializedInitMsgBatch,
+	}
+	err = tracker.AddSequencerBatches(ctx, nil, []*SequencerInboxBatch{emptyBatch})
+	Require(t, err)
+
+	msgCount, err = streamer.GetMessageCount()
+	Require(t, err)
+	if msgCount != 2 {
+		Fail(t, "Unexpected tx streamer message count", msgCount, "(expected 2)")
+	}
+
+	batchCount, err = tracker.GetBatchCount()
+	Require(t, err)
+	if batchCount != 2 {
+		Fail(t, "Unexpected tracker batch count", batchCount, "(expected 2)")
+	}
+}

--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -40,16 +40,17 @@ func NewTransactionStreamerForTest(t *testing.T, ownerAddress common.Address) (*
 		},
 	}
 
-	db := rawdb.NewMemoryDatabase()
+	chainDb := rawdb.NewMemoryDatabase()
+	arbDb := rawdb.NewMemoryDatabase()
 	initReader := statetransfer.NewMemoryInitDataReader(&initData)
 
-	bc, err := WriteOrTestBlockChain(db, nil, initReader, 0, chainConfig)
+	bc, err := WriteOrTestBlockChain(chainDb, nil, initReader, 0, chainConfig)
 
 	if err != nil {
 		Fail(t, err)
 	}
 
-	inbox, err := NewTransactionStreamer(db, bc, nil)
+	inbox, err := NewTransactionStreamer(arbDb, bc, nil)
 	if err != nil {
 		Fail(t, err)
 	}
@@ -60,7 +61,7 @@ func NewTransactionStreamerForTest(t *testing.T, ownerAddress common.Address) (*
 		Fail(t, err)
 	}
 
-	return inbox, db, bc
+	return inbox, arbDb, bc
 }
 
 type blockTestState struct {

--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -22,12 +22,13 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbstate"
 )
 
-func NewTransactionStreamerForTest(t *testing.T, ownerAddress common.Address) (*TransactionStreamer, *core.BlockChain) {
+func NewTransactionStreamerForTest(t *testing.T, ownerAddress common.Address) (*TransactionStreamer, ethdb.Database, *core.BlockChain) {
 	chainConfig := params.ArbitrumDevTestChainConfig()
 
 	initData := statetransfer.ArbosInitializationInfo{
@@ -59,7 +60,7 @@ func NewTransactionStreamerForTest(t *testing.T, ownerAddress common.Address) (*
 		Fail(t, err)
 	}
 
-	return inbox, bc
+	return inbox, db, bc
 }
 
 type blockTestState struct {
@@ -72,7 +73,7 @@ type blockTestState struct {
 func TestTransactionStreamer(t *testing.T) {
 	ownerAddress := common.HexToAddress("0x1111111111111111111111111111111111111111")
 
-	inbox, bc := NewTransactionStreamerForTest(t, ownerAddress)
+	inbox, _, bc := NewTransactionStreamerForTest(t, ownerAddress)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -143,7 +143,7 @@ func TestTransactionStreamer(t *testing.T) {
 						},
 						L2msg: l2Message,
 					},
-					DelayedMessagesRead: 0,
+					DelayedMessagesRead: 1,
 				})
 				state.balances[source].Sub(state.balances[source], value)
 				if state.balances[dest] == nil {

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -277,7 +277,7 @@ func (t *InboxTracker) setDelayedCountReorgAndWriteBatch(batch ethdb.Batch, newD
 		return err
 	}
 
-	seqBatchIter := t.db.NewIterator(delayedSequencedPrefix, uint64ToKey(newDelayedCount))
+	seqBatchIter := t.db.NewIterator(delayedSequencedPrefix, uint64ToKey(newDelayedCount+1))
 	defer seqBatchIter.Release()
 	var reorgSeqBatchesToCount *uint64
 	for seqBatchIter.Next() {

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -29,16 +28,16 @@ type InboxTracker struct {
 	das        arbstate.DataAvailabilityReader
 }
 
-func NewInboxTracker(raw ethdb.Database, txStreamer *TransactionStreamer, das arbstate.DataAvailabilityReader) (*InboxTracker, error) {
+func NewInboxTracker(db ethdb.Database, txStreamer *TransactionStreamer, das arbstate.DataAvailabilityReader) (*InboxTracker, error) {
 	if txStreamer.bc.Config().ArbitrumChainParams.DataAvailabilityCommittee && das == nil {
 		return nil, errors.New("data availability service required but unconfigured")
 	}
-	db := &InboxTracker{
-		db:         rawdb.NewTable(raw, arbitrumPrefix),
+	tracker := &InboxTracker{
+		db:         db,
 		txStreamer: txStreamer,
 		das:        das,
 	}
-	return db, nil
+	return tracker, nil
 }
 
 func (t *InboxTracker) SetBlockValidator(validator *validator.BlockValidator) {

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -85,7 +85,7 @@ func (t *InboxTracker) Initialize() error {
 var accumulatorNotFound error = errors.New("accumulator not found")
 
 func (t *InboxTracker) GetDelayedAcc(seqNum uint64) (common.Hash, error) {
-	key := dbKey(delayedMessagePrefix, seqNum)
+	key := dbKey(delayedMessageColumn, seqNum)
 	hasKey, err := t.db.Has(key)
 	if err != nil {
 		return common.Hash{}, err
@@ -126,7 +126,7 @@ type BatchMetadata struct {
 }
 
 func (t *InboxTracker) GetBatchMetadata(seqNum uint64) (BatchMetadata, error) {
-	key := dbKey(sequencerBatchMetaPrefix, seqNum)
+	key := dbKey(sequencerBatchMetaColumn, seqNum)
 	hasKey, err := t.db.Has(key)
 	if err != nil {
 		return BatchMetadata{}, err
@@ -168,7 +168,7 @@ func (t *InboxTracker) GetBatchCount() (uint64, error) {
 }
 
 func (t *InboxTracker) getDelayedMessageBytesAndAccumulator(seqNum uint64) ([]byte, common.Hash, error) {
-	key := dbKey(delayedMessagePrefix, seqNum)
+	key := dbKey(delayedMessageColumn, seqNum)
 	data, err := t.db.Get(key)
 	if err != nil {
 		return nil, common.Hash{}, err
@@ -240,7 +240,7 @@ func (t *InboxTracker) AddDelayedMessages(messages []*DelayedInboxMessage) error
 		}
 		nextAcc = message.AfterInboxAcc()
 
-		msgKey := dbKey(delayedMessagePrefix, seqNum)
+		msgKey := dbKey(delayedMessageColumn, seqNum)
 
 		msgData, err := message.Message.Serialize()
 		if err != nil {
@@ -263,7 +263,7 @@ func (t *InboxTracker) AddDelayedMessages(messages []*DelayedInboxMessage) error
 // Requires the mutex is held. Sets the delayed count and performs any sequencer batch reorg necessary.
 // Also deletes any future delayed messages.
 func (t *InboxTracker) setDelayedCountReorgAndWriteBatch(batch ethdb.Batch, newDelayedCount uint64) error {
-	err := deleteStartingAt(t.db, batch, delayedMessagePrefix, uint64ToKey(newDelayedCount))
+	err := deleteStartingAt(t.db, batch, delayedMessageColumn, uint64ToKey(newDelayedCount))
 	if err != nil {
 		return err
 	}
@@ -277,16 +277,20 @@ func (t *InboxTracker) setDelayedCountReorgAndWriteBatch(batch ethdb.Batch, newD
 		return err
 	}
 
-	seqBatchIter := t.db.NewIterator(delayedSequencedPrefix, uint64ToKey(newDelayedCount+1))
+	seqBatchIter := t.db.NewIterator(delayedSequencedColumn.Prefix, uint64ToKey(newDelayedCount+1))
 	defer seqBatchIter.Release()
 	var reorgSeqBatchesToCount *uint64
 	for seqBatchIter.Next() {
+		key := seqBatchIter.Key()
+		if len(key) != delayedSequencedColumn.KeyLength() {
+			continue
+		}
 		var batchSeqNum uint64
 		err := rlp.DecodeBytes(seqBatchIter.Value(), &batchSeqNum)
 		if err != nil {
 			return err
 		}
-		err = batch.Delete(seqBatchIter.Key())
+		err = batch.Delete(key)
 		if err != nil {
 			return err
 		}
@@ -319,7 +323,7 @@ func (t *InboxTracker) setDelayedCountReorgAndWriteBatch(batch ethdb.Batch, newD
 			return err
 		}
 		log.Info("InboxTracker", "sequencerBatchCount", count)
-		err = deleteStartingAt(t.db, batch, sequencerBatchMetaPrefix, uint64ToKey(count))
+		err = deleteStartingAt(t.db, batch, sequencerBatchMetaColumn, uint64ToKey(count))
 		if err != nil {
 			return err
 		}
@@ -406,7 +410,7 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L
 	}
 
 	dbBatch := t.db.NewBatch()
-	err := deleteStartingAt(t.db, dbBatch, delayedSequencedPrefix, uint64ToKey(prevbatchmeta.DelayedMessageCount+1))
+	err := deleteStartingAt(t.db, dbBatch, delayedSequencedColumn, uint64ToKey(prevbatchmeta.DelayedMessageCount+1))
 	if err != nil {
 		return err
 	}
@@ -474,7 +478,7 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L
 		if err != nil {
 			return err
 		}
-		err = dbBatch.Put(dbKey(sequencerBatchMetaPrefix, batch.SequenceNumber), metaBytes)
+		err = dbBatch.Put(dbKey(sequencerBatchMetaColumn, batch.SequenceNumber), metaBytes)
 		if err != nil {
 			return err
 		}
@@ -487,7 +491,7 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L
 			return errors.New("batch delayed message count went backwards")
 		}
 		if batch.AfterDelayedCount > lastBatchMeta.DelayedMessageCount {
-			err = dbBatch.Put(dbKey(delayedSequencedPrefix, batch.AfterDelayedCount), seqNumData)
+			err = dbBatch.Put(dbKey(delayedSequencedColumn, batch.AfterDelayedCount), seqNumData)
 			if err != nil {
 				return err
 			}
@@ -495,7 +499,7 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L
 		lastBatchMeta = meta
 	}
 
-	err = deleteStartingAt(t.db, dbBatch, sequencerBatchMetaPrefix, uint64ToKey(pos))
+	err = deleteStartingAt(t.db, dbBatch, sequencerBatchMetaColumn, uint64ToKey(pos))
 	if err != nil {
 		return err
 	}
@@ -592,11 +596,11 @@ func (t *InboxTracker) ReorgBatchesTo(count uint64) error {
 
 	dbBatch := t.db.NewBatch()
 
-	err := deleteStartingAt(t.db, dbBatch, delayedSequencedPrefix, uint64ToKey(prevBatchMeta.DelayedMessageCount+1))
+	err := deleteStartingAt(t.db, dbBatch, delayedSequencedColumn, uint64ToKey(prevBatchMeta.DelayedMessageCount+1))
 	if err != nil {
 		return err
 	}
-	err = deleteStartingAt(t.db, dbBatch, sequencerBatchMetaPrefix, uint64ToKey(count))
+	err = deleteStartingAt(t.db, dbBatch, sequencerBatchMetaColumn, uint64ToKey(count))
 	if err != nil {
 		return err
 	}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -575,6 +575,7 @@ func createNodeImpl(
 	ctx context.Context,
 	stack *node.Node,
 	chainDb ethdb.Database,
+	arbDb ethdb.Database,
 	config *Config,
 	l2BlockChain *core.BlockChain,
 	l1client arbutil.L1Interface,
@@ -592,7 +593,7 @@ func createNodeImpl(
 		l1Reader = headerreader.New(l1client, config.L1Reader)
 	}
 
-	txStreamer, err := NewTransactionStreamer(chainDb, l2BlockChain, broadcastServer)
+	txStreamer, err := NewTransactionStreamer(arbDb, l2BlockChain, broadcastServer)
 	if err != nil {
 		return nil, err
 	}
@@ -685,7 +686,7 @@ func createNodeImpl(
 	}
 
 	var dataAvailabilityReader arbstate.DataAvailabilityReader = dataAvailabilityService
-	inboxTracker, err := NewInboxTracker(chainDb, txStreamer, dataAvailabilityReader)
+	inboxTracker, err := NewInboxTracker(arbDb, txStreamer, dataAvailabilityReader)
 	if err != nil {
 		return nil, err
 	}
@@ -710,7 +711,7 @@ func createNodeImpl(
 
 	var blockValidator *validator.BlockValidator
 	if config.BlockValidator.Enable {
-		blockValidator, err = validator.NewBlockValidator(inboxReader, inboxTracker, txStreamer, l2BlockChain, rawdb.NewTable(chainDb, blockValidatorPrefix), &config.BlockValidator, nitroMachineLoader, dataAvailabilityReader)
+		blockValidator, err = validator.NewBlockValidator(inboxReader, inboxTracker, txStreamer, l2BlockChain, rawdb.NewTable(arbDb, blockValidatorPrefix), &config.BlockValidator, nitroMachineLoader, dataAvailabilityReader)
 		if err != nil {
 			return nil, err
 		}
@@ -958,6 +959,7 @@ func CreateNode(
 	ctx context.Context,
 	stack *node.Node,
 	chainDb ethdb.Database,
+	arbDb ethdb.Database,
 	config *Config,
 	l2BlockChain *core.BlockChain,
 	l1client arbutil.L1Interface,
@@ -965,7 +967,7 @@ func CreateNode(
 	txOpts *bind.TransactOpts,
 	daSigner das.DasSigner,
 ) (newNode *Node, err error) {
-	currentNode, err := createNodeImpl(ctx, stack, chainDb, config, l2BlockChain, l1client, deployInfo, txOpts, daSigner)
+	currentNode, err := createNodeImpl(ctx, stack, chainDb, arbDb, config, l2BlockChain, l1client, deployInfo, txOpts, daSigner)
 	if err != nil {
 		return nil, err
 	}

--- a/arbnode/schema.go
+++ b/arbnode/schema.go
@@ -3,13 +3,27 @@
 
 package arbnode
 
+type databaseColumn struct {
+	Prefix               []byte
+	keyLengthAfterPrefix int
+}
+
+func (c *databaseColumn) KeyLength() int {
+	fullLen := len(c.Prefix) + c.keyLengthAfterPrefix
+	if fullLen+len(arbitrumPrefix) == 32 {
+		panic("Database column with prefix " + string(c.Prefix) + " has the same key length as a hash")
+	}
+	return fullLen
+}
+
 var (
-	arbitrumPrefix           string = "\t"                 // the prefix for all Arbitrum specific keys
-	blockValidatorPrefix     string = arbitrumPrefix + "v" // the prefix for all block validator keys
-	messagePrefix            []byte = []byte("m")          // maps a message sequence number to a message
-	delayedMessagePrefix     []byte = []byte("d")          // maps a delayed sequence number to an accumulator and a message
-	sequencerBatchMetaPrefix []byte = []byte("s")          // maps a batch sequence number to BatchMetadata
-	delayedSequencedPrefix   []byte = []byte("a")          // maps a delayed message count to the first sequencer batch sequence number with this delayed count
+	arbitrumPrefix       = "\t"                 // the prefix for all Arbitrum specific keys
+	blockValidatorPrefix = arbitrumPrefix + "v" // the prefix for all block validator keys
+
+	messageColumn            = databaseColumn{[]byte("m"), 8} // maps a message sequence number to a message
+	delayedMessageColumn     = databaseColumn{[]byte("d"), 8} // maps a delayed sequence number to an accumulator and a message
+	sequencerBatchMetaColumn = databaseColumn{[]byte("s"), 8} // maps a batch sequence number to BatchMetadata
+	delayedSequencedColumn   = databaseColumn{[]byte("a"), 8} // maps a delayed message count to the first sequencer batch sequence number with this delayed count
 
 	messageCountKey        []byte = []byte("_messageCount")        // contains the current message count
 	delayedMessageCountKey []byte = []byte("_delayedMessageCount") // contains the current delayed message count

--- a/arbnode/schema.go
+++ b/arbnode/schema.go
@@ -4,12 +4,11 @@
 package arbnode
 
 var (
-	arbitrumPrefix           string = "\t"                 // the prefix for all Arbitrum specific keys
-	blockValidatorPrefix     string = arbitrumPrefix + "v" // the prefix for all block validator keys
-	messagePrefix            []byte = []byte("m")          // maps a message sequence number to a message
-	delayedMessagePrefix     []byte = []byte("d")          // maps a delayed sequence number to an accumulator and a message
-	sequencerBatchMetaPrefix []byte = []byte("s")          // maps a batch sequence number to BatchMetadata
-	delayedSequencedPrefix   []byte = []byte("a")          // maps a delayed message count to the first sequencer batch sequence number with this delayed count
+	blockValidatorPrefix     string = "v"         // the prefix for all block validator keys
+	messagePrefix            []byte = []byte("m") // maps a message sequence number to a message
+	delayedMessagePrefix     []byte = []byte("d") // maps a delayed sequence number to an accumulator and a message
+	sequencerBatchMetaPrefix []byte = []byte("s") // maps a batch sequence number to BatchMetadata
+	delayedSequencedPrefix   []byte = []byte("a") // maps a delayed message count to the first sequencer batch sequence number with this delayed count
 
 	messageCountKey        []byte = []byte("_messageCount")        // contains the current message count
 	delayedMessageCountKey []byte = []byte("_delayedMessageCount") // contains the current delayed message count

--- a/arbnode/schema.go
+++ b/arbnode/schema.go
@@ -3,27 +3,13 @@
 
 package arbnode
 
-type databaseColumn struct {
-	Prefix               []byte
-	keyLengthAfterPrefix int
-}
-
-func (c *databaseColumn) KeyLength() int {
-	fullLen := len(c.Prefix) + c.keyLengthAfterPrefix
-	if fullLen+len(arbitrumPrefix) == 32 {
-		panic("Database column with prefix " + string(c.Prefix) + " has the same key length as a hash")
-	}
-	return fullLen
-}
-
 var (
-	arbitrumPrefix       = "\t"                 // the prefix for all Arbitrum specific keys
-	blockValidatorPrefix = arbitrumPrefix + "v" // the prefix for all block validator keys
-
-	messageColumn            = databaseColumn{[]byte("m"), 8} // maps a message sequence number to a message
-	delayedMessageColumn     = databaseColumn{[]byte("d"), 8} // maps a delayed sequence number to an accumulator and a message
-	sequencerBatchMetaColumn = databaseColumn{[]byte("s"), 8} // maps a batch sequence number to BatchMetadata
-	delayedSequencedColumn   = databaseColumn{[]byte("a"), 8} // maps a delayed message count to the first sequencer batch sequence number with this delayed count
+	arbitrumPrefix           string = "\t"                 // the prefix for all Arbitrum specific keys
+	blockValidatorPrefix     string = arbitrumPrefix + "v" // the prefix for all block validator keys
+	messagePrefix            []byte = []byte("m")          // maps a message sequence number to a message
+	delayedMessagePrefix     []byte = []byte("d")          // maps a delayed sequence number to an accumulator and a message
+	sequencerBatchMetaPrefix []byte = []byte("s")          // maps a batch sequence number to BatchMetadata
+	delayedSequencedPrefix   []byte = []byte("a")          // maps a delayed message count to the first sequencer batch sequence number with this delayed count
 
 	messageCountKey        []byte = []byte("_messageCount")        // contains the current message count
 	delayedMessageCountKey []byte = []byte("_delayedMessageCount") // contains the current delayed message count

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -60,7 +59,7 @@ type TransactionStreamer struct {
 
 func NewTransactionStreamer(db ethdb.Database, bc *core.BlockChain, broadcastServer *broadcaster.Broadcaster) (*TransactionStreamer, error) {
 	inbox := &TransactionStreamer{
-		db:                 rawdb.NewTable(db, arbitrumPrefix),
+		db:                 db,
 		bc:                 bc,
 		newMessageNotifier: make(chan struct{}, 1),
 		newBlockNotifier:   make(chan struct{}, 1),

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -272,11 +273,13 @@ func (s *TransactionStreamer) AddFakeInitMessage() error {
 	return s.AddMessages(0, false, []arbstate.MessageWithMetadata{{
 		Message: &arbos.L1IncomingMessage{
 			Header: &arbos.L1IncomingMessageHeader{
-				Kind: arbos.L1MessageType_Initialize,
+				Kind:      arbos.L1MessageType_Initialize,
+				RequestId: &common.Hash{},
+				L1BaseFee: common.Big0,
 			},
 			L2msg: math.U256Bytes(s.bc.Config().ChainID),
 		},
-		DelayedMessagesRead: 0,
+		DelayedMessagesRead: 1,
 	}})
 }
 

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -142,15 +142,11 @@ func (s *TransactionStreamer) ReorgToAndEndBatch(batch ethdb.Batch, count arbuti
 	return batch.Write()
 }
 
-func deleteStartingAt(db ethdb.Database, batch ethdb.Batch, column databaseColumn, minKey []byte) error {
-	iter := db.NewIterator(column.Prefix, minKey)
+func deleteStartingAt(db ethdb.Database, batch ethdb.Batch, prefix []byte, minKey []byte) error {
+	iter := db.NewIterator(prefix, minKey)
 	defer iter.Release()
 	for iter.Next() {
-		key := iter.Key()
-		if len(key) != column.KeyLength() {
-			continue
-		}
-		err := batch.Delete(key)
+		err := batch.Delete(iter.Key())
 		if err != nil {
 			return err
 		}
@@ -188,7 +184,7 @@ func (s *TransactionStreamer) reorgToInternal(batch ethdb.Batch, count arbutil.M
 		log.Warn("reorg target block not found", "block", targetBlock)
 	}
 
-	err = deleteStartingAt(s.db, batch, messageColumn, uint64ToKey(uint64(count)))
+	err = deleteStartingAt(s.db, batch, messagePrefix, uint64ToKey(uint64(count)))
 	if err != nil {
 		return err
 	}
@@ -204,16 +200,16 @@ func (s *TransactionStreamer) reorgToInternal(batch ethdb.Batch, count arbutil.M
 	return nil
 }
 
-func dbKey(column databaseColumn, pos uint64) []byte {
+func dbKey(prefix []byte, pos uint64) []byte {
 	var key []byte
-	key = append(key, column.Prefix...)
+	key = append(key, prefix...)
 	key = append(key, uint64ToKey(uint64(pos))...)
 	return key
 }
 
 // Note: if changed to acquire the mutex, some internal users may need to be updated to a non-locking version.
 func (s *TransactionStreamer) GetMessage(seqNum arbutil.MessageIndex) (arbstate.MessageWithMetadata, error) {
-	key := dbKey(messageColumn, uint64(seqNum))
+	key := dbKey(messagePrefix, uint64(seqNum))
 	data, err := s.db.Get(key)
 	if err != nil {
 		return arbstate.MessageWithMetadata{}, err
@@ -326,7 +322,7 @@ func (s *TransactionStreamer) addMessagesAndEndBatchImpl(pos arbutil.MessageInde
 		if len(messages) == 0 {
 			break
 		}
-		key := dbKey(messageColumn, uint64(pos))
+		key := dbKey(messagePrefix, uint64(pos))
 		hasMessage, err := s.db.Has(key)
 		if err != nil {
 			return err
@@ -643,7 +639,7 @@ func (s *TransactionStreamer) writeMessages(pos arbutil.MessageIndex, messages [
 		batch = s.db.NewBatch()
 	}
 	for i, msg := range messages {
-		key := dbKey(messageColumn, uint64(pos)+uint64(i))
+		key := dbKey(messagePrefix, uint64(pos)+uint64(i))
 		msgBytes, err := rlp.EncodeToBytes(msg)
 		if err != nil {
 			return err

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -180,7 +180,7 @@ func (s *TransactionStreamer) reorgToInternal(batch ethdb.Batch, count arbutil.M
 			return err
 		}
 	} else {
-		log.Warn("reorg target block not found", "block", targetBlock)
+		log.Warn("reorg target block not found", "block", blockNum)
 	}
 
 	err = deleteStartingAt(s.db, batch, messagePrefix, uint64ToKey(uint64(count)))

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -71,7 +71,7 @@ func NewTransactionStreamer(db ethdb.Database, bc *core.BlockChain, broadcastSer
 // Encodes a uint64 as bytes in a lexically sortable manner for database iteration.
 // Generally this is only used for database keys, which need sorted.
 // A shorter RLP encoding is usually used for database values.
-func uint64ToBytes(x uint64) []byte {
+func uint64ToKey(x uint64) []byte {
 	data := make([]byte, 8)
 	binary.BigEndian.PutUint64(data, x)
 	return data
@@ -183,7 +183,7 @@ func (s *TransactionStreamer) reorgToInternal(batch ethdb.Batch, count arbutil.M
 		return err
 	}
 
-	err = deleteStartingAt(s.db, batch, messagePrefix, uint64ToBytes(uint64(count)))
+	err = deleteStartingAt(s.db, batch, messagePrefix, uint64ToKey(uint64(count)))
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func (s *TransactionStreamer) reorgToInternal(batch ethdb.Batch, count arbutil.M
 func dbKey(prefix []byte, pos uint64) []byte {
 	var key []byte
 	key = append(key, prefix...)
-	key = append(key, uint64ToBytes(uint64(pos))...)
+	key = append(key, uint64ToKey(uint64(pos))...)
 	return key
 }
 

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -214,6 +214,11 @@ func main() {
 		panic(fmt.Sprintf("Failed to open database: %v", err))
 	}
 
+	arbDb, err := stack.OpenDatabaseWithFreezer("arbitrumdata", 0, 0, "", "", false)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to open database: %v", err))
+	}
+
 	if nodeConfig.ImportFile != "" {
 		initDataReader, err = statetransfer.NewJsonInitDataReader(nodeConfig.ImportFile)
 		if err != nil {
@@ -299,7 +304,7 @@ func main() {
 		}
 	}
 
-	currentNode, err := arbnode.CreateNode(ctx, stack, chainDb, &nodeConfig.Node, l2BlockChain, l1Client, &rollupAddrs, l1TransactionOpts, daSigner)
+	currentNode, err := arbnode.CreateNode(ctx, stack, chainDb, arbDb, &nodeConfig.Node, l2BlockChain, l1Client, &rollupAddrs, l1TransactionOpts, daSigner)
 	if err != nil {
 		panic(err)
 	}

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -179,18 +179,19 @@ func DeployOnTestL1(t *testing.T, ctx context.Context, l1info info, l1client cli
 	return addresses
 }
 
-func createL2BlockChain(t *testing.T, l2info *BlockchainTestInfo, chainConfig *params.ChainConfig) (*BlockchainTestInfo, *node.Node, ethdb.Database, *core.BlockChain) {
+func createL2BlockChain(t *testing.T, l2info *BlockchainTestInfo, chainConfig *params.ChainConfig) (*BlockchainTestInfo, *node.Node, ethdb.Database, ethdb.Database, *core.BlockChain) {
 	if l2info == nil {
 		l2info = NewArbTestInfo(t, chainConfig.ChainID)
 	}
 	stack, err := arbnode.CreateDefaultStack()
 	Require(t, err)
 	chainDb := rawdb.NewMemoryDatabase()
+	arbDb := rawdb.NewMemoryDatabase()
 
 	initReader := statetransfer.NewMemoryInitDataReader(&l2info.ArbInitData)
 	blockchain, err := arbnode.WriteOrTestBlockChain(chainDb, nil, initReader, 0, chainConfig)
 	Require(t, err)
-	return l2info, stack, chainDb, blockchain
+	return l2info, stack, chainDb, arbDb, blockchain
 }
 
 func ClientForArbBackend(t *testing.T, backend *arbitrum.Backend) *ethclient.Client {
@@ -213,7 +214,7 @@ func CreateTestNodeOnL1(t *testing.T, ctx context.Context, isSequencer bool) (l2
 
 func CreateTestNodeOnL1WithConfig(t *testing.T, ctx context.Context, isSequencer bool, nodeConfig *arbnode.Config, chainConfig *params.ChainConfig) (l2info info, node *arbnode.Node, l2client *ethclient.Client, l1info info, l1backend *eth.Ethereum, l1client *ethclient.Client, l1stack *node.Node) {
 	l1info, l1client, l1backend, l1stack = CreateTestL1BlockChain(t, nil)
-	l2info, l2stack, l2chainDb, l2blockchain := createL2BlockChain(t, nil, chainConfig)
+	l2info, l2stack, l2chainDb, l2arbDb, l2blockchain := createL2BlockChain(t, nil, chainConfig)
 	addresses := DeployOnTestL1(t, ctx, l1info, l1client, chainConfig.ChainID)
 	var sequencerTxOptsPtr *bind.TransactOpts
 	if isSequencer {
@@ -226,7 +227,7 @@ func CreateTestNodeOnL1WithConfig(t *testing.T, ctx context.Context, isSequencer
 		nodeConfig.Sequencer.Enable = false
 		nodeConfig.DelayedSequencer.Enable = false
 	}
-	node, err := arbnode.CreateNode(ctx, l2stack, l2chainDb, nodeConfig, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil)
+	node, err := arbnode.CreateNode(ctx, l2stack, l2chainDb, l2arbDb, nodeConfig, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil)
 
 	Require(t, err)
 	Require(t, node.Start(ctx))
@@ -242,8 +243,8 @@ func CreateTestL2(t *testing.T, ctx context.Context) (*BlockchainTestInfo, *arbn
 }
 
 func CreateTestL2WithConfig(t *testing.T, ctx context.Context, l2Info *BlockchainTestInfo, nodeConfig *arbnode.Config, takeOwnership bool) (*BlockchainTestInfo, *arbnode.Node, *ethclient.Client) {
-	l2info, stack, chainDb, blockchain := createL2BlockChain(t, l2Info, params.ArbitrumDevTestChainConfig())
-	node, err := arbnode.CreateNode(ctx, stack, chainDb, nodeConfig, blockchain, nil, nil, nil, nil)
+	l2info, stack, chainDb, arbDb, blockchain := createL2BlockChain(t, l2Info, params.ArbitrumDevTestChainConfig())
+	node, err := arbnode.CreateNode(ctx, stack, chainDb, arbDb, nodeConfig, blockchain, nil, nil, nil, nil)
 	Require(t, err)
 
 	// Give the node an init message
@@ -296,12 +297,13 @@ func Create2ndNodeWithConfig(t *testing.T, ctx context.Context, first *arbnode.N
 	l2stack, err := arbnode.CreateDefaultStack()
 	Require(t, err)
 	l2chainDb := rawdb.NewMemoryDatabase()
+	l2arbDb := rawdb.NewMemoryDatabase()
 	initReader := statetransfer.NewMemoryInitDataReader(l2InitData)
 
 	l2blockchain, err := arbnode.WriteOrTestBlockChain(l2chainDb, nil, initReader, 0, first.ArbInterface.BlockChain().Config())
 	Require(t, err)
 
-	node, err := arbnode.CreateNode(ctx, l2stack, l2chainDb, nodeConfig, l2blockchain, l1client, first.DeployInfo, nil, nil)
+	node, err := arbnode.CreateNode(ctx, l2stack, l2chainDb, l2arbDb, nodeConfig, l2blockchain, l1client, first.DeployInfo, nil, nil)
 	Require(t, err)
 
 	err = node.Start(ctx)

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -107,7 +107,7 @@ func TestDASRekey(t *testing.T) {
 	authorizeDASKeyset(t, ctx, pubkeyA, l1info, l1client)
 
 	// Setup L2 chain
-	l2info, l2stack, l2chainDb, l2blockchain := createL2BlockChain(t, nil, chainConfig)
+	l2info, l2stack, l2chainDb, l2arbDb, l2blockchain := createL2BlockChain(t, nil, chainConfig)
 	l2info.GenerateAccount("User2")
 
 	// Setup DAS config
@@ -117,7 +117,7 @@ func TestDASRekey(t *testing.T) {
 
 	sequencerTxOpts := l1info.GetDefaultTransactOpts("Sequencer", ctx)
 	sequencerTxOptsPtr := &sequencerTxOpts
-	nodeA, err := arbnode.CreateNode(ctx, l2stack, l2chainDb, l1NodeConfigA, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil)
+	nodeA, err := arbnode.CreateNode(ctx, l2stack, l2chainDb, l2arbDb, l1NodeConfigA, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil)
 	Require(t, err)
 	Require(t, nodeA.Start(ctx))
 	l2clientA := ClientForArbBackend(t, nodeA.Backend)
@@ -148,7 +148,7 @@ func TestDASRekey(t *testing.T) {
 	l2blockchain, err = arbnode.GetBlockChain(l2chainDb, nil, chainConfig)
 	Require(t, err)
 	l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, backendConfigB)
-	nodeA, err = arbnode.CreateNode(ctx, l2stack, l2chainDb, l1NodeConfigA, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil)
+	nodeA, err = arbnode.CreateNode(ctx, l2stack, l2chainDb, l2arbDb, l1NodeConfigA, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil)
 	Require(t, err)
 	Require(t, nodeA.Start(ctx))
 	l2clientA = ClientForArbBackend(t, nodeA.Backend)
@@ -303,12 +303,12 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 	Require(t, err)
 
 	// Setup L2 chain
-	l2info, l2stack, l2chainDb, l2blockchain := createL2BlockChain(t, nil, chainConfig)
+	l2info, l2stack, l2chainDb, l2arbDb, l2blockchain := createL2BlockChain(t, nil, chainConfig)
 	l2info.GenerateAccount("User2")
 
 	sequencerTxOpts := l1info.GetDefaultTransactOpts("Sequencer", ctx)
 	sequencerTxOptsPtr := &sequencerTxOpts
-	nodeA, err := arbnode.CreateNode(ctx, l2stack, l2chainDb, l1NodeConfigA, l2blockchain, l1client, addresses, sequencerTxOptsPtr, daSigner)
+	nodeA, err := arbnode.CreateNode(ctx, l2stack, l2chainDb, l2arbDb, l1NodeConfigA, l2blockchain, l1client, addresses, sequencerTxOptsPtr, daSigner)
 	Require(t, err)
 	Require(t, nodeA.Start(ctx))
 	l2clientA := ClientForArbBackend(t, nodeA.Backend)

--- a/system_tests/full_challenge_impl_test.go
+++ b/system_tests/full_challenge_impl_test.go
@@ -241,16 +241,16 @@ func RunChallengeTest(t *testing.T, asserterIsCorrect bool) {
 	_, err = EnsureTxSucceeded(context.Background(), l1Backend, tx)
 	Require(t, err)
 
-	asserterL2Info, asserterL2Stack, asserterL2ChainDb, asserterL2Blockchain := createL2BlockChain(t, nil, chainConfig)
+	asserterL2Info, asserterL2Stack, asserterL2ChainDb, asserterL2ArbDb, asserterL2Blockchain := createL2BlockChain(t, nil, chainConfig)
 	rollupAddresses.SequencerInbox = asserterSeqInboxAddr
-	asserterL2, err := arbnode.CreateNode(ctx, asserterL2Stack, asserterL2ChainDb, conf, asserterL2Blockchain, l1Backend, rollupAddresses, nil, nil)
+	asserterL2, err := arbnode.CreateNode(ctx, asserterL2Stack, asserterL2ChainDb, asserterL2ArbDb, conf, asserterL2Blockchain, l1Backend, rollupAddresses, nil, nil)
 	Require(t, err)
 	err = asserterL2.Start(ctx)
 	Require(t, err)
 
-	challengerL2Info, challengerL2Stack, challengerL2ChainDb, challengerL2Blockchain := createL2BlockChain(t, nil, chainConfig)
+	challengerL2Info, challengerL2Stack, challengerL2ChainDb, challengerL2ArbDb, challengerL2Blockchain := createL2BlockChain(t, nil, chainConfig)
 	rollupAddresses.SequencerInbox = challengerSeqInboxAddr
-	challengerL2, err := arbnode.CreateNode(ctx, challengerL2Stack, challengerL2ChainDb, conf, challengerL2Blockchain, l1Backend, rollupAddresses, nil, nil)
+	challengerL2, err := arbnode.CreateNode(ctx, challengerL2Stack, challengerL2ChainDb, challengerL2ArbDb, conf, challengerL2Blockchain, l1Backend, rollupAddresses, nil, nil)
 	Require(t, err)
 	err = challengerL2.Start(ctx)
 	Require(t, err)

--- a/system_tests/seq_coordinator_test.go
+++ b/system_tests/seq_coordinator_test.go
@@ -91,7 +91,7 @@ func TestSeqCoordinatorPriorities(t *testing.T) {
 				},
 				L2msg: nil,
 			},
-			DelayedMessagesRead: 0,
+			DelayedMessagesRead: 1,
 		}
 		err = node.SeqCoordinator.SequencingMessage(curMsgs, &emptyMessage)
 		if errors.Is(err, arbnode.ErrNotMainSequencer) {


### PR DESCRIPTION
`uint64ToBytes` was mistakenly used to encode a database value which should've been RLP encoded. I've also renamed the function to `uint64ToKey` as part of this PR.