### PR TITLE
Add geth metrics server to daserver

### DIFF
--- a/cmd/daserver/daserver.go
+++ b/cmd/daserver/daserver.go
@@ -17,6 +17,8 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/metrics/exp"
 
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
@@ -38,18 +40,23 @@ type DAServerConfig struct {
 
 	ConfConfig genericconf.ConfConfig `koanf:"conf"`
 	LogLevel   int                    `koanf:"log-level"`
+
+	Metrics       bool                            `koanf:"metrics"`
+	MetricsServer genericconf.MetricsServerConfig `koanf:"metrics-server"`
 }
 
 var DefaultDAServerConfig = DAServerConfig{
-	EnableRPC:  false,
-	RPCAddr:    "localhost",
-	RPCPort:    9876,
-	EnableREST: false,
-	RESTAddr:   "localhost",
-	RESTPort:   9877,
-	DAConf:     das.DefaultDataAvailabilityConfig,
-	ConfConfig: genericconf.ConfConfigDefault,
-	LogLevel:   3,
+	EnableRPC:     false,
+	RPCAddr:       "localhost",
+	RPCPort:       9876,
+	EnableREST:    false,
+	RESTAddr:      "localhost",
+	RESTPort:      9877,
+	DAConf:        das.DefaultDataAvailabilityConfig,
+	ConfConfig:    genericconf.ConfConfigDefault,
+	Metrics:       false,
+	MetricsServer: genericconf.MetricsServerConfigDefault,
+	LogLevel:      3,
 }
 
 func main() {
@@ -73,6 +80,9 @@ func parseDAServer(args []string) (*DAServerConfig, error) {
 	f.Bool("enable-rest", DefaultDAServerConfig.EnableREST, "enable the REST server listening on rest-addr and rest-port")
 	f.String("rest-addr", DefaultDAServerConfig.RESTAddr, "REST server listening interface")
 	f.Uint64("rest-port", DefaultDAServerConfig.RESTPort, "REST server listening port")
+
+	f.Bool("metrics", DefaultDAServerConfig.Metrics, "enable metrics")
+	genericconf.MetricsServerAddOptions("metrics-server", f)
 
 	f.Int("log-level", int(log.LvlInfo), "log level; 1: ERROR, 2: WARN, 3: INFO, 4: DEBUG, 5: TRACE")
 	das.DataAvailabilityConfigAddOptions("data-availability", f)
@@ -131,6 +141,15 @@ func startup() error {
 	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
 	glogger.Verbosity(log.Lvl(serverConfig.LogLevel))
 	log.Root().SetHandler(glogger)
+
+	if serverConfig.Metrics {
+		go metrics.CollectProcessMetrics(serverConfig.MetricsServer.UpdateInterval)
+
+		if serverConfig.MetricsServer.Addr != "" {
+			address := fmt.Sprintf("%v:%v", serverConfig.MetricsServer.Addr, serverConfig.MetricsServer.Port)
+			exp.Setup(address)
+		}
+	}
 
 	sigint := make(chan os.Signal, 1)
 	signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)

--- a/cmd/datool/datool.go
+++ b/cmd/datool/datool.go
@@ -116,13 +116,8 @@ func startClientStore(args []string) error {
 	}
 
 	serializedCert := das.Serialize(cert)
-	encodedCert := make([]byte, base64.StdEncoding.EncodedLen(len(serializedCert)))
-	base64.StdEncoding.Encode(encodedCert, serializedCert)
-	fmt.Printf("Base64 Encoded Cert: %s\n", string(encodedCert))
-
-	encodedDataHash := make([]byte, base64.StdEncoding.EncodedLen(len(cert.DataHash)))
-	base64.StdEncoding.Encode(encodedDataHash, cert.DataHash[:])
-	fmt.Printf("Base64 Encoded Data Hash: %s\n", string(encodedDataHash))
+	fmt.Printf("Hex Encoded Cert: %s\n", string(hexutil.Encode(serializedCert)))
+	fmt.Printf("Hex Encoded Data Hash: %s\n", string(hexutil.Encode(cert.DataHash[:])))
 
 	return nil
 }


### PR DESCRIPTION
# Testing

```
$ cat datestconf/test-metrics.conf 
{
  "data-availability": {
    "enable": true,
    "key": {
      "key-dir": "/tmp/das-test-metrics"
    },
    "l1-node-url": "none",
    "local-file-storage": {
      "data-dir": "/tmp/das-test-metrics",
      "enable": true
    },
    "sequencer-inbox-address": "none"
  },
  "enable-rest": true,
  "enable-rpc": true,
  "log-level": 5,
  "rest-addr": "localhost",
  "rest-port": "9877",
  "rpc-addr": "localhost",
  "rpc-port": "9876",
  "metrics": true
}


$ ./target/bin/datool client rest getbyhash --url http://localhost:9877   --data-hash 0xdac8a9f2bbcca34aecad0af5a43dcb48c94f0755f7cf4d87bc01925eb390b762

$ ./target/bin/datool client rpc getbyhash --url http://localhost:9876   --data-hash 0xdac8a9f2bbcca34aecad0af5a43dcb48c94f0755f7cf4d87bc01925eb390b762

$ ./target/bin/datool client rpc store  --url http://localhost:9876 --message "asdf12"


$ ./target/bin/daserver --conf.file datestconf/test-metrics.conf
INFO [06-30|21:14:34.567] Starting metrics server                  addr=http://127.0.0.1:6070/debug/metrics
INFO [06-30|21:14:34.572] Starting HTTP-RPC server                 addr=localhost                           port=9876
INFO [06-30|21:14:34.573] Starting REST server                     addr=localhost                           port=9877


$ watch 'curl localhost:6070/debug/metrics/prometheus | grep arb_das'
# TYPE arb_das_rest_getbyhash_bytes gauge
arb_das_rest_getbyhash_bytes 1056
# TYPE arb_das_rest_getbyhash_duration_count counter
arb_das_rest_getbyhash_duration_count 66
# TYPE arb_das_rest_getbyhash_duration summary
arb_das_rest_getbyhash_duration {quantile="0.5"} 46383.5
arb_das_rest_getbyhash_duration {quantile="0.75"} 54644.5
arb_das_rest_getbyhash_duration {quantile="0.95"} 81481.14999999998
arb_das_rest_getbyhash_duration {quantile="0.99"} 393719
arb_das_rest_getbyhash_duration {quantile="0.999"} 393719
arb_das_rest_getbyhash_duration {quantile="0.9999"} 393719
# TYPE arb_das_rest_getbyhash_failure gauge
arb_das_rest_getbyhash_failure 0
# TYPE arb_das_rest_getbyhash_requests gauge
arb_das_rest_getbyhash_requests 66
# TYPE arb_das_rest_getbyhash_success gauge
arb_das_rest_getbyhash_success 66
# TYPE arb_das_rpc_getbyhash_bytes gauge
arb_das_rpc_getbyhash_bytes 1830
# TYPE arb_das_rpc_getbyhash_duration_count counter
arb_das_rpc_getbyhash_duration_count 183
# TYPE arb_das_rpc_getbyhash_duration summary
arb_das_rpc_getbyhash_duration {quantile="0.5"} 43302
arb_das_rpc_getbyhash_duration {quantile="0.75"} 49903
arb_das_rpc_getbyhash_duration {quantile="0.95"} 63096.799999999974
arb_das_rpc_getbyhash_duration {quantile="0.99"} 133846.95999999996
arb_das_rpc_getbyhash_duration {quantile="0.999"} 145234
arb_das_rpc_getbyhash_duration {quantile="0.9999"} 145234
# TYPE arb_das_rpc_getbyhash_failure gauge
arb_das_rpc_getbyhash_failure 0
# TYPE arb_das_rpc_getbyhash_requests gauge
arb_das_rpc_getbyhash_requests 183
# TYPE arb_das_rpc_getbyhash_success gauge
arb_das_rpc_getbyhash_success 183
# TYPE arb_das_rpc_store_bytes gauge
arb_das_rpc_store_bytes 982
# TYPE arb_das_rpc_store_duration_count counter
arb_das_rpc_store_duration_count 163
# TYPE arb_das_rpc_store_duration summary
arb_das_rpc_store_duration {quantile="0.5"} 432601
arb_das_rpc_store_duration {quantile="0.75"} 464685
arb_das_rpc_store_duration {quantile="0.95"} 576422
arb_das_rpc_store_duration {quantile="0.99"} 651041
arb_das_rpc_store_duration {quantile="0.999"} 651041
arb_das_rpc_store_duration {quantile="0.9999"} 651041
# TYPE arb_das_rpc_store_failure gauge
arb_das_rpc_store_failure 0
# TYPE arb_das_rpc_store_requests gauge
arb_das_rpc_store_requests 163
# TYPE arb_das_rpc_store_success gauge
arb_das_rpc_store_success 163


```