### PR TITLE
Fix LOG15_ERROR msgs from logging odd # of args

### DIFF
--- a/das/util.go
+++ b/das/util.go
@@ -12,8 +12,15 @@ import (
 )
 
 func logPut(store string, data []byte, timeout uint64, reader arbstate.DataAvailabilityReader, more ...interface{}) {
-	log.Trace(
-		store, "message", pretty.FirstFewBytes(data), "timeout", time.Unix(int64(timeout), 0),
-		"this", reader, more,
-	)
+	if len(more) == 0 {
+		log.Trace(
+			store, "message", pretty.FirstFewBytes(data), "timeout", time.Unix(int64(timeout), 0),
+			"this", reader,
+		)
+	} else {
+		log.Trace(
+			store, "message", pretty.FirstFewBytes(data), "timeout", time.Unix(int64(timeout), 0),
+			"this", reader, more,
+		)
+	}
 }


### PR DESCRIPTION
This fixes messages like this:
```
TRACE[08-04|11:56:25.759] das.LocalFileStorageService.Store        message="[fe e8 4a 5b c1 3e 98 bb ... ]" timeout=2314-11-14T11:40:35-0800 this=LocalFileStorageService(/tmp/mainnet-sync3) LOG15_ERROR= LOG15_ERROR="Normalized odd number of arguments by adding nil"   
```