### PR TITLE
Aggregator error logging metrics

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -761,9 +761,6 @@ func createNodeImpl(
 			}
 		}
 
-		if daWriter != nil {
-			daWriter = das.NewWriterTimeoutWrapper(daWriter, config.DataAvailability.RequestTimeout)
-		}
 		daReader = das.NewReaderTimeoutWrapper(daReader, config.DataAvailability.RequestTimeout)
 
 		if config.DataAvailability.PanicOnError {

--- a/das/aggregator.go
+++ b/das/aggregator.go
@@ -216,6 +216,7 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64, 
 			defer cancel()
 			incFailureMetric := func() {
 				metrics.GetOrRegisterGauge("arb/das/rpc/aggregator/store/"+d.metricName+"/failure", nil).Inc(1)
+				metrics.GetOrRegisterGauge("arb/das/rpc/aggregator/store/all/failure", nil).Inc(1)
 			}
 
 			cert, err := d.service.Store(storeCtx, message, timeout, sig)
@@ -262,6 +263,7 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64, 
 			}
 
 			metrics.GetOrRegisterGauge("arb/das/rpc/aggregator/store/"+d.metricName+"/success", nil).Inc(1)
+			metrics.GetOrRegisterGauge("arb/das/rpc/aggregator/store/all/success", nil).Inc(1)
 			responses <- storeResponse{d, cert.Sig, nil}
 		}(ctx, d)
 	}

--- a/das/aggregator_test.go
+++ b/das/aggregator_test.go
@@ -44,7 +44,7 @@ func TestDAS_BasicAggregationLocal(t *testing.T) {
 		das, err := NewSignAfterStoreDAS(ctx, config, storageServices[i])
 		Require(t, err)
 		signerMask := uint64(1 << i)
-		details, err := NewServiceDetails(das, *das.pubKey, signerMask)
+		details, err := NewServiceDetails(das, *das.pubKey, signerMask, "service"+strconv.Itoa(i))
 		Require(t, err)
 		backends = append(backends, *details)
 	}
@@ -197,7 +197,7 @@ func testConfigurableStorageFailures(t *testing.T, shouldFailAggregation bool) {
 		das, err := NewSignAfterStoreDAS(ctx, config, storageServices[i])
 		Require(t, err)
 		signerMask := uint64(1 << i)
-		details, err := NewServiceDetails(&WrapStore{t, injectedFailures, das}, *das.pubKey, signerMask)
+		details, err := NewServiceDetails(&WrapStore{t, injectedFailures, das}, *das.pubKey, signerMask, "service"+strconv.Itoa(i))
 		Require(t, err)
 		backends = append(backends, *details)
 	}

--- a/das/aggregator_test.go
+++ b/das/aggregator_test.go
@@ -202,9 +202,14 @@ func testConfigurableStorageFailures(t *testing.T, shouldFailAggregation bool) {
 		backends = append(backends, *details)
 	}
 
-	unwrappedAggregator, err := NewAggregator(ctx, DataAvailabilityConfig{AggregatorConfig: AggregatorConfig{AssumedHonest: assumedHonest}, L1NodeURL: "none"}, backends)
+	aggregator, err := NewAggregator(
+		ctx,
+		DataAvailabilityConfig{
+			AggregatorConfig: AggregatorConfig{AssumedHonest: assumedHonest},
+			L1NodeURL:        "none",
+			RequestTimeout:   time.Millisecond * 2000,
+		}, backends)
 	Require(t, err)
-	aggregator := WriterTimeoutWrapper{time.Millisecond * 2000, unwrappedAggregator}
 
 	rawMsg := []byte("It's time for you to see the fnords.")
 	cert, err := aggregator.Store(ctx, rawMsg, 0, []byte{})

--- a/das/rpc_aggregator.go
+++ b/das/rpc_aggregator.go
@@ -20,14 +20,14 @@ type BackendConfig struct {
 }
 
 func NewRPCAggregator(ctx context.Context, config DataAvailabilityConfig) (*Aggregator, error) {
-	services, err := setUpServices(config.AggregatorConfig)
+	services, err := setUpServices(config)
 	if err != nil {
 		return nil, err
 	}
 	return NewAggregator(ctx, config, services)
 }
 
-func NewRPCAggregatorWithL1Info(config AggregatorConfig, l1client arbutil.L1Interface, seqInboxAddress common.Address) (*Aggregator, error) {
+func NewRPCAggregatorWithL1Info(config DataAvailabilityConfig, l1client arbutil.L1Interface, seqInboxAddress common.Address) (*Aggregator, error) {
 	services, err := setUpServices(config)
 	if err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func NewRPCAggregatorWithL1Info(config AggregatorConfig, l1client arbutil.L1Inte
 	return NewAggregatorWithL1Info(config, services, l1client, seqInboxAddress)
 }
 
-func NewRPCAggregatorWithSeqInboxCaller(config AggregatorConfig, seqInboxCaller *bridgegen.SequencerInboxCaller) (*Aggregator, error) {
+func NewRPCAggregatorWithSeqInboxCaller(config DataAvailabilityConfig, seqInboxCaller *bridgegen.SequencerInboxCaller) (*Aggregator, error) {
 	services, err := setUpServices(config)
 	if err != nil {
 		return nil, err
@@ -43,9 +43,9 @@ func NewRPCAggregatorWithSeqInboxCaller(config AggregatorConfig, seqInboxCaller 
 	return NewAggregatorWithSeqInboxCaller(config, services, seqInboxCaller)
 }
 
-func setUpServices(config AggregatorConfig) ([]ServiceDetails, error) {
+func setUpServices(config DataAvailabilityConfig) ([]ServiceDetails, error) {
 	var cs []BackendConfig
-	err := json.Unmarshal([]byte(config.Backends), &cs)
+	err := json.Unmarshal([]byte(config.AggregatorConfig.Backends), &cs)
 	if err != nil {
 		return nil, err
 	}

--- a/das/rpc_aggregator.go
+++ b/das/rpc_aggregator.go
@@ -6,6 +6,8 @@ package das
 import (
 	"context"
 	"encoding/json"
+	"net/url"
+	"strings"
 
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 
@@ -53,6 +55,13 @@ func setUpServices(config DataAvailabilityConfig) ([]ServiceDetails, error) {
 	var services []ServiceDetails
 
 	for _, b := range cs {
+		url, err := url.Parse(b.URL)
+		if err != nil {
+			return nil, err
+		}
+		// Prometheus metric names must contain only chars [a-zA-Z0-9:_]
+		metricName := strings.ReplaceAll(url.Hostname(), ".", "_")
+
 		service, err := NewDASRPCClient(b.URL)
 		if err != nil {
 			return nil, err
@@ -63,7 +72,7 @@ func setUpServices(config DataAvailabilityConfig) ([]ServiceDetails, error) {
 			return nil, err
 		}
 
-		d, err := NewServiceDetails(service, *pubKey, uint64(b.SignerMask))
+		d, err := NewServiceDetails(service, *pubKey, uint64(b.SignerMask), metricName)
 		if err != nil {
 			return nil, err
 		}

--- a/das/rpc_test.go
+++ b/das/rpc_test.go
@@ -65,9 +65,12 @@ func TestRPC(t *testing.T) {
 
 	backendsJsonByte, err := json.Marshal([]BackendConfig{beConfig})
 	testhelpers.RequireImpl(t, err)
-	aggConf := AggregatorConfig{
-		AssumedHonest: 1,
-		Backends:      string(backendsJsonByte),
+	aggConf := DataAvailabilityConfig{
+		AggregatorConfig: AggregatorConfig{
+			AssumedHonest: 1,
+			Backends:      string(backendsJsonByte),
+		},
+		RequestTimeout: 5 * time.Second,
 	}
 	rpcAgg, err := NewRPCAggregatorWithSeqInboxCaller(aggConf, nil)
 	testhelpers.RequireImpl(t, err)

--- a/das/timeout_wrapper.go
+++ b/das/timeout_wrapper.go
@@ -9,33 +9,21 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/offchainlabs/nitro/arbstate"
 )
 
 type ReaderTimeoutWrapper struct {
 	t time.Duration
 	DataAvailabilityServiceReader
 }
-type WriterTimeoutWrapper struct {
-	t time.Duration
-	DataAvailabilityServiceWriter
-}
 
 type TimeoutWrapper struct {
 	ReaderTimeoutWrapper
-	WriterTimeoutWrapper
 }
 
 func NewReaderTimeoutWrapper(dataAvailabilityServiceReader DataAvailabilityServiceReader, t time.Duration) DataAvailabilityServiceReader {
 	return &ReaderTimeoutWrapper{
 		t:                             t,
 		DataAvailabilityServiceReader: dataAvailabilityServiceReader,
-	}
-}
-func NewWriterTimeoutWrapper(dataAvailabilityServiceWriter DataAvailabilityServiceWriter, t time.Duration) DataAvailabilityServiceWriter {
-	return &WriterTimeoutWrapper{
-		t:                             t,
-		DataAvailabilityServiceWriter: dataAvailabilityServiceWriter,
 	}
 }
 
@@ -47,22 +35,6 @@ func (w *ReaderTimeoutWrapper) GetByHash(ctx context.Context, hash common.Hash) 
 	return w.DataAvailabilityServiceReader.GetByHash(deadlineCtx, hash)
 }
 
-func (w *WriterTimeoutWrapper) Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (*arbstate.DataAvailabilityCertificate, error) {
-	deadlineCtx, cancel := context.WithDeadline(ctx, time.Now().Add(w.t))
-	// In the case of the aggregator, allow goroutines started by Store(...)
-	// to continue until the end of the deadline even after a result
-	// has been returned.
-	go func() {
-		<-deadlineCtx.Done()
-		cancel()
-	}()
-	return w.DataAvailabilityServiceWriter.Store(deadlineCtx, message, timeout, sig)
-}
-
 func (w *ReaderTimeoutWrapper) String() string {
 	return fmt.Sprintf("ReaderTimeoutWrapper{%v}", w.DataAvailabilityServiceReader)
-}
-
-func (w *WriterTimeoutWrapper) String() string {
-	return fmt.Sprintf("WriterTimeoutWrapper{%v}", w.DataAvailabilityServiceWriter)
 }


### PR DESCRIPTION
Keep a goroutine running in the Aggregator to collect responses from the backend even after enough successes/failures have been captured in order to log and produce metrics for each backend.

# Testing done
Unit tests pass