### PR TITLE
Make test-node.bash portable

### DIFF
--- a/test-node.bash
+++ b/test-node.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Not all bashes are installed in /bin/bash - e.g. NixOS.