### PR TITLE
Fix delayed messages being replayed causing a sequencer batch reorg

### DIFF
--- a/arbnode/delayed_seq_reorg_test.go
+++ b/arbnode/delayed_seq_reorg_test.go
@@ -44,7 +44,7 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 			},
 		},
 	}
-	err = tracker.AddDelayedMessages([]*DelayedInboxMessage{initMsgDelayed, userDelayed})
+	err = tracker.AddDelayedMessages([]*DelayedInboxMessage{initMsgDelayed, userDelayed}, false)
 	Require(t, err)
 
 	serializedInitMsgBatch := make([]byte, 40)

--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -470,7 +470,7 @@ func (ir *InboxReader) run(ctx context.Context, hadError bool) error {
 }
 
 func (r *InboxReader) addMessages(ctx context.Context, sequencerBatches []*SequencerInboxBatch, delayedMessages []*DelayedInboxMessage) (bool, error) {
-	err := r.tracker.AddDelayedMessages(delayedMessages)
+	err := r.tracker.AddDelayedMessages(delayedMessages, r.config.HardReorg)
 	if err != nil {
 		return false, err
 	}

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -211,18 +211,6 @@ func (t *InboxTracker) AddDelayedMessages(messages []*DelayedInboxMessage, hardR
 	if err != nil {
 		return err
 	}
-	var nextAcc common.Hash
-	if pos > 0 {
-		var err error
-		nextAcc, err = t.GetDelayedAcc(pos - 1)
-		if err != nil {
-			if errors.Is(err, accumulatorNotFound) {
-				return errors.New("missing previous delayed message")
-			} else {
-				return err
-			}
-		}
-	}
 
 	if !hardReorg {
 		// This math is safe to do as we know len(messages) > 0
@@ -234,6 +222,19 @@ func (t *InboxTracker) AddDelayedMessages(messages []*DelayedInboxMessage, hardR
 			}
 		} else if !errors.Is(err, accumulatorNotFound) {
 			return err
+		}
+	}
+
+	var nextAcc common.Hash
+	if pos > 0 {
+		var err error
+		nextAcc, err = t.GetDelayedAcc(pos - 1)
+		if err != nil {
+			if errors.Is(err, accumulatorNotFound) {
+				return errors.New("missing previous delayed message")
+			} else {
+				return err
+			}
 		}
 	}
 

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -335,7 +335,7 @@ func (t *InboxTracker) setDelayedCountReorgAndWriteBatch(batch ethdb.Batch, newD
 		if err != nil {
 			return err
 		}
-		log.Warn("InboxTracker delayed message reorg is causing a sequencer batch reorg", "sequencerBatchCount", count)
+		log.Warn("InboxTracker delayed message reorg is causing a sequencer batch reorg", "sequencerBatchCount", count, "delayedCount", newDelayedCount)
 		err = deleteStartingAt(t.db, batch, sequencerBatchMetaPrefix, uint64ToKey(count))
 		if err != nil {
 			return err


### PR DESCRIPTION
This would only happen if the chain reorg'd backwards past the sequencer's confirmation window, and then caught back up.