### PR TITLE
Fix some spelling errors

### DIFF
--- a/contracts/src/bridge/IOutbox.sol
+++ b/contracts/src/bridge/IOutbox.sol
@@ -81,7 +81,7 @@ interface IOutbox {
      *       not really a fixed cost, but can be treated as so with a fixed overhead for gas estimation).
      *       We can't include the cost of proof validation since this is intended to be used to simulate txs
      *       that are included in yet-to-be confirmed merkle roots. The simulation entrypoint could instead pretend
-     *       to confirm a pending merkle root, but that would be less pratical for integrating with tooling.
+     *       to confirm a pending merkle root, but that would be less practical for integrating with tooling.
      *       It is only possible to trigger it when the msg sender is address zero, which should be impossible
      *       unless under simulation in an eth_call or eth_estimateGas
      */

--- a/contracts/src/precompiles/ArbSys.sol
+++ b/contracts/src/precompiles/ArbSys.sol
@@ -137,7 +137,7 @@ interface ArbSys {
     );
 
     /**
-     * @notice logs a merkle branch for proof sythesis
+     * @notice logs a merkle branch for proof synthesis
      * @param reserved an index meant only to align the 4th index with L2ToL1Transaction's 4th event
      * @param hash the merkle hash
      * @param position = (level << 192) + leaf


### PR DESCRIPTION
Not an exhaustive search, just some errors raised by our codespell when upgrading the vendored contracts (https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3692)
