### PR TITLE
Support --node.dangerous.reorg-to-block with the block validator

### DIFF
--- a/validator/block_validator.go
+++ b/validator/block_validator.go
@@ -107,7 +107,17 @@ type validationStatus struct {
 	ModuleRoots []common.Hash    // non-atomic: present from the start
 }
 
-func NewBlockValidator(inboxReader InboxReaderInterface, inbox InboxTrackerInterface, streamer TransactionStreamerInterface, blockchain *core.BlockChain, db ethdb.Database, config *BlockValidatorConfig, machineLoader *NitroMachineLoader, das arbstate.DataAvailabilityReader) (*BlockValidator, error) {
+func NewBlockValidator(
+	inboxReader InboxReaderInterface,
+	inbox InboxTrackerInterface,
+	streamer TransactionStreamerInterface,
+	blockchain *core.BlockChain,
+	db ethdb.Database,
+	config *BlockValidatorConfig,
+	machineLoader *NitroMachineLoader,
+	das arbstate.DataAvailabilityReader,
+	reorgingToBlock *types.Block,
+) (*BlockValidator, error) {
 	concurrent := config.ConcurrentRunsLimit
 	if concurrent == 0 {
 		concurrent = runtime.NumCPU()
@@ -132,7 +142,7 @@ func NewBlockValidator(inboxReader InboxReaderInterface, inbox InboxTrackerInter
 		concurrentRunsLimit:     int32(concurrent),
 		config:                  config,
 	}
-	err = validator.readLastBlockValidatedDbInfo()
+	err = validator.readLastBlockValidatedDbInfo(reorgingToBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +168,7 @@ func NewBlockValidator(inboxReader InboxReaderInterface, inbox InboxTrackerInter
 	return validator, nil
 }
 
-func (v *BlockValidator) readLastBlockValidatedDbInfo() error {
+func (v *BlockValidator) readLastBlockValidatedDbInfo(reorgingToBlock *types.Block) error {
 	v.lastBlockValidatedMutex.Lock()
 	defer v.lastBlockValidatedMutex.Unlock()
 
@@ -195,15 +205,29 @@ func (v *BlockValidator) readLastBlockValidatedDbInfo() error {
 		return err
 	}
 
-	expectedHash := v.blockchain.GetCanonicalHash(info.BlockNumber)
-	if expectedHash != info.BlockHash {
-		return fmt.Errorf("last validated block %v stored with hash %v, but blockchain has hash %v", info.BlockNumber, info.BlockHash, expectedHash)
+	if reorgingToBlock != nil && reorgingToBlock.NumberU64() >= info.BlockNumber {
+		// Disregard this reorg as it doesn't affect the last validated block
+		reorgingToBlock = nil
+	}
+
+	if reorgingToBlock == nil {
+		expectedHash := v.blockchain.GetCanonicalHash(info.BlockNumber)
+		if expectedHash != info.BlockHash {
+			return fmt.Errorf("last validated block %v stored with hash %v, but blockchain has hash %v", info.BlockNumber, info.BlockHash, expectedHash)
+		}
 	}
 
 	v.lastBlockValidated = info.BlockNumber
 	v.lastBlockValidatedHash = info.BlockHash
 	v.nextBlockToValidate = v.lastBlockValidated + 1
 	v.globalPosNextSend = info.AfterPosition
+
+	if reorgingToBlock != nil {
+		err = v.reorgToBlockImpl(reorgingToBlock.NumberU64(), reorgingToBlock.Hash(), true)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -677,7 +701,7 @@ func (v *BlockValidator) ReorgToBlock(blockNum uint64, blockHash common.Hash) er
 
 	if blockNum+1 < v.nextValidationEntryBlock {
 		log.Warn("block validator processing reorg", "blockNum", blockNum)
-		err := v.reorgToBlockImpl(blockNum, blockHash)
+		err := v.reorgToBlockImpl(blockNum, blockHash, false)
 		if err != nil {
 			return fmt.Errorf("block validator reorg failed: %w", err)
 		}
@@ -686,7 +710,7 @@ func (v *BlockValidator) ReorgToBlock(blockNum uint64, blockHash common.Hash) er
 	return nil
 }
 
-func (v *BlockValidator) reorgToBlockImpl(blockNum uint64, blockHash common.Hash) error {
+func (v *BlockValidator) reorgToBlockImpl(blockNum uint64, blockHash common.Hash, hasLastValidatedMutex bool) error {
 	for b := blockNum + 1; b < v.nextValidationEntryBlock; b++ {
 		entry, found := v.validationEntries.Load(b)
 		if !found {
@@ -750,10 +774,14 @@ func (v *BlockValidator) reorgToBlockImpl(blockNum uint64, blockHash common.Hash
 	}
 
 	if v.lastBlockValidated > blockNum {
-		v.lastBlockValidatedMutex.Lock()
+		if !hasLastValidatedMutex {
+			v.lastBlockValidatedMutex.Lock()
+		}
 		atomic.StoreUint64(&v.lastBlockValidated, blockNum)
 		v.lastBlockValidatedHash = blockHash
-		v.lastBlockValidatedMutex.Unlock()
+		if !hasLastValidatedMutex {
+			v.lastBlockValidatedMutex.Unlock()
+		}
 
 		err = v.writeLastValidatedToDb(blockNum, blockHash, v.globalPosNextSend)
 		if err != nil {


### PR DESCRIPTION
This will also reorg the block validator's `lastBlockValidated` when reorging on startup