### PR TITLE
Arbowner public fix

### DIFF
--- a/precompiles/ArbOwnerPublic.go
+++ b/precompiles/ArbOwnerPublic.go
@@ -31,5 +31,8 @@ func (con ArbOwnerPublic) GetNetworkFeeAccount(c ctx, evm mech) (addr, error) {
 
 // Gets the infrastructure fee collector
 func (con ArbOwnerPublic) GetInfraFeeAccount(c ctx, evm mech) (addr, error) {
-	return c.State.NetworkFeeAccount()
+	if c.State.FormatVersion() < 6 {
+		return c.State.NetworkFeeAccount()
+	}
+	return c.State.InfraFeeAccount()
 }

--- a/precompiles/ArbOwner_test.go
+++ b/precompiles/ArbOwner_test.go
@@ -120,14 +120,26 @@ func TestArbInfraFeeAccount(t *testing.T) {
 	evm = newMockEVMForTestingWithVersion(&version5)
 	callCtx = testContext(caller, evm)
 	prec = &ArbOwner{}
+	precPublic := &ArbOwnerPublic{}
 	addr, err := prec.GetInfraFeeAccount(callCtx, evm)
 	Require(t, err)
 	if addr != (common.Address{}) {
 		t.Fatal()
 	}
+	addr, err = precPublic.GetInfraFeeAccount(callCtx, evm)
+	Require(t, err)
+	if addr != (common.Address{}) {
+		t.Fatal()
+	}
+
 	err = prec.SetInfraFeeAccount(callCtx, evm, newAddr)
 	Require(t, err)
 	addr, err = prec.GetInfraFeeAccount(callCtx, evm)
+	Require(t, err)
+	if addr != newAddr {
+		t.Fatal()
+	}
+	addr, err = precPublic.GetInfraFeeAccount(callCtx, evm)
 	Require(t, err)
 	if addr != newAddr {
 		t.Fatal()


### PR DESCRIPTION
Fixes a bug in the `GetInfraFeeAccount` getter in `ArbOwnerPublic`.  Includes a regression test.

Fix takes effect as of ArbOS version 6.