### PR TITLE
Fix postTxFilter with new geth result filter hook

### DIFF
--- a/arbnode/sequencer.go
+++ b/arbnode/sequencer.go
@@ -118,8 +118,8 @@ func (s *Sequencer) preTxFilter(state *arbosState.ArbosState, tx *types.Transact
 	return nil
 }
 
-func (s *Sequencer) postTxFilter(state *arbosState.ArbosState, tx *types.Transaction, sender common.Address, dataGas uint64, receipt *types.Receipt) error {
-	if receipt.Status == types.ReceiptStatusFailed && receipt.GasUsed > dataGas && receipt.GasUsed-dataGas <= s.config.MaxRevertGasReject {
+func (s *Sequencer) postTxFilter(state *arbosState.ArbosState, tx *types.Transaction, sender common.Address, dataGas uint64, result *core.ExecutionResult) error {
+	if result.Err != nil && result.UsedGas > dataGas && result.UsedGas-dataGas <= s.config.MaxRevertGasReject {
 		return vm.ErrExecutionReverted
 	}
 	return nil


### PR DESCRIPTION
The issue was that previously, we attempted to `RevertToSnapshot` after `Finalise` had been called on the statedb, which isn't possible. With the new geth hook pulled in from https://github.com/OffchainLabs/go-ethereum/pull/141 , we can reject ExecutionResults before Finalise is called.