### PR TITLE
Revert "Use 🖋️ as cla-signed label"

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,5 +1,4 @@
 {
   "contributors": "https://api.github.com/repos/OffchainLabs/clabot-config/contents/nitro-contributors.json",
-  "message": "We require contributors to sign our Contributor License Agreement. In order for us to review and merge your code, please sign the linked documents below to get yourself added. https://na3.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=b15c81cc-b5ea-42a6-9107-3992526f2898&env=na3&acct=6e152afc-6284-44af-a4c1-d8ef291db402&v=2",
-  "label": "🖋️"
+  "message": "We require contributors to sign our Contributor License Agreement. In order for us to review and merge your code, please sign the linked documents below to get yourself added. https://na3.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=b15c81cc-b5ea-42a6-9107-3992526f2898&env=na3&acct=6e152afc-6284-44af-a4c1-d8ef291db402&v=2"
 }


### PR DESCRIPTION
This reverts commit 6d9c04c306fe2879f5f455bc18aff990d391081e. It appears that the cal-bot doesn't handle the new label, possibly because it's unicode