### PR TITLE
Add safety checks that we aren't accidentally accepting an internal tx

### DIFF
--- a/arbnode/sequencer.go
+++ b/arbnode/sequencer.go
@@ -94,6 +94,10 @@ func (s *Sequencer) PublishTransaction(ctx context.Context, tx *types.Transactio
 			return errors.New("transaction sender is not on the whitelist")
 		}
 	}
+	if tx.Type() >= types.ArbitrumDepositTxType {
+		// Should be unreachable due to UnmarshalBinary not accepting Arbitrum internal txs
+		return types.ErrTxTypeNotSupported
+	}
 
 	resultChan := make(chan error, 1)
 	queueItem := txQueueItem{

--- a/arbos/incomingmessage.go
+++ b/arbos/incomingmessage.go
@@ -333,6 +333,10 @@ func parseL2Message(rd io.Reader, poster common.Address, timestamp uint64, reque
 		if err := newTx.UnmarshalBinary(bytes); err != nil {
 			return nil, err
 		}
+		if newTx.Type() >= types.ArbitrumDepositTxType {
+			// Should be unreachable due to UnmarshalBinary not accepting Arbitrum internal txs
+			return nil, types.ErrTxTypeNotSupported
+		}
 		return types.Transactions{newTx}, nil
 	case L2MessageKind_Heartbeat:
 		if timestamp >= HeartbeatsDisabledAt {


### PR DESCRIPTION
These are unreachable, but it's probably a good idea to guard against any e.g. upstream geth changes breaking our assumptions.