### PR TITLE
Fix gosec ci lint

### DIFF
--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -686,8 +686,9 @@ func (h seqCoordinatorChosenHealthcheck) ServeHTTP(response http.ResponseWriter,
 
 func (c *SeqCoordinator) launchHealthcheckServer(ctx context.Context) {
 	server := &http.Server{
-		Addr:    c.config.ChosenHealthcheckAddr,
-		Handler: seqCoordinatorChosenHealthcheck{c},
+		Addr:              c.config.ChosenHealthcheckAddr,
+		Handler:           seqCoordinatorChosenHealthcheck{c},
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	go func() {

--- a/das/dasrpc/dasRpcServer.go
+++ b/das/dasrpc/dasRpcServer.go
@@ -62,7 +62,8 @@ func StartDASRPCServerOnListener(ctx context.Context, listener net.Listener, loc
 	}
 
 	srv := &http.Server{
-		Handler: rpcServer,
+		Handler:           rpcServer,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	go func() {

--- a/das/restful_server.go
+++ b/das/restful_server.go
@@ -56,7 +56,8 @@ func NewRestfulDasServerOnListener(listener net.Listener, storageService arbstat
 	}
 
 	ret.server = &http.Server{
-		Handler: ret,
+		Handler:           ret,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	go func() {

--- a/das/restful_server_list_test.go
+++ b/das/restful_server_list_test.go
@@ -75,7 +75,8 @@ func stringListIsPermutation(lis1, lis2 []string) bool {
 
 func newListHttpServerForTest(t *testing.T, contents string) (int, *http.Server) {
 	server := &http.Server{
-		Handler: &testHandler{contents},
+		Handler:           &testHandler{contents},
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 	listener, err := net.Listen("tcp", "localhost:0")
 	Require(t, err)


### PR DESCRIPTION
Adds header-reading timeouts to suppress the `slowloris` lint