### PR TITLE
Disable RetryWrapper in RPC Aggregator

### DIFF
--- a/das/dasrpc/rpc_aggregator.go
+++ b/das/dasrpc/rpc_aggregator.go
@@ -60,14 +60,12 @@ func setUpServices(config das.AggregatorConfig) ([]das.ServiceDetails, error) {
 			return nil, err
 		}
 
-		serviceWithRetryWrapper := das.NewRetryWrapper(service)
-
 		pubKey, err := das.DecodeBase64BLSPublicKey([]byte(b.PubKeyBase64Encoded))
 		if err != nil {
 			return nil, err
 		}
 
-		d, err := das.NewServiceDetails(serviceWithRetryWrapper, *pubKey, uint64(b.SignerMask))
+		d, err := das.NewServiceDetails(service, *pubKey, uint64(b.SignerMask))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
There is already a top-level retry in the Batch Poster so we don't need
multiple levels of retrying.