### PR TITLE
Add retries for upstream L1 connection for daserver

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"golang.org/x/term"
 
@@ -790,7 +789,7 @@ func SetUpDataAvailability(
 		l1Client = nil
 		seqInboxAddress = nil
 	} else if len(config.L1NodeURL) > 0 && len(config.SequencerInboxAddress) > 0 {
-		l1Client, err = ethclient.DialContext(ctx, config.L1NodeURL)
+		l1Client, err := das.GetL1Client(ctx, config.L1ConnectionAttempts, config.L1NodeURL)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/das/aggregator.go
+++ b/das/aggregator.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/util/pretty"
@@ -84,7 +83,7 @@ func NewAggregator(ctx context.Context, config DataAvailabilityConfig, services 
 	if config.L1NodeURL == "none" {
 		return NewAggregatorWithSeqInboxCaller(config.AggregatorConfig, services, nil)
 	}
-	l1client, err := ethclient.DialContext(ctx, config.L1NodeURL)
+	l1client, err := GetL1Client(ctx, config.L1ConnectionAttempts, config.L1NodeURL)
 	if err != nil {
 		return nil, err
 	}

--- a/das/das.go
+++ b/das/das.go
@@ -8,9 +8,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
 	flag "github.com/spf13/pflag"
 
 	"github.com/offchainlabs/nitro/arbstate"
@@ -46,6 +49,7 @@ type DataAvailabilityConfig struct {
 	RestfulClientAggregatorConfig RestfulClientAggregatorConfig `koanf:"rest-aggregator"`
 
 	L1NodeURL             string `koanf:"l1-node-url"`
+	L1ConnectionAttempts  int    `koanf:"l1-connection-attempts"`
 	SequencerInboxAddress string `koanf:"sequencer-inbox-address"`
 }
 
@@ -53,6 +57,7 @@ var DefaultDataAvailabilityConfig = DataAvailabilityConfig{
 	RequestTimeout:                5 * time.Second,
 	Enable:                        false,
 	RestfulClientAggregatorConfig: DefaultRestfulClientAggregatorConfig,
+	L1ConnectionAttempts:          15,
 }
 
 /* TODO put these checks somewhere
@@ -122,6 +127,7 @@ func DataAvailabilityConfigAddOptions(prefix string, f *flag.FlagSet) {
 	RestfulClientAggregatorConfigAddOptions(prefix+".rest-aggregator", f)
 
 	f.String(prefix+".l1-node-url", DefaultDataAvailabilityConfig.L1NodeURL, "URL for L1 node, only used in standalone daserver; when running as part of a node that node's L1 configuration is used")
+	f.Int(prefix+".l1-connection-attempts", DefaultDataAvailabilityConfig.L1ConnectionAttempts, "layer 1 RPC connection attempts (spaced out at least 1 second per attempt, 0 to retry infinitely), only used in standalone daserver; when running as part of a node that node's L1 configuration is used")
 	f.String(prefix+".sequencer-inbox-address", DefaultDataAvailabilityConfig.SequencerInboxAddress, "L1 address of SequencerInbox contract")
 }
 
@@ -150,4 +156,28 @@ func Serialize(c *arbstate.DataAvailabilityCertificate) []byte {
 	buf = append(buf, intData[:]...)
 
 	return append(buf, blsSignatures.SignatureToBytes(c.Sig)...)
+}
+
+func GetL1Client(ctx context.Context, maxConnectionAttempts int, l1URL string) (*ethclient.Client, error) {
+	if maxConnectionAttempts <= 0 {
+		maxConnectionAttempts = math.MaxInt
+	}
+	var l1Client *ethclient.Client
+	var err error
+	for i := 1; i <= maxConnectionAttempts; i++ {
+		l1Client, err = ethclient.DialContext(ctx, l1URL)
+		if err == nil {
+			return l1Client, nil
+		}
+		log.Warn("error connecting to L1", "err", err)
+
+		timer := time.NewTimer(time.Second * 1)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, errors.New("aborting startup")
+		case <-timer.C:
+		}
+	}
+	return nil, err
 }

--- a/das/sign_after_store_das.go
+++ b/das/sign_after_store_das.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/offchainlabs/nitro/arbstate"
@@ -61,7 +60,7 @@ func NewSignAfterStoreDAS(ctx context.Context, config DataAvailabilityConfig, st
 	if config.L1NodeURL == "none" {
 		return NewSignAfterStoreDASWithSeqInboxCaller(ctx, config.KeyConfig, nil, storageService)
 	}
-	l1client, err := ethclient.Dial(config.L1NodeURL)
+	l1client, err := GetL1Client(ctx, config.L1ConnectionAttempts, config.L1NodeURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add retries for upstream L1 connection for daserver based on simiar design used for [node](https://github.com/OffchainLabs/nitro/blob/master/cmd/nitro/nitro.go#L425).