### PR TITLE
Use current basefee to calculate submission fee if baseFee set to 0

### DIFF
--- a/contracts/src/bridge/Inbox.sol
+++ b/contracts/src/bridge/Inbox.sol
@@ -257,14 +257,15 @@ contract Inbox is DelegateCallAware, PausableUpgradeable, IInbox {
      * @dev This fee can be paid by funds already in the L2 aliased address or by the current message value
      * @dev This formula may change in the future, to future proof your code query this method instead of inlining!!
      * @param dataLength The length of the retryable's calldata, in bytes
-     * @param baseFee The block basefee when the retryable is included in the chain
+     * @param baseFee The block basefee when the retryable is included in the chain, if 0 current block.basefee will be used
      */
     function calculateRetryableSubmissionFee(uint256 dataLength, uint256 baseFee)
         public
-        pure
+        view
         returns (uint256)
     {
-        return (1400 + 6 * dataLength) * baseFee;
+        // Use current block basefee if baseFee parameter is 0
+        return (1400 + 6 * dataLength) * (baseFee == 0 ? block.basefee : baseFee);
     }
 
     /// @notice deposit eth from L1 to L2
@@ -441,7 +442,7 @@ contract Inbox is DelegateCallAware, PausableUpgradeable, IInbox {
                 data
             );
 
-        uint256 submissionFee = calculateRetryableSubmissionFee(data.length, block.basefee);
+        uint256 submissionFee = calculateRetryableSubmissionFee(data.length, 0);
         if (maxSubmissionCost < submissionFee)
             revert InsufficientSubmissionCost(submissionFee, maxSubmissionCost);
 

--- a/contracts/src/bridge/Inbox.sol
+++ b/contracts/src/bridge/Inbox.sol
@@ -442,7 +442,7 @@ contract Inbox is DelegateCallAware, PausableUpgradeable, IInbox {
                 data
             );
 
-        uint256 submissionFee = calculateRetryableSubmissionFee(data.length, 0);
+        uint256 submissionFee = calculateRetryableSubmissionFee(data.length, block.basefee);
         if (maxSubmissionCost < submissionFee)
             revert InsufficientSubmissionCost(submissionFee, maxSubmissionCost);
 


### PR DESCRIPTION
This allow contracts compiled with solidity < 0.8.7 (which does not support block.basefee) to calculate current submission fee with current basefee.