### PR TITLE
MessageDelivered event reports irrelavent sender address

### DIFF
--- a/contracts/src/bridge/Bridge.sol
+++ b/contracts/src/bridge/Bridge.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+import "../libraries/AddressAliasHelper.sol";
 
 import {
     NotContract,
@@ -194,7 +195,7 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
             prevAcc,
             msg.sender,
             kind,
-            sender,
+            AddressAliasHelper.applyL1ToL2Alias(sender),
             messageDataHash,
             baseFeeL1,
             blockTimestamp


### PR DESCRIPTION
MessageDelivered event reports the sender address as the result of the earlier undoL1ToL2Alias(sender) conversion which is not very useful (since it is non-existent) when searching event logs.