### PR TITLE
Don't panic when connected to a classic feed

### DIFF
--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -214,6 +214,10 @@ func (bc *BroadcastClient) startBackgroundReader(earlyFrameData io.Reader) {
 					if len(res.Messages) > 0 {
 						messages := []arbstate.MessageWithMetadata{}
 						for _, message := range res.Messages {
+							if message == nil {
+								log.Warn("ignoring nil feed message")
+								continue
+							}
 							messages = append(messages, message.Message)
 						}
 						if err := bc.txStreamer.AddBroadcastMessages(res.Messages[0].SequenceNumber, messages); err != nil {


### PR DESCRIPTION
Classic messages deserialized as a nil nitro message, which caused a nil deref in the transaction streamer logging. I've also hardened the transaction streamer and broadcast client in a number of similar places.