### PR TITLE
Check types when unpacking calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN . ~/.cargo/env && NITRO_BUILD_IGNORE_TIMESTAMPS=1 RUSTFLAGS='-C symbol-mangl
 
 FROM wasm-base as wasm-bin-builder
     # pinned go version
-RUN curl -L https://golang.org/dl/go1.17.8.linux-`dpkg --print-architecture`.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://golang.org/dl/go1.19.linux-`dpkg --print-architecture`.tar.gz | tar -C /usr/local -xzf -
 COPY ./Makefile ./go.mod ./go.sum ./
 COPY ./arbcompress ./arbcompress
 COPY ./arbos ./arbos
@@ -133,7 +133,7 @@ RUN bash -c 'r=0xcfba6a883c50a1b4475ab909600fa88fc9cceed9e3ff6f43dccd2d27f6bd57c
 RUN bash -c 'r=0xa24ccdb052d92c5847e8ea3ce722442358db4b00985a9ee737c4e601b6ed9876 && mkdir $r && ln -sfT $r latest && cd $r && echo $r > module-root.txt && wget https://github.com/OffchainLabs/nitro/releases/download/consensus-v4/machine.wavm.br'
 RUN bash -c 'r=0x1e09e6d9e35b93f33ed22b2bc8dc10bbcf63fdde5e8a1fb8cc1bcd1a52f14bd0 && mkdir $r && ln -sfT $r latest && cd $r && echo $r > module-root.txt && wget https://github.com/OffchainLabs/nitro/releases/download/consensus-v5/machine.wavm.br'
 
-FROM golang:1.17-bullseye as node-builder
+FROM golang:1.19-bullseye as node-builder
 WORKDIR /workspace
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -49,10 +49,12 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 		if err != nil {
 			panic(err)
 		}
-		l1BlockNumber, _ := inputs[1].(uint64) // current block's
-		timePassed, _ := inputs[2].(uint64)    // actually the L2 block number, fixed in upgrade 3
-		if state.FormatVersion() >= 3 {
-			timePassed, _ = inputs[3].(uint64) // time passed since last block
+
+		l1BlockNumber := util.SafeMapGet[uint64](inputs, "l1BlockNumber")
+		timePassed := util.SafeMapGet[uint64](inputs, "timePassed")
+		if state.FormatVersion() < 3 {
+			// (incorrectly) use the L2 block number instead
+			timePassed = util.SafeMapGet[uint64](inputs, "l2BlockNumber")
 		}
 
 		nextL1BlockNumber, err := state.Blockhashes().NextBlockNumber()
@@ -83,11 +85,10 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 		if err != nil {
 			panic(err)
 		}
-		batchTimestamp, _ := inputs[0].(*big.Int)
-		batchPosterAddress, _ := inputs[1].(common.Address)
-		// ignore input[2], batchNumber, which exist because we might need them in the future
-		batchDataGas, _ := inputs[3].(uint64)
-		l1BaseFeeWei, _ := inputs[4].(*big.Int)
+		batchTimestamp := util.SafeMapGet[*big.Int](inputs, "batchTimestamp")
+		batchPosterAddress := util.SafeMapGet[common.Address](inputs, "batchPosterAddress")
+		batchDataGas := util.SafeMapGet[uint64](inputs, "batchDataGas")
+		l1BaseFeeWei := util.SafeMapGet[*big.Int](inputs, "l1BaseFeeWei")
 
 		l1p := state.L1PricingState()
 		perBatchGas, err := l1p.PerBatchGasCost()


### PR DESCRIPTION
Uses generic type-checking to make unpacking calls safer

Unfortunately go generics don't support the following without parameterizing the receiver, so I used a stand-alone function
```go
func (safeMap SafeMap) Get[T any](field string) T {
	value, ok := safeMap.entries[field]
	if !ok {
		panic(fmt.Sprintf("map does not contain field %v", field))
	}
	cast, ok := value.(T)
	if !ok {
		panic(fmt.Sprintf("field %v is of the wrong type", field))
	}
	return cast
}
```

Fixes https://github.com/OffchainLabs/nitro/issues/800