### PR TITLE
Check that solidity methods exist

### DIFF
--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -232,6 +232,14 @@ func MakePrecompile(metadata *bind.MetaData, implementer interface{}) (addr, Pre
 		methodsByName[name] = &method
 	}
 
+	for i := 0; i < implementerType.NumMethod(); i++ {
+		method := implementerType.Method(i)
+		name := method.Name
+		if method.IsExported() && methodsByName[name] == nil {
+			log.Crit(contract + " is missing a solidity interface for " + name)
+		}
+	}
+
 	// provide the implementer mechanisms to emit logs for the solidity events
 
 	supportedIndices := map[string]struct{}{


### PR DESCRIPTION
Ensures that all precompile methods have a corresponding entry in their solidity interface