### PR TITLE
Fix from and currentHeight aliasing in inbox reader

### DIFF
--- a/arbnode/delayed_sequencer.go
+++ b/arbnode/delayed_sequencer.go
@@ -45,13 +45,13 @@ func DelayedSequencerConfigAddOptions(prefix string, f *flag.FlagSet) {
 
 var DefaultDelayedSequencerConfig = DelayedSequencerConfig{
 	Enable:           false,
-	FinalizeDistance: 12,
+	FinalizeDistance: 20,
 	TimeAggregate:    time.Minute,
 }
 
 var TestDelayedSequencerConfig = DelayedSequencerConfig{
 	Enable:           true,
-	FinalizeDistance: 12,
+	FinalizeDistance: 20,
 	TimeAggregate:    time.Second,
 }
 

--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -294,12 +294,12 @@ func (ir *InboxReader) run(ctx context.Context) error {
 				if !reorgingDelayed && !reorgingSequencer {
 					break
 				} else {
-					from = currentHeight
+					from = new(big.Int).Set(currentHeight)
 				}
 			}
 			to := new(big.Int).Add(from, new(big.Int).SetUint64(blocksToFetch))
 			if to.Cmp(currentHeight) > 0 {
-				to = currentHeight
+				to.Set(currentHeight)
 			}
 			var delayedMessages []*DelayedInboxMessage
 			delayedMessages, err := ir.delayedBridge.LookupMessagesInRange(ctx, from, to)
@@ -405,7 +405,7 @@ func (ir *InboxReader) run(ctx context.Context) error {
 					return err
 				}
 			} else {
-				from = from.Add(to, big.NewInt(1))
+				from = arbmath.BigAddByUint(to, 1)
 			}
 		}
 
@@ -437,7 +437,7 @@ func (r *InboxReader) getPrevBlockForReorg(from *big.Int) (*big.Int, error) {
 	if from.Cmp(r.firstMessageBlock) <= 0 {
 		return nil, errors.New("can't get older messages")
 	}
-	newFrom := new(big.Int).Sub(from, big.NewInt(10))
+	newFrom := arbmath.BigSub(from, big.NewInt(10))
 	if newFrom.Cmp(r.firstMessageBlock) < 0 {
 		newFrom = new(big.Int).Set(r.firstMessageBlock)
 	}


### PR DESCRIPTION
After a reorg, `from` and `currentHeight` could be aliased, causing incrementing the former to increment the latter. I've removed both aliasing and mutating in this PR.