### PR TITLE
Add additional L1 pricing testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ target/
 yarn-error.log
 local/
 testdata
-system_tests/testSequencerPriceAdjusts.csv
+system_tests/testSequencerPriceAdjusts*.csv

--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbcompress"
-	"github.com/offchainlabs/nitro/util/arbmath"
 	am "github.com/offchainlabs/nitro/util/arbmath"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -209,14 +208,6 @@ func (ps *L1PricingState) PricePerUnit() (*big.Int, error) {
 
 func (ps *L1PricingState) SetPricePerUnit(price *big.Int) error {
 	return ps.pricePerUnit.Set(price)
-}
-
-func (ps *L1PricingState) L1BaseFeeEstimate() (*big.Int, error) {
-	perUnit, err := ps.pricePerUnit.Get()
-	if err != nil {
-		return nil, err
-	}
-	return arbmath.BigMulByUint(perUnit, 16), nil
 }
 
 // Update the pricing model based on a payment by a batch poster

--- a/contracts/src/precompiles/ArbGasInfo.sol
+++ b/contracts/src/precompiles/ArbGasInfo.sol
@@ -109,4 +109,7 @@ interface ArbGasInfo {
 
     /// @notice Get the forgivable amount of backlogged gas ArbOS will ignore when raising the basefee
     function getGasBacklogTolerance() external view returns (uint64);
+
+    /// @notice Returns the surplus of funds for L1 batch posting payments (may be negative).
+    function getL1PricingSurplus() external view returns (int256);
 }

--- a/contracts/src/precompiles/ArbOwner.sol
+++ b/contracts/src/precompiles/ArbOwner.sol
@@ -66,6 +66,9 @@ interface ArbOwner {
     /// @notice Sets reward amount for L1 price adjustment algorithm, in wei per unit
     function setL1PricingRewardRate(uint64 weiPerUnit) external;
 
+    /// @notice Set how much ArbOS charges per L1 gas spent on transaction data.
+    function setL1PricePerUnit(uint256 pricePerUnit) external;
+
     // Emitted when a successful call is made to this precompile
     event OwnerActs(bytes4 indexed method, address indexed owner, bytes data);
 }

--- a/nodeInterface/NodeInterface.go
+++ b/nodeInterface/NodeInterface.go
@@ -476,7 +476,7 @@ func (n NodeInterface) GasEstimateComponents(
 	if err != nil {
 		return 0, 0, nil, nil, err
 	}
-	l1BaseFeeEstimate, err := pricing.L1BaseFeeEstimate()
+	l1BaseFeeEstimate, err := pricing.PricePerUnit()
 	if err != nil {
 		return 0, 0, nil, nil, err
 	}

--- a/precompiles/ArbGasInfo.go
+++ b/precompiles/ArbGasInfo.go
@@ -125,3 +125,18 @@ func (con ArbGasInfo) GetPricingInertia(c ctx, evm mech) (uint64, error) {
 func (con ArbGasInfo) GetGasBacklogTolerance(c ctx, evm mech) (uint64, error) {
 	return c.State.L2PricingState().BacklogTolerance()
 }
+
+func (con ArbGasInfo) GetL1PricingSurplus(c ctx, evm mech) (*big.Int, error) {
+	ps := c.State.L1PricingState()
+	fundsDueForRefunds, err := ps.BatchPosterTable().TotalFundsDue()
+	if err != nil {
+		return nil, err
+	}
+	fundsDueForRewards, err := ps.FundsDueForRewards()
+	if err != nil {
+		return nil, err
+	}
+	haveFunds := evm.StateDB.GetBalance(l1pricing.L1PricerFundsPoolAddress)
+	needFunds := arbmath.BigAdd(fundsDueForRefunds, fundsDueForRewards)
+	return arbmath.BigSub(haveFunds, needFunds), nil
+}

--- a/precompiles/ArbOwner.go
+++ b/precompiles/ArbOwner.go
@@ -5,6 +5,7 @@ package precompiles
 
 import (
 	"errors"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -111,4 +112,8 @@ func (con ArbOwner) SetL1PricingRewardRecipient(c ctx, evm mech, recipient addr)
 
 func (con ArbOwner) SetL1PricingRewardRate(c ctx, evm mech, weiPerUnit uint64) error {
 	return c.State.L1PricingState().SetPerUnitReward(weiPerUnit)
+}
+
+func (con ArbOwner) SetL1PricePerUnit(c ctx, evm mech, pricePerUnit *big.Int) error {
+	return c.State.L1PricingState().SetPricePerUnit(pricePerUnit)
 }

--- a/system_tests/estimation_test.go
+++ b/system_tests/estimation_test.go
@@ -131,7 +131,7 @@ func TestComponentEstimate(t *testing.T) {
 	defer cancel()
 
 	l2info, node, client := CreateTestL2(t, ctx)
-	l1BaseFee := big.NewInt(l1pricing.InitialPricePerUnitWei * 16)
+	l1BaseFee := big.NewInt(l1pricing.InitialPricePerUnitWei)
 	l2BaseFee := GetBaseFee(t, client, ctx)
 
 	colors.PrintGrey("l1 basefee ", l1BaseFee)

--- a/system_tests/fees_test.go
+++ b/system_tests/fees_test.go
@@ -68,12 +68,13 @@ func TestSequencerFeePaid(t *testing.T) {
 	}
 }
 
-func TestSequencerPriceAdjusts(t *testing.T) {
-	f, err := os.Create("testSequencerPriceAdjusts.csv")
-	Require(t, err)
-	defer func() { _ = f.Close() }()
-
+func testSequencerPriceAdjustsFrom(t *testing.T, initialEstimate uint64) {
 	t.Parallel()
+
+	f, err := os.Create(fmt.Sprintf("testSequencerPriceAdjustsFrom%v.csv", initialEstimate))
+	Require(t, err)
+	defer func() { Require(t, f.Close()) }()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -81,8 +82,26 @@ func TestSequencerPriceAdjusts(t *testing.T) {
 	conf := arbnode.ConfigDefaultL1Test()
 	conf.DelayedSequencer.FinalizeDistance = 1
 
-	l2info, node, l2client, _, _, l1client, stack := CreateTestNodeOnL1WithConfig(t, ctx, true, conf, chainConfig)
+	l2info, node, l2client, l1info, _, l1client, stack := CreateTestNodeOnL1WithConfig(t, ctx, true, conf, chainConfig)
 	defer stack.Close()
+
+	ownerAuth := l2info.GetDefaultTransactOpts("Owner", ctx)
+
+	// make ownerAuth a chain owner
+	arbdebug, err := precompilesgen.NewArbDebug(common.HexToAddress("0xff"), l2client)
+	Require(t, err)
+	tx, err := arbdebug.BecomeChainOwner(&ownerAuth)
+	Require(t, err)
+	_, err = EnsureTxSucceeded(ctx, l2client, tx)
+
+	// use ownerAuth to set the L1 price per unit
+	Require(t, err)
+	arbOwner, err := precompilesgen.NewArbOwner(common.HexToAddress("0x70"), l2client)
+	Require(t, err)
+	tx, err = arbOwner.SetL1PricePerUnit(&ownerAuth, new(big.Int).SetUint64(initialEstimate))
+	Require(t, err)
+	_, err = WaitForTx(ctx, l2client, tx.Hash(), time.Second*5)
+	Require(t, err)
 
 	arbGasInfo, err := precompilesgen.NewArbGasInfo(common.HexToAddress("0x6c"), l2client)
 	Require(t, err)
@@ -93,7 +112,8 @@ func TestSequencerPriceAdjusts(t *testing.T) {
 	l1Header, err := l1client.HeaderByNumber(ctx, nil)
 	Require(t, err)
 
-	sequencerBalanceBefore := GetBalance(t, ctx, l2client, l1pricing.BatchPosterAddress)
+	batchPosterBalanceBefore := GetBalance(t, ctx, l2client, l1pricing.BatchPosterAddress)
+	rewardBalanceBefore := GetBalance(t, ctx, l2client, l1pricing.BatchPosterAddress)
 	timesPriceAdjusted := 0
 
 	colors.PrintBlue("Initial values")
@@ -101,7 +121,7 @@ func TestSequencerPriceAdjusts(t *testing.T) {
 	colors.PrintBlue("    L1 estimate ", lastEstimate)
 
 	numRetrogradeMoves := 0
-	for i := 0; i < 128; i++ {
+	for i := 0; i < 256; i++ {
 		tx, receipt := TransferBalance(t, "Owner", "Owner", common.Big1, l2info, l2client, ctx)
 		header, err := l2client.HeaderByHash(ctx, receipt.BlockHash)
 		Require(t, err)
@@ -116,21 +136,25 @@ func TestSequencerPriceAdjusts(t *testing.T) {
 			callOpts := &bind.CallOpts{Context: ctx, BlockNumber: receipt.BlockNumber}
 			actualL1FeePerUnit, err := arbGasInfo.GetL1BaseFeeEstimate(callOpts)
 			Require(t, err)
+			surplus, err := arbGasInfo.GetL1PricingSurplus(callOpts)
+			Require(t, err)
 
 			colors.PrintGrey("ArbOS updated its L1 estimate")
 			colors.PrintGrey("    L1 base fee ", l1Header.BaseFee)
 			colors.PrintGrey("    L1 estimate ", lastEstimate, " ➤ ", estimatedL1FeePerUnit, " = ", actualL1FeePerUnit)
-			fmt.Fprintln(f, i, ",", l1Header.BaseFee, ",", lastEstimate, ",", estimatedL1FeePerUnit, ",", actualL1FeePerUnit)
+			colors.PrintGrey("    Surplus ", surplus)
+			fmt.Fprintln(f, i, ",", l1Header.BaseFee, ",", lastEstimate, ",", estimatedL1FeePerUnit, ",", actualL1FeePerUnit, ",", surplus)
 
 			oldDiff := arbmath.BigAbs(arbmath.BigSub(lastEstimate, l1Header.BaseFee))
 			newDiff := arbmath.BigAbs(arbmath.BigSub(actualL1FeePerUnit, l1Header.BaseFee))
 
-			if timesPriceAdjusted > 0 && arbmath.BigGreaterThan(newDiff, oldDiff) {
-				if numRetrogradeMoves == 0 {
-					numRetrogradeMoves++
-				} else {
-					Fail(t, "L1 gas price estimate should tend toward the basefee", timesPriceAdjusted, newDiff, oldDiff, lastEstimate, estimatedL1FeePerUnit, l1Header.BaseFee, actualL1FeePerUnit)
+			if timesPriceAdjusted > 0 && arbmath.BigGreaterThan(newDiff, oldDiff) && surplus.Sign() == arbmath.BigSub(actualL1FeePerUnit, l1Header.BaseFee).Sign() {
+				numRetrogradeMoves++
+				if numRetrogradeMoves > 1 {
+					Fail(t, "L1 gas price estimate should tend toward the basefee", timesPriceAdjusted, newDiff, oldDiff, lastEstimate, estimatedL1FeePerUnit, l1Header.BaseFee, actualL1FeePerUnit, surplus)
 				}
+			} else {
+				numRetrogradeMoves = 0
 			}
 			diff := arbmath.BigAbs(arbmath.BigSub(actualL1FeePerUnit, estimatedL1FeePerUnit))
 			maxDiffToAllow := arbmath.BigDivByUint(actualL1FeePerUnit, 100)
@@ -163,16 +187,39 @@ func TestSequencerPriceAdjusts(t *testing.T) {
 		}
 	}
 
-	sequencerBalanceAfter := GetBalance(t, ctx, l2client, l1pricing.BatchPosterAddress)
-	colors.PrintMint("sequencer balance ", sequencerBalanceBefore, " ➤ ", sequencerBalanceAfter)
-	colors.PrintMint("price changes     ", timesPriceAdjusted)
+	batchPoster := l1info.GetAddress("Sequencer")
+	batchPosterBalanceAfter := GetBalance(t, ctx, l2client, batchPoster)
+	rewardBalanceAfter := GetBalance(t, ctx, l2client, l1pricing.BatchPosterAddress)
+	colors.PrintMint("batch poster balance ", batchPosterBalanceBefore, " ➤ ", batchPosterBalanceAfter)
+	colors.PrintMint("reward balance       ", rewardBalanceBefore, " ➤ ", rewardBalanceAfter)
+	colors.PrintMint("price changes        ", timesPriceAdjusted)
 
 	if timesPriceAdjusted == 0 {
 		Fail(t, "L1 gas price estimate never adjusted")
 	}
-	if !arbmath.BigGreaterThan(sequencerBalanceAfter, sequencerBalanceBefore) {
-		Fail(t, "sequencer didn't get paid")
+	if !arbmath.BigGreaterThan(batchPosterBalanceAfter, batchPosterBalanceBefore) {
+		Fail(t, "batch poster didn't get paid")
 	}
+}
+
+func TestSequencerPriceAdjustsFrom1Gwei(t *testing.T) {
+	testSequencerPriceAdjustsFrom(t, params.GWei)
+}
+
+func TestSequencerPriceAdjustsFrom2Gwei(t *testing.T) {
+	testSequencerPriceAdjustsFrom(t, 2*params.GWei)
+}
+
+func TestSequencerPriceAdjustsFrom5Gwei(t *testing.T) {
+	testSequencerPriceAdjustsFrom(t, 5*params.GWei)
+}
+
+func TestSequencerPriceAdjustsFrom10Gwei(t *testing.T) {
+	testSequencerPriceAdjustsFrom(t, 10*params.GWei)
+}
+
+func TestSequencerPriceAdjustsFrom25Gwei(t *testing.T) {
+	testSequencerPriceAdjustsFrom(t, 25*params.GWei)
 }
 
 func compressedTxSize(t *testing.T, tx *types.Transaction) uint64 {


### PR DESCRIPTION
Targets https://github.com/OffchainLabs/nitro/pull/754

Adds tests that start at different initial estimates and show that the L1 price estimate stabilizes