### PR TITLE
Improve two's complement testing and fix overflow/underflow edge cases

### DIFF
--- a/arbos/burn/burn.go
+++ b/arbos/burn/burn.go
@@ -4,6 +4,8 @@
 package burn
 
 import (
+	"fmt"
+
 	glog "github.com/ethereum/go-ethereum/log"
 	"github.com/offchainlabs/nitro/arbos/util"
 )
@@ -12,6 +14,7 @@ type Burner interface {
 	Burn(amount uint64) error
 	Burned() uint64
 	Restrict(err error)
+	HandleError(err error) error
 	ReadOnly() bool
 	TracingInfo() *util.TracingInfo
 }
@@ -42,6 +45,10 @@ func (burner *SystemBurner) Restrict(err error) {
 	if err != nil {
 		glog.Error("Restrict() received an error", "err", err)
 	}
+}
+
+func (burner *SystemBurner) HandleError(err error) error {
+	panic(fmt.Sprintf("fatal error in system burner: %v", err))
 }
 
 func (burner *SystemBurner) ReadOnly() bool {

--- a/arbos/storage/storage.go
+++ b/arbos/storage/storage.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -458,11 +459,11 @@ func (sbbi *StorageBackedBigInt) Get() (*big.Int, error) {
 func (sbbi *StorageBackedBigInt) Set(val *big.Int) error {
 	if val.Sign() < 0 {
 		val = new(big.Int).Add(val, twoToThe256)
-		if val.Sign() <= 0 {
-			panic("underflow in StorageBackedBigInt.Set")
+		if val.BitLen() < 256 { // require that the top bit is set
+			return sbbi.burner.HandleError(fmt.Errorf("underflow in StorageBackedBigInt.Set setting value %v", val))
 		}
-	} else if val.BitLen() > 256 {
-		panic("overflow in StorageBackedBigInt.Set")
+	} else if val.BitLen() >= 256 {
+		return sbbi.burner.HandleError(fmt.Errorf("overflow in StorageBackedBigInt.Set setting value %v", val))
 	}
 	return sbbi.StorageSlot.Set(common.BytesToHash(val.Bytes()))
 }

--- a/arbos/storage/storage.go
+++ b/arbos/storage/storage.go
@@ -459,7 +459,7 @@ func (sbbi *StorageBackedBigInt) Get() (*big.Int, error) {
 func (sbbi *StorageBackedBigInt) Set(val *big.Int) error {
 	if val.Sign() < 0 {
 		val = new(big.Int).Add(val, twoToThe256)
-		if val.BitLen() < 256 { // require that the top bit is set
+		if val.BitLen() < 256 || val.Sign() <= 0 { // require that it's positive and the top bit is set
 			return sbbi.burner.HandleError(fmt.Errorf("underflow in StorageBackedBigInt.Set setting value %v", val))
 		}
 	} else if val.BitLen() >= 256 {

--- a/arbos/storage/storage_test.go
+++ b/arbos/storage/storage_test.go
@@ -26,9 +26,9 @@ func TestStorageBackedBigInt(t *testing.T) {
 	rawSlot := sto.NewSlot(0)
 
 	twoToThe255 := new(big.Int).Lsh(big.NewInt(1), 255)
+	maxUint256 := new(big.Int).Sub(twoToThe255, big.NewInt(1))
+	minUint256 := new(big.Int).Neg(twoToThe255)
 	for _, in := range []*big.Int{
-		new(big.Int).Sub(twoToThe255, big.NewInt(1)), // MaxUint256
-		new(big.Int).Neg(twoToThe255),                // MinUint256
 		big.NewInt(0),
 		big.NewInt(1),
 		big.NewInt(33),
@@ -36,6 +36,8 @@ func TestStorageBackedBigInt(t *testing.T) {
 		big.NewInt(-1),
 		big.NewInt(-33),
 		big.NewInt(-31591083),
+		maxUint256,
+		minUint256,
 	} {
 		err := sbbi.Set(in)
 		if err != nil {
@@ -77,12 +79,12 @@ func TestStorageBackedBigInt(t *testing.T) {
 		}
 	}
 	for _, in := range []*big.Int{
-		twoToThe255, // MaxUint256 + 1
-		new(big.Int).Sub(big.NewInt(-1), twoToThe255), // MinUint256 - 1
-		new(big.Int).Add(big.NewInt(1), twoToThe255),  // MaxUint256 + 2
-		new(big.Int).Sub(big.NewInt(-2), twoToThe255), // MinUint256 - 2
-		new(big.Int).Mul(big.NewInt(2), twoToThe255),  // MaxUint256 * 2
-		new(big.Int).Mul(big.NewInt(-2), twoToThe255), // MinUint256 * 2
+		new(big.Int).Add(maxUint256, big.NewInt(1)),
+		new(big.Int).Sub(minUint256, big.NewInt(1)),
+		new(big.Int).Mul(maxUint256, big.NewInt(2)),
+		new(big.Int).Mul(minUint256, big.NewInt(2)),
+		new(big.Int).Exp(maxUint256, big.NewInt(1025), nil),
+		new(big.Int).Exp(minUint256, big.NewInt(1025), nil),
 	} {
 		requirePanic(t, in, func() {
 			_ = sbbi.Set(in)

--- a/arbos/storage/storage_test.go
+++ b/arbos/storage/storage_test.go
@@ -1,51 +1,58 @@
 package storage
 
 import (
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/offchainlabs/nitro/arbos/burn"
 	"math/big"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/offchainlabs/nitro/arbos/burn"
+	"github.com/offchainlabs/nitro/util/arbmath"
 )
+
+func requirePanic(t *testing.T, testCase interface{}, f func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("panic expected but function exited successfully for test case", testCase)
+		}
+	}()
+	f()
+}
 
 func TestStorageBackedBigInt(t *testing.T) {
 	sto := NewMemoryBacked(burn.NewSystemBurner(nil, false))
 	sbbi := sto.OpenStorageBackedBigInt(0)
-
-	for _, testCase := range []int64{0, 1, 33, 31591083, -1, -33, -31591083} {
-		in := big.NewInt(testCase)
-		err := sbbi.Set(in)
-		if err != nil {
-			t.Fatal(err)
-		}
-		out, err := sbbi.Get()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if in.Cmp(out) != 0 {
-			t.Fatal(in, out, common.BytesToHash(out.Bytes()))
-		}
-
-		err = sbbi.Set_preVersion7(in)
-		if err != nil {
-			t.Fatal(err)
-		}
-		out, err = sbbi.Get()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if new(big.Int).Abs(in).Cmp(out) != 0 {
-			t.Fatal(in, out, common.BytesToHash(out.Bytes()))
-		}
-	}
+	rawSlot := sto.NewSlot(0)
 
 	twoToThe255 := new(big.Int).Lsh(big.NewInt(1), 255)
 	for _, in := range []*big.Int{
 		new(big.Int).Sub(twoToThe255, big.NewInt(1)), // MaxUint256
 		new(big.Int).Neg(twoToThe255),                // MinUint256
+		big.NewInt(0),
+		big.NewInt(1),
+		big.NewInt(33),
+		big.NewInt(31591083),
+		big.NewInt(-1),
+		big.NewInt(-33),
+		big.NewInt(-31591083),
 	} {
 		err := sbbi.Set(in)
 		if err != nil {
 			t.Fatal(err)
+		}
+		rawVal, err := rawSlot.Get()
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Verify that our encoding matches geth's signed complement impl
+		expectedRawVal := common.BigToHash(math.U256(new(big.Int).Set(in)))
+		if rawVal != expectedRawVal {
+			t.Fatal("for input", in, "expected raw value", expectedRawVal, "but got", rawVal)
+		}
+		gotInverse := math.S256(rawVal.Big())
+		if !arbmath.BigEquals(gotInverse, in) {
+			t.Fatal("for input", in, "expected raw value", rawVal, "to convert back into input but got", gotInverse)
 		}
 		out, err := sbbi.Get()
 		if err != nil {
@@ -54,5 +61,31 @@ func TestStorageBackedBigInt(t *testing.T) {
 		if in.Cmp(out) != 0 {
 			t.Fatal(in, out, common.BytesToHash(out.Bytes()))
 		}
+
+		if in.BitLen() < 200 {
+			err = sbbi.Set_preVersion7(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out, err = sbbi.Get()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if new(big.Int).Abs(in).Cmp(out) != 0 {
+				t.Fatal(in, out, common.BytesToHash(out.Bytes()))
+			}
+		}
+	}
+	for _, in := range []*big.Int{
+		twoToThe255, // MaxUint256 + 1
+		new(big.Int).Sub(big.NewInt(-1), twoToThe255), // MinUint256 - 1
+		new(big.Int).Add(big.NewInt(1), twoToThe255),  // MaxUint256 + 2
+		new(big.Int).Sub(big.NewInt(-2), twoToThe255), // MinUint256 - 2
+		new(big.Int).Mul(big.NewInt(2), twoToThe255),  // MaxUint256 * 2
+		new(big.Int).Mul(big.NewInt(-2), twoToThe255), // MinUint256 * 2
+	} {
+		requirePanic(t, in, func() {
+			_ = sbbi.Set(in)
+		})
 	}
 }

--- a/precompiles/context.go
+++ b/precompiles/context.go
@@ -53,6 +53,10 @@ func (c *Context) Restrict(err error) {
 	log.Fatal("A metered burner was used for access-controlled work", err)
 }
 
+func (c *Context) HandleError(err error) error {
+	return err
+}
+
 func (c *Context) ReadOnly() bool {
 	return c.readOnly
 }


### PR DESCRIPTION
Points into https://github.com/OffchainLabs/nitro/pull/1112

My thinking with the `HandleError` is that if a user context like a precompile hits an under/overflow, we'll just want to revert, but for system operations we should panic.