### PR TITLE
Recover latest state if missing in transaction streamer

### DIFF
--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -708,7 +708,12 @@ func (s *TransactionStreamer) createBlocks(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	lastBlockHeader := s.bc.CurrentBlock().Header()
+	initialLastBlock := s.bc.CurrentBlock()
+	err = s.bc.RecoverState(initialLastBlock)
+	if err != nil {
+		return fmt.Errorf("failed to recover state: %w", err)
+	}
+	lastBlockHeader := initialLastBlock.Header()
 	if lastBlockHeader == nil {
 		return errors.New("current block header not found")
 	}


### PR DESCRIPTION
This may involve re-executing past blocks if necessary.

Pulls in https://github.com/OffchainLabs/go-ethereum/pull/163