### PR TITLE
Fix off by one with DAS Aggregator AssumedHonest

### DIFF
--- a/das/aggregator.go
+++ b/das/aggregator.go
@@ -155,7 +155,7 @@ func NewAggregatorWithSeqInboxCaller(
 		config:                         config,
 		services:                       services,
 		requiredServicesForStore:       len(services) + 1 - config.AssumedHonest,
-		maxAllowedServiceStoreFailures: config.AssumedHonest - 1,
+		maxAllowedServiceStoreFailures: config.AssumedHonest,
 		keysetHash:                     keysetHash,
 		keysetBytes:                    ksBuf.Bytes(),
 		bpVerifier:                     bpVerifier,


### PR DESCRIPTION
If >=AssumedHonest Store requests failed, then all of the failures could
have been on the honest committee members. We had >=AssumedHonest-1,
which left one potentially honest member remaining.