### PR TITLE
Cap l1 cost amortization

### DIFF
--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -228,10 +228,14 @@ func (state *ArbosState) UpgradeArbosVersionIfNecessary(currentTimestamp uint64,
 		for upgradeTo > state.arbosVersion && currentTimestamp >= flagday {
 			switch state.arbosVersion {
 			case 1:
-				if err := state.l1PricingState.SetLastSurplus(common.Big0); err != nil {
+				l1p := state.l1PricingState
+				if err := l1p.SetLastSurplus(common.Big0); err != nil {
 					panic("Error encountered when trying to upgrade ArbOS version 1 to version 2")
 				}
-				if err := state.l1PricingState.SetPerBatchGasCost(common.Big0); err != nil {
+				if err := l1p.SetPerBatchGasCost(common.Big0); err != nil {
+					panic("Error encountered when trying to upgrade ArbOS version 1 to version 2")
+				}
+				if err := l1p.SetPerBatchCostCap(0); err != nil {
 					panic("Error encountered when trying to upgrade ArbOS version 1 to version 2")
 				}
 			default:

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -235,7 +235,7 @@ func (state *ArbosState) UpgradeArbosVersionIfNecessary(currentTimestamp uint64,
 				if err := l1p.SetPerBatchGasCost(common.Big0); err != nil {
 					panic("Error encountered when trying to upgrade ArbOS version 1 to version 2")
 				}
-				if err := l1p.SetPerBatchCostCap(0); err != nil {
+				if err := l1p.SetAmortizedCostCapBP(0); err != nil {
 					panic("Error encountered when trying to upgrade ArbOS version 1 to version 2")
 				}
 			default:

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -6,6 +6,7 @@ package arbosState
 import (
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/common/math"
 	"log"
 	"math/big"
 
@@ -183,7 +184,7 @@ func InitializeArbosState(stateDB vm.StateDB, burner burn.Burner, chainConfig *p
 	}
 
 	arbosVersion = chainConfig.ArbitrumChainParams.InitialArbOSVersion
-	if arbosVersion < 1 || arbosVersion > 2 {
+	if arbosVersion < 1 || arbosVersion > 3 {
 		return nil, fmt.Errorf("cannot initialize to unsupported ArbOS version %v", arbosVersion)
 	}
 
@@ -235,8 +236,9 @@ func (state *ArbosState) UpgradeArbosVersionIfNecessary(currentTimestamp uint64,
 				if err := l1p.SetPerBatchGasCost(common.Big0); err != nil {
 					panic("Error encountered when trying to upgrade ArbOS version 1 to version 2")
 				}
-				if err := l1p.SetAmortizedCostCapBP(0); err != nil {
-					panic("Error encountered when trying to upgrade ArbOS version 1 to version 2")
+			case 2:
+				if err := state.l1PricingState.SetAmortizedCostCapBP(math.MaxUint64); err != nil {
+					panic("Error encountered when trying to upgrade ArbOS version 2 to version 3")
 				}
 			default:
 				panic("Unable to perform requested ArbOS upgrade")

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -100,6 +100,7 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 			evm.Context.Time.Uint64(),
 			batchPosterAddress,
 			weiSpent,
+			l1BaseFeeWei,
 			util.TracingDuringEVM,
 		)
 		if err != nil {

--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -41,6 +41,7 @@ type L1PricingState struct {
 	pricePerUnit     storage.StorageBackedBigInt // current price per calldata unit
 	lastSurplus      storage.StorageBackedBigInt // introduced in ArbOS version 2
 	perBatchGasCost  storage.StorageBackedBigInt // introduced in ArbOS version 2
+	perBatchCostCap  storage.StorageBackedUint64 // introduced in ArbOS version 2
 }
 
 var (
@@ -63,6 +64,7 @@ const (
 	pricePerUnitOffset
 	lastSurplusOffset
 	perBatchGasCostOffset
+	perBatchCostCapOffset
 )
 
 const (
@@ -124,6 +126,7 @@ func OpenL1PricingState(sto *storage.Storage) *L1PricingState {
 		sto.OpenStorageBackedBigInt(pricePerUnitOffset),
 		sto.OpenStorageBackedBigInt(lastSurplusOffset),
 		sto.OpenStorageBackedBigInt(perBatchGasCostOffset),
+		sto.OpenStorageBackedUint64(perBatchCostCapOffset),
 	}
 }
 
@@ -217,6 +220,14 @@ func (ps *L1PricingState) PerBatchGasCost() (*big.Int, error) {
 
 func (ps *L1PricingState) SetPerBatchGasCost(cost *big.Int) error {
 	return ps.perBatchGasCost.Set(cost)
+}
+
+func (ps *L1PricingState) PerBatchCostCap() (uint64, error) {
+	return ps.perBatchCostCap.Get()
+}
+
+func (ps *L1PricingState) SetPerBatchCostCap(cap uint64) error {
+	return ps.perBatchCostCap.Set(cap)
 }
 
 // Update the pricing model based on a payment by a batch poster

--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -37,11 +37,11 @@ type L1PricingState struct {
 	lastUpdateTime     storage.StorageBackedUint64 // timestamp of the last update from L1 that we processed
 	fundsDueForRewards storage.StorageBackedBigInt
 	// funds collected since update are recorded as the balance in account L1PricerFundsPoolAddress
-	unitsSinceUpdate storage.StorageBackedUint64 // calldata units collected for since last update
-	pricePerUnit     storage.StorageBackedBigInt // current price per calldata unit
-	lastSurplus      storage.StorageBackedBigInt // introduced in ArbOS version 2
-	perBatchGasCost  storage.StorageBackedBigInt // introduced in ArbOS version 2
-	perBatchCostCap  storage.StorageBackedUint64 // introduced in ArbOS version 2
+	unitsSinceUpdate   storage.StorageBackedUint64 // calldata units collected for since last update
+	pricePerUnit       storage.StorageBackedBigInt // current price per calldata unit
+	lastSurplus        storage.StorageBackedBigInt // introduced in ArbOS version 2
+	perBatchGasCost    storage.StorageBackedBigInt // introduced in ArbOS version 2
+	amortizedCostCapBP storage.StorageBackedUint64 // in basis points, 0 means no cap; introduced in ArbOS version 2
 }
 
 var (
@@ -64,7 +64,7 @@ const (
 	pricePerUnitOffset
 	lastSurplusOffset
 	perBatchGasCostOffset
-	perBatchCostCapOffset
+	amortizedCostCapBPOffset
 )
 
 const (
@@ -126,7 +126,7 @@ func OpenL1PricingState(sto *storage.Storage) *L1PricingState {
 		sto.OpenStorageBackedBigInt(pricePerUnitOffset),
 		sto.OpenStorageBackedBigInt(lastSurplusOffset),
 		sto.OpenStorageBackedBigInt(perBatchGasCostOffset),
-		sto.OpenStorageBackedUint64(perBatchCostCapOffset),
+		sto.OpenStorageBackedUint64(amortizedCostCapBPOffset),
 	}
 }
 
@@ -222,12 +222,12 @@ func (ps *L1PricingState) SetPerBatchGasCost(cost *big.Int) error {
 	return ps.perBatchGasCost.Set(cost)
 }
 
-func (ps *L1PricingState) PerBatchCostCap() (uint64, error) {
-	return ps.perBatchCostCap.Get()
+func (ps *L1PricingState) AmortizedCostCapBP() (uint64, error) {
+	return ps.amortizedCostCapBP.Get()
 }
 
-func (ps *L1PricingState) SetPerBatchCostCap(cap uint64) error {
-	return ps.perBatchCostCap.Set(cap)
+func (ps *L1PricingState) SetAmortizedCostCapBP(cap uint64) error {
+	return ps.amortizedCostCapBP.Set(cap)
 }
 
 // Update the pricing model based on a payment by a batch poster


### PR DESCRIPTION
Put a cap on the amortized cost charged to transactions. When a batch posting report is processed, the amount due to the batch poster from this report is capped at the product of three things: the L1 basefee reported in the batch, the number of data units allocated to this batch, and a coefficient measured in basis points. The coefficient is a new parameter of the L1 pricer, and is initialized to MaxUint64 (which means effectively no cap on the charge).

This is a consensus change, enabled in ArbOS version 3. 