### PR TITLE
Fix `ioutil` lint

### DIFF
--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -9,8 +9,8 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -145,7 +145,7 @@ func loadSigningKey(keyConfig string) (*[32]byte, error) {
 	if keyIsHex {
 		keyString = keyConfig
 	} else {
-		contents, err := ioutil.ReadFile(keyConfig)
+		contents, err := os.ReadFile(keyConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read signing key file: %w", err)
 		}

--- a/cmd/datool/datool.go
+++ b/cmd/datool/datool.go
@@ -9,7 +9,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -217,7 +217,7 @@ func startRPCClientGetByHash(args []string) error {
 		}
 	} else {
 		hashDecoder := base64.NewDecoder(base64.StdEncoding, bytes.NewReader([]byte(config.DataHash)))
-		decodedHash, err = ioutil.ReadAll(hashDecoder)
+		decodedHash, err = io.ReadAll(hashDecoder)
 		if err != nil {
 			return err
 		}
@@ -278,7 +278,7 @@ func startRESTClientGetByHash(args []string) error {
 		}
 	} else {
 		hashDecoder := base64.NewDecoder(base64.StdEncoding, bytes.NewReader([]byte(config.DataHash)))
-		decodedHash, err = ioutil.ReadAll(hashDecoder)
+		decodedHash, err = io.ReadAll(hashDecoder)
 		if err != nil {
 			return err
 		}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"time"
@@ -107,7 +106,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if err := ioutil.WriteFile(*outfile, deployData, 0600); err != nil {
+	if err := os.WriteFile(*outfile, deployData, 0600); err != nil {
 		panic(err)
 	}
 }

--- a/das/key_utils.go
+++ b/das/key_utils.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -20,7 +20,7 @@ import (
 
 func DecodeBase64BLSPublicKey(pubKeyEncodedBytes []byte) (*blsSignatures.PublicKey, error) {
 	pubKeyDecoder := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(pubKeyEncodedBytes))
-	pubKeyBytes, err := ioutil.ReadAll(pubKeyDecoder)
+	pubKeyBytes, err := io.ReadAll(pubKeyDecoder)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func DecodeBase64BLSPublicKey(pubKeyEncodedBytes []byte) (*blsSignatures.PublicK
 
 func DecodeBase64BLSPrivateKey(privKeyEncodedBytes []byte) (*blsSignatures.PrivateKey, error) {
 	privKeyDecoder := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(privKeyEncodedBytes))
-	privKeyBytes, err := ioutil.ReadAll(privKeyDecoder)
+	privKeyBytes, err := io.ReadAll(privKeyDecoder)
 	if err != nil {
 		return nil, err
 	}

--- a/das/restful_client.go
+++ b/das/restful_client.go
@@ -9,7 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -48,7 +48,7 @@ func (c *RestfulDasClient) GetByHash(ctx context.Context, hash common.Hash) ([]b
 		return nil, fmt.Errorf("HTTP error with status %d returned by server: %s", res.StatusCode, http.StatusText(res.StatusCode))
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (c *RestfulDasClient) GetByHash(ctx context.Context, hash common.Hash) ([]b
 	}
 
 	decoder := base64.NewDecoder(base64.StdEncoding, bytes.NewReader([]byte(response.Data)))
-	decodedBytes, err := ioutil.ReadAll(decoder)
+	decodedBytes, err := io.ReadAll(decoder)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (c *RestfulDasClient) ExpirationPolicy(ctx context.Context) (arbstate.Expir
 	if res.StatusCode != http.StatusOK {
 		return -1, err
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return -1, fmt.Errorf("HTTP error with status %d returned by server: %s", res.StatusCode, http.StatusText(res.StatusCode))
 	}

--- a/das/sign_after_store_das.go
+++ b/das/sign_after_store_das.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -144,7 +143,7 @@ func NewSignAfterStoreDASWithSeqInboxCaller(
 				return nil, err
 			}
 		} else {
-			pubkeyEncoded, err := ioutil.ReadFile(extraSignatureCheckingPublicKey)
+			pubkeyEncoded, err := os.ReadFile(extraSignatureCheckingPublicKey)
 			if err != nil {
 				return nil, err
 			}

--- a/solgen/gen.go
+++ b/solgen/gen.go
@@ -6,7 +6,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -46,7 +45,7 @@ func (m *moduleInfo) exportABIs(dest string) {
 		abi := m.abis[i] + "\n"
 
 		// #nosec G306
-		err := ioutil.WriteFile(path, []byte(abi), 0o644)
+		err := os.WriteFile(path, []byte(abi), 0o644)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -80,7 +79,7 @@ func main() {
 
 		name := file[:len(file)-5]
 
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			log.Fatal("could not read", path, "for contract", name, err)
 		}
@@ -124,7 +123,7 @@ func main() {
 			#nosec G306
 			This file contains no private information so the permissions can be lenient
 		*/
-		err = ioutil.WriteFile(filepath.Join(folder, module+".go"), []byte(code), 0o644)
+		err = os.WriteFile(filepath.Join(folder, module+".go"), []byte(code), 0o644)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/statetransfer/jsondatareader.go
+++ b/statetransfer/jsondatareader.go
@@ -6,7 +6,6 @@ package statetransfer
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path"
@@ -70,7 +69,7 @@ func (m *JsonInitDataReader) getListReader(fileName string) (JsonListReader, err
 }
 
 func NewJsonInitDataReader(filepath string) (InitDataReader, error) {
-	data, err := ioutil.ReadFile(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, err
 	}

--- a/validator/nitro_machine.go
+++ b/validator/nitro_machine.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -60,7 +59,7 @@ func (c NitroMachineConfig) getMachinePath(moduleRoot common.Hash) string {
 
 func (c NitroMachineConfig) ReadLatestWasmModuleRoot() (common.Hash, error) {
 	fileToRead := filepath.Join(c.getMachinePath(common.Hash{}), "module-root.txt")
-	fileBytes, err := ioutil.ReadFile(fileToRead)
+	fileBytes, err := os.ReadFile(fileToRead)
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/wavmio/stub.go
+++ b/wavmio/stub.go
@@ -11,7 +11,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -90,14 +89,14 @@ func StubInit() {
 	delayedMsgFirstPos = uint64(*delayedPositionFlag)
 	lastBlockHash = common.HexToHash(*lastBlockFlag)
 	for _, path := range delayedMsgPath {
-		msg, err := ioutil.ReadFile(path)
+		msg, err := os.ReadFile(path)
 		if err != nil {
 			panic(err)
 		}
 		delayedMsgs = append(delayedMsgs, msg)
 	}
 	if *inboxPath != "" {
-		msg, err := ioutil.ReadFile(*inboxPath)
+		msg, err := os.ReadFile(*inboxPath)
 		if err != nil {
 			panic(err)
 		}

--- a/wsbroadcastserver/utils.go
+++ b/wsbroadcastserver/utils.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 	"strings"
 	"time"
@@ -119,7 +118,7 @@ func ReadData(ctx context.Context, conn net.Conn, earlyFrameData io.Reader, idle
 			continue
 		}
 
-		data, err := ioutil.ReadAll(&reader)
+		data, err := io.ReadAll(&reader)
 
 		return data, header.OpCode, err
 	}


### PR DESCRIPTION
Fixes the new `golangci` lint now that `ioutil` has been deprecated