### PR TITLE
Optionally make DAS fail early

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -680,7 +680,12 @@ func createNodeImpl(
 		} else {
 			dataAvailabilityService = das.NewReadLimitedDataAvailabilityService(dataAvailabilityService)
 		}
-		dataAvailabilityService = das.NewTimeoutWrapper(dataAvailabilityService, config.DataAvailability.RequestTimeout)
+		dataAvailabilityService = das.NewTimeoutWrapper(
+			dataAvailabilityService, config.DataAvailability.RequestTimeout,
+		)
+		if config.DataAvailability.PanicOnError {
+			dataAvailabilityService = das.NewPanicWrapper(dataAvailabilityService)
+		}
 	} else if l2BlockChain.Config().ArbitrumChainParams.DataAvailabilityCommittee {
 		return nil, errors.New("a data availability service is required for this chain, but it was not configured")
 	}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -791,9 +791,6 @@ func SetUpDataAvailability(
 			return nil, nil, err
 		}
 		seqInboxCaller = &seqInbox.SequencerInboxCaller
-	} else if config.L1NodeURL == "none" && config.SequencerInboxAddress == "none" {
-		l1Client = nil
-		seqInboxAddress = nil
 	} else if len(config.L1NodeURL) > 0 && len(config.SequencerInboxAddress) > 0 {
 		l1Client, err = ethclient.DialContext(ctx, config.L1NodeURL)
 		if err != nil {
@@ -900,12 +897,16 @@ func SetUpDataAvailability(
 
 		topLevelDas = rpcAggregator
 	} else if hasPersistentStorage && (config.KeyConfig.KeyDir != "" || config.KeyConfig.PrivKey != "") {
+		_seqInboxCaller := seqInboxCaller
+		if config.DisableSignatureChecking {
+			_seqInboxCaller = nil
+		}
 
 		// TODO rename StorageServiceDASAdapter
 		topLevelDas, err = das.NewSignAfterStoreDASWithSeqInboxCaller(
 			ctx,
 			config.KeyConfig,
-			seqInboxCaller,
+			_seqInboxCaller,
 			topLevelStorageService,
 		)
 		if err != nil {

--- a/das/das.go
+++ b/das/das.go
@@ -47,12 +47,15 @@ type DataAvailabilityConfig struct {
 
 	L1NodeURL             string `koanf:"l1-node-url"`
 	SequencerInboxAddress string `koanf:"sequencer-inbox-address"`
+
+	PanicOnError bool `koanf:"panic-on-error"`
 }
 
 var DefaultDataAvailabilityConfig = DataAvailabilityConfig{
 	RequestTimeout:                5 * time.Second,
 	Enable:                        false,
 	RestfulClientAggregatorConfig: DefaultRestfulClientAggregatorConfig,
+	PanicOnError:                  false,
 }
 
 /* TODO put these checks somewhere
@@ -102,6 +105,7 @@ func OptionalAddressFromString(s string) (*common.Address, error) {
 
 func DataAvailabilityConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultDataAvailabilityConfig.Enable, "enable Anytrust Data Availability mode")
+	f.Bool(prefix+".panic-on-error", DefaultDataAvailabilityConfig.PanicOnError, "whether the Data Availability Service should fail immediately on errors (not recommended)")
 
 	f.Duration(prefix+".request-timeout", DefaultDataAvailabilityConfig.RequestTimeout, "Data Availability Service request timeout duration")
 

--- a/das/das.go
+++ b/das/das.go
@@ -48,7 +48,8 @@ type DataAvailabilityConfig struct {
 	L1NodeURL             string `koanf:"l1-node-url"`
 	SequencerInboxAddress string `koanf:"sequencer-inbox-address"`
 
-	PanicOnError bool `koanf:"panic-on-error"`
+	PanicOnError             bool `koanf:"panic-on-error"`
+	DisableSignatureChecking bool `koanf:"disable-signature-checking"`
 }
 
 var DefaultDataAvailabilityConfig = DataAvailabilityConfig{
@@ -106,6 +107,7 @@ func OptionalAddressFromString(s string) (*common.Address, error) {
 func DataAvailabilityConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultDataAvailabilityConfig.Enable, "enable Anytrust Data Availability mode")
 	f.Bool(prefix+".panic-on-error", DefaultDataAvailabilityConfig.PanicOnError, "whether the Data Availability Service should fail immediately on errors (not recommended)")
+	f.Bool(prefix+".disable-signature-checking", DefaultDataAvailabilityConfig.DisableSignatureChecking, "disables signature checking on Data Availability Store requests (DANGEROUS, FOR TESTING ONLY)")
 
 	f.Duration(prefix+".request-timeout", DefaultDataAvailabilityConfig.RequestTimeout, "Data Availability Service request timeout duration")
 

--- a/das/dasrpc/rpc_test.go
+++ b/das/dasrpc/rpc_test.go
@@ -39,7 +39,8 @@ func TestRPC(t *testing.T) {
 			Enable:  true,
 			DataDir: dataDir,
 		},
-		L1NodeURL: "none",
+		L1NodeURL:      "none",
+		RequestTimeout: 5 * time.Second,
 	}
 
 	storageService, lifecycleManager, err := das.CreatePersistentStorageService(ctx, &config)

--- a/das/panic_wrapper.go
+++ b/das/panic_wrapper.go
@@ -1,0 +1,41 @@
+// Copyright 2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package das
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/offchainlabs/nitro/arbstate"
+)
+
+type PanicWrapper struct {
+	DataAvailabilityService
+}
+
+func NewPanicWrapper(dataAvailabilityService DataAvailabilityService) DataAvailabilityService {
+	return &PanicWrapper{
+		DataAvailabilityService: dataAvailabilityService,
+	}
+}
+
+func (w *PanicWrapper) GetByHash(ctx context.Context, hash []byte) ([]byte, error) {
+	data, err := w.DataAvailabilityService.GetByHash(ctx, hash)
+	if err != nil {
+		panic(fmt.Sprintf("panic wrapper GetByHash: %v", err))
+	}
+	return data, nil
+}
+
+func (w *PanicWrapper) Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (*arbstate.DataAvailabilityCertificate, error) {
+	cert, err := w.DataAvailabilityService.Store(ctx, message, timeout, sig)
+	if err != nil {
+		panic(fmt.Sprintf("panic wrapper Store: %v", err))
+	}
+	return cert, nil
+}
+
+func (w *PanicWrapper) String() string {
+	return fmt.Sprintf("PanicWrapper{%v}", w.DataAvailabilityService)
+}

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -376,7 +376,8 @@ func setupConfigWithDAS(t *testing.T, dasModeString string) (*params.ChainConfig
 			Enable:  enableDbStorage,
 			DataDir: dbPath,
 		},
-		L1NodeURL: "none",
+		L1NodeURL:    "none",
+		PanicOnError: true,
 	}
 
 	l1NodeConfigA.DataAvailability = dasConfig

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -376,8 +376,10 @@ func setupConfigWithDAS(t *testing.T, dasModeString string) (*params.ChainConfig
 			Enable:  enableDbStorage,
 			DataDir: dbPath,
 		},
-		L1NodeURL:    "none",
-		PanicOnError: true,
+		PanicOnError:             true,
+		DisableSignatureChecking: true,
+		L1NodeURL:                "none",
+		RequestTimeout:           5 * time.Second,
 	}
 
 	l1NodeConfigA.DataAvailability = dasConfig

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -53,7 +53,8 @@ func startLocalDASServer(
 			Enable:  true,
 			DataDir: keyDir,
 		},
-		L1NodeURL: "none",
+		L1NodeURL:      "none",
+		RequestTimeout: 5 * time.Second,
 	}
 
 	storageService, lifecycleManager, err := das.CreatePersistentStorageService(ctx, &config)
@@ -257,6 +258,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 			KeyDir: keyDir,
 		},
 
+		RequestTimeout: 5 * time.Second,
 		// L1NodeURL: normally we would have to set this but we are passing in the already constructed client and addresses to the factory
 	}
 
@@ -286,6 +288,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 		},
 
 		// AggregatorConfig set up below
+		RequestTimeout: 5 * time.Second,
 	}
 
 	beConfigA := dasrpc.BackendConfig{
@@ -330,7 +333,8 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 
 		// AggregatorConfig set up below
 
-		L1NodeURL: "none",
+		L1NodeURL:      "none",
+		RequestTimeout: 5 * time.Second,
 	}
 
 	l1NodeConfigB.BatchPoster.Enable = false
@@ -348,6 +352,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 			Enable:  true,
 			DataDir: fileDataDir,
 		},
+		RequestTimeout: 5 * time.Second,
 	}
 
 	restServerDAS, rpcServerLifecycleManager, err := das.CreatePersistentStorageService(ctx, &restServerConfig)
@@ -382,6 +387,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 		},
 
 		// L1NodeURL: normally we would have to set this but we are passing in the already constructed client and addresses to the factory
+		RequestTimeout: 5 * time.Second,
 	}
 	l2clientC, nodeC := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, &l2info.ArbInitData, l1NodeConfigC)
 


### PR DESCRIPTION
Adds a panic wrapper and `panic-on-error` config option to make DAS readers fail early