### PR TITLE
Test upgradability of RollupProxy

### DIFF
--- a/contracts/src/libraries/AdminFallbackProxy.sol
+++ b/contracts/src/libraries/AdminFallbackProxy.sol
@@ -87,7 +87,7 @@ abstract contract DoubleLogicERC1967Upgrade is ERC1967Upgrade {
             try IERC1822Proxiable(newImplementation).proxiableUUID() returns (bytes32 slot) {
                 require(
                     slot == _IMPLEMENTATION_SECONDARY_SLOT,
-                    "ERC1967Upgrade: unsupported proxiableUUID"
+                    "ERC1967Upgrade: unsupported secondary proxiableUUID"
                 );
             } catch {
                 revert("ERC1967Upgrade: new secondary implementation is not UUPS");

--- a/contracts/src/libraries/DoubleLogicUUPSUpgradeable.sol
+++ b/contracts/src/libraries/DoubleLogicUUPSUpgradeable.sol
@@ -8,6 +8,7 @@ import {DoubleLogicERC1967Upgrade} from "./AdminFallbackProxy.sol";
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 /// @notice An extension to OZ's UUPSUpgradeable contract to be used for handling UUPS upgrades with a DoubleLogicERC1967Upgrade proxy
+///         The should be used in the primary implementation slot of the DoubleLogicUUPS proxy
 /// @dev upgrades should be handles by the primary logic contract in order to pass the `onlyProxy` check
 abstract contract DoubleLogicUUPSUpgradeable is UUPSUpgradeable, DoubleLogicERC1967Upgrade {
     /// @inheritdoc UUPSUpgradeable

--- a/contracts/src/libraries/DoubleLogicUUPSUpgradeable.sol
+++ b/contracts/src/libraries/DoubleLogicUUPSUpgradeable.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 /// @notice An extension to OZ's UUPSUpgradeable contract to be used for handling UUPS upgrades with a DoubleLogicERC1967Upgrade proxy
 /// @dev upgrades should be handles by the primary logic contract in order to pass the `onlyProxy` check
-abstract contract SecondaryLogicUUPSUpgradeable is UUPSUpgradeable, DoubleLogicERC1967Upgrade {
+abstract contract DoubleLogicUUPSUpgradeable is UUPSUpgradeable, DoubleLogicERC1967Upgrade {
     /// @inheritdoc UUPSUpgradeable
     function proxiableUUID() external view override notDelegated returns (bytes32) {
         return _IMPLEMENTATION_SLOT;

--- a/contracts/src/rollup/RollupAdminLogic.sol
+++ b/contracts/src/rollup/RollupAdminLogic.sol
@@ -9,12 +9,12 @@ import "./RollupCore.sol";
 import "../bridge/IOutbox.sol";
 import "../bridge/ISequencerInbox.sol";
 import "../challenge/IChallengeManager.sol";
-import "../libraries/SecondaryLogicUUPSUpgradeable.sol";
+import "../libraries/DoubleLogicUUPSUpgradeable.sol";
 import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 
 import {NO_CHAL_INDEX} from "../libraries/Constants.sol";
 
-contract RollupAdminLogic is RollupCore, IRollupAdmin, SecondaryLogicUUPSUpgradeable {
+contract RollupAdminLogic is RollupCore, IRollupAdmin, DoubleLogicUUPSUpgradeable {
     function initialize(Config calldata config, ContractDependencies calldata connectedContracts)
         external
         override

--- a/contracts/test/contract/arbRollup.spec.ts
+++ b/contracts/test/contract/arbRollup.spec.ts
@@ -945,7 +945,7 @@ describe("ArbRollup", () => {
     const newAdminLogicImpl = await rollupAdminLogicFac.deploy()
     // first pause the contract so we can unpause after upgrade
     await rollupAdmin.pause()
-    // 0x046f7da2 - pause()
+    // 0x046f7da2 - resume()
     await expect(rollupAdmin.upgradeToAndCall(newAdminLogicImpl.address, "0x046f7da2")).to.emit(
       rollupAdmin,
       "Unpaused"

--- a/contracts/test/contract/arbRollup.spec.ts
+++ b/contracts/test/contract/arbRollup.spec.ts
@@ -60,9 +60,6 @@ const ZERO_ADDR = ethers.constants.AddressZero;
 const extraChallengeTimeBlocks = 20;
 const wasmModuleRoot = "0x9900000000000000000000000000000000000000000000000000000000000010";
 
-const _IMPLEMENTATION_PRIMARY_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
-const _IMPLEMENTATION_SECONDARY_SLOT = "0x2b1dbce74324248c222f0ec2d5ed7bd323cfc425b336f0253c5ccfda7265546d"
-
 // let rollup: RollupContract
 let rollup: RollupContract;
 let rollupUser: RollupUserLogic;
@@ -330,7 +327,10 @@ function updatePrevNode(node: Node) {
   prevNodes.push(node);
 }
 
-const getDoubleLogicUUPSTarget = async (slot: "user" | "admin", provider: providers.Provider) => {
+const _IMPLEMENTATION_PRIMARY_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
+const _IMPLEMENTATION_SECONDARY_SLOT = "0x2b1dbce74324248c222f0ec2d5ed7bd323cfc425b336f0253c5ccfda7265546d"
+
+const getDoubleLogicUUPSTarget = async (slot: "user" | "admin", provider: providers.Provider) : Promise<string> => {
   return `0x${(await provider.getStorageAt(rollupAdmin.address, slot === "admin" ? 
                 _IMPLEMENTATION_PRIMARY_SLOT : _IMPLEMENTATION_SECONDARY_SLOT)).substring(26).toLowerCase()}`
 }
@@ -885,8 +885,8 @@ describe("ArbRollup", () => {
     const user = rollupUser.signer
 
     // store the current implementation addresses
-    const proxyPrimaryImplSlot0 = await getDoubleLogicUUPSTarget("admin", user.provider!)
-    const proxySecondaryImplSlot0 = await getDoubleLogicUUPSTarget("user", user.provider!)
+    const proxyPrimaryTarget0 = await getDoubleLogicUUPSTarget("admin", user.provider!)
+    const proxySecondaryTarget0 = await getDoubleLogicUUPSTarget("user", user.provider!)
 
     // deploy a new admin logic
     const rollupAdminLogicFac = (await ethers.getContractFactory(
@@ -903,21 +903,21 @@ describe("ArbRollup", () => {
     );
 
     // check the new implementation address is set
-    const proxyPrimaryImplSlot = await getDoubleLogicUUPSTarget("admin", user.provider!)
-    await expect(proxyPrimaryImplSlot).to.not.eq(proxyPrimaryImplSlot0)
-    await expect(proxyPrimaryImplSlot).to.eq(newAdminLogicImpl.address.toLowerCase())
+    const proxyPrimaryTarget = await getDoubleLogicUUPSTarget("admin", user.provider!)
+    await expect(proxyPrimaryTarget).to.not.eq(proxyPrimaryTarget0)
+    await expect(proxyPrimaryTarget).to.eq(newAdminLogicImpl.address.toLowerCase())
 
     // check the other implementation address is unchanged
-    const proxySecondaryImplSlot = await getDoubleLogicUUPSTarget("user", user.provider!)
-    await expect(proxySecondaryImplSlot).to.eq(proxySecondaryImplSlot0)
+    const proxySecondaryTarget = await getDoubleLogicUUPSTarget("user", user.provider!)
+    await expect(proxySecondaryTarget).to.eq(proxySecondaryTarget0)
   });
 
   it("should only allow admin to upgrade secondary logic", async function () {
     const user = rollupUser.signer
 
     // store the current implementation addresses
-    const proxyPrimaryImplSlot0 = await getDoubleLogicUUPSTarget("admin", user.provider!)
-    const proxySecondaryImplSlot0 = await getDoubleLogicUUPSTarget("user", user.provider!)
+    const proxyPrimaryTarget0 = await getDoubleLogicUUPSTarget("admin", user.provider!)
+    const proxySecondaryTarget0 = await getDoubleLogicUUPSTarget("user", user.provider!)
 
     // deploy a new user logic
     const rollupUserLogicFac = (await ethers.getContractFactory(
@@ -934,13 +934,13 @@ describe("ArbRollup", () => {
     );
 
     // check the new implementation address is set
-    const proxySecondaryImplSlot = await getDoubleLogicUUPSTarget("user", user.provider!)
-    await expect(proxySecondaryImplSlot).to.not.eq(proxySecondaryImplSlot0)
-    await expect(proxySecondaryImplSlot).to.eq(newUserLogicImpl.address.toLowerCase())
+    const proxySecondaryTarget = await getDoubleLogicUUPSTarget("user", user.provider!)
+    await expect(proxySecondaryTarget).to.not.eq(proxySecondaryTarget0)
+    await expect(proxySecondaryTarget).to.eq(newUserLogicImpl.address.toLowerCase())
 
     // check the other implementation address is unchanged
-    const proxyPrimaryImplSlot = await getDoubleLogicUUPSTarget("admin", user.provider!)
-    await expect(proxyPrimaryImplSlot).to.eq(proxyPrimaryImplSlot0)
+    const proxyPrimaryTarget = await getDoubleLogicUUPSTarget("admin", user.provider!)
+    await expect(proxyPrimaryTarget).to.eq(proxyPrimaryTarget0)
   });
 
   it("should allow admin to upgrade primary logic and call", async function () {

--- a/contracts/test/contract/arbRollup.spec.ts
+++ b/contracts/test/contract/arbRollup.spec.ts
@@ -979,7 +979,7 @@ describe("ArbRollup", () => {
       "RollupAdminLogic"
     )) as RollupAdminLogic__factory;
     const newAdminLogicImpl = await rollupAdminLogicFac.deploy()
-    await expect(rollupAdmin.upgradeSecondaryTo(newAdminLogicImpl.address)).to.revertedWith('ERC1967Upgrade: unsupported proxiableUUID')
+    await expect(rollupAdmin.upgradeSecondaryTo(newAdminLogicImpl.address)).to.revertedWith('ERC1967Upgrade: unsupported secondary proxiableUUID')
   });
 
   it("should fail upgrade to proxy primary logic", async function () {

--- a/contracts/test/contract/arbRollup.spec.ts
+++ b/contracts/test/contract/arbRollup.spec.ts
@@ -995,4 +995,37 @@ describe("ArbRollup", () => {
     await expect(rollupAdmin.upgradeSecondaryTo(rollupAdmin.address)).to.revertedWith('ERC1967Upgrade: new secondary implementation is not UUPS')
   });
 
+  it("should fail to init rollupAdminLogic without proxy", async function () {
+    const user = rollupUser.signer
+    const rollupAdminLogicFac = (await ethers.getContractFactory(
+      "RollupAdminLogic"
+    )) as RollupAdminLogic__factory;
+    const proxyPrimaryTarget = await getDoubleLogicUUPSTarget("admin", user.provider!)
+    const proxyPrimaryImpl = rollupAdminLogicFac.attach(proxyPrimaryTarget)
+    await expect(
+      proxyPrimaryImpl.initialize(await getDefaultConfig(), {
+        challengeManager: constants.AddressZero,
+        bridge: constants.AddressZero,
+        inbox: constants.AddressZero,
+        outbox: constants.AddressZero,
+        rollupAdminLogic: constants.AddressZero,
+        rollupEventInbox: constants.AddressZero,
+        rollupUserLogic: constants.AddressZero,
+        sequencerInbox: constants.AddressZero,
+        validatorUtils: constants.AddressZero,
+        validatorWalletCreator: constants.AddressZero,
+      })
+    ).to.be.revertedWith("Function must be called through delegatecall");
+  });
+
+  it("should fail to init rollupUserLogic without proxy", async function () {
+    const user = rollupUser.signer
+    const rollupUserLogicFac = (await ethers.getContractFactory(
+      "RollupUserLogic"
+    )) as RollupUserLogic__factory;
+    const proxySecondaryTarget = await getDoubleLogicUUPSTarget("user", user.provider!)
+    const proxySecondaryImpl = rollupUserLogicFac.attach(proxySecondaryTarget)
+    await expect(proxySecondaryImpl.interface.functions["initialize(address)"].stateMutability).to.eq('view')
+  });
+
 });


### PR DESCRIPTION
Also
- renamed `SecondaryLogicUUPSUpgradeable` to `DoubleLogicUUPSUpgradeable`
- specified `unsupported secondary proxiableUUID` in revert string