### PR TITLE
Small sequencer fixes

### DIFF
--- a/arbnode/sequencer.go
+++ b/arbnode/sequencer.go
@@ -181,7 +181,7 @@ func (s *Sequencer) forwardIfSet(queueItems []txQueueItem) bool {
 		if errors.Is(res, ErrNoSequencer) {
 			s.requeueOrFail(item, ErrNoSequencer)
 		} else {
-			item.resultChan <- res
+			item.returnResult(res)
 		}
 	}
 	return true
@@ -298,10 +298,10 @@ func (s *Sequencer) sequenceTransactions(ctx context.Context) {
 
 	for i, err := range hooks.TxErrors {
 		queueItem := queueItems[i]
-		if errors.Is(err, core.ErrGasLimit) {
+		if errors.Is(err, core.ErrGasLimitReached) {
 			// There's not enough gas left in the block for this tx.
 			// Attempt to re-queue the transaction.
-			s.requeueOrFail(queueItem, core.ErrGasLimit)
+			s.requeueOrFail(queueItem, core.ErrGasLimitReached)
 			continue
 		}
 		queueItem.returnResult(err)


### PR DESCRIPTION
Touches up parts of the sequencer that weren't modified in https://github.com/OffchainLabs/nitro/pull/891 but I noticed were wrong.

- Use the right gas limit error
- Use the `returnResult` helper which closes the channel to prevent another incorrect writer getting stuck