### PR TITLE
Method for estimating just l1 costs

### DIFF
--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -654,6 +654,7 @@ const estimationPaddingBasisPoints = 100
 var randomNonce = binary.BigEndian.Uint64(crypto.Keccak256([]byte("Nonce"))[:8])
 var randomGasTipCap = new(big.Int).SetBytes(crypto.Keccak256([]byte("GasTipCap"))[:4])
 var randomGasFeeCap = new(big.Int).SetBytes(crypto.Keccak256([]byte("GasFeeCap"))[:4])
+var randomGas = binary.BigEndian.Uint32(crypto.Keccak256([]byte("Gas"))[:4])
 var randV = arbmath.BigMulByUint(params.ArbitrumOneChainConfig().ChainID, 3)
 var randR = crypto.Keccak256Hash([]byte("R")).Big()
 var randS = crypto.Keccak256Hash([]byte("S")).Big()
@@ -673,11 +674,15 @@ func makeFakeTxForMessage(message core.Message) *types.Transaction {
 	if gasFeeCap.Sign() == 0 {
 		gasFeeCap = randomGasFeeCap
 	}
+	gas := message.Gas()
+	if gas == 0 {
+		gas = uint64(randomGas) // 4 bytes long
+	}
 	return types.NewTx(&types.DynamicFeeTx{
 		Nonce:      nonce,
 		GasTipCap:  gasTipCap,
 		GasFeeCap:  gasFeeCap,
-		Gas:        message.Gas(),
+		Gas:        gas,
 		To:         message.To(),
 		Value:      message.Value(),
 		Data:       message.Data(),

--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -654,7 +654,7 @@ const estimationPaddingBasisPoints = 100
 var randomNonce = binary.BigEndian.Uint64(crypto.Keccak256([]byte("Nonce"))[:8])
 var randomGasTipCap = new(big.Int).SetBytes(crypto.Keccak256([]byte("GasTipCap"))[:4])
 var randomGasFeeCap = new(big.Int).SetBytes(crypto.Keccak256([]byte("GasFeeCap"))[:4])
-var randomGas = binary.BigEndian.Uint32(crypto.Keccak256([]byte("Gas"))[:4])
+var RandomGas = uint64(binary.BigEndian.Uint32(crypto.Keccak256([]byte("Gas"))[:4]))
 var randV = arbmath.BigMulByUint(params.ArbitrumOneChainConfig().ChainID, 3)
 var randR = crypto.Keccak256Hash([]byte("R")).Big()
 var randS = crypto.Keccak256Hash([]byte("S")).Big()
@@ -676,7 +676,7 @@ func makeFakeTxForMessage(message core.Message) *types.Transaction {
 	}
 	gas := message.Gas()
 	if gas == 0 {
-		gas = uint64(randomGas) // 4 bytes long
+		gas = RandomGas
 	}
 	return types.NewTx(&types.DynamicFeeTx{
 		Nonce:      nonce,

--- a/contracts/src/node-interface/NodeInterface.sol
+++ b/contracts/src/node-interface/NodeInterface.sol
@@ -96,6 +96,31 @@ interface NodeInterface {
         );
 
     /**
+     * @notice Estimates a transaction's l1 costs.
+     * @dev Use eth_call to call.
+     *      This method is exactly like gasEstimateComponents, but doesn't include the l2 component
+     *      so that the l1 component can be known even when the tx may fail.
+     * @param data the tx's calldata. Everything else like "From" and "Gas" are copied over
+     * @param to the tx's "To" (ignored when contractCreation is true)
+     * @param contractCreation whether "To" is omitted
+     * @return gasEstimateForL1 an estimate of the amount of gas needed for the l1 component of this tx
+     * @return baseFee the l2 base fee
+     * @return l1BaseFeeEstimate ArbOS's l1 estimate of the l1 base fee
+     */
+    function gasEstimateL1Component(
+        address to,
+        bool contractCreation,
+        bytes calldata data
+    )
+        external
+        payable
+        returns (
+            uint64 gasEstimateForL1,
+            uint256 baseFee,
+            uint256 l1BaseFeeEstimate
+        );
+
+    /**
      * @notice Returns the proof necessary to redeem a message
      * @param batchNum index of outbox entry (i.e., outgoing messages Merkle root) in array of outbox entries
      * @param index index of outgoing message in outbox entry

--- a/nodeInterface/NodeInterface.go
+++ b/nodeInterface/NodeInterface.go
@@ -465,6 +465,10 @@ func (n NodeInterface) GasEstimateL1Component(
 	gasCap := backend.RPCGasCap()
 	args := n.messageArgs(evm, value, to, contractCreation, data)
 
+	// assign 0 so that PosterDataCost uses its better value
+	zeroGas := hexutil.Uint64(0)
+	args.Gas = &zeroGas
+
 	msg, err := args.ToMessage(gasCap, n.header, evm.StateDB.(*state.StateDB))
 	if err != nil {
 		return 0, nil, nil, err

--- a/nodeInterface/NodeInterface.go
+++ b/nodeInterface/NodeInterface.go
@@ -423,25 +423,11 @@ func (n NodeInterface) ConstructOutboxProof(c ctx, evm mech, size, leaf uint64) 
 	return send, root, hashes32, nil
 }
 
-func (n NodeInterface) GasEstimateComponents(
-	c ctx, evm mech, value huge, to addr, contractCreation bool, data []byte,
-) (uint64, uint64, huge, huge, error) {
-	node, err := arbNodeFromNodeInterfaceBackend(n.backend)
-	if err != nil {
-		return 0, 0, nil, nil, err
-	}
-
-	if to == types.NodeInterfaceAddress || to == types.NodeInterfaceDebugAddress {
-		return 0, 0, nil, nil, errors.New("cannot estimate virtual contract")
-	}
-
+func (n NodeInterface) messageArgs(
+	evm mech, value huge, to addr, contractCreation bool, data []byte,
+) arbitrum.TransactionArgs {
 	msg := n.sourceMessage
-	context := n.context
 	chainid := evm.ChainConfig().ChainID
-	backend := node.Backend.APIBackend()
-	gasCap := backend.RPCGasCap()
-	block := rpc.BlockNumberOrHashWithHash(n.header.Hash(), false)
-
 	from := msg.From()
 	gas := msg.Gas()
 	nonce := msg.Nonce()
@@ -461,6 +447,67 @@ func (n NodeInterface) GasEstimateComponents(
 	if !contractCreation {
 		args.To = &to
 	}
+	return args
+}
+
+func (n NodeInterface) GasEstimateL1Component(
+	c ctx, evm mech, value huge, to addr, contractCreation bool, data []byte,
+) (uint64, huge, huge, error) {
+	node, err := arbNodeFromNodeInterfaceBackend(n.backend)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	if to == types.NodeInterfaceAddress || to == types.NodeInterfaceDebugAddress {
+		return 0, nil, nil, errors.New("cannot estimate virtual contract")
+	}
+
+	backend := node.Backend.APIBackend()
+	gasCap := backend.RPCGasCap()
+
+	args := n.messageArgs(evm, value, to, contractCreation, data)
+	//args.Gas = ;
+
+	msg, err := args.ToMessage(gasCap, n.header, evm.StateDB.(*state.StateDB))
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	pricing := c.State.L1PricingState()
+	feeForL1, _ := pricing.PosterDataCost(msg, l1pricing.BatchPosterAddress)
+
+	baseFee, err := c.State.L2PricingState().BaseFeeWei()
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	l1BaseFeeEstimate, err := pricing.PricePerUnit()
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	// Compute the fee paid for L1 in L2 terms
+	//   See in GasChargingHook that this does not induce truncation error
+	//
+	feeForL1 = arbmath.BigMulByBips(feeForL1, arbos.GasEstimationL1PricePadding)
+	gasForL1 := arbmath.BigDiv(feeForL1, baseFee).Uint64()
+	return gasForL1, baseFee, l1BaseFeeEstimate, nil
+}
+
+func (n NodeInterface) GasEstimateComponents(
+	c ctx, evm mech, value huge, to addr, contractCreation bool, data []byte,
+) (uint64, uint64, huge, huge, error) {
+	node, err := arbNodeFromNodeInterfaceBackend(n.backend)
+	if err != nil {
+		return 0, 0, nil, nil, err
+	}
+	if to == types.NodeInterfaceAddress || to == types.NodeInterfaceDebugAddress {
+		return 0, 0, nil, nil, errors.New("cannot estimate virtual contract")
+	}
+
+	context := n.context
+	backend := node.Backend.APIBackend()
+	gasCap := backend.RPCGasCap()
+	block := rpc.BlockNumberOrHashWithHash(n.header.Hash(), false)
+	args := n.messageArgs(evm, value, to, contractCreation, data)
 
 	totalRaw, err := arbitrum.EstimateGas(context, backend, args, block, gasCap)
 	if err != nil {
@@ -472,7 +519,7 @@ func (n NodeInterface) GasEstimateComponents(
 
 	// Setting the gas will affect the poster data cost
 	args.Gas = &totalRaw
-	msg, err = args.ToMessage(gasCap, n.header, evm.StateDB.(*state.StateDB))
+	msg, err := args.ToMessage(gasCap, n.header, evm.StateDB.(*state.StateDB))
 	if err != nil {
 		return 0, 0, nil, nil, err
 	}


### PR DESCRIPTION
This PR adds a new `NodeInterface` method called `GasEstimateL1Component` for estimating the l1 component of a transaction's costs without requiring the tx be ran and succeed.

Additionally, this PR improves the fake transaction used during gas estimation in cases where the gas limit is 0