### PR TITLE
Refactor sequencer inbox validation

### DIFF
--- a/contracts/src/bridge/Bridge.sol
+++ b/contracts/src/bridge/Bridge.sol
@@ -53,6 +53,9 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
     IOwnable public rollup;
     address public sequencerInbox;
 
+    // `sequencerReportedSubMessageCount` used to live here but moved to the sequencer inbox
+    uint256 private storageGap;
+
     address private constant EMPTY_ACTIVEOUTBOX = address(type(uint160).max);
 
     function initialize(IOwnable rollup_) external initializer onlyDelegated {

--- a/contracts/src/bridge/Bridge.sol
+++ b/contracts/src/bridge/Bridge.sol
@@ -94,10 +94,7 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
         _;
     }
 
-    function enqueueSequencerMessage(
-        bytes32 dataHash,
-        uint256 afterDelayedMessagesRead
-    )
+    function enqueueSequencerMessage(bytes32 dataHash, uint256 afterDelayedMessagesRead)
         external
         onlySequencerInbox
         returns (

--- a/contracts/src/bridge/Bridge.sol
+++ b/contracts/src/bridge/Bridge.sol
@@ -13,8 +13,7 @@ import {
     NotDelayedInbox,
     NotSequencerInbox,
     NotOutbox,
-    InvalidOutboxSet,
-    BadSequencerMessageNumber
+    InvalidOutboxSet
 } from "../libraries/Error.sol";
 import "./IBridge.sol";
 import "./Messages.sol";
@@ -53,8 +52,6 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
 
     IOwnable public rollup;
     address public sequencerInbox;
-
-    uint256 public override sequencerReportedSubMessageCount;
 
     address private constant EMPTY_ACTIVEOUTBOX = address(type(uint160).max);
 
@@ -99,9 +96,7 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
 
     function enqueueSequencerMessage(
         bytes32 dataHash,
-        uint256 afterDelayedMessagesRead,
-        uint256 prevMessageCount,
-        uint256 newMessageCount
+        uint256 afterDelayedMessagesRead
     )
         external
         onlySequencerInbox
@@ -112,14 +107,6 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
             bytes32 acc
         )
     {
-        if (
-            sequencerReportedSubMessageCount != prevMessageCount &&
-            prevMessageCount != 0 &&
-            sequencerReportedSubMessageCount != 0
-        ) {
-            revert BadSequencerMessageNumber(sequencerReportedSubMessageCount, prevMessageCount);
-        }
-        sequencerReportedSubMessageCount = newMessageCount;
         seqMessageIndex = sequencerInboxAccs.length;
         if (sequencerInboxAccs.length > 0) {
             beforeAcc = sequencerInboxAccs[sequencerInboxAccs.length - 1];
@@ -264,10 +251,6 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
             allowedOutboxList.pop();
             delete allowedOutboxesMap[outbox];
         }
-    }
-
-    function setSequencerReportedSubMessageCount(uint256 newMsgCount) external onlyRollupOrOwner {
-        sequencerReportedSubMessageCount = newMsgCount;
     }
 
     function delayedMessageCount() external view override returns (uint256) {

--- a/contracts/src/bridge/IBridge.sol
+++ b/contracts/src/bridge/IBridge.sol
@@ -52,8 +52,6 @@ interface IBridge {
 
     function allowedOutboxes(address outbox) external view returns (bool);
 
-    function sequencerReportedSubMessageCount() external view returns (uint256);
-
     /**
      * @dev Enqueue a message in the delayed inbox accumulator.
      *      These messages are later sequenced in the SequencerInbox, either
@@ -79,9 +77,7 @@ interface IBridge {
 
     function enqueueSequencerMessage(
         bytes32 dataHash,
-        uint256 afterDelayedMessagesRead,
-        uint256 prevMessageCount,
-        uint256 newMessageCount
+        uint256 afterDelayedMessagesRead
     )
         external
         returns (

--- a/contracts/src/bridge/IBridge.sol
+++ b/contracts/src/bridge/IBridge.sol
@@ -75,10 +75,7 @@ interface IBridge {
 
     // ---------- onlySequencerInbox functions ----------
 
-    function enqueueSequencerMessage(
-        bytes32 dataHash,
-        uint256 afterDelayedMessagesRead
-    )
+    function enqueueSequencerMessage(bytes32 dataHash, uint256 afterDelayedMessagesRead)
         external
         returns (
             uint256 seqMessageIndex,

--- a/contracts/src/bridge/ISequencerInbox.sol
+++ b/contracts/src/bridge/ISequencerInbox.sol
@@ -109,21 +109,21 @@ interface ISequencerInbox is IDelayedMessageProvider {
     // ---------- BatchPoster functions ----------
 
     function addSequencerL2BatchFromOrigin(
-        uint256 sequenceNumber,
+        uint256 expectedSequenceNumber,
         bytes calldata data,
         uint256 afterDelayedMessagesRead,
         IGasRefunder gasRefunder,
-        uint256 prevMessageCount,
-        uint64 newMessageCount
+        uint256 expectedUntrustedMessageCount,
+        uint64 newUntrustedMessageCount
     ) external;
 
     function addSequencerL2Batch(
-        uint256 sequenceNumber,
+        uint256 expectedSequenceNumber,
         bytes calldata data,
         uint256 afterDelayedMessagesRead,
         IGasRefunder gasRefunder,
-        uint256 prevMessageCount,
-        uint64 newMessageCount
+        uint256 expectedUntrustedMessageCount,
+        uint64 newUntrustedMessageCount
     ) external;
 
     // ---------- onlyRollupOrOwner functions ----------

--- a/contracts/src/bridge/ISequencerInbox.sol
+++ b/contracts/src/bridge/ISequencerInbox.sol
@@ -112,7 +112,9 @@ interface ISequencerInbox is IDelayedMessageProvider {
         uint256 sequenceNumber,
         bytes calldata data,
         uint256 afterDelayedMessagesRead,
-        IGasRefunder gasRefunder
+        IGasRefunder gasRefunder,
+        uint256 prevMessageCount,
+        uint64 newMessageCount
     ) external;
 
     function addSequencerL2Batch(
@@ -121,10 +123,16 @@ interface ISequencerInbox is IDelayedMessageProvider {
         uint256 afterDelayedMessagesRead,
         IGasRefunder gasRefunder,
         uint256 prevMessageCount,
-        uint256 newMessageCount
+        uint64 newMessageCount
     ) external;
 
     // ---------- onlyRollupOrOwner functions ----------
+
+    /**
+     * @notice Allows the value of untrusted msg count to be updated
+     * @param newUntrustedMessageCount updated value to be set
+     */
+    function setUntrustedMessageCount(uint64 newUntrustedMessageCount) external;
 
     /**
      * @notice Set max delay for sequencer inbox

--- a/contracts/src/bridge/SequencerInbox.sol
+++ b/contracts/src/bridge/SequencerInbox.sol
@@ -62,12 +62,12 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
      * @notice magic value used to skip validation against untrustedMessageCount
      * @dev this is never a valid value for untrustedMessageCount since its bigger than uint64
      */
-    uint256 constant public SKIP_UNTRUSTED_MSG_COUNT = uint256(type(uint64).max) + 1;
+    uint256 public constant SKIP_UNTRUSTED_MSG_COUNT = uint256(type(uint64).max) + 1;
 
     /**
      * @notice magic value used to skip validation against the msg count after including a batch
      */
-    uint256 constant public SKIP_POST_MSG_COUNT = type(uint256).max;
+    uint256 public constant SKIP_POST_MSG_COUNT = type(uint256).max;
 
     /**
      * @notice This value should not be trusted since it can be arbitrarily set by the sequencer
@@ -100,15 +100,18 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         if (expectedUntrustedMessageCount != SKIP_UNTRUSTED_MSG_COUNT) {
             // This is used to help validate/coordinate multiple messages initiated by multiple offchain batch posters.
             // They might have slightly different views of the chain and this helps ensure invalid state isn't posted.
-            if(expectedUntrustedMessageCount != untrustedMessageCount) {
-                revert BadSequencerMessageNumber(untrustedMessageCount, expectedUntrustedMessageCount);
+            if (expectedUntrustedMessageCount != untrustedMessageCount) {
+                revert BadSequencerMessageNumber(
+                    untrustedMessageCount,
+                    expectedUntrustedMessageCount
+                );
             }
             untrustedMessageCount = newUntrustedMessageCount;
         }
 
         _;
 
-        if(expectedSequenceNumber != SKIP_POST_MSG_COUNT) {
+        if (expectedSequenceNumber != SKIP_POST_MSG_COUNT) {
             // Validate correct batch index was added
             uint256 newCount = bridge.sequencerMessageCount() - 1;
             if (newCount != expectedSequenceNumber) {
@@ -203,11 +206,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
             bytes32 beforeAcc,
             bytes32 delayedAcc,
             bytes32 afterAcc
-        ) = addSequencerL2BatchImpl(
-                dataHash,
-                __totalDelayedMessagesRead,
-                0
-            );
+        ) = addSequencerL2BatchImpl(dataHash, __totalDelayedMessagesRead, 0);
         emit SequencerBatchDelivered(
             seqMessageIndex,
             beforeAcc,
@@ -230,7 +229,11 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     )
         external
         refundsGas(gasRefunder)
-        validateBatchOrder(expectedSequenceNumber, expectedUntrustedMessageCount, newUntrustedMessageCount)
+        validateBatchOrder(
+            expectedSequenceNumber,
+            expectedUntrustedMessageCount,
+            newUntrustedMessageCount
+        )
     {
         // solhint-disable-next-line avoid-tx-origin
         if (msg.sender != tx.origin) revert NotOrigin();
@@ -249,11 +252,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
             bytes32 beforeAcc,
             bytes32 delayedAcc,
             bytes32 afterAcc
-        ) = addSequencerL2BatchImpl(
-                dataHash_,
-                afterDelayedMessagesRead_,
-                dataLength
-            );
+        ) = addSequencerL2BatchImpl(dataHash_, afterDelayedMessagesRead_, dataLength);
         emit SequencerBatchDelivered(
             seqMessageIndex,
             beforeAcc,
@@ -277,7 +276,11 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         external
         override
         refundsGas(gasRefunder)
-        validateBatchOrder(expectedSequenceNumber, expectedUntrustedMessageCount, newUntrustedMessageCount)
+        validateBatchOrder(
+            expectedSequenceNumber,
+            expectedUntrustedMessageCount,
+            newUntrustedMessageCount
+        )
     {
         if (!isBatchPoster[msg.sender] && msg.sender != address(rollup)) revert NotBatchPoster();
         (bytes32 dataHash, TimeBounds memory timeBounds) = formDataHash(

--- a/contracts/src/bridge/SequencerInbox.sol
+++ b/contracts/src/bridge/SequencerInbox.sol
@@ -117,7 +117,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         }
     }
 
-    modifier validateSequencerBatchData(bytes calldata data) {
+    modifier validateBatchData(bytes calldata data) {
         // validate data
         uint256 fullDataLen = HEADER_LENGTH + data.length;
         if (fullDataLen > MAX_DATA_SIZE) revert DataTooLarge(fullDataLen, MAX_DATA_SIZE);
@@ -197,7 +197,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
             _totalDelayedMessagesRead
         );
         uint256 __totalDelayedMessagesRead = _totalDelayedMessagesRead;
-        // this skips `validateSequencerBatchData` since no sequencer batch is actually added here
+        // this skips `validateBatchData` since no sequencer batch is actually added here
         (
             uint256 seqMessageIndex,
             bytes32 beforeAcc,
@@ -334,7 +334,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     function formDataHash(bytes calldata data, uint256 afterDelayedMessagesRead)
         internal
         view
-        validateSequencerBatchData(data)
+        validateBatchData(data)
         returns (bytes32, TimeBounds memory)
     {
         (bytes memory header, TimeBounds memory timeBounds) = packHeader(afterDelayedMessagesRead);

--- a/contracts/src/mocks/BridgeStub.sol
+++ b/contracts/src/mocks/BridgeStub.sol
@@ -59,10 +59,7 @@ contract BridgeStub is IBridge {
             );
     }
 
-    function enqueueSequencerMessage(
-        bytes32 dataHash,
-        uint256 afterDelayedMessagesRead
-    )
+    function enqueueSequencerMessage(bytes32 dataHash, uint256 afterDelayedMessagesRead)
         external
         returns (
             uint256 seqMessageIndex,

--- a/contracts/src/mocks/BridgeStub.sol
+++ b/contracts/src/mocks/BridgeStub.sol
@@ -5,7 +5,6 @@
 pragma solidity ^0.8.0;
 
 import "./InboxStub.sol";
-import {BadSequencerMessageNumber} from "../libraries/Error.sol";
 
 import "../bridge/IBridge.sol";
 
@@ -29,7 +28,6 @@ contract BridgeStub is IBridge {
     bytes32[] public override sequencerInboxAccs;
 
     address public sequencerInbox;
-    uint256 public override sequencerReportedSubMessageCount;
 
     function setSequencerInbox(address _sequencerInbox) external override {
         sequencerInbox = _sequencerInbox;
@@ -63,9 +61,7 @@ contract BridgeStub is IBridge {
 
     function enqueueSequencerMessage(
         bytes32 dataHash,
-        uint256 afterDelayedMessagesRead,
-        uint256 prevMessageCount,
-        uint256 newMessageCount
+        uint256 afterDelayedMessagesRead
     )
         external
         returns (
@@ -75,14 +71,6 @@ contract BridgeStub is IBridge {
             bytes32 acc
         )
     {
-        if (
-            sequencerReportedSubMessageCount != prevMessageCount &&
-            prevMessageCount != 0 &&
-            sequencerReportedSubMessageCount != 0
-        ) {
-            revert BadSequencerMessageNumber(sequencerReportedSubMessageCount, prevMessageCount);
-        }
-        sequencerReportedSubMessageCount = newMessageCount;
         seqMessageIndex = sequencerInboxAccs.length;
         if (sequencerInboxAccs.length > 0) {
             beforeAcc = sequencerInboxAccs[sequencerInboxAccs.length - 1];

--- a/contracts/src/mocks/SequencerInboxStub.sol
+++ b/contracts/src/mocks/SequencerInboxStub.sol
@@ -19,13 +19,22 @@ contract SequencerInboxStub is SequencerInbox {
     }
 
     function addInitMessage() external {
+        // this replicates the rollup admin's call
+        // connectedContracts.sequencerInbox.addSequencerL2Batch(
+        //     0,
+        //     "",
+        //     1,
+        //     IGasRefunder(address(0)),
+        //     Uint64SyncLib.toUint64SyncVal(0),
+        //     Uint64SyncLib.toUint64SyncVal(1)
+        // );
         (bytes32 dataHash, TimeBounds memory timeBounds) = formEmptyDataHash(0);
         (
             uint256 sequencerMessageCount,
             bytes32 beforeAcc,
             bytes32 delayedAcc,
             bytes32 afterAcc
-        ) = addSequencerL2BatchImpl(dataHash, 0, 0, 0, 1);
+        ) = addSequencerL2BatchImpl(dataHash, 0, 0);
         emit SequencerBatchDelivered(
             sequencerMessageCount,
             beforeAcc,

--- a/contracts/src/test-helpers/BridgeTester.sol
+++ b/contracts/src/test-helpers/BridgeTester.sol
@@ -64,7 +64,6 @@ contract BridgeTester is Initializable, DelegateCallAware, IBridge {
     bytes32[] public override delayedInboxAccs;
 
     bytes32[] public override sequencerInboxAccs;
-    uint256 public override sequencerReportedSubMessageCount;
 
     address private constant EMPTY_ACTIVEOUTBOX = address(type(uint160).max);
 
@@ -88,9 +87,7 @@ contract BridgeTester is Initializable, DelegateCallAware, IBridge {
 
     function enqueueSequencerMessage(
         bytes32 dataHash,
-        uint256 afterDelayedMessagesRead,
-        uint256 prevMessageCount,
-        uint256 newMessageCount
+        uint256 afterDelayedMessagesRead
     )
         external
         returns (

--- a/contracts/src/test-helpers/BridgeTester.sol
+++ b/contracts/src/test-helpers/BridgeTester.sol
@@ -85,10 +85,7 @@ contract BridgeTester is Initializable, DelegateCallAware, IBridge {
         return allowedOutboxesMap[outbox].allowed;
     }
 
-    function enqueueSequencerMessage(
-        bytes32 dataHash,
-        uint256 afterDelayedMessagesRead
-    )
+    function enqueueSequencerMessage(bytes32 dataHash, uint256 afterDelayedMessagesRead)
         external
         returns (
             uint256 seqMessageIndex,


### PR DESCRIPTION
Refactor based on review from https://github.com/OffchainLabs/nitro/pull/1048

The batch order validation is now done in the sequencer inbox
 - `sequencerReportedSubMessageCount` now called `untrustedMessageCount`
 - capped to `uint64` so that `uint64.max + 1` can be used as a safe magic value
 - value tracked in SequencerInbox instead of Bridge
 - post-inclusion message index validation was now moved to the same modifier
 
This change adds a new storage cell at the end of the contract so it shouldn't create an upgradeability issue.
This is a breaking change since `uint256 newMessageCount` changed to `uint64 newUntrustedMessageCount` (we can add a backwards compatible entrypoint to make transition smoother).
The upgrade process will leave a "phantom value" in the bridge contract. We can wipe it during the upgrade process or leave an explicit gap there for now.

worth noting that since https://github.com/OffchainLabs/nitro/pull/1048 we can't trust `sequenceNumber` param supplied in functions since its now possible to skip the validation step against the bridge (that made me rename it to `expectedSequenceNumber` but we could make it a bit more aggressive like `unsafeExpectedSequenceNumber` or add a linter/slither validation that the value is only used inside the `validateBatchOrder` modifier