### PR TITLE
Fix random panic in DAS tests

### DIFF
--- a/das/panic_wrapper.go
+++ b/das/panic_wrapper.go
@@ -5,9 +5,11 @@ package das
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/offchainlabs/nitro/arbstate"
 )
 
@@ -24,6 +26,10 @@ func NewPanicWrapper(dataAvailabilityService DataAvailabilityService) DataAvaila
 func (w *PanicWrapper) GetByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
 	data, err := w.DataAvailabilityService.GetByHash(ctx, hash)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			log.Error("DAS hash lookup failed from cancelled context")
+			return nil, err
+		}
 		panic(fmt.Sprintf("panic wrapper GetByHash: %v", err))
 	}
 	return data, nil


### PR DESCRIPTION
- Track validation threads for clean shutdown now that arbitrator respects cancellation
- Log context cancellation errors in the DAS `PanicWrapper` rather than panicking because if the thread calling `GetByHash` has its context cancelled, the call to `GetByHash` could fail. Instead log and error for visibility in case this occurs in some unexpected circumstance. The `PanicWrapper` is only used for tests, so this seems like a good idea for safety