### PR TITLE
Allow watchtower validators to run without a key

### DIFF
--- a/arbnode/api.go
+++ b/arbnode/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/arbitrum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -42,9 +43,9 @@ func (a *BlockValidatorAPI) RevalidateBlock(ctx context.Context, blockNum rpc.Bl
 	return a.val.ValidateBlock(ctx, header, moduleRoot)
 }
 
-func (a *BlockValidatorAPI) LatestValidatedBlock(ctx context.Context) (uint64, error) {
+func (a *BlockValidatorAPI) LatestValidatedBlock(ctx context.Context) (hexutil.Uint64, error) {
 	block := a.val.LastBlockValidated()
-	return block, nil
+	return hexutil.Uint64(block), nil
 }
 
 func (a *BlockValidatorAPI) LatestValidatedBlockHash(ctx context.Context) (common.Hash, error) {

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -116,7 +116,8 @@ func main() {
 			panic(err)
 		}
 
-		if nodeConfig.Node.BatchPoster.Enable || nodeConfig.Node.Validator.Enable {
+		validatorNeedsKey := nodeConfig.Node.Validator.Enable && !strings.EqualFold(nodeConfig.Node.Validator.Strategy, "watchtower")
+		if nodeConfig.Node.BatchPoster.Enable || validatorNeedsKey {
 			l1TransactionOpts, err = util.GetTransactOptsFromWallet(
 				l1Wallet,
 				new(big.Int).SetUint64(nodeConfig.L1.ChainID),

--- a/validator/validator_wallet.go
+++ b/validator/validator_wallet.go
@@ -72,6 +72,9 @@ func (v *ValidatorWallet) Address() *common.Address {
 }
 
 func (v *ValidatorWallet) From() common.Address {
+	if v.auth == nil {
+		return common.Address{}
+	}
 	return v.auth.From
 }
 


### PR DESCRIPTION
Also makes the `arb_latestValidatedBlock` RPC return the result as a hex number, to match with `eth_blockNumber`