### PR TITLE
Represent deposit in tracing as mint to tx from account

### DIFF
--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -134,16 +134,18 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 
 	switch tx := underlyingTx.GetInner().(type) {
 	case *types.ArbitrumDepositTx:
-		if p.msg.To() == nil {
+		from := p.msg.From()
+		to := p.msg.To()
+		value := p.msg.Value()
+		if to == nil {
 			return true, 0, errors.New("eth deposit has no To address"), nil
 		}
-		from := p.msg.From()
-		util.MintBalance(&from, p.msg.Value(), evm, util.TracingBeforeEVM, "deposit")
+		util.MintBalance(&from, value, evm, util.TracingBeforeEVM, "deposit")
 		defer (startTracer())()
 		// We intentionally use the variant here that doesn't do tracing,
 		// because this transfer is represented as the outer eth transaction.
 		// This transfer is necessary because we don't actually invoke the EVM.
-		core.Transfer(evm.StateDB, p.msg.From(), *p.msg.To(), p.msg.Value())
+		core.Transfer(evm.StateDB, from, *to, value)
 		return true, 0, nil, nil
 	case *types.ArbitrumInternalTx:
 		defer (startTracer())()

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -134,8 +134,9 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 
 	switch tx := underlyingTx.GetInner().(type) {
 	case *types.ArbitrumDepositTx:
+		from := p.msg.From()
+		util.MintBalance(&from, p.msg.Value(), evm, util.TracingBeforeEVM, "deposit")
 		defer (startTracer())()
-		util.MintBalance(p.msg.To(), p.msg.Value(), evm, util.TracingDuringEVM, "deposit")
 		return true, 0, nil, nil
 	case *types.ArbitrumInternalTx:
 		defer (startTracer())()


### PR DESCRIPTION
This is relevant now that with the deposit from address change, a deposit's from address and to address are different. Previously, this didn't matter because they were the same.