### PR TITLE
Batch posting reports that include runtime gas costs

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -426,7 +426,10 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context, batchSeqNum u
 	txOpts := *b.transactOpts
 	txOpts.Context = ctx
 	txOpts.NoSend = true
-	tx, err := b.inboxContract.AddSequencerL2BatchFromOrigin(&txOpts, new(big.Int).SetUint64(batchSeqNum), sequencerMsg, new(big.Int).SetUint64(b.building.segments.delayedMsg), b.gasRefunder)
+	tx, err := b.inboxContract.AddSequencerL2BatchFromOrigin(
+		&txOpts, arbmath.UintToBig(batchSeqNum), sequencerMsg,
+		arbmath.UintToBig(b.building.segments.delayedMsg), b.gasRefunder,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -31,6 +31,7 @@ var ArbRetryableTxAddress common.Address
 var ArbSysAddress common.Address
 var InternalTxStartBlockMethodID [4]byte
 var InternalTxBatchPostingReportMethodID [4]byte
+var InternalTxBatchPostingReportV2MethodID [4]byte
 var RedeemScheduledEventID common.Hash
 var L2ToL1TransactionEventID common.Hash
 var L2ToL1TxEventID common.Hash

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -75,7 +75,7 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 		state.L2PricingState().UpdatePricingModel(l2BaseFee, timePassed, false)
 
 		state.UpgradeArbosVersionIfNecessary(currentTime, evm.ChainConfig())
-	case InternalTxBatchPostingReportMethodID:
+	case InternalTxBatchPostingReportV2MethodID:
 		inputs, err := util.UnpackInternalTxDataBatchPostingReport(tx.Data)
 		if err != nil {
 			panic(err)
@@ -83,6 +83,17 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 		batchTimestamp, _ := inputs[0].(*big.Int)
 		batchPosterAddress, _ := inputs[1].(common.Address)
 		// ignore input[2], batchNumber, which exist because we might need them in the future
+		batchDataGas, _ := inputs[3].(uint64)
+		l1BaseFeeWei, _ := inputs[4].(*big.Int)
+
+	case InternalTxBatchPostingReportMethodID:
+		inputs, err := util.UnpackInternalTxDataBatchPostingReport(tx.Data)
+		if err != nil {
+			panic(err)
+		}
+		batchTimestamp, _ := inputs[0].(*big.Int)
+		batchPosterAddress, _ := inputs[1].(common.Address)
+		// we ignore input[2], the batchNumber
 		batchDataGas, _ := inputs[3].(uint64)
 		l1BaseFeeWei, _ := inputs[4].(*big.Int)
 

--- a/arbos/util/util.go
+++ b/arbos/util/util.go
@@ -27,6 +27,9 @@ var PackInternalTxDataStartBlock func(...interface{}) ([]byte, error)
 var UnpackInternalTxDataStartBlock func([]byte) ([]interface{}, error)
 var PackInternalTxDataBatchPostingReport func(...interface{}) ([]byte, error)
 var UnpackInternalTxDataBatchPostingReport func([]byte) ([]interface{}, error)
+var PackInternalTxDataBatchPostingReportV2 func(...interface{}) ([]byte, error)
+var UnpackInternalTxDataBatchPostingReportV2 func([]byte) ([]interface{}, error)
+
 var PackArbRetryableTxRedeem func(...interface{}) ([]byte, error)
 
 func init() {
@@ -91,7 +94,12 @@ func init() {
 
 	acts := precompilesgen.ArbosActsABI
 	PackInternalTxDataStartBlock, UnpackInternalTxDataStartBlock = callParser(acts, "startBlock")
-	PackInternalTxDataBatchPostingReport, UnpackInternalTxDataBatchPostingReport = callParser(acts, "batchPostingReport")
+	PackInternalTxDataBatchPostingReport, UnpackInternalTxDataBatchPostingReport = callParser(
+		acts, "batchPostingReport",
+	)
+	PackInternalTxDataBatchPostingReportV2, UnpackInternalTxDataBatchPostingReportV2 = callParser(
+		acts, "batchPostingReportV2",
+	)
 	PackArbRetryableTxRedeem, _ = callParser(precompilesgen.ArbRetryableTxABI, "redeem")
 }
 
@@ -105,6 +113,14 @@ func HashFromReader(rd io.Reader) (common.Hash, error) {
 		return common.Hash{}, err
 	}
 	return common.BytesToHash(buf), nil
+}
+
+func BigIntFromReader(rd io.Reader) (*big.Int, error) {
+	hash, err := HashFromReader(rd)
+	if err != nil {
+		return nil, err
+	}
+	return hash.Big(), nil
 }
 
 func HashToWriter(val common.Hash, wr io.Writer) error {

--- a/contracts/src/precompiles/ArbosActs.sol
+++ b/contracts/src/precompiles/ArbosActs.sol
@@ -44,5 +44,14 @@ interface ArbosActs {
         uint256 l1BaseFeeWei
     ) external;
 
+    function batchPostingReportV2(
+        uint256 batchTimestamp,
+        address batchPosterAddress,
+        uint64 batchNumber,
+        uint64 batchDataGas,
+        uint256 l1BaseFeeWei
+        uint64 runtimeGas,
+    ) external;
+
     error CallerNotArbOS();
 }

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -568,6 +568,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 	ArbosActs := insert(MakePrecompile(templates.ArbosActsMetaData, &ArbosActs{Address: types.ArbosAddress}))
 	arbos.InternalTxStartBlockMethodID = ArbosActs.GetMethodID("StartBlock")
 	arbos.InternalTxBatchPostingReportMethodID = ArbosActs.GetMethodID("BatchPostingReport")
+	arbos.InternalTxBatchPostingReportV2MethodID = ArbosActs.GetMethodID("BatchPostingReportV2")
 
 	return contracts
 }


### PR DESCRIPTION
The idea here is to include additional info in batch posting reports concerning the fixed cost overhead. Because the report itself isn't included, we'd still need to add a constant which means just having a configurable overhead variable is probably better