### PR TITLE
Make ConfigFetcher an interface

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -403,7 +403,7 @@ type Config struct {
 	TxLookupLimit        uint64                         `koanf:"tx-lookup-limit"`
 }
 
-func (c *Config) Get() *Config {
+func (c *Config) GetNodeConfig() *Config {
 	return c
 }
 
@@ -591,7 +591,7 @@ type Node struct {
 }
 
 type ConfigFetcher interface {
-	Get() *Config
+	GetNodeConfig() *Config
 }
 type SequencerConfigFetcher func() *SequencerConfig
 
@@ -608,7 +608,7 @@ func createNodeImpl(
 	daSigner das.DasSigner,
 	feedErrChan chan error,
 ) (*Node, error) {
-	config := configFetcher.Get()
+	config := configFetcher.GetNodeConfig()
 	var reorgingToBlock *types.Block
 	if config.Dangerous.ReorgToBlock >= 0 {
 		blockNum := uint64(config.Dangerous.ReorgToBlock)
@@ -659,7 +659,7 @@ func createNodeImpl(
 		if !(config.SeqCoordinator.Enable || config.Sequencer.Dangerous.NoCoordinator) {
 			return nil, errors.New("sequencer must be enabled with coordinator, unless dangerous.no-coordinator set")
 		}
-		sequencerConfigFetcher := func() *SequencerConfig { return &configFetcher.Get().Sequencer }
+		sequencerConfigFetcher := func() *SequencerConfig { return &configFetcher.GetNodeConfig().Sequencer }
 		if config.L1Reader.Enable {
 			if l1client == nil {
 				return nil, errors.New("l1client is nil")
@@ -1131,7 +1131,7 @@ func CreateNode(
 		Service:   &ArbAPI{currentNode.TxPublisher},
 		Public:    false,
 	})
-	config := configFetcher.Get()
+	config := configFetcher.GetNodeConfig()
 	apis = append(apis, rpc.API{
 		Namespace: "arbdebug",
 		Version:   "1.0",

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -403,6 +403,10 @@ type Config struct {
 	TxLookupLimit        uint64                         `koanf:"tx-lookup-limit"`
 }
 
+func (c *Config) Get() *Config {
+	return c
+}
+
 func (c *Config) ForwardingTarget() string {
 	if c.ForwardingTargetImpl == "null" {
 		return ""
@@ -586,7 +590,9 @@ type Node struct {
 	ClassicOutboxRetriever *ClassicOutboxRetriever
 }
 
-type ConfigFetcher func() *Config
+type ConfigFetcher interface {
+	Get() *Config
+}
 type SequencerConfigFetcher func() *SequencerConfig
 
 func createNodeImpl(
@@ -602,7 +608,7 @@ func createNodeImpl(
 	daSigner das.DasSigner,
 	feedErrChan chan error,
 ) (*Node, error) {
-	config := configFetcher()
+	config := configFetcher.Get()
 	var reorgingToBlock *types.Block
 	if config.Dangerous.ReorgToBlock >= 0 {
 		blockNum := uint64(config.Dangerous.ReorgToBlock)
@@ -653,7 +659,7 @@ func createNodeImpl(
 		if !(config.SeqCoordinator.Enable || config.Sequencer.Dangerous.NoCoordinator) {
 			return nil, errors.New("sequencer must be enabled with coordinator, unless dangerous.no-coordinator set")
 		}
-		sequencerConfigFetcher := func() *SequencerConfig { return &configFetcher().Sequencer }
+		sequencerConfigFetcher := func() *SequencerConfig { return &configFetcher.Get().Sequencer }
 		if config.L1Reader.Enable {
 			if l1client == nil {
 				return nil, errors.New("l1client is nil")
@@ -1125,7 +1131,7 @@ func CreateNode(
 		Service:   &ArbAPI{currentNode.TxPublisher},
 		Public:    false,
 	})
-	config := configFetcher()
+	config := configFetcher.Get()
 	apis = append(apis, rpc.API{
 		Namespace: "arbdebug",
 		Version:   "1.0",

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -515,14 +515,13 @@ func main() {
 	}
 
 	liveNodeConfig := NewLiveNodeConfig(args, nodeConfig)
-	nodeConfigFetcher := LiveNodeConfigFetcher{liveNodeConfig}
 	feedErrChan := make(chan error, 10)
 	currentNode, err := arbnode.CreateNode(
 		ctx,
 		stack,
 		chainDb,
 		arbDb,
-		&nodeConfigFetcher,
+		liveNodeConfig,
 		l2BlockChain,
 		l1Client,
 		&rollupAddrs,
@@ -1035,10 +1034,6 @@ func NewLiveNodeConfig(args []string, config *NodeConfig) *LiveNodeConfig {
 	}
 }
 
-type LiveNodeConfigFetcher struct {
-	*LiveNodeConfig
-}
-
-func (f *LiveNodeConfigFetcher) Get() *arbnode.Config {
-	return &f.LiveNodeConfig.get().Node
+func (c *LiveNodeConfig) GetNodeConfig() *arbnode.Config {
+	return &c.get().Node
 }

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -515,15 +515,14 @@ func main() {
 	}
 
 	liveNodeConfig := NewLiveNodeConfig(args, nodeConfig)
-	nodeConfigFetcher := func() *arbnode.Config { return &liveNodeConfig.get().Node }
-
+	nodeConfigFetcher := LiveNodeConfigFetcher{liveNodeConfig}
 	feedErrChan := make(chan error, 10)
 	currentNode, err := arbnode.CreateNode(
 		ctx,
 		stack,
 		chainDb,
 		arbDb,
-		nodeConfigFetcher,
+		&nodeConfigFetcher,
 		l2BlockChain,
 		l1Client,
 		&rollupAddrs,
@@ -1034,4 +1033,12 @@ func NewLiveNodeConfig(args []string, config *NodeConfig) *LiveNodeConfig {
 		args:   args,
 		config: config,
 	}
+}
+
+type LiveNodeConfigFetcher struct {
+	*LiveNodeConfig
+}
+
+func (f *LiveNodeConfigFetcher) Get() *arbnode.Config {
+	return &f.LiveNodeConfig.get().Node
 }

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -341,8 +341,7 @@ func createTestNodeOnL1WithConfig(
 	}
 
 	var err error
-	nodeConfigFetcher := func() *arbnode.Config { return nodeConfig }
-	currentNode, err = arbnode.CreateNode(ctx, l2stack, l2chainDb, l2arbDb, nodeConfigFetcher, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil, feedErrChan)
+	currentNode, err = arbnode.CreateNode(ctx, l2stack, l2chainDb, l2arbDb, nodeConfig, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil, feedErrChan)
 	Require(t, err)
 
 	Require(t, l2stack.Start())
@@ -365,8 +364,7 @@ func CreateTestL2WithConfig(
 ) (*BlockchainTestInfo, *arbnode.Node, *ethclient.Client, *node.Node) {
 	feedErrChan := make(chan error, 10)
 	l2info, stack, chainDb, arbDb, blockchain := createL2BlockChain(t, l2Info, "", params.ArbitrumDevTestChainConfig())
-	nodeConfigFetcher := func() *arbnode.Config { return nodeConfig }
-	currentNode, err := arbnode.CreateNode(ctx, stack, chainDb, arbDb, nodeConfigFetcher, blockchain, nil, nil, nil, nil, feedErrChan)
+	currentNode, err := arbnode.CreateNode(ctx, stack, chainDb, arbDb, nodeConfig, blockchain, nil, nil, nil, nil, feedErrChan)
 	Require(t, err)
 
 	// Give the node an init message
@@ -465,8 +463,7 @@ func Create2ndNodeWithConfig(
 	l2blockchain, err := arbnode.WriteOrTestBlockChain(l2chainDb, nil, initReader, first.ArbInterface.BlockChain().Config(), arbnode.ConfigDefaultL2Test(), 0)
 	Require(t, err)
 
-	nodeConfigFetcher := func() *arbnode.Config { return nodeConfig }
-	currentNode, err := arbnode.CreateNode(ctx, l2stack, l2chainDb, l2arbDb, nodeConfigFetcher, l2blockchain, l1client, first.DeployInfo, nil, nil, feedErrChan)
+	currentNode, err := arbnode.CreateNode(ctx, l2stack, l2chainDb, l2arbDb, nodeConfig, l2blockchain, l1client, first.DeployInfo, nil, nil, feedErrChan)
 	Require(t, err)
 
 	err = l2stack.Start()

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -129,8 +129,7 @@ func TestDASRekey(t *testing.T) {
 		l1NodeConfigA.DataAvailability.Enable = true
 		l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, backendConfigA)
 
-		nodeConfigFetcher := func() *arbnode.Config { return l1NodeConfigA }
-		nodeA, err := arbnode.CreateNode(ctx, l2stackA, l2chainDb, l2arbDb, nodeConfigFetcher, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil, feedErrChan)
+		nodeA, err := arbnode.CreateNode(ctx, l2stackA, l2chainDb, l2arbDb, l1NodeConfigA, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil, feedErrChan)
 		Require(t, err)
 		Require(t, l2stackA.Start())
 		l2clientA := ClientForStack(t, l2stackA)
@@ -167,9 +166,7 @@ func TestDASRekey(t *testing.T) {
 	l2blockchain, err := arbnode.GetBlockChain(l2chainDb, nil, chainConfig, arbnode.ConfigDefaultL2Test())
 	Require(t, err)
 	l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, backendConfigB)
-
-	nodeConfigFetcher := func() *arbnode.Config { return l1NodeConfigA }
-	nodeA, err := arbnode.CreateNode(ctx, l2stackA, l2chainDb, l2arbDb, nodeConfigFetcher, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil, feedErrChan)
+	nodeA, err := arbnode.CreateNode(ctx, l2stackA, l2chainDb, l2arbDb, l1NodeConfigA, l2blockchain, l1client, addresses, sequencerTxOptsPtr, nil, feedErrChan)
 	Require(t, err)
 	Require(t, l2stackA.Start())
 	l2clientA := ClientForStack(t, l2stackA)
@@ -329,8 +326,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 
 	sequencerTxOpts := l1info.GetDefaultTransactOpts("Sequencer", ctx)
 	sequencerTxOptsPtr := &sequencerTxOpts
-	nodeConfigFetcher := func() *arbnode.Config { return l1NodeConfigA }
-	nodeA, err := arbnode.CreateNode(ctx, l2stackA, l2chainDb, l2arbDb, nodeConfigFetcher, l2blockchain, l1client, addresses, sequencerTxOptsPtr, daSigner, feedErrChan)
+	nodeA, err := arbnode.CreateNode(ctx, l2stackA, l2chainDb, l2arbDb, l1NodeConfigA, l2blockchain, l1client, addresses, sequencerTxOptsPtr, daSigner, feedErrChan)
 	Require(t, err)
 	Require(t, l2stackA.Start())
 	l2clientA := ClientForStack(t, l2stackA)

--- a/system_tests/full_challenge_impl_test.go
+++ b/system_tests/full_challenge_impl_test.go
@@ -246,15 +246,14 @@ func RunChallengeTest(t *testing.T, asserterIsCorrect bool) {
 	asserterL2Info, asserterL2Stack, asserterL2ChainDb, asserterL2ArbDb, asserterL2Blockchain := createL2BlockChain(t, nil, "", chainConfig)
 	rollupAddresses.SequencerInbox = asserterSeqInboxAddr
 
-	nodeConfigFetcher := func() *arbnode.Config { return conf }
-	asserterL2, err := arbnode.CreateNode(ctx, asserterL2Stack, asserterL2ChainDb, asserterL2ArbDb, nodeConfigFetcher, asserterL2Blockchain, l1Backend, rollupAddresses, nil, nil, feedErrChan)
+	asserterL2, err := arbnode.CreateNode(ctx, asserterL2Stack, asserterL2ChainDb, asserterL2ArbDb, conf, asserterL2Blockchain, l1Backend, rollupAddresses, nil, nil, feedErrChan)
 	Require(t, err)
 	err = asserterL2Stack.Start()
 	Require(t, err)
 
 	challengerL2Info, challengerL2Stack, challengerL2ChainDb, challengerL2ArbDb, challengerL2Blockchain := createL2BlockChain(t, nil, "", chainConfig)
 	rollupAddresses.SequencerInbox = challengerSeqInboxAddr
-	challengerL2, err := arbnode.CreateNode(ctx, challengerL2Stack, challengerL2ChainDb, challengerL2ArbDb, nodeConfigFetcher, challengerL2Blockchain, l1Backend, rollupAddresses, nil, nil, feedErrChan)
+	challengerL2, err := arbnode.CreateNode(ctx, challengerL2Stack, challengerL2ChainDb, challengerL2ArbDb, conf, challengerL2Blockchain, l1Backend, rollupAddresses, nil, nil, feedErrChan)
 	Require(t, err)
 	err = challengerL2Stack.Start()
 	Require(t, err)


### PR DESCRIPTION
Make ConfigFetcher an interface implemented both by arbnode.Config and LiveNodeConfigFetcher to simplify high level API and avoid changes in tests.

Is it a good way to go?