### PR TITLE
Use gotestsum for CI again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,15 +147,15 @@ jobs:
 
       - name: run tests without race detection
         if: matrix.test-mode == 'defaults'
-        run: gotestsum -- -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=1
+        run: gotestsum ./... -- -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=1
 
       - name: run tests with race detection
         if: matrix.test-mode == 'race'
-        run: gotestsum -- -race -parallel=1
+        run: gotestsum ./... -- -race -parallel=1
 
       - name: run redis tests
         if: matrix.test-mode == 'defaults'
-        run: gotestsum -- -p 1 -run TestSeqCoordinator -tags redistest ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
+        run: gotestsum ./... -- -p 1 -run TestSeqCoordinator -tags redistest ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,15 +149,15 @@ jobs:
 
       - name: run tests without race detection
         if: matrix.test-mode == 'defaults'
-        run: gotestsum --format testname ./... -- -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=1
+        run: gotestsum --format short-verbose ./... -- -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=1
 
       - name: run tests with race detection
         if: matrix.test-mode == 'race'
-        run: gotestsum --format testname ./... -- -race -parallel=1
+        run: gotestsum --format short-verbose ./... -- -race -parallel=1
 
       - name: run redis tests
         if: matrix.test-mode == 'defaults'
-        run: gotestsum --format testname ./... -- -p 1 -run TestSeqCoordinator -tags redistest ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
+        run: gotestsum --format short-verbose ./... -- -p 1 -run TestSeqCoordinator -tags redistest ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,15 +149,15 @@ jobs:
 
       - name: run tests without race detection
         if: matrix.test-mode == 'defaults'
-        run: gotestsum ./... -- -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=1
+        run: gotestsum --format testname ./... -- -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=1
 
       - name: run tests with race detection
         if: matrix.test-mode == 'race'
-        run: gotestsum ./... -- -race -parallel=1
+        run: gotestsum --format testname ./... -- -race -parallel=1
 
       - name: run redis tests
         if: matrix.test-mode == 'defaults'
-        run: gotestsum ./... -- -p 1 -run TestSeqCoordinator -tags redistest ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
+        run: gotestsum --format testname ./... -- -p 1 -run TestSeqCoordinator -tags redistest ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,15 +149,15 @@ jobs:
 
       - name: run tests without race detection
         if: matrix.test-mode == 'defaults'
-        run: gotestsum --format short-verbose ./... -- -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=1
+        run: gotestsum --format short-verbose -- ./... -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=1
 
       - name: run tests with race detection
         if: matrix.test-mode == 'race'
-        run: gotestsum --format short-verbose ./... -- -race -parallel=1
+        run: gotestsum --format short-verbose -- ./... -race -parallel=1
 
       - name: run redis tests
         if: matrix.test-mode == 'defaults'
-        run: gotestsum --format short-verbose ./... -- -p 1 -run TestSeqCoordinator -tags redistest ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
+        run: gotestsum --format short-verbose -- -p 1 -run TestSeqCoordinator -tags redistest ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,12 @@ jobs:
           skip-go-installation: true
           skip-pkg-cache: true
 
-      - name: Set TMPDIR
+      - name: Set environment variables
         run: |
           mkdir -p target/tmp
           echo "TMPDIR=$(pwd)/target/tmp" >> "$GITHUB_ENV"
+          echo "GOMEMLIMIT=6GB" >> "$GITHUB_ENV"
+          echo "GOGC=80" >> "$GITHUB_ENV"
 
       - name: run tests without race detection
         if: matrix.test-mode == 'defaults'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: true
 
       - name: Install dependencies
-        run: sudo apt update && sudo apt install -y wabt
+        run: sudo apt update && sudo apt install -y wabt gotestsum
 
       - name: Setup nodejs
         uses: actions/setup-node@v2
@@ -147,15 +147,15 @@ jobs:
 
       - name: run tests without race detection
         if: matrix.test-mode == 'defaults'
-        run: go test ./... -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=1
+        run: gotestsum -- -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=1
 
       - name: run tests with race detection
         if: matrix.test-mode == 'race'
-        run: go test ./... -race -parallel=1
+        run: gotestsum -- -race -parallel=1
 
       - name: run redis tests
         if: matrix.test-mode == 'defaults'
-        run: go test ./... -p 1 -run TestSeqCoordinator -tags redistest ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
+        run: gotestsum -- -p 1 -run TestSeqCoordinator -tags redistest ./arbnode/... ./system_tests/... -coverprofile=coverage-redis.txt -covermode=atomic -coverpkg=./...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
I had hoped using normal `go test ./...` would give us more insight when CI has an unexplained failure, but it doesn't seem to have: https://github.com/OffchainLabs/nitro/runs/7602018626?check_suite_focus=true