### PR TITLE
Set better arbos defaults for new chains

### DIFF
--- a/arbnode/api.go
+++ b/arbnode/api.go
@@ -87,16 +87,18 @@ type PricingModelHistory struct {
 	PricingInertia   uint64     `json:"pricingInertia"`
 	BacklogTolerance uint64     `json:"backlogTolerance"`
 
-	L1BaseFeeEstimate    []*big.Int `json:"l1BaseFeeEstimate"`
-	L1LastSurplus        []*big.Int `json:"l1LastSurplus"`
-	L1FundsDue           []*big.Int `json:"l1FundsDue"`
-	L1FundsDueForRewards []*big.Int `json:"l1FundsDueForRewards"`
-	L1UnitsSinceUpdate   []uint64   `json:"l1UnitsSinceUpdate"`
-	L1LastUpdateTime     []uint64   `json:"l1LastUpdateTime"`
-	L1EquilibrationUnits *big.Int   `json:"l1EquilibrationUnits"`
-	L1PricingInertia     uint64     `json:"l1PricingInertia"`
-	L1PerUnitReward      uint64     `json:"l1PerUnitReward"`
-	L1PayRewardTo        string     `json:"l1PayRewardTo"`
+	L1BaseFeeEstimate      []*big.Int `json:"l1BaseFeeEstimate"`
+	L1LastSurplus          []*big.Int `json:"l1LastSurplus"`
+	L1FundsDue             []*big.Int `json:"l1FundsDue"`
+	L1FundsDueForRewards   []*big.Int `json:"l1FundsDueForRewards"`
+	L1UnitsSinceUpdate     []uint64   `json:"l1UnitsSinceUpdate"`
+	L1LastUpdateTime       []uint64   `json:"l1LastUpdateTime"`
+	L1EquilibrationUnits   *big.Int   `json:"l1EquilibrationUnits"`
+	L1PerBatchCost         int64      `json:"l1PerBatchCost"`
+	L1AmortizedCostCapBips uint64     `json:"l1AmortizedCostCapBips"`
+	L1PricingInertia       uint64     `json:"l1PricingInertia"`
+	L1PerUnitReward        uint64     `json:"l1PerUnitReward"`
+	L1PayRewardTo          string     `json:"l1PayRewardTo"`
 }
 
 func (api *ArbDebugAPI) PricingModel(ctx context.Context, start, end rpc.BlockNumber) (PricingModelHistory, error) {
@@ -164,6 +166,8 @@ func (api *ArbDebugAPI) PricingModel(ctx context.Context, start, end rpc.BlockNu
 
 			l1PricingInertia, _ := l1Pricing.Inertia()
 			l1EquilibrationUnits, _ := l1Pricing.EquilibrationUnits()
+			l1PerBatchCost, _ := l1Pricing.PerBatchGasCost()
+			l1AmortizedCostCapBips, _ := l1Pricing.AmortizedCostCapBips()
 			l1PerUnitReward, _ := l1Pricing.PerUnitReward()
 			l1PayRewardsTo, err := l1Pricing.PayRewardsTo()
 
@@ -175,9 +179,10 @@ func (api *ArbDebugAPI) PricingModel(ctx context.Context, start, end rpc.BlockNu
 			history.PerBlockGasLimit = perBlockGasLimit
 			history.PricingInertia = pricingInertia
 			history.BacklogTolerance = backlogTolerance
-
 			history.L1PricingInertia = l1PricingInertia
 			history.L1EquilibrationUnits = l1EquilibrationUnits
+			history.L1PerBatchCost = l1PerBatchCost
+			history.L1AmortizedCostCapBips = l1AmortizedCostCapBips
 			history.L1PerUnitReward = l1PerUnitReward
 			history.L1PayRewardTo = l1PayRewardsTo.Hex()
 		}

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -232,7 +232,7 @@ func InitializeArbosState(stateDB vm.StateDB, burner burn.Burner, chainConfig *p
 		return nil, err
 	}
 	if desiredArbosVersion > 1 {
-		aState.UpgradeArbosVersion(desiredArbosVersion)
+		aState.UpgradeArbosVersion(desiredArbosVersion, true)
 	}
 	return aState, err
 }
@@ -242,11 +242,11 @@ func (state *ArbosState) UpgradeArbosVersionIfNecessary(currentTimestamp uint64)
 	state.Restrict(err)
 	flagday, _ := state.upgradeTimestamp.Get()
 	if state.arbosVersion < upgradeTo && currentTimestamp >= flagday {
-		state.UpgradeArbosVersion(upgradeTo)
+		state.UpgradeArbosVersion(upgradeTo, false)
 	}
 }
 
-func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64) {
+func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool) {
 	for state.arbosVersion < upgradeTo {
 		ensure := func(err error) {
 			if err != nil {
@@ -275,6 +275,14 @@ func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64) {
 		}
 		state.arbosVersion++
 	}
+
+	if firstTime && upgradeTo >= 7 {
+		state.Restrict(state.l1PricingState.SetPerBatchGasCost(l1pricing.InitialPerBatchGasCostV7))
+		state.Restrict(state.l1PricingState.SetEquilibrationUnits(l1pricing.InitialEquilibrationUnitsV7))
+		state.Restrict(state.l2PricingState.SetSpeedLimitPerSecond(l2pricing.InitialSpeedLimitPerSecondV7))
+		state.Restrict(state.l2PricingState.SetMaxPerBlockGasLimit(l2pricing.InitialPerBlockGasLimitV7))
+	}
+
 	state.Restrict(state.backingStorage.SetUint64ByUint64(uint64(versionOffset), state.arbosVersion))
 }
 

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -276,7 +276,7 @@ func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool) {
 		state.arbosVersion++
 	}
 
-	if firstTime && upgradeTo >= 7 {
+	if firstTime && upgradeTo >= 6 {
 		state.Restrict(state.l1PricingState.SetPerBatchGasCost(l1pricing.InitialPerBatchGasCostV7))
 		state.Restrict(state.l1PricingState.SetEquilibrationUnits(l1pricing.InitialEquilibrationUnitsV7))
 		state.Restrict(state.l2PricingState.SetSpeedLimitPerSecond(l2pricing.InitialSpeedLimitPerSecondV7))

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -277,10 +277,10 @@ func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool) {
 	}
 
 	if firstTime && upgradeTo >= 6 {
-		state.Restrict(state.l1PricingState.SetPerBatchGasCost(l1pricing.InitialPerBatchGasCostV7))
-		state.Restrict(state.l1PricingState.SetEquilibrationUnits(l1pricing.InitialEquilibrationUnitsV7))
-		state.Restrict(state.l2PricingState.SetSpeedLimitPerSecond(l2pricing.InitialSpeedLimitPerSecondV7))
-		state.Restrict(state.l2PricingState.SetMaxPerBlockGasLimit(l2pricing.InitialPerBlockGasLimitV7))
+		state.Restrict(state.l1PricingState.SetPerBatchGasCost(l1pricing.InitialPerBatchGasCostV6))
+		state.Restrict(state.l1PricingState.SetEquilibrationUnits(l1pricing.InitialEquilibrationUnitsV6))
+		state.Restrict(state.l2PricingState.SetSpeedLimitPerSecond(l2pricing.InitialSpeedLimitPerSecondV6))
+		state.Restrict(state.l2PricingState.SetMaxPerBlockGasLimit(l2pricing.InitialPerBlockGasLimitV6))
 	}
 
 	state.Restrict(state.backingStorage.SetUint64ByUint64(uint64(versionOffset), state.arbosVersion))

--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -72,12 +72,12 @@ const (
 	InitialInertia           = 10
 	InitialPerUnitReward     = 10
 	InitialPricePerUnitWei   = 50 * params.GWei
-	InitialPerBatchGasCostV7 = 100000
+	InitialPerBatchGasCostV6 = 100000
 )
 
 // one minute at 100000 bytes / sec
 var InitialEquilibrationUnitsV0 = arbmath.UintToBig(60 * params.TxDataNonZeroGasEIP2028 * 100000)
-var InitialEquilibrationUnitsV7 = arbmath.UintToBig(params.TxDataNonZeroGasEIP2028 * 10000000)
+var InitialEquilibrationUnitsV6 = arbmath.UintToBig(params.TxDataNonZeroGasEIP2028 * 10000000)
 
 func InitializeL1PricingState(sto *storage.Storage, initialRewardsRecipient common.Address) error {
 	bptStorage := sto.OpenSubStorage(BatchPosterTableKey)

--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbcompress"
+	"github.com/offchainlabs/nitro/util/arbmath"
 	am "github.com/offchainlabs/nitro/util/arbmath"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -74,8 +75,9 @@ const (
 	InitialPerBatchGasCostV7 = 141000
 )
 
-var InitialEquilibrationUnitsV0 = 60 * params.TxDataNonZeroGasEIP2028 * 100000 // one minute at 100000 bytes / sec
-var InitialEquilibrationUnitsV7 = big.NewInt(141000)
+// one minute at 100000 bytes / sec
+var InitialEquilibrationUnitsV0 = arbmath.UintToBig(60 * params.TxDataNonZeroGasEIP2028 * 100000)
+var InitialEquilibrationUnitsV7 = big.NewInt(160000000)
 
 func InitializeL1PricingState(sto *storage.Storage, initialRewardsRecipient common.Address) error {
 	bptStorage := sto.OpenSubStorage(BatchPosterTableKey)
@@ -90,7 +92,7 @@ func InitializeL1PricingState(sto *storage.Storage, initialRewardsRecipient comm
 		return err
 	}
 	equilibrationUnits := sto.OpenStorageBackedBigInt(equilibrationUnitsOffset)
-	if err := equilibrationUnits.Set(am.UintToBig(InitialEquilibrationUnitsV0)); err != nil {
+	if err := equilibrationUnits.Set(InitialEquilibrationUnitsV0); err != nil {
 		return err
 	}
 	if err := sto.SetUint64ByUint64(inertiaOffset, InitialInertia); err != nil {

--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -68,11 +68,14 @@ const (
 )
 
 const (
-	InitialEquilibrationUnits uint64 = 60 * params.TxDataNonZeroGasEIP2028 * 100000 // one minute at 100000 bytes / sec
-	InitialInertia                   = 10
-	InitialPerUnitReward             = 10
-	InitialPricePerUnitWei           = 50 * params.GWei
+	InitialInertia           = 10
+	InitialPerUnitReward     = 10
+	InitialPricePerUnitWei   = 50 * params.GWei
+	InitialPerBatchGasCostV7 = 141000
 )
+
+var InitialEquilibrationUnitsV0 = 60 * params.TxDataNonZeroGasEIP2028 * 100000 // one minute at 100000 bytes / sec
+var InitialEquilibrationUnitsV7 = big.NewInt(141000)
 
 func InitializeL1PricingState(sto *storage.Storage, initialRewardsRecipient common.Address) error {
 	bptStorage := sto.OpenSubStorage(BatchPosterTableKey)
@@ -87,7 +90,7 @@ func InitializeL1PricingState(sto *storage.Storage, initialRewardsRecipient comm
 		return err
 	}
 	equilibrationUnits := sto.OpenStorageBackedBigInt(equilibrationUnitsOffset)
-	if err := equilibrationUnits.Set(am.UintToBig(InitialEquilibrationUnits)); err != nil {
+	if err := equilibrationUnits.Set(am.UintToBig(InitialEquilibrationUnitsV0)); err != nil {
 		return err
 	}
 	if err := sto.SetUint64ByUint64(inertiaOffset, InitialInertia); err != nil {

--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -72,12 +72,12 @@ const (
 	InitialInertia           = 10
 	InitialPerUnitReward     = 10
 	InitialPricePerUnitWei   = 50 * params.GWei
-	InitialPerBatchGasCostV7 = 141000
+	InitialPerBatchGasCostV7 = 100000
 )
 
 // one minute at 100000 bytes / sec
 var InitialEquilibrationUnitsV0 = arbmath.UintToBig(60 * params.TxDataNonZeroGasEIP2028 * 100000)
-var InitialEquilibrationUnitsV7 = big.NewInt(160000000)
+var InitialEquilibrationUnitsV7 = arbmath.UintToBig(params.TxDataNonZeroGasEIP2028 * 10000000)
 
 func InitializeL1PricingState(sto *storage.Storage, initialRewardsRecipient common.Address) error {
 	bptStorage := sto.OpenSubStorage(BatchPosterTableKey)

--- a/arbos/l1pricing_test.go
+++ b/arbos/l1pricing_test.go
@@ -260,7 +260,7 @@ func _testL1PriceEquilibration(t *testing.T, initialL1BasefeeEstimate *big.Int, 
 	bpAddr := common.Address{3, 4, 5, 6}
 	l1PoolAddress := l1pricing.L1PricerFundsPoolAddress
 	for i := 0; i < 10; i++ {
-		unitsToAdd := l1pricing.InitialEquilibrationUnits
+		unitsToAdd := l1pricing.InitialEquilibrationUnitsV0
 		oldUnits, err := l1p.UnitsSinceUpdate()
 		Require(t, err)
 		err = l1p.SetUnitsSinceUpdate(oldUnits + unitsToAdd)

--- a/arbos/l1pricing_test.go
+++ b/arbos/l1pricing_test.go
@@ -258,7 +258,7 @@ func _testL1PriceEquilibration(t *testing.T, initialL1BasefeeEstimate *big.Int, 
 	bpAddr := common.Address{3, 4, 5, 6}
 	l1PoolAddress := l1pricing.L1PricerFundsPoolAddress
 	for i := 0; i < 10; i++ {
-		unitsToAdd := l1pricing.InitialEquilibrationUnitsV7.Uint64()
+		unitsToAdd := l1pricing.InitialEquilibrationUnitsV6.Uint64()
 		oldUnits, err := l1p.UnitsSinceUpdate()
 		Require(t, err)
 		err = l1p.SetUnitsSinceUpdate(oldUnits + unitsToAdd)

--- a/arbos/l1pricing_test.go
+++ b/arbos/l1pricing_test.go
@@ -252,15 +252,13 @@ func _testL1PriceEquilibration(t *testing.T, initialL1BasefeeEstimate *big.Int, 
 	Require(t, err)
 
 	l1p := state.L1PricingState()
-	err = l1p.SetPerUnitReward(0)
-	Require(t, err)
-	err = l1p.SetPricePerUnit(initialL1BasefeeEstimate)
-	Require(t, err)
+	Require(t, l1p.SetPerUnitReward(0))
+	Require(t, l1p.SetPricePerUnit(initialL1BasefeeEstimate))
 
 	bpAddr := common.Address{3, 4, 5, 6}
 	l1PoolAddress := l1pricing.L1PricerFundsPoolAddress
 	for i := 0; i < 10; i++ {
-		unitsToAdd := l1pricing.InitialEquilibrationUnitsV0
+		unitsToAdd := l1pricing.InitialEquilibrationUnitsV7.Uint64()
 		oldUnits, err := l1p.UnitsSinceUpdate()
 		Require(t, err)
 		err = l1p.SetUnitsSinceUpdate(oldUnits + unitsToAdd)
@@ -292,7 +290,7 @@ func _testL1PriceEquilibration(t *testing.T, initialL1BasefeeEstimate *big.Int, 
 	expectedMovement = new(big.Int).Abs(expectedMovement)
 	actualMovement = new(big.Int).Abs(actualMovement)
 	if !_withinOnePercent(expectedMovement, actualMovement) {
-		Fail(t, "Expected vs actual movement are too far apart")
+		Fail(t, "Expected vs actual movement are too far apart", expectedMovement, actualMovement)
 	}
 }
 

--- a/arbos/l2pricing/l2pricing.go
+++ b/arbos/l2pricing/l2pricing.go
@@ -33,8 +33,8 @@ const (
 const GethBlockGasLimit = 1 << 50
 
 func InitializeL2PricingState(sto *storage.Storage) error {
-	_ = sto.SetUint64ByUint64(speedLimitPerSecondOffset, InitialSpeedLimitPerSecond)
-	_ = sto.SetUint64ByUint64(perBlockGasLimitOffset, InitialPerBlockGasLimit)
+	_ = sto.SetUint64ByUint64(speedLimitPerSecondOffset, InitialSpeedLimitPerSecondV0)
+	_ = sto.SetUint64ByUint64(perBlockGasLimitOffset, InitialPerBlockGasLimitV0)
 	_ = sto.SetUint64ByUint64(baseFeeWeiOffset, InitialBaseFeeWei)
 	_ = sto.SetUint64ByUint64(gasBacklogOffset, 0)
 	_ = sto.SetUint64ByUint64(pricingInertiaOffset, InitialPricingInertia)

--- a/arbos/l2pricing/model.go
+++ b/arbos/l2pricing/model.go
@@ -12,8 +12,8 @@ import (
 
 const InitialSpeedLimitPerSecondV0 = 1000000
 const InitialPerBlockGasLimitV0 uint64 = 20 * 1000000
-const InitialSpeedLimitPerSecondV7 = 7000000
-const InitialPerBlockGasLimitV7 uint64 = 32 * 1000000
+const InitialSpeedLimitPerSecondV6 = 7000000
+const InitialPerBlockGasLimitV6 uint64 = 32 * 1000000
 const InitialMinimumBaseFeeWei = params.GWei / 10
 const InitialBaseFeeWei = InitialMinimumBaseFeeWei
 const InitialGasPoolSeconds = 10 * 60

--- a/arbos/l2pricing/model.go
+++ b/arbos/l2pricing/model.go
@@ -10,8 +10,10 @@ import (
 	"github.com/offchainlabs/nitro/util/arbmath"
 )
 
-const InitialSpeedLimitPerSecond = 1000000
-const InitialPerBlockGasLimit uint64 = 20 * 1000000
+const InitialSpeedLimitPerSecondV0 = 1000000
+const InitialPerBlockGasLimitV0 uint64 = 20 * 1000000
+const InitialSpeedLimitPerSecondV7 = 7000000
+const InitialPerBlockGasLimitV7 uint64 = 32 * 1000000
 const InitialMinimumBaseFeeWei = params.GWei / 10
 const InitialBaseFeeWei = InitialMinimumBaseFeeWei
 const InitialGasPoolSeconds = 10 * 60

--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -56,7 +56,7 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, expensiveTx bo
 		ownerInfo := l2info.GetInfoWithPrivKey("Owner")
 		tx = l2info.SignTxAs("Owner", &types.DynamicFeeTx{
 			To:        nil,
-			Gas:       l2info.TransferGas*2 + l2pricing.InitialPerBlockGasLimitV0,
+			Gas:       l2info.TransferGas*2 + l2pricing.InitialPerBlockGasLimitV7,
 			GasFeeCap: new(big.Int).Set(l2info.GasPrice),
 			Value:     common.Big0,
 			Nonce:     ownerInfo.Nonce,

--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -56,7 +56,7 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, expensiveTx bo
 		ownerInfo := l2info.GetInfoWithPrivKey("Owner")
 		tx = l2info.SignTxAs("Owner", &types.DynamicFeeTx{
 			To:        nil,
-			Gas:       l2info.TransferGas*2 + l2pricing.InitialPerBlockGasLimitV7,
+			Gas:       l2info.TransferGas*2 + l2pricing.InitialPerBlockGasLimitV6,
 			GasFeeCap: new(big.Int).Set(l2info.GasPrice),
 			Value:     common.Big0,
 			Nonce:     ownerInfo.Nonce,

--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -56,7 +56,7 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, expensiveTx bo
 		ownerInfo := l2info.GetInfoWithPrivKey("Owner")
 		tx = l2info.SignTxAs("Owner", &types.DynamicFeeTx{
 			To:        nil,
-			Gas:       l2info.TransferGas*2 + l2pricing.InitialPerBlockGasLimit,
+			Gas:       l2info.TransferGas*2 + l2pricing.InitialPerBlockGasLimitV0,
 			GasFeeCap: new(big.Int).Set(l2info.GasPrice),
 			Value:     common.Big0,
 			Nonce:     ownerInfo.Nonce,

--- a/system_tests/fees_test.go
+++ b/system_tests/fees_test.go
@@ -108,7 +108,7 @@ func testSequencerPriceAdjustsFrom(t *testing.T, initialEstimate uint64) {
 	Require(t, err)
 	arbOwner, err := precompilesgen.NewArbOwner(common.HexToAddress("0x70"), l2client)
 	Require(t, err)
-	tx, err = arbOwner.SetL1PricePerUnit(&ownerAuth, new(big.Int).SetUint64(initialEstimate))
+	tx, err = arbOwner.SetL1PricePerUnit(&ownerAuth, arbmath.UintToBig(initialEstimate))
 	Require(t, err)
 	_, err = WaitForTx(ctx, l2client, tx.Hash(), time.Second*5)
 	Require(t, err)

--- a/system_tests/test_info.go
+++ b/system_tests/test_info.go
@@ -53,8 +53,12 @@ func NewBlockChainTestInfo(t *testing.T, signer types.Signer, gasPrice *big.Int,
 }
 
 func NewArbTestInfo(t *testing.T, chainId *big.Int) *BlockchainTestInfo {
-	var transferGas uint64 = util.NormalizeL2GasForL1GasInitial(300_000, params.GWei) // include room for aggregator L1 costs
-	arbinfo := NewBlockChainTestInfo(t, types.NewArbitrumSigner(types.NewLondonSigner(chainId)), big.NewInt(l2pricing.InitialBaseFeeWei*2), transferGas)
+	var transferGas uint64 = util.NormalizeL2GasForL1GasInitial(800_000, params.GWei) // include room for aggregator L1 costs
+	arbinfo := NewBlockChainTestInfo(
+		t,
+		types.NewArbitrumSigner(types.NewLondonSigner(chainId)), big.NewInt(l2pricing.InitialBaseFeeWei*2),
+		transferGas,
+	)
 	arbinfo.GenerateGenesysAccount("Owner", new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9)))
 	arbinfo.GenerateGenesysAccount("Faucet", new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9)))
 	return arbinfo


### PR DESCRIPTION
Adds a `firstTime` flag to the upgrade loop so that new chains can have different defaults
Also exposes additional l1 pricing params in `arbdebug`