### PR TITLE
Drop error when user tx uses too little gas (happens for deposits)

### DIFF
--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -323,17 +323,7 @@ func ProduceBlockAdvanced(
 		if gasUsed < dataGas {
 			log.Error("ApplyTransaction() used less gas than it should have", "delta", dataGas-gasUsed)
 			computeUsed = params.TxGas
-		}
-
-		if computeUsed < params.TxGas {
-			if isUserTx {
-				log.Error(
-					"user tx used less compute than params.TxGas",
-					"computeUsed", computeUsed,
-					"totalGasUsed", gasUsed,
-					"dataGas", dataGas,
-				)
-			}
+		} else if computeUsed < params.TxGas {
 			computeUsed = params.TxGas
 		}
 


### PR DESCRIPTION
Txs which end the state transition early can be user txs and can succeed using 0 gas, so we shouldn't log here.