### PR TITLE
Silence old timestamp warning

### DIFF
--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -455,7 +455,7 @@ func (ps *L1PricingState) _preVersion2_UpdateForBatchPosterSpending(
 		lastUpdateTime = updateTime - 1
 	}
 	if updateTime >= currentTime || updateTime < lastUpdateTime {
-		return ErrInvalidTime
+		return nil // historically this returned an error
 	}
 	allocationNumerator := updateTime - lastUpdateTime
 	allocationDenominator := currentTime - lastUpdateTime

--- a/arbos/l1pricing_test.go
+++ b/arbos/l1pricing_test.go
@@ -212,7 +212,8 @@ func TestUpdateTimeUpgradeBehavior(t *testing.T) {
 	l1p := arbosSt.L1PricingState()
 	amount := arbmath.UintToBig(10 * params.GWei)
 	poster := common.Address{3, 4, 5}
-	l1p.BatchPosterTable().AddPoster(poster, poster)
+	_, err = l1p.BatchPosterTable().AddPoster(poster, poster)
+	Require(t, err)
 
 	// In the past this would have errored due to an invalid timestamp.
 	// We don't want to error since it'd create noise in the console,

--- a/arbos/l1pricing_test.go
+++ b/arbos/l1pricing_test.go
@@ -218,7 +218,10 @@ func TestUpdateTimeUpgradeBehavior(t *testing.T) {
 	// In the past this would have errored due to an invalid timestamp.
 	// We don't want to error since it'd create noise in the console,
 	// so instead let's check that nothing happened
-	statedb := evm.StateDB.(*state.StateDB)
+	statedb, ok := evm.StateDB.(*state.StateDB)
+	if !ok {
+		panic("not a statedb")
+	}
 	stateCheck(t, statedb, false, "uh oh, nothing should have happened", func() {
 		Require(t, l1p.UpdateForBatchPosterSpending(
 			evm.StateDB, evm, 1, 1, 1, poster, common.Big1, amount, util.TracingDuringEVM,

--- a/arbos/l1pricing_test.go
+++ b/arbos/l1pricing_test.go
@@ -4,12 +4,12 @@
 package arbos
 
 import (
-	"errors"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/l1pricing"
@@ -209,17 +209,24 @@ func TestUpdateTimeUpgradeBehavior(t *testing.T) {
 	arbosSt, err := arbosState.OpenArbosState(evm.StateDB, burner)
 	Require(t, err)
 
-	poster := common.Address{3, 4, 5}
-
 	l1p := arbosSt.L1PricingState()
+	amount := arbmath.UintToBig(10 * params.GWei)
+	poster := common.Address{3, 4, 5}
+	l1p.BatchPosterTable().AddPoster(poster, poster)
 
-	err = l1p.UpdateForBatchPosterSpending(evm.StateDB, evm, 1, 1, 1, poster, common.Big1, arbmath.UintToBig(10*params.GWei), util.TracingDuringEVM)
-	if !errors.Is(err, l1pricing.ErrInvalidTime) {
-		Fail(t)
-	}
+	// In the past this would have errored due to an invalid timestamp.
+	// We don't want to error since it'd create noise in the console,
+	// so instead let's check that nothing happened
+	statedb := evm.StateDB.(*state.StateDB)
+	stateCheck(t, statedb, false, "uh oh, nothing should have happened", func() {
+		Require(t, l1p.UpdateForBatchPosterSpending(
+			evm.StateDB, evm, 1, 1, 1, poster, common.Big1, amount, util.TracingDuringEVM,
+		))
+	})
 
-	err = l1p.UpdateForBatchPosterSpending(evm.StateDB, evm, 3, 1, 1, poster, common.Big1, arbmath.UintToBig(10*params.GWei), util.TracingDuringEVM)
-	Require(t, err)
+	Require(t, l1p.UpdateForBatchPosterSpending(
+		evm.StateDB, evm, 3, 1, 1, poster, common.Big1, amount, util.TracingDuringEVM,
+	))
 }
 
 func TestL1PriceEquilibrationUp(t *testing.T) {


### PR DESCRIPTION
Removes the historical warning on invalid timestamps