### PR TITLE
Improve retryable autoredeem gas checks

### DIFF
--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -5,6 +5,7 @@ package arbos
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"time"
@@ -154,19 +155,37 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 			return util.TransferBalance(from, to, amount, evm, scenario, "during evm execution")
 		}
 
-		// collect the submission fee
+		// check that the user has enough balance to pay for the max submission fee
+		balanceAfterMint := evm.StateDB.GetBalance(tx.From)
+		if balanceAfterMint.Cmp(tx.MaxSubmissionFee) < 0 {
+			err := fmt.Errorf(
+				"insufficient funds for max submission fee: address %v have %v want %v",
+				tx.From, balanceAfterMint, tx.MaxSubmissionFee,
+			)
+			return true, 0, err, nil
+		}
+
 		submissionFee := retryables.RetryableSubmissionFee(len(tx.RetryData), tx.L1BaseFee)
+		if arbmath.BigLessThan(tx.MaxSubmissionFee, submissionFee) {
+			// should be impossible as this is checked at L1
+			err := fmt.Errorf(
+				"max submission fee %v is less than the actual submission fee %v",
+				tx.MaxSubmissionFee, submissionFee,
+			)
+			return true, 0, err, nil
+		}
+
+		// collect the submission fee
 		if err := transfer(&tx.From, &networkFeeAccount, submissionFee); err != nil {
+			// should be impossible as we just checked that they have enough balance for the max submission fee,
+			// and we also checked that the max submission fee is at least the actual submission fee
+			glog.Error("failed to transfer submissionFee", "err", err)
 			return true, 0, err, nil
 		}
 		withheldSubmissionFee := takeFunds(availableRefund, submissionFee)
 
 		// refund excess submission fee
-		submissionFeeRefund := arbmath.BigSub(tx.MaxSubmissionFee, submissionFee)
-		if submissionFeeRefund.Sign() < 0 {
-			return true, 0, errors.New("max submission fee is less than the actual submission fee"), nil
-		}
-		submissionFeeRefund = takeFunds(availableRefund, submissionFeeRefund)
+		submissionFeeRefund := takeFunds(availableRefund, arbmath.BigSub(tx.MaxSubmissionFee, submissionFee))
 		if err := transfer(&tx.From, &tx.FeeRefundAddr, submissionFeeRefund); err != nil {
 			// should never happen as from's balance should be at least availableRefund at this point
 			glog.Error("failed to transfer submissionFeeRefund", "err", err)
@@ -205,7 +224,7 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 		)
 		p.state.Restrict(err)
 
-		err = EmitTicketCreatedEvent(evm, underlyingTx.Hash())
+		err = EmitTicketCreatedEvent(evm, ticketId)
 		if err != nil {
 			glog.Error("failed to emit TicketCreated event", "err", err)
 		}
@@ -230,14 +249,15 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 				// should never happen as from's balance should be at least availableRefund at this point
 				glog.Error("failed to transfer gasCostRefund", "err", err)
 			}
-			return true, 0, nil, underlyingTx.Hash().Bytes()
+			return true, 0, nil, ticketId.Bytes()
 		}
 
 		// pay for the retryable's gas and update the pools
 		gascost := arbmath.BigMulByUint(basefee, usergas)
 		if transfer(&tx.From, &networkFeeAccount, gascost) != nil {
 			// should be impossible because we just checked the tx.From balance
-			panic(err)
+			glog.Error("failed to transfer gas cost to network fee account", "err", err)
+			return true, 0, nil, ticketId.Bytes()
 		}
 
 		withheldGasFunds := takeFunds(availableRefund, gascost) // gascost is conceptually charged before the gas price refund
@@ -292,7 +312,7 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 			}
 		}
 
-		return true, usergas, nil, underlyingTx.Hash().Bytes()
+		return true, usergas, nil, ticketId.Bytes()
 	case *types.ArbitrumRetryTx:
 
 		// Transfer callvalue from escrow

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -202,10 +202,30 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 		usergas := p.msg.Gas()
 
 		maxGasCost := arbmath.BigMulByUint(tx.GasFeeCap, usergas)
-		maxFeePerGasTooLow := arbmath.BigLessThan(tx.GasFeeCap, basefee) && (p.msg.RunMode() != types.MessageGasEstimationMode || tx.GasFeeCap.BitLen() > 0)
+		maxFeePerGasTooLow := arbmath.BigLessThan(tx.GasFeeCap, basefee)
+		if p.msg.RunMode() == types.MessageGasEstimationMode && tx.GasFeeCap.BitLen() == 0 {
+			// In gas estimation mode, we permit a zero gas fee cap.
+			// This matches behavior with normal tx gas estimation.
+			maxFeePerGasTooLow = false
+		}
 		if arbmath.BigLessThan(balance, maxGasCost) || usergas < params.TxGas || maxFeePerGasTooLow {
-			// user either specified too low of a gas fee cap, didn't have enough balance to pay for gas,
-			// or the specified gas limit is below the minimum transaction gas cost
+			// User either specified too low of a gas fee cap, didn't have enough balance to pay for gas,
+			// or the specified gas limit is below the minimum transaction gas cost.
+			// Either way, attempt to refund the gas costs and the submission fee, since we're not doing the auto-redeem.
+
+			// First, we give the submission fee back to the transaction sender:
+			if err := transfer(&networkFeeAccount, &tx.From, submissionFee); err != nil {
+				glog.Error("failed to refund submissionFee", "err", err)
+			}
+			// Then, as was previously limited by availableRefund, we attempt to move the refund to the fee refund address.
+			// If the deposit value was lower than the submission fee, only some (or none) of the submission fee may be moved.
+			// In that case, any amount up to the deposit value will be refunded to the fee refund address,
+			// with the rest remaining in the transaction sender's address (as that's where the funds were pulled from).
+			if err := transfer(&tx.From, &tx.FeeRefundAddr, withheldSubmissionFee); err != nil {
+				glog.Error("failed to refund withheldSubmissionFee", "err", err)
+			}
+
+			// Next, attempt to refund the gas costs (currently sitting in the transaction sender's account).
 			gasCostRefund := takeFunds(availableRefund, maxGasCost)
 			if err := transfer(&tx.From, &tx.FeeRefundAddr, gasCostRefund); err != nil {
 				// should never happen as from's balance should be at least availableRefund at this point


### PR DESCRIPTION
Effectively pulls in #764

Changes:
- Fails if the user doesn't have enough balance to pay for the max submission fee
- Refunds submission fee if the user is lacking balance for the L2 callvalue
- Refunds gas costs if it can't create an auto-redeem
- Doesn't create the auto-redeem if the user doesn't have enough balance to pay for `gasFeeCap * gasLimit` (meaning you can no longer set a max gas fee cap)