### PR TITLE
Use rpc aggregator only for stores

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -43,7 +43,7 @@ type BatchPoster struct {
 	building            *buildingBatch
 	pendingMsgTimestamp time.Time
 	lastBatchCount      uint64
-	das                 das.DataAvailabilityService
+	daWriter            das.DataAvailabilityServiceWriter
 }
 
 type BatchPosterConfig struct {
@@ -101,7 +101,7 @@ var TestBatchPosterConfig = BatchPosterConfig{
 	GasRefunderAddress:   "",
 }
 
-func NewBatchPoster(l1Reader *headerreader.HeaderReader, inbox *InboxTracker, streamer *TransactionStreamer, config *BatchPosterConfig, contractAddress common.Address, transactOpts *bind.TransactOpts, das das.DataAvailabilityService) (*BatchPoster, error) {
+func NewBatchPoster(l1Reader *headerreader.HeaderReader, inbox *InboxTracker, streamer *TransactionStreamer, config *BatchPosterConfig, contractAddress common.Address, transactOpts *bind.TransactOpts, daWriter das.DataAvailabilityServiceWriter) (*BatchPoster, error) {
 	inboxContract, err := bridgegen.NewSequencerInbox(contractAddress, l1Reader.Client())
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func NewBatchPoster(l1Reader *headerreader.HeaderReader, inbox *InboxTracker, st
 		inboxContract: inboxContract,
 		transactOpts:  transactOpts,
 		gasRefunder:   common.HexToAddress(config.GasRefunderAddress),
-		das:           das,
+		daWriter:      daWriter,
 	}, nil
 }
 
@@ -411,8 +411,8 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context, batchSeqNum u
 		return nil, nil
 	}
 
-	if b.das != nil {
-		cert, err := b.das.Store(ctx, sequencerMsg, uint64(time.Now().Add(b.config.DASRetentionPeriod).Unix()), []byte{}) // b.das will append signature if enabled
+	if b.daWriter != nil {
+		cert, err := b.daWriter.Store(ctx, sequencerMsg, uint64(time.Now().Add(b.config.DASRetentionPeriod).Unix()), []byte{}) // b.daWriter will append signature if enabled
 		if err != nil {
 			log.Warn("Unable to batch to DAS, falling back to storing data on chain", "err", err)
 			if b.config.DisableDasFallbackStoreDataOnChain {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -749,16 +749,18 @@ func createNodeImpl(
 			if err != nil {
 				return nil, err
 			}
+			daWriter = das.NewWriterTimeoutWrapper(daWriter, config.DataAvailability.RequestTimeout)
 		} else {
 			daReader, dasLifecycleManager, err = SetUpDataAvailability(ctx, &config.DataAvailability, l1Reader, deployInfo)
 			if err != nil {
 				return nil, err
 			}
 		}
+		daReader = das.NewReaderTimeoutWrapper(daReader, config.DataAvailability.RequestTimeout)
 	} else if l2BlockChain.Config().ArbitrumChainParams.DataAvailabilityCommittee {
 		return nil, errors.New("a data availability service is required for this chain, but it was not configured")
 	}
-	// TODO timeouts
+
 	// TODO panic on error
 
 	inboxTracker, err := NewInboxTracker(arbDb, txStreamer, daReader)

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -771,8 +771,6 @@ func createNodeImpl(
 		return nil, errors.New("a data availability service is required for this chain, but it was not configured")
 	}
 
-	// TODO panic on error
-
 	inboxTracker, err := NewInboxTracker(arbDb, txStreamer, daReader)
 	if err != nil {
 		return nil, err

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -37,7 +37,6 @@ import (
 	"github.com/offchainlabs/nitro/broadcastclient"
 	"github.com/offchainlabs/nitro/broadcaster"
 	"github.com/offchainlabs/nitro/das"
-	"github.com/offchainlabs/nitro/das/dasrpc"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/solgen/go/challengegen"
 	"github.com/offchainlabs/nitro/solgen/go/ospgen"
@@ -1005,7 +1004,7 @@ func SetUpDataAvailability(
 		if topLevelStorageService != nil {
 			return nil, nil, errors.New("If rpc-aggregator is enabled, none of rest-aggregator or any -storage mode can be specified")
 		}
-		rpcAggregator, err := dasrpc.NewRPCAggregatorWithSeqInboxCaller(config.AggregatorConfig, seqInboxCaller)
+		rpcAggregator, err := das.NewRPCAggregatorWithSeqInboxCaller(config.AggregatorConfig, seqInboxCaller)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -749,14 +749,24 @@ func createNodeImpl(
 			if err != nil {
 				return nil, err
 			}
-			daWriter = das.NewWriterTimeoutWrapper(daWriter, config.DataAvailability.RequestTimeout)
 		} else {
 			daReader, dasLifecycleManager, err = SetUpDataAvailability(ctx, &config.DataAvailability, l1Reader, deployInfo)
 			if err != nil {
 				return nil, err
 			}
 		}
+
+		if daWriter != nil {
+			daWriter = das.NewWriterTimeoutWrapper(daWriter, config.DataAvailability.RequestTimeout)
+		}
 		daReader = das.NewReaderTimeoutWrapper(daReader, config.DataAvailability.RequestTimeout)
+
+		if config.DataAvailability.PanicOnError {
+			if daWriter != nil {
+				daWriter = das.NewWriterPanicWrapper(daWriter)
+			}
+			daReader = das.NewReaderPanicWrapper(daReader)
+		}
 	} else if l2BlockChain.Config().ArbitrumChainParams.DataAvailabilityCommittee {
 		return nil, errors.New("a data availability service is required for this chain, but it was not configured")
 	}

--- a/cmd/daserver/daserver.go
+++ b/cmd/daserver/daserver.go
@@ -24,7 +24,6 @@ import (
 	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/cmd/util"
 	"github.com/offchainlabs/nitro/das"
-	"github.com/offchainlabs/nitro/das/dasrpc"
 )
 
 type DAServerConfig struct {
@@ -172,7 +171,7 @@ func startup() error {
 	if serverConfig.EnableRPC {
 		log.Info("Starting HTTP-RPC server", "addr", serverConfig.RPCAddr, "port", serverConfig.RPCPort)
 
-		rpcServer, err = dasrpc.StartDASRPCServer(ctx, serverConfig.RPCAddr, serverConfig.RPCPort, serverConfig.RPCServerTimeouts, dasImpl)
+		rpcServer, err = das.StartDASRPCServer(ctx, serverConfig.RPCAddr, serverConfig.RPCPort, serverConfig.RPCServerTimeouts, dasImpl)
 		if err != nil {
 			return err
 		}

--- a/cmd/datool/datool.go
+++ b/cmd/datool/datool.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/offchainlabs/nitro/cmd/util"
 	"github.com/offchainlabs/nitro/das"
-	"github.com/offchainlabs/nitro/das/dasrpc"
 	"github.com/offchainlabs/nitro/das/dastree"
 	flag "github.com/spf13/pflag"
 )
@@ -120,7 +119,7 @@ func startClientStore(args []string) error {
 		return err
 	}
 
-	client, err := dasrpc.NewDASRPCClient(config.URL)
+	client, err := das.NewDASRPCClient(config.URL)
 	if err != nil {
 		return err
 	}
@@ -222,7 +221,7 @@ func startRPCClientGetByHash(args []string) error {
 		return err
 	}
 
-	client, err := dasrpc.NewDASRPCClient(config.URL)
+	client, err := das.NewDASRPCClient(config.URL)
 	if err != nil {
 		return err
 	}

--- a/cmd/datool/datool.go
+++ b/cmd/datool/datool.go
@@ -124,7 +124,7 @@ func startClientStore(args []string) error {
 		return err
 	}
 
-	var dasClient das.DataAvailabilityService = client
+	var dasClient das.DataAvailabilityServiceWriter = client
 	if config.SigningKey != "" {
 		var privateKey *ecdsa.PrivateKey
 		if config.SigningKey[:2] == "0x" {

--- a/das/aggregator_test.go
+++ b/das/aggregator_test.go
@@ -228,7 +228,7 @@ func testConfigurableStorageFailures(t *testing.T, shouldFailAggregation bool) {
 
 	unwrappedAggregator, err := NewAggregator(ctx, DataAvailabilityConfig{AggregatorConfig: AggregatorConfig{AssumedHonest: assumedHonest}, L1NodeURL: "none"}, backends)
 	Require(t, err)
-	aggregator := TimeoutWrapper{time.Millisecond * 2000, unwrappedAggregator}
+	aggregator := TimeoutWrapper{ReaderTimeoutWrapper{time.Millisecond * 2000, unwrappedAggregator}, WriterTimeoutWrapper{time.Millisecond * 2000, unwrappedAggregator}}
 
 	rawMsg := []byte("It's time for you to see the fnords.")
 	cert, err := aggregator.Store(ctx, rawMsg, 0, []byte{})
@@ -341,7 +341,7 @@ func testConfigurableRetrieveFailures(t *testing.T, shouldFail bool) {
 	// it should get all successes.
 	unwrappedAggregator, err := NewAggregator(ctx, DataAvailabilityConfig{AggregatorConfig: AggregatorConfig{AssumedHonest: 1}, L1NodeURL: "none"}, backends)
 	Require(t, err)
-	aggregator := TimeoutWrapper{time.Millisecond * 2000, unwrappedAggregator}
+	aggregator := TimeoutWrapper{ReaderTimeoutWrapper{time.Millisecond * 2000, unwrappedAggregator}, WriterTimeoutWrapper{time.Millisecond * 2000, unwrappedAggregator}}
 
 	rawMsg := []byte("It's time for you to see the fnords.")
 	cert, err := unwrappedAggregator.Store(ctx, rawMsg, 0, []byte{})

--- a/das/chain_fetch_das.go
+++ b/das/chain_fetch_das.go
@@ -95,6 +95,9 @@ func (this *ChainFetchReader) GetByHash(ctx context.Context, hash common.Hash) (
 	log.Trace("das.ChainFetchReader.GetByHash", "hash", pretty.PrettyHash(hash))
 	return chainFetchGetByHash(ctx, this.DataAvailabilityReader, &this.keysetCache, this.seqInboxCaller, this.seqInboxFilterer, hash)
 }
+func (this *ChainFetchReader) String() string {
+	return "ChainFetchReader"
+}
 
 func chainFetchGetByHash(
 	ctx context.Context,

--- a/das/das.go
+++ b/das/das.go
@@ -23,6 +23,12 @@ import (
 type DataAvailabilityServiceWriter interface {
 	// Requests that the message be stored until timeout (UTC time in unix epoch seconds).
 	Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (*arbstate.DataAvailabilityCertificate, error)
+	fmt.Stringer
+}
+
+type DataAvailabilityServiceReader interface {
+	arbstate.DataAvailabilityReader
+	fmt.Stringer
 }
 
 type DataAvailabilityService interface {
@@ -138,7 +144,7 @@ func GetL1Client(ctx context.Context, maxConnectionAttempts int, l1URL string) (
 		if err == nil {
 			return l1Client, nil
 		}
-		log.Warn("error connecting to L1", "err", err)
+		log.Warn("error connecting to L1 from DAS", "l1URL", l1URL, "err", err)
 
 		timer := time.NewTimer(time.Second * 1)
 		select {

--- a/das/dasRpcClient.go
+++ b/das/dasRpcClient.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2022, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-package dasrpc
+package das
 
 import (
 	"context"

--- a/das/dasRpcServer.go
+++ b/das/dasRpcServer.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2022, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-package dasrpc
+package das
 
 import (
 	"context"
@@ -19,7 +19,6 @@ import (
 
 	"github.com/offchainlabs/nitro/blsSignatures"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
-	"github.com/offchainlabs/nitro/das"
 	"github.com/offchainlabs/nitro/util/pretty"
 )
 
@@ -45,10 +44,10 @@ var (
 )
 
 type DASRPCServer struct {
-	localDAS das.DataAvailabilityService
+	localDAS DataAvailabilityService
 }
 
-func StartDASRPCServer(ctx context.Context, addr string, portNum uint64, rpcServerTimeouts genericconf.HTTPServerTimeoutConfig, localDAS das.DataAvailabilityService) (*http.Server, error) {
+func StartDASRPCServer(ctx context.Context, addr string, portNum uint64, rpcServerTimeouts genericconf.HTTPServerTimeoutConfig, localDAS DataAvailabilityService) (*http.Server, error) {
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", addr, portNum))
 	if err != nil {
 		return nil, err
@@ -56,7 +55,7 @@ func StartDASRPCServer(ctx context.Context, addr string, portNum uint64, rpcServ
 	return StartDASRPCServerOnListener(ctx, listener, rpcServerTimeouts, localDAS)
 }
 
-func StartDASRPCServerOnListener(ctx context.Context, listener net.Listener, rpcServerTimeouts genericconf.HTTPServerTimeoutConfig, localDAS das.DataAvailabilityService) (*http.Server, error) {
+func StartDASRPCServerOnListener(ctx context.Context, listener net.Listener, rpcServerTimeouts genericconf.HTTPServerTimeoutConfig, localDAS DataAvailabilityService) (*http.Server, error) {
 	rpcServer := rpc.NewServer()
 	err := rpcServer.RegisterName("das", &DASRPCServer{localDAS: localDAS})
 	if err != nil {

--- a/das/extra_signature_checker_test.go
+++ b/das/extra_signature_checker_test.go
@@ -62,7 +62,7 @@ func TestExtraSignatureCheck(t *testing.T) {
 	Require(t, err)
 	signer := DasSignerFromPrivateKey(privateKey)
 
-	var da DataAvailabilityService = &StubSignatureCheckDAS{keyDir}
+	var da DataAvailabilityServiceWriter = &StubSignatureCheckDAS{keyDir}
 	da, err = NewStoreSigningDAS(da, signer)
 	Require(t, err)
 

--- a/das/factory.go
+++ b/das/factory.go
@@ -5,6 +5,10 @@ package das
 
 import (
 	"context"
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/offchainlabs/nitro/arbutil"
 )
 
 // Create any storage services that persist to files, database, cloud storage,
@@ -54,4 +58,55 @@ func CreatePersistentStorageService(
 		return storageServices[0], &lifecycleManager, nil
 	}
 	return nil, &lifecycleManager, nil
+}
+
+func CreateBatchPosterDAS(
+	ctx context.Context,
+	config *DataAvailabilityConfig,
+	daSigner DasSigner,
+	l1Reader arbutil.L1Interface,
+	sequencerInboxAddr common.Address,
+) (DataAvailabilityServiceWriter, DataAvailabilityServiceReader, *LifecycleManager, error) {
+	if !config.Enable {
+		return nil, nil, nil, nil
+	}
+
+	if !config.AggregatorConfig.Enable || !config.RestfulClientAggregatorConfig.Enable {
+		return nil, nil, nil, errors.New("--node.data-availabilty.rpc-aggregator.enable and rest-aggregator.enable must be set when running a Batch Poster in AnyTrust mode.")
+	}
+
+	if config.LocalDBStorageConfig.Enable || config.LocalFileStorageConfig.Enable || config.S3StorageServiceConfig.Enable {
+		return nil, nil, nil, errors.New("--node.data-availability.local-db-storage.enable, local-file-storage.enable, s3-storage.enable may not be set when running a Batch Poster in AnyTrust mode.")
+	}
+
+	if config.KeyConfig.KeyDir != "" || config.KeyConfig.PrivKey != "" {
+		return nil, nil, nil, errors.New("--node.data-availability.key.key-dir, priv-key not be set when running a Batch Poster in AnyTrust mode.")
+	}
+
+	var daWriter DataAvailabilityServiceWriter
+	daWriter, err := NewRPCAggregator(ctx, *config)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if daSigner != nil {
+		daWriter, err = NewStoreSigningDAS(daWriter, daSigner)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	restAgg, err := NewRestfulClientAggregator(ctx, &config.RestfulClientAggregatorConfig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	restAgg.Start(ctx)
+	var lifecycleManager LifecycleManager
+	lifecycleManager.Register(restAgg)
+	var daReader DataAvailabilityServiceReader = restAgg
+	daReader, err = NewChainFetchReader(daReader, l1Reader, sequencerInboxAddr)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return daWriter, daReader, &lifecycleManager, nil
 }

--- a/das/factory.go
+++ b/das/factory.go
@@ -80,7 +80,7 @@ func CreateBatchPosterDAS(
 	}
 
 	if config.KeyConfig.KeyDir != "" || config.KeyConfig.PrivKey != "" {
-		return nil, nil, nil, errors.New("--node.data-availability.key.key-dir, priv-key not be set when running a Batch Poster in AnyTrust mode.")
+		return nil, nil, nil, errors.New("--node.data-availability.key.key-dir, priv-key may not be set when running a Batch Poster in AnyTrust mode.")
 	}
 
 	var daWriter DataAvailabilityServiceWriter
@@ -89,6 +89,7 @@ func CreateBatchPosterDAS(
 		return nil, nil, nil, err
 	}
 	if daSigner != nil {
+		// In some tests the batch poster does not sign Store requests
 		daWriter, err = NewStoreSigningDAS(daWriter, daSigner)
 		if err != nil {
 			return nil, nil, nil, err

--- a/das/rpc_aggregator.go
+++ b/das/rpc_aggregator.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2022, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-package dasrpc
+package das
 
 import (
 	"context"
@@ -11,8 +11,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/offchainlabs/nitro/arbutil"
-
-	"github.com/offchainlabs/nitro/das"
 )
 
 type BackendConfig struct {
@@ -21,38 +19,38 @@ type BackendConfig struct {
 	SignerMask          uint64 `json:"signermask"`
 }
 
-func NewRPCAggregator(ctx context.Context, config das.DataAvailabilityConfig) (*das.Aggregator, error) {
+func NewRPCAggregator(ctx context.Context, config DataAvailabilityConfig) (*Aggregator, error) {
 	services, err := setUpServices(config.AggregatorConfig)
 	if err != nil {
 		return nil, err
 	}
-	return das.NewAggregator(ctx, config, services)
+	return NewAggregator(ctx, config, services)
 }
 
-func NewRPCAggregatorWithL1Info(config das.AggregatorConfig, l1client arbutil.L1Interface, seqInboxAddress common.Address) (*das.Aggregator, error) {
+func NewRPCAggregatorWithL1Info(config AggregatorConfig, l1client arbutil.L1Interface, seqInboxAddress common.Address) (*Aggregator, error) {
 	services, err := setUpServices(config)
 	if err != nil {
 		return nil, err
 	}
-	return das.NewAggregatorWithL1Info(config, services, l1client, seqInboxAddress)
+	return NewAggregatorWithL1Info(config, services, l1client, seqInboxAddress)
 }
 
-func NewRPCAggregatorWithSeqInboxCaller(config das.AggregatorConfig, seqInboxCaller *bridgegen.SequencerInboxCaller) (*das.Aggregator, error) {
+func NewRPCAggregatorWithSeqInboxCaller(config AggregatorConfig, seqInboxCaller *bridgegen.SequencerInboxCaller) (*Aggregator, error) {
 	services, err := setUpServices(config)
 	if err != nil {
 		return nil, err
 	}
-	return das.NewAggregatorWithSeqInboxCaller(config, services, seqInboxCaller)
+	return NewAggregatorWithSeqInboxCaller(config, services, seqInboxCaller)
 }
 
-func setUpServices(config das.AggregatorConfig) ([]das.ServiceDetails, error) {
+func setUpServices(config AggregatorConfig) ([]ServiceDetails, error) {
 	var cs []BackendConfig
 	err := json.Unmarshal([]byte(config.Backends), &cs)
 	if err != nil {
 		return nil, err
 	}
 
-	var services []das.ServiceDetails
+	var services []ServiceDetails
 
 	for _, b := range cs {
 		service, err := NewDASRPCClient(b.URL)
@@ -60,12 +58,12 @@ func setUpServices(config das.AggregatorConfig) ([]das.ServiceDetails, error) {
 			return nil, err
 		}
 
-		pubKey, err := das.DecodeBase64BLSPublicKey([]byte(b.PubKeyBase64Encoded))
+		pubKey, err := DecodeBase64BLSPublicKey([]byte(b.PubKeyBase64Encoded))
 		if err != nil {
 			return nil, err
 		}
 
-		d, err := das.NewServiceDetails(service, *pubKey, uint64(b.SignerMask))
+		d, err := NewServiceDetails(service, *pubKey, uint64(b.SignerMask))
 		if err != nil {
 			return nil, err
 		}

--- a/das/rpc_test.go
+++ b/das/rpc_test.go
@@ -1,4 +1,4 @@
-package dasrpc
+package das
 
 import (
 	"bytes"
@@ -11,7 +11,6 @@ import (
 
 	"github.com/offchainlabs/nitro/blsSignatures"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
-	"github.com/offchainlabs/nitro/das"
 	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 
@@ -28,15 +27,15 @@ func TestRPC(t *testing.T) {
 	testhelpers.RequireImpl(t, err)
 	keyDir := t.TempDir()
 	dataDir := t.TempDir()
-	pubkey, _, err := das.GenerateAndStoreKeys(keyDir)
+	pubkey, _, err := GenerateAndStoreKeys(keyDir)
 	testhelpers.RequireImpl(t, err)
 
-	config := das.DataAvailabilityConfig{
+	config := DataAvailabilityConfig{
 		Enable: true,
-		KeyConfig: das.KeyConfig{
+		KeyConfig: KeyConfig{
 			KeyDir: keyDir,
 		},
-		LocalFileStorageConfig: das.LocalFileStorageConfig{
+		LocalFileStorageConfig: LocalFileStorageConfig{
 			Enable:  true,
 			DataDir: dataDir,
 		},
@@ -44,12 +43,12 @@ func TestRPC(t *testing.T) {
 		RequestTimeout: 5 * time.Second,
 	}
 
-	storageService, lifecycleManager, err := das.CreatePersistentStorageService(ctx, &config)
+	storageService, lifecycleManager, err := CreatePersistentStorageService(ctx, &config)
 	testhelpers.RequireImpl(t, err)
 	defer lifecycleManager.StopAndWaitUntil(time.Second)
 	privKey, err := config.KeyConfig.BLSPrivKey()
 	testhelpers.RequireImpl(t, err)
-	localDas, err := das.NewSignAfterStoreDASWithSeqInboxCaller(privKey, nil, storageService, "")
+	localDas, err := NewSignAfterStoreDASWithSeqInboxCaller(privKey, nil, storageService, "")
 	testhelpers.RequireImpl(t, err)
 	dasServer, err := StartDASRPCServerOnListener(ctx, lis, genericconf.HTTPServerTimeoutConfigDefault, localDas)
 	defer func() {
@@ -66,7 +65,7 @@ func TestRPC(t *testing.T) {
 
 	backendsJsonByte, err := json.Marshal([]BackendConfig{beConfig})
 	testhelpers.RequireImpl(t, err)
-	aggConf := das.AggregatorConfig{
+	aggConf := AggregatorConfig{
 		AssumedHonest: 1,
 		Backends:      string(backendsJsonByte),
 	}

--- a/das/store_signing.go
+++ b/das/store_signing.go
@@ -46,12 +46,12 @@ func dasStoreHash(data []byte, timeout uint64) []byte {
 }
 
 type StoreSigningDAS struct {
-	DataAvailabilityService
+	DataAvailabilityServiceWriter
 	signer DasSigner
 	addr   common.Address
 }
 
-func NewStoreSigningDAS(inner DataAvailabilityService, signer DasSigner) (DataAvailabilityService, error) {
+func NewStoreSigningDAS(inner DataAvailabilityServiceWriter, signer DasSigner) (DataAvailabilityServiceWriter, error) {
 	sig, err := applyDasSigner(signer, []byte{}, 0)
 	if err != nil {
 		return nil, err
@@ -69,11 +69,11 @@ func (s *StoreSigningDAS) Store(ctx context.Context, message []byte, timeout uin
 	if err != nil {
 		return nil, err
 	}
-	return s.DataAvailabilityService.Store(ctx, message, timeout, mySig)
+	return s.DataAvailabilityServiceWriter.Store(ctx, message, timeout, mySig)
 }
 
 func (s *StoreSigningDAS) String() string {
-	return "StoreSigningDAS (" + s.SignerAddress().Hex() + " ," + s.DataAvailabilityService.String() + ")"
+	return "StoreSigningDAS (" + s.SignerAddress().Hex() + " ," + s.DataAvailabilityServiceWriter.String() + ")"
 }
 
 func (s *StoreSigningDAS) SignerAddress() common.Address {

--- a/das/timeout_wrapper.go
+++ b/das/timeout_wrapper.go
@@ -41,7 +41,7 @@ func NewWriterTimeoutWrapper(dataAvailabilityServiceWriter DataAvailabilityServi
 
 func (w *ReaderTimeoutWrapper) GetByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
 	deadlineCtx, cancel := context.WithDeadline(ctx, time.Now().Add(w.t))
-	// For Retrieve we want fast cancellation of all goroutines started by
+	// For GetByHash we want fast cancellation of all goroutines started by
 	// the aggregator as soon as one returns.
 	defer cancel()
 	return w.DataAvailabilityServiceReader.GetByHash(deadlineCtx, hash)

--- a/das/timeout_wrapper.go
+++ b/das/timeout_wrapper.go
@@ -12,27 +12,42 @@ import (
 	"github.com/offchainlabs/nitro/arbstate"
 )
 
-type TimeoutWrapper struct {
+type ReaderTimeoutWrapper struct {
 	t time.Duration
-	DataAvailabilityService
+	DataAvailabilityServiceReader
+}
+type WriterTimeoutWrapper struct {
+	t time.Duration
+	DataAvailabilityServiceWriter
 }
 
-func NewTimeoutWrapper(dataAvailabilityService DataAvailabilityService, t time.Duration) DataAvailabilityService {
-	return &TimeoutWrapper{
-		t:                       t,
-		DataAvailabilityService: dataAvailabilityService,
+type TimeoutWrapper struct {
+	ReaderTimeoutWrapper
+	WriterTimeoutWrapper
+}
+
+func NewReaderTimeoutWrapper(dataAvailabilityServiceReader DataAvailabilityServiceReader, t time.Duration) DataAvailabilityServiceReader {
+	return &ReaderTimeoutWrapper{
+		t:                             t,
+		DataAvailabilityServiceReader: dataAvailabilityServiceReader,
+	}
+}
+func NewWriterTimeoutWrapper(dataAvailabilityServiceWriter DataAvailabilityServiceWriter, t time.Duration) DataAvailabilityServiceWriter {
+	return &WriterTimeoutWrapper{
+		t:                             t,
+		DataAvailabilityServiceWriter: dataAvailabilityServiceWriter,
 	}
 }
 
-func (w *TimeoutWrapper) GetByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
+func (w *ReaderTimeoutWrapper) GetByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
 	deadlineCtx, cancel := context.WithDeadline(ctx, time.Now().Add(w.t))
 	// For Retrieve we want fast cancellation of all goroutines started by
 	// the aggregator as soon as one returns.
 	defer cancel()
-	return w.DataAvailabilityService.GetByHash(deadlineCtx, hash)
+	return w.DataAvailabilityServiceReader.GetByHash(deadlineCtx, hash)
 }
 
-func (w *TimeoutWrapper) Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (*arbstate.DataAvailabilityCertificate, error) {
+func (w *WriterTimeoutWrapper) Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (*arbstate.DataAvailabilityCertificate, error) {
 	deadlineCtx, cancel := context.WithDeadline(ctx, time.Now().Add(w.t))
 	// In the case of the aggregator, allow goroutines started by Store(...)
 	// to continue until the end of the deadline even after a result
@@ -41,9 +56,13 @@ func (w *TimeoutWrapper) Store(ctx context.Context, message []byte, timeout uint
 		<-deadlineCtx.Done()
 		cancel()
 	}()
-	return w.DataAvailabilityService.Store(deadlineCtx, message, timeout, sig)
+	return w.DataAvailabilityServiceWriter.Store(deadlineCtx, message, timeout, sig)
 }
 
-func (w *TimeoutWrapper) String() string {
-	return fmt.Sprintf("TimeoutWrapper{%v}", w.DataAvailabilityService)
+func (w *ReaderTimeoutWrapper) String() string {
+	return fmt.Sprintf("ReaderTimeoutWrapper{%v}", w.DataAvailabilityServiceReader)
+}
+
+func (w *WriterTimeoutWrapper) String() string {
+	return fmt.Sprintf("WriterTimeoutWrapper{%v}", w.DataAvailabilityServiceWriter)
 }

--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -10,7 +10,6 @@ package arbtest
 import (
 	"context"
 	"math/big"
-	"net"
 	"testing"
 	"time"
 
@@ -18,8 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbos/l2pricing"
-	"github.com/offchainlabs/nitro/cmd/genericconf"
-	"github.com/offchainlabs/nitro/das"
 )
 
 func testBlockValidatorSimple(t *testing.T, dasModeString string, expensiveTx bool) {
@@ -27,32 +24,7 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, expensiveTx bo
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	chainConfig, l1NodeConfigA, dasConfig, _, dasSignerKey := setupConfigWithDAS(t, ctx, dasModeString)
-	dasServerStack, lifecycleManager, err := arbnode.SetUpDataAvailability(ctx, dasConfig, nil, nil)
-	l1NodeConfigA.DataAvailability = das.DefaultDataAvailabilityConfig
-	if dasModeString != "onchain" {
-		Require(t, err)
-		rpcLis, err := net.Listen("tcp", "localhost:0")
-		Require(t, err)
-		restLis, err := net.Listen("tcp", "localhost:0")
-		Require(t, err)
-		_, err = das.StartDASRPCServerOnListener(ctx, rpcLis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
-		Require(t, err)
-		_, err = das.NewRestfulDasServerOnListener(restLis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
-		Require(t, err)
-
-		beConfigA := das.BackendConfig{
-			URL:                 "http://" + rpcLis.Addr().String(),
-			PubKeyBase64Encoded: blsPubToBase64(dasSignerKey),
-			SignerMask:          1,
-		}
-		l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, beConfigA)
-		l1NodeConfigA.DataAvailability.Enable = true
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Enable = true
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{"http://" + restLis.Addr().String()}
-		l1NodeConfigA.DataAvailability.L1NodeURL = "none"
-	}
+	chainConfig, l1NodeConfigA, lifecycleManager, _, dasSignerKey := setupConfigWithDAS(t, ctx, dasModeString)
 
 	l2info, nodeA, l2client, l2stackA, l1info, _, l1client, l1stack := createTestNodeOnL1WithConfig(t, ctx, true, l1NodeConfigA, chainConfig)
 	defer requireClose(t, l1stack)
@@ -70,7 +42,7 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, expensiveTx bo
 
 	tx := l2info.PrepareTx("Owner", "User2", l2info.TransferGas, big.NewInt(1e12), nil)
 
-	err = l2client.SendTransaction(ctx, tx)
+	err := l2client.SendTransaction(ctx, tx)
 	Require(t, err)
 
 	_, err = EnsureTxSucceeded(ctx, l2client, tx)

--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -25,6 +25,7 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, expensiveTx bo
 	defer cancel()
 
 	chainConfig, l1NodeConfigA, lifecycleManager, _, dasSignerKey := setupConfigWithDAS(t, ctx, dasModeString)
+	defer lifecycleManager.StopAndWaitUntil(time.Second)
 
 	l2info, nodeA, l2client, l2stackA, l1info, _, l1client, l1stack := createTestNodeOnL1WithConfig(t, ctx, true, l1NodeConfigA, chainConfig)
 	defer requireClose(t, l1stack)
@@ -114,8 +115,6 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, expensiveTx bo
 	if !nodeB.BlockValidator.WaitForBlock(ctx, lastBlock.NumberU64(), timeout) {
 		Fail(t, "did not validate all blocks")
 	}
-
-	lifecycleManager.StopAndWaitUntil(time.Second)
 }
 
 func TestBlockValidatorSimple(t *testing.T) {

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -454,8 +454,8 @@ func authorizeDASKeyset(
 }
 
 func setupConfigWithDAS(
-	t *testing.T, dasModeString string,
-) (*params.ChainConfig, *arbnode.Config, string, *blsSignatures.PublicKey) {
+	t *testing.T, ctx context.Context, dasModeString string,
+) (*params.ChainConfig, *arbnode.Config, *das.DataAvailabilityConfig, string, *blsSignatures.PublicKey) {
 	l1NodeConfigA := arbnode.ConfigDefaultL1Test()
 	chainConfig := params.ArbitrumDevTestChainConfig()
 	var dbPath string
@@ -478,7 +478,7 @@ func setupConfigWithDAS(
 	dasSignerKey, _, err := das.GenerateAndStoreKeys(dbPath)
 	Require(t, err)
 
-	dasConfig := das.DataAvailabilityConfig{
+	dasConfig := &das.DataAvailabilityConfig{
 		Enable: enableDas,
 		KeyConfig: das.KeyConfig{
 			KeyDir: dbPath,
@@ -493,12 +493,12 @@ func setupConfigWithDAS(
 		},
 		RequestTimeout:           5 * time.Second,
 		L1NodeURL:                "none",
+		SequencerInboxAddress:    "none",
 		PanicOnError:             true,
 		DisableSignatureChecking: true,
 	}
 
-	l1NodeConfigA.DataAvailability = dasConfig
-	return chainConfig, l1NodeConfigA, dbPath, dasSignerKey
+	return chainConfig, l1NodeConfigA, dasConfig, dbPath, dasSignerKey
 }
 
 func getDeadlineTimeout(t *testing.T, defaultTimeout time.Duration) time.Duration {

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/offchainlabs/nitro/arbnode"
 
-	"github.com/offchainlabs/nitro/das/dasrpc"
-
 	"github.com/offchainlabs/nitro/das"
 )
 
@@ -39,7 +37,7 @@ func startLocalDASServer(
 	dataDir string,
 	l1client arbutil.L1Interface,
 	seqInboxAddress common.Address,
-) (*http.Server, *blsSignatures.PublicKey, dasrpc.BackendConfig) {
+) (*http.Server, *blsSignatures.PublicKey, das.BackendConfig) {
 	lis, err := net.Listen("tcp", "localhost:0")
 	Require(t, err)
 	keyDir := t.TempDir()
@@ -69,9 +67,9 @@ func startLocalDASServer(
 	Require(t, err)
 	currentDas, err := das.NewSignAfterStoreDASWithSeqInboxCaller(privKey, seqInboxCaller, storageService, "")
 	Require(t, err)
-	dasServer, err := dasrpc.StartDASRPCServerOnListener(ctx, lis, genericconf.HTTPServerTimeoutConfigDefault, currentDas)
+	dasServer, err := das.StartDASRPCServerOnListener(ctx, lis, genericconf.HTTPServerTimeoutConfigDefault, currentDas)
 	Require(t, err)
-	beConfig := dasrpc.BackendConfig{
+	beConfig := das.BackendConfig{
 		URL:                 "http://" + lis.Addr().String(),
 		PubKeyBase64Encoded: blsPubToBase64(pubkey),
 		SignerMask:          1,
@@ -86,8 +84,8 @@ func blsPubToBase64(pubkey *blsSignatures.PublicKey) string {
 	return string(encodedPubkey)
 }
 
-func aggConfigForBackend(t *testing.T, backendConfig dasrpc.BackendConfig) das.AggregatorConfig {
-	backendsJsonByte, err := json.Marshal([]dasrpc.BackendConfig{backendConfig})
+func aggConfigForBackend(t *testing.T, backendConfig das.BackendConfig) das.AggregatorConfig {
+	backendsJsonByte, err := json.Marshal([]das.BackendConfig{backendConfig})
 	Require(t, err)
 	return das.AggregatorConfig{
 		Enable:        true,
@@ -282,7 +280,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 
 	dasServerStack, lifecycleManager, err := arbnode.SetUpDataAvailability(ctx, &serverConfig, l1Reader, addresses)
 	Require(t, err)
-	dasServer, err := dasrpc.StartDASRPCServerOnListener(ctx, lis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
+	dasServer, err := das.StartDASRPCServerOnListener(ctx, lis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
 	Require(t, err)
 
 	_ = dasServer
@@ -306,7 +304,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 		RequestTimeout: 5 * time.Second,
 	}
 
-	beConfigA := dasrpc.BackendConfig{
+	beConfigA := das.BackendConfig{
 		URL:                 "http://" + lis.Addr().String(),
 		PubKeyBase64Encoded: blsPubToBase64(pubkey),
 		SignerMask:          1,

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -37,9 +37,7 @@ func startLocalDASServer(
 	dataDir string,
 	l1client arbutil.L1Interface,
 	seqInboxAddress common.Address,
-) (*http.Server, *blsSignatures.PublicKey, das.BackendConfig) {
-	lis, err := net.Listen("tcp", "localhost:0")
-	Require(t, err)
+) (*http.Server, *blsSignatures.PublicKey, das.BackendConfig, *das.RestfulDasServer, string) {
 	keyDir := t.TempDir()
 	pubkey, _, err := das.GenerateAndStoreKeys(keyDir)
 	Require(t, err)
@@ -67,14 +65,20 @@ func startLocalDASServer(
 	Require(t, err)
 	currentDas, err := das.NewSignAfterStoreDASWithSeqInboxCaller(privKey, seqInboxCaller, storageService, "")
 	Require(t, err)
-	dasServer, err := das.StartDASRPCServerOnListener(ctx, lis, genericconf.HTTPServerTimeoutConfigDefault, currentDas)
+	rpcLis, err := net.Listen("tcp", "localhost:0")
+	Require(t, err)
+	rpcServer, err := das.StartDASRPCServerOnListener(ctx, rpcLis, genericconf.HTTPServerTimeoutConfigDefault, currentDas)
+	Require(t, err)
+	restLis, err := net.Listen("tcp", "localhost:0")
+	Require(t, err)
+	restServer, err := das.NewRestfulDasServerOnListener(restLis, genericconf.HTTPServerTimeoutConfigDefault, currentDas)
 	Require(t, err)
 	beConfig := das.BackendConfig{
-		URL:                 "http://" + lis.Addr().String(),
+		URL:                 "http://" + rpcLis.Addr().String(),
 		PubKeyBase64Encoded: blsPubToBase64(pubkey),
 		SignerMask:          1,
 	}
-	return dasServer, pubkey, beConfig
+	return rpcServer, pubkey, beConfig, restServer, "http://" + restLis.Addr().String()
 }
 
 func blsPubToBase64(pubkey *blsSignatures.PublicKey) string {
@@ -108,7 +112,7 @@ func TestDASRekey(t *testing.T) {
 	// Setup DAS servers
 	dasDataDir := t.TempDir()
 	nodeDir := t.TempDir()
-	dasServerA, pubkeyA, backendConfigA := startLocalDASServer(t, ctx, dasDataDir, l1client, addresses.SequencerInbox)
+	dasRpcServerA, pubkeyA, backendConfigA, _, restServerUrlA := startLocalDASServer(t, ctx, dasDataDir, l1client, addresses.SequencerInbox)
 	l2info := NewArbTestInfo(t, chainConfig.ChainID)
 	l1NodeConfigA := arbnode.ConfigDefaultL1Test()
 	l1NodeConfigB := arbnode.ConfigDefaultL1NonSequencerTest()
@@ -126,6 +130,10 @@ func TestDASRekey(t *testing.T) {
 
 		l1NodeConfigA.DataAvailability.Enable = true
 		l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, backendConfigA)
+		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
+		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Enable = true
+		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{restServerUrlA}
+		l1NodeConfigA.DataAvailability.L1NodeURL = "none"
 
 		nodeA, err := arbnode.CreateNode(ctx, l2stackA, l2chainDb, l2arbDb, l1NodeConfigA, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil, feedErrChan)
 		Require(t, err)
@@ -134,18 +142,23 @@ func TestDASRekey(t *testing.T) {
 
 		l1NodeConfigB.BlockValidator.Enable = false
 		l1NodeConfigB.DataAvailability.Enable = true
-		l1NodeConfigB.DataAvailability.AggregatorConfig = aggConfigForBackend(t, backendConfigA)
+		l1NodeConfigB.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
+		l1NodeConfigB.DataAvailability.RestfulClientAggregatorConfig.Enable = true
+		l1NodeConfigB.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{restServerUrlA}
+
+		l1NodeConfigB.DataAvailability.L1NodeURL = "none"
+
 		l2clientB, _, l2stackB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, &l2info.ArbInitData, l1NodeConfigB)
 		checkBatchPosting(t, ctx, l1client, l2clientA, l1info, l2info, big.NewInt(1e12), l2clientB)
 		requireClose(t, l2stackA)
 		requireClose(t, l2stackB)
 	}
 
-	err := dasServerA.Shutdown(ctx)
+	err := dasRpcServerA.Shutdown(ctx)
 	Require(t, err)
-	dasServerB, pubkeyB, backendConfigB := startLocalDASServer(t, ctx, dasDataDir, l1client, addresses.SequencerInbox)
+	dasRpcServerB, pubkeyB, backendConfigB, _, _ := startLocalDASServer(t, ctx, dasDataDir, l1client, addresses.SequencerInbox)
 	defer func() {
-		err = dasServerB.Shutdown(ctx)
+		err = dasRpcServerB.Shutdown(ctx)
 		Require(t, err)
 	}()
 	authorizeDASKeyset(t, ctx, pubkeyB, l1info, l1client)
@@ -169,7 +182,6 @@ func TestDASRekey(t *testing.T) {
 	Require(t, l2stackA.Start())
 	l2clientA := ClientForStack(t, l2stackA)
 
-	l1NodeConfigB.DataAvailability.AggregatorConfig = aggConfigForBackend(t, backendConfigB)
 	l2clientB, _, l2stackB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, &l2info.ArbInitData, l1NodeConfigB)
 	checkBatchPosting(t, ctx, l1client, l2clientA, l1info, l2info, big.NewInt(2e12), l2clientB)
 
@@ -224,8 +236,6 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 	feedErrChan := make(chan error, 10)
 	addresses := DeployOnTestL1(t, ctx, l1info, l1client, chainConfig.ChainID)
 
-	lis, err := net.Listen("tcp", "localhost:0")
-	Require(t, err)
 	keyDir, fileDataDir, dbDataDir := t.TempDir(), t.TempDir(), t.TempDir()
 	pubkey, _, err := das.GenerateAndStoreKeys(keyDir)
 	Require(t, err)
@@ -234,12 +244,6 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 		Enable: true,
 
 		LocalCacheConfig: das.TestBigCacheConfig,
-		RedisCacheConfig: das.RedisConfig{
-			Enable:     false,
-			RedisUrl:   "",
-			Expiration: time.Hour,
-			KeyConfig:  "",
-		},
 
 		LocalFileStorageConfig: das.LocalFileStorageConfig{
 			Enable:  true,
@@ -248,26 +252,6 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 		LocalDBStorageConfig: das.LocalDBStorageConfig{
 			Enable:  true,
 			DataDir: dbDataDir,
-		},
-		S3StorageServiceConfig: das.S3StorageServiceConfig{
-			Enable:    false,
-			AccessKey: "",
-			Bucket:    "",
-			Region:    "",
-			SecretKey: "",
-		},
-
-		RestfulClientAggregatorConfig: das.RestfulClientAggregatorConfig{
-			Enable:                 false,
-			Urls:                   []string{},
-			Strategy:               "",
-			StrategyUpdateInterval: time.Second,
-			WaitBeforeTryNext:      time.Second,
-			MaxPerEndpointStats:    20,
-			SimpleExploreExploitStrategyConfig: das.SimpleExploreExploitStrategyConfig{
-				ExploreIterations: 1,
-				ExploitIterations: 1,
-			},
 		},
 
 		KeyConfig: das.KeyConfig{
@@ -280,10 +264,14 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 
 	dasServerStack, lifecycleManager, err := arbnode.SetUpDataAvailability(ctx, &serverConfig, l1Reader, addresses)
 	Require(t, err)
-	dasServer, err := das.StartDASRPCServerOnListener(ctx, lis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
+	rpcLis, err := net.Listen("tcp", "localhost:0")
 	Require(t, err)
+	_, err = das.StartDASRPCServerOnListener(ctx, rpcLis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
+	Require(t, err)
+	restLis, err := net.Listen("tcp", "localhost:0")
+	Require(t, err)
+	restServer, err := das.NewRestfulDasServerOnListener(restLis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
 
-	_ = dasServer
 	pubkeyA := pubkey
 	authorizeDASKeyset(t, ctx, pubkeyA, l1info, l1client)
 
@@ -293,24 +281,20 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 		Enable: true,
 
 		LocalCacheConfig: das.TestBigCacheConfig,
-		RedisCacheConfig: das.RedisConfig{
-			Enable:     false,
-			RedisUrl:   "",
-			Expiration: time.Hour,
-			KeyConfig:  "",
-		},
 
 		// AggregatorConfig set up below
 		RequestTimeout: 5 * time.Second,
 	}
-
 	beConfigA := das.BackendConfig{
-		URL:                 "http://" + lis.Addr().String(),
+		URL:                 "http://" + rpcLis.Addr().String(),
 		PubKeyBase64Encoded: blsPubToBase64(pubkey),
 		SignerMask:          1,
 	}
-
 	l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, beConfigA)
+	l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
+	l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Enable = true
+	l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{"http://" + restLis.Addr().String()}
+	l1NodeConfigA.DataAvailability.L1NodeURL = "none"
 
 	var daSigner das.DasSigner = func(data []byte) ([]byte, error) {
 		return crypto.Sign(data, l1info.Accounts["Sequencer"].PrivateKey)
@@ -329,17 +313,12 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 	Require(t, l2stackA.Start())
 	l2clientA := ClientForStack(t, l2stackA)
 
+	// Create node to sync from chain
 	l1NodeConfigB := arbnode.ConfigDefaultL1NonSequencerTest()
 	l1NodeConfigB.DataAvailability = das.DataAvailabilityConfig{
 		Enable: true,
 
 		LocalCacheConfig: das.TestBigCacheConfig,
-		RedisCacheConfig: das.RedisConfig{
-			Enable:     false,
-			RedisUrl:   "",
-			Expiration: time.Hour,
-			KeyConfig:  "",
-		},
 
 		// AggregatorConfig set up below
 
@@ -348,66 +327,22 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 	}
 
 	l1NodeConfigB.BlockValidator.Enable = false
-	l1NodeConfigA.DataAvailability.Enable = true
-	l1NodeConfigB.DataAvailability.AggregatorConfig = aggConfigForBackend(t, beConfigA)
+	l1NodeConfigB.DataAvailability.Enable = true
+	l1NodeConfigB.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
+	l1NodeConfigB.DataAvailability.RestfulClientAggregatorConfig.Enable = true
+	l1NodeConfigB.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{"http://" + restLis.Addr().String()}
+	l1NodeConfigB.DataAvailability.L1NodeURL = "none"
 	l2clientB, _, l2stackB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, &l2info.ArbInitData, l1NodeConfigB)
 
-	// Now create a separate REST DAS server using the same local disk storage
-	// and connect a node to it, and make sure it syncs.
-	restServerConfig := das.DataAvailabilityConfig{
-		Enable: true,
-
-		LocalFileStorageConfig: das.LocalFileStorageConfig{
-			Enable:  true,
-			DataDir: fileDataDir,
-		},
-		RequestTimeout: 5 * time.Second,
-	}
-
-	restServerDAS, rpcServerLifecycleManager, err := das.CreatePersistentStorageService(ctx, &restServerConfig)
-	Require(t, err)
-	restLis, err := net.Listen("tcp", "localhost:0")
-	Require(t, err)
-	restServer, err := das.NewRestfulDasServerOnListener(restLis, genericconf.HTTPServerTimeoutConfigDefault, restServerDAS)
-	Require(t, err)
-
-	l1NodeConfigC := arbnode.ConfigDefaultL1NonSequencerTest()
-	l1NodeConfigC.BlockValidator.Enable = false
-	l1NodeConfigC.DataAvailability = das.DataAvailabilityConfig{
-		Enable: true,
-
-		LocalCacheConfig: das.TestBigCacheConfig,
-
-		RestfulClientAggregatorConfig: das.RestfulClientAggregatorConfig{
-			Enable:                 true,
-			Urls:                   []string{"http://" + restLis.Addr().String()},
-			Strategy:               "simple-explore-exploit",
-			StrategyUpdateInterval: time.Second,
-			WaitBeforeTryNext:      time.Second,
-			MaxPerEndpointStats:    20,
-			SimpleExploreExploitStrategyConfig: das.SimpleExploreExploitStrategyConfig{
-				ExploreIterations: 1,
-				ExploitIterations: 5,
-			},
-		},
-
-		// L1NodeURL: normally we would have to set this but we are passing in the already constructed client and addresses to the factory
-		RequestTimeout: 5 * time.Second,
-	}
-	l2clientC, _, l2stackC := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, &l2info.ArbInitData, l1NodeConfigC)
-
-	checkBatchPosting(t, ctx, l1client, l2clientA, l1info, l2info, big.NewInt(1e12), l2clientB, l2clientC)
+	checkBatchPosting(t, ctx, l1client, l2clientA, l1info, l2info, big.NewInt(1e12), l2clientB)
 
 	requireClose(t, l2stackA)
 	requireClose(t, l2stackB)
-	requireClose(t, l2stackC)
 
 	err = restServer.Shutdown()
 	Require(t, err)
 
 	lifecycleManager.StopAndWaitUntil(time.Second)
-	rpcServerLifecycleManager.StopAndWaitUntil(time.Second)
-
 }
 
 func enableLogging(logLvl int) {

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -264,6 +264,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 
 	dasServerStack, lifecycleManager, err := arbnode.SetUpDataAvailability(ctx, &serverConfig, l1Reader, addresses)
 	Require(t, err)
+	defer lifecycleManager.StopAndWaitUntil(time.Second)
 	rpcLis, err := net.Listen("tcp", "localhost:0")
 	Require(t, err)
 	_, err = das.StartDASRPCServerOnListener(ctx, rpcLis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
@@ -341,8 +342,6 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 
 	err = restServer.Shutdown()
 	Require(t, err)
-
-	lifecycleManager.StopAndWaitUntil(time.Second)
 }
 
 func enableLogging(logLvl int) {

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -123,6 +123,7 @@ func testLyingSequencer(t *testing.T, dasModeStr string) {
 
 	// The truthful sequencer
 	chainConfig, nodeConfigA, lifecycleManager, _, dasSignerKey := setupConfigWithDAS(t, ctx, dasModeStr)
+	defer lifecycleManager.StopAndWaitUntil(time.Second)
 
 	nodeConfigA.BatchPoster.Enable = true
 	nodeConfigA.Feed.Output.Enable = false
@@ -213,8 +214,6 @@ func testLyingSequencer(t *testing.T, dasModeStr string) {
 	if l2balanceRealAcct.Cmp(big.NewInt(1e12)) != 0 {
 		t.Fatal("Unexpected balance:", l2balanceRealAcct)
 	}
-
-	lifecycleManager.StopAndWaitUntil(time.Second)
 }
 
 func TestLyingSequencer(t *testing.T) {

--- a/system_tests/twonodes_test.go
+++ b/system_tests/twonodes_test.go
@@ -6,10 +6,14 @@ package arbtest
 import (
 	"context"
 	"math/big"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/offchainlabs/nitro/arbnode"
+	"github.com/offchainlabs/nitro/cmd/genericconf"
+	"github.com/offchainlabs/nitro/das"
 )
 
 func testTwoNodesSimple(t *testing.T, dasModeStr string) {
@@ -17,22 +21,48 @@ func testTwoNodesSimple(t *testing.T, dasModeStr string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	chainConfig, l1NodeConfigA, _, dasSignerKey := setupConfigWithDAS(t, dasModeStr)
+	chainConfig, l1NodeConfigA, dasConfig, _, dasSignerKey := setupConfigWithDAS(t, ctx, dasModeStr)
+	dasServerStack, lifecycleManager, err := arbnode.SetUpDataAvailability(ctx, dasConfig, nil, nil)
+	Require(t, err)
+	rpcLis, err := net.Listen("tcp", "localhost:0")
+	Require(t, err)
+	restLis, err := net.Listen("tcp", "localhost:0")
+	Require(t, err)
+	l1NodeConfigA.DataAvailability = das.DefaultDataAvailabilityConfig
+	if dasModeStr != "onchain" {
+		_, err = das.StartDASRPCServerOnListener(ctx, rpcLis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
+		Require(t, err)
+		_, err = das.NewRestfulDasServerOnListener(restLis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
+		Require(t, err)
+
+		beConfigA := das.BackendConfig{
+			URL:                 "http://" + rpcLis.Addr().String(),
+			PubKeyBase64Encoded: blsPubToBase64(dasSignerKey),
+			SignerMask:          1,
+		}
+		l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, beConfigA)
+		l1NodeConfigA.DataAvailability.Enable = true
+		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
+		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Enable = true
+		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{"http://" + restLis.Addr().String()}
+		l1NodeConfigA.DataAvailability.L1NodeURL = "none"
+	}
 
 	l2info, nodeA, l2clientA, l2stackA, l1info, _, l1client, l1stack := createTestNodeOnL1WithConfig(t, ctx, true, l1NodeConfigA, chainConfig)
 	defer requireClose(t, l1stack)
 	defer requireClose(t, l2stackA)
 
 	authorizeDASKeyset(t, ctx, dasSignerKey, l1info, l1client)
-
-	l2clientB, _, l2stackB := Create2ndNode(t, ctx, nodeA, l1stack, &l2info.ArbInitData, &l1NodeConfigA.DataAvailability)
+	l1NodeConfigBDataAvailability := l1NodeConfigA.DataAvailability
+	l1NodeConfigBDataAvailability.AggregatorConfig.Enable = false
+	l2clientB, _, l2stackB := Create2ndNode(t, ctx, nodeA, l1stack, &l2info.ArbInitData, &l1NodeConfigBDataAvailability)
 	defer requireClose(t, l2stackB)
 
 	l2info.GenerateAccount("User2")
 
 	tx := l2info.PrepareTx("Owner", "User2", l2info.TransferGas, big.NewInt(1e12), nil)
 
-	err := l2clientA.SendTransaction(ctx, tx)
+	err = l2clientA.SendTransaction(ctx, tx)
 	Require(t, err)
 
 	_, err = EnsureTxSucceeded(ctx, l2clientA, tx)
@@ -57,6 +87,8 @@ func testTwoNodesSimple(t *testing.T, dasModeStr string) {
 	if l2balance.Cmp(big.NewInt(1e12)) != 0 {
 		Fail(t, "Unexpected balance:", l2balance)
 	}
+
+	lifecycleManager.StopAndWaitUntil(time.Second)
 }
 
 func TestTwoNodesSimple(t *testing.T) {

--- a/system_tests/twonodes_test.go
+++ b/system_tests/twonodes_test.go
@@ -18,6 +18,7 @@ func testTwoNodesSimple(t *testing.T, dasModeStr string) {
 	defer cancel()
 
 	chainConfig, l1NodeConfigA, lifecycleManager, _, dasSignerKey := setupConfigWithDAS(t, ctx, dasModeStr)
+	defer lifecycleManager.StopAndWaitUntil(time.Second)
 
 	l2info, nodeA, l2clientA, l2stackA, l1info, _, l1client, l1stack := createTestNodeOnL1WithConfig(t, ctx, true, l1NodeConfigA, chainConfig)
 	defer requireClose(t, l1stack)
@@ -58,8 +59,6 @@ func testTwoNodesSimple(t *testing.T, dasModeStr string) {
 	if l2balance.Cmp(big.NewInt(1e12)) != 0 {
 		Fail(t, "Unexpected balance:", l2balance)
 	}
-
-	lifecycleManager.StopAndWaitUntil(time.Second)
 }
 
 func TestTwoNodesSimple(t *testing.T) {

--- a/system_tests/twonodes_test.go
+++ b/system_tests/twonodes_test.go
@@ -6,14 +6,10 @@ package arbtest
 import (
 	"context"
 	"math/big"
-	"net"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/offchainlabs/nitro/arbnode"
-	"github.com/offchainlabs/nitro/cmd/genericconf"
-	"github.com/offchainlabs/nitro/das"
 )
 
 func testTwoNodesSimple(t *testing.T, dasModeStr string) {
@@ -21,32 +17,7 @@ func testTwoNodesSimple(t *testing.T, dasModeStr string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	chainConfig, l1NodeConfigA, dasConfig, _, dasSignerKey := setupConfigWithDAS(t, ctx, dasModeStr)
-	dasServerStack, lifecycleManager, err := arbnode.SetUpDataAvailability(ctx, dasConfig, nil, nil)
-	Require(t, err)
-	rpcLis, err := net.Listen("tcp", "localhost:0")
-	Require(t, err)
-	restLis, err := net.Listen("tcp", "localhost:0")
-	Require(t, err)
-	l1NodeConfigA.DataAvailability = das.DefaultDataAvailabilityConfig
-	if dasModeStr != "onchain" {
-		_, err = das.StartDASRPCServerOnListener(ctx, rpcLis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
-		Require(t, err)
-		_, err = das.NewRestfulDasServerOnListener(restLis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
-		Require(t, err)
-
-		beConfigA := das.BackendConfig{
-			URL:                 "http://" + rpcLis.Addr().String(),
-			PubKeyBase64Encoded: blsPubToBase64(dasSignerKey),
-			SignerMask:          1,
-		}
-		l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, beConfigA)
-		l1NodeConfigA.DataAvailability.Enable = true
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Enable = true
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{"http://" + restLis.Addr().String()}
-		l1NodeConfigA.DataAvailability.L1NodeURL = "none"
-	}
+	chainConfig, l1NodeConfigA, lifecycleManager, _, dasSignerKey := setupConfigWithDAS(t, ctx, dasModeStr)
 
 	l2info, nodeA, l2clientA, l2stackA, l1info, _, l1client, l1stack := createTestNodeOnL1WithConfig(t, ctx, true, l1NodeConfigA, chainConfig)
 	defer requireClose(t, l1stack)
@@ -62,7 +33,7 @@ func testTwoNodesSimple(t *testing.T, dasModeStr string) {
 
 	tx := l2info.PrepareTx("Owner", "User2", l2info.TransferGas, big.NewInt(1e12), nil)
 
-	err = l2clientA.SendTransaction(ctx, tx)
+	err := l2clientA.SendTransaction(ctx, tx)
 	Require(t, err)
 
 	_, err = EnsureTxSucceeded(ctx, l2clientA, tx)

--- a/system_tests/twonodeslong_test.go
+++ b/system_tests/twonodeslong_test.go
@@ -39,6 +39,7 @@ func testTwoNodesLong(t *testing.T, dasModeStr string) {
 	defer cancel()
 
 	chainConfig, l1NodeConfigA, lifecycleManager, _, dasSignerKey := setupConfigWithDAS(t, ctx, dasModeStr)
+	defer lifecycleManager.StopAndWaitUntil(time.Second)
 
 	l2info, nodeA, l2client, l2stackA, l1info, l1backend, l1client, l1stack := createTestNodeOnL1WithConfig(t, ctx, true, l1NodeConfigA, chainConfig)
 	defer requireClose(t, l1stack)
@@ -176,8 +177,6 @@ func testTwoNodesLong(t *testing.T, dasModeStr string) {
 			Fail(t, "did not validate all blocks")
 		}
 	}
-
-	lifecycleManager.StopAndWaitUntil(time.Second)
 }
 
 func TestTwoNodesLong(t *testing.T) {

--- a/system_tests/twonodeslong_test.go
+++ b/system_tests/twonodeslong_test.go
@@ -11,14 +11,10 @@ import (
 	"context"
 	"math/big"
 	"math/rand"
-	"net"
 	"testing"
 	"time"
 
-	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbos/l2pricing"
-	"github.com/offchainlabs/nitro/cmd/genericconf"
-	"github.com/offchainlabs/nitro/das"
 
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -42,32 +38,7 @@ func testTwoNodesLong(t *testing.T, dasModeStr string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	chainConfig, l1NodeConfigA, dasConfig, _, dasSignerKey := setupConfigWithDAS(t, ctx, dasModeStr)
-	dasServerStack, lifecycleManager, err := arbnode.SetUpDataAvailability(ctx, dasConfig, nil, nil)
-	l1NodeConfigA.DataAvailability = das.DefaultDataAvailabilityConfig
-	if dasModeStr != "onchain" {
-		Require(t, err)
-		rpcLis, err := net.Listen("tcp", "localhost:0")
-		Require(t, err)
-		restLis, err := net.Listen("tcp", "localhost:0")
-		Require(t, err)
-		_, err = das.StartDASRPCServerOnListener(ctx, rpcLis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
-		Require(t, err)
-		_, err = das.NewRestfulDasServerOnListener(restLis, genericconf.HTTPServerTimeoutConfigDefault, dasServerStack)
-		Require(t, err)
-
-		beConfigA := das.BackendConfig{
-			URL:                 "http://" + rpcLis.Addr().String(),
-			PubKeyBase64Encoded: blsPubToBase64(dasSignerKey),
-			SignerMask:          1,
-		}
-		l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, beConfigA)
-		l1NodeConfigA.DataAvailability.Enable = true
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Enable = true
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{"http://" + restLis.Addr().String()}
-		l1NodeConfigA.DataAvailability.L1NodeURL = "none"
-	}
+	chainConfig, l1NodeConfigA, lifecycleManager, _, dasSignerKey := setupConfigWithDAS(t, ctx, dasModeStr)
 
 	l2info, nodeA, l2client, l2stackA, l1info, l1backend, l1client, l1stack := createTestNodeOnL1WithConfig(t, ctx, true, l1NodeConfigA, chainConfig)
 	defer requireClose(t, l1stack)


### PR DESCRIPTION
This PR creates a separate factory method for creating DAS reader/writer components for use by the Batch Poster only, and switches the batch poster to use it. Non-batch-posters still use the old large factory method, which is left unchanged for this PR to minimize the code diff; the same goes for the GetByHash method on the RPC aggregator. The timeout behavior is kept as-is and the new separate reader/writer timeout wrappers are kind of ugly, but this will be changed in the upcoming PR to improve the timeout error reporting by moving the timeout inside the rpc aggregator.

# Testing Done
Unit tests pass locally