### PR TITLE
Datool wallet file

### DIFF
--- a/cmd/datool/datool.go
+++ b/cmd/datool/datool.go
@@ -335,7 +335,7 @@ func startKeyGen(args []string) error {
 	} else {
 		walletConf := &genericconf.WalletConfig{
 			Pathname:      config.Dir,
-			PasswordImpl:  genericconf.PASSWORD_NOT_SET,
+			PasswordImpl:  genericconf.PASSWORD_NOT_SET, // This causes a prompt for the password
 			PrivateKey:    "",
 			Account:       "",
 			OnlyCreateKey: true,


### PR DESCRIPTION
This PR adds support for `datool` to do geth style wallet generation and to use the key in the wallet to sign Store messages. This could be useful for checking that committee members are correctly set up, from the batch poster pod. 

# Testing done 

Generate wallet
```
$ ./target/bin/datool keygen --dir /tmp/wallet3 --ecdsa --wallet
Enter new account password: Pub key: 043a83ffe092144584bdece1d13f5ca1b71b455da88673d6efab6a58fa98e1758dfb4296c5b775314fe37d553ab797626ea57d611bc11daa181507a35257877dba
```

Start server with public key
```
$ ./target/bin/daserver --conf.file datestconf/test-anystore2.conf --data-availability.extra-signature-checking-public-key "0x043a83ffe092144584bdece1d13f5ca1b71b455da88673d6efab6a58fa98e1758dfb4296c5b775314fe37d553ab797626ea57d611bc11daa181507a35257877dba"
```

Send Store messages signed using wallet
```
tristan@ramona ~/offchain/nitro 0
Wed Aug 03 09:43:07
$ ./target/bin/datool client rpc store  --url http://localhost:9876 --message "Hello world" --signing-wallet /tmp/wallet3 --signing-wallet-password "test"
Hex Encoded Cert: 0x8868589c339f4800b4afeccd1f05abaa6be7f9bb3fb9bfabf62e1bd9fc392a6dd6052cca0e379137c975c966bcc69ac8237ac38dc1fcf21ac9a6524c87a2aab4230000000062ebf73c0100000000000000010f36466d04917ddde52fcabc35f1aa0d57bae3d00c578a4f946661772939f11b79146011311ded064e0b8ef7c2c4b83e0ee708ebe088d7af6e9e8a73e3a6a39db557913bef4ef3b3a2ae859c21a1f923ed47f926ed58e5cf57c1e1f37f11bfc9
Hex Encoded Data Hash: 0x052cca0e379137c975c966bcc69ac8237ac38dc1fcf21ac9a6524c87a2aab423
tristan@ramona ~/offchain/nitro 0
Wed Aug 03 09:43:40
$ target/bin/datool client rest getbyhash --url  http://localhost:9877 --data-hash 0x052cca0e379137c975c966bcc69ac8237ac38dc1fcf21ac9a6524c87a2aab423
Message: Hello world
tristan@ramona ~/offchain/nitro 0
Wed Aug 03 09:43:57
$ ./target/bin/datool client rpc store  --url http://localhost:9876 --message "Testing signature checking" --signing-wallet /tmp/wallet3 --signing-wallet-password "test"
Hex Encoded Cert: 0x8868589c339f4800b4afeccd1f05abaa6be7f9bb3fb9bfabf62e1bd9fc392a6dd62c20b3e068f07bb77126a8563604edacdecb7eb5e24400b2cf7fc741d2b3ff390000000062ebf83a01000000000000000100fab0b7807cb71fb2b63c89da8078219e6fa20aa2c693e15234504ab1a284e4db44ec326165934214096aa694c06a4e0944a53c1bdc61b892573908b61299e532462e834b70375d4d071da5a0ade276a0523401fbccd9a248f4cb3c1e63b58f
Hex Encoded Data Hash: 0x2c20b3e068f07bb77126a8563604edacdecb7eb5e24400b2cf7fc741d2b3ff39
tristan@ramona ~/offchain/nitro 0
Wed Aug 03 09:47:54
$ target/bin/datool client rest getbyhash --url  http://localhost:9877 --data-hash 0x2c20b3e068f07bb77126a8563604edacdecb7eb5e24400b2cf7fc741d2b3ff39
Message: Testing signature checking
```