### PR TITLE
Auto fetch mirror list without needing restart

### DIFF
--- a/das/reader_aggregator_strategies.go
+++ b/das/reader_aggregator_strategies.go
@@ -30,10 +30,15 @@ func (s *abstractAggregatorStrategy) update(readers []arbstate.DataAvailabilityR
 	s.Lock()
 	defer s.Unlock()
 
-	s.readers = make([]arbstate.DataAvailabilityReader, len(readers))
-	copy(s.readers, readers)
-
-	s.stats = make(map[arbstate.DataAvailabilityReader]readerStats)
+	if len(s.readers) == 0 {
+		s.readers = make([]arbstate.DataAvailabilityReader, len(readers))
+		copy(s.readers, readers)
+	} else {
+		s.readers = append(s.readers, readers...)
+	}
+	if s.stats == nil {
+		s.stats = make(map[arbstate.DataAvailabilityReader]readerStats)
+	}
 	for k, v := range stats {
 		s.stats[k] = v
 	}

--- a/das/reader_aggregator_strategies.go
+++ b/das/reader_aggregator_strategies.go
@@ -30,15 +30,10 @@ func (s *abstractAggregatorStrategy) update(readers []arbstate.DataAvailabilityR
 	s.Lock()
 	defer s.Unlock()
 
-	if len(s.readers) == 0 {
-		s.readers = make([]arbstate.DataAvailabilityReader, len(readers))
-		copy(s.readers, readers)
-	} else {
-		s.readers = append(s.readers, readers...)
-	}
-	if s.stats == nil {
-		s.stats = make(map[arbstate.DataAvailabilityReader]readerStats)
-	}
+	s.readers = make([]arbstate.DataAvailabilityReader, len(readers))
+	copy(s.readers, readers)
+
+	s.stats = make(map[arbstate.DataAvailabilityReader]readerStats)
 	for k, v := range stats {
 		s.stats[k] = v
 	}

--- a/das/simple_das_reader_aggregator.go
+++ b/das/simple_das_reader_aggregator.go
@@ -283,7 +283,6 @@ func (a *SimpleDASReaderAggregator) Start(ctx context.Context) {
 			a.readers = append(a.readers, reader)
 			a.stats[reader] = make([]readerStat, 0, a.config.MaxPerEndpointStats)
 		}
-		a.strategy.update(a.readers, a.stats)
 		return true
 	}
 	a.StopWaiter.Start(ctx)

--- a/das/simple_das_reader_aggregator.go
+++ b/das/simple_das_reader_aggregator.go
@@ -77,7 +77,7 @@ func SimpleExploreExploitStrategyConfigAddOptions(prefix string, f *flag.FlagSet
 	f.Int(prefix+".exploit-iterations", DefaultSimpleExploreExploitStrategyConfig.ExploitIterations, "number of consecutive GetByHash calls to the aggregator where each call will cause it to select from REST endpoints in order of best latency and success rate, before switching to explore mode")
 }
 
-func AddAggregatorReadersOnRestfulServerListUpdate(ctx context.Context, config *RestfulClientAggregatorConfig, a *SimpleDASReaderAggregator, combinedUrls map[string]bool) {
+func addAggregatorReadersOnRestfulServerListUpdate(ctx context.Context, config *RestfulClientAggregatorConfig, a *SimpleDASReaderAggregator, combinedUrls map[string]bool) {
 	onlineUrlsChan := StartRestfulServerListFetchDaemon(ctx, config.OnlineUrlList, config.OnlineUrlListFetchInterval)
 
 	addRestfulDasClients := func(urls []string) bool {
@@ -163,7 +163,7 @@ func NewRestfulClientAggregator(ctx context.Context, config *RestfulClientAggreg
 		return nil, fmt.Errorf("Unknown RestfulClientAggregator strategy '%s', use --help to see available strategies.", config.Strategy)
 	}
 	a.strategy.update(a.readers, a.stats)
-	AddAggregatorReadersOnRestfulServerListUpdate(ctx, config, &a, combinedUrls)
+	addAggregatorReadersOnRestfulServerListUpdate(ctx, config, &a, combinedUrls)
 	return &a, nil
 }
 

--- a/das/simple_das_reader_aggregator.go
+++ b/das/simple_das_reader_aggregator.go
@@ -268,7 +268,8 @@ func (a *SimpleDASReaderAggregator) Start(ctx context.Context) {
 	onlineUrlsChan := StartRestfulServerListFetchDaemon(ctx, a.config.OnlineUrlList, a.config.OnlineUrlListFetchInterval)
 
 	updateRestfulDasClients := func(urls []string) bool {
-		combinedUrls := append(a.config.Urls, urls...)
+		combinedUrls := a.config.Urls
+		combinedUrls = append(combinedUrls, urls...)
 		combinedReaders := make(map[arbstate.DataAvailabilityReader]bool)
 		for _, url := range combinedUrls {
 			reader, err := NewRestfulDasClientFromURL(url)


### PR DESCRIPTION
Added OnlineUrlListFetchInterval in RestfulClientAggregatorConfig, used as time interval to periodically fetch url list from online-url-list.

Added StartRestfulServerListFetchDaemon in SimpleDASReaderAggregator start, where onlineUrlsChan keeps track of latest Online Url List which is used in function updateRestfulDasClients to add and remove a.readers and a.stats based on the combinedUrls.

updateRestfulDasClients is called in same goroutine as updates to the stats to avoid needing extra synchronization.