### PR TITLE
Fix GetL1GasPriceEstimate precompile

### DIFF
--- a/precompiles/ArbGasInfo.go
+++ b/precompiles/ArbGasInfo.go
@@ -103,7 +103,10 @@ func (con ArbGasInfo) GetL1GasPriceEstimate(c ctx, evm mech) (huge, error) {
 	if err != nil {
 		return nil, err
 	}
-	return arbmath.BigMulByUint(ppu, params.TxDataNonZeroGasEIP2028), nil
+	if c.State.FormatVersion() < 2 {
+		ppu = arbmath.BigMulByUint(ppu, params.TxDataNonZeroGasEIP2028)
+	}
+	return ppu, nil
 }
 
 // Get the fee paid to the aggregator for posting this tx

--- a/precompiles/ArbGasInfo.go
+++ b/precompiles/ArbGasInfo.go
@@ -99,14 +99,7 @@ func (con ArbGasInfo) GetL1BaseFeeEstimateInertia(c ctx, evm mech) (uint64, erro
 
 // Get the current estimate of the L1 basefee
 func (con ArbGasInfo) GetL1GasPriceEstimate(c ctx, evm mech) (huge, error) {
-	ppu, err := c.State.L1PricingState().PricePerUnit()
-	if err != nil {
-		return nil, err
-	}
-	if c.State.FormatVersion() < 2 {
-		ppu = arbmath.BigMulByUint(ppu, params.TxDataNonZeroGasEIP2028)
-	}
-	return ppu, nil
+	return con.GetL1BaseFeeEstimate(c, evm)
 }
 
 // Get the fee paid to the aggregator for posting this tx


### PR DESCRIPTION
Fix error in GetL1GasPriceEstimate precompile.  ArbOS version 1 retains the old behavior for backward compatibility. Newer versions get the updated behavior.