### PR TITLE
Create `RedisCoordinator` for just `recommendLiveSequencer`

### DIFF
--- a/arbnode/redis_coordinator.go
+++ b/arbnode/redis_coordinator.go
@@ -26,10 +26,9 @@ const INVALID_URL string = "<?INVALID-URL?>"
 
 type RedisCoordinator struct {
 	client redis.UniversalClient
-	myUrl  string
 }
 
-func NewRedisCoordinator(redisUrl string, myUrl string) (*RedisCoordinator, error) {
+func NewRedisCoordinator(redisUrl string) (*RedisCoordinator, error) {
 	redisClient, err := redisutil.RedisClientFromURL(redisUrl)
 	if err != nil {
 		return nil, err
@@ -37,7 +36,6 @@ func NewRedisCoordinator(redisUrl string, myUrl string) (*RedisCoordinator, erro
 
 	return &RedisCoordinator{
 		client: redisClient,
-		myUrl:  myUrl,
 	}, nil
 }
 
@@ -60,7 +58,7 @@ func (c *RedisCoordinator) RecommendLiveSequencer(ctx context.Context) (string, 
 		}
 		return url, nil
 	}
-	log.Info("no sequencer appears live on redis", "priorities", prioritiesString, "self", c.myUrl)
+	log.Info("no sequencer appears live on redis", "priorities", prioritiesString)
 	return "", nil
 }
 

--- a/arbnode/redis_coordinator.go
+++ b/arbnode/redis_coordinator.go
@@ -2,7 +2,6 @@ package arbnode
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"strings"
@@ -64,27 +63,4 @@ func (c *RedisCoordinator) RecommendLiveSequencer(ctx context.Context) (string, 
 
 func messageKeyFor(pos arbutil.MessageIndex) string {
 	return fmt.Sprintf("%s%d", MESSAGE_KEY_PREFIX, pos)
-}
-
-func (c *SeqCoordinator) getRemoteMsgCountImpl(ctx context.Context, r redis.Cmdable) (arbutil.MessageIndex, error) {
-	resStr, err := r.Get(ctx, MSG_COUNT_KEY).Result()
-	if errors.Is(err, redis.Nil) {
-		return 0, nil
-	}
-	if err != nil {
-		return 0, err
-	}
-	resBytes := []byte(resStr)
-	resBytes, err = c.signer.VerifyMessageSignature(nil, resBytes)
-	if err != nil {
-		return 0, err
-	}
-	if len(resBytes) != 8 {
-		return 0, fmt.Errorf("unexpected msg count value length %v", len(resBytes))
-	}
-	return arbutil.MessageIndex(binary.BigEndian.Uint64(resBytes)), nil
-}
-
-func (c *SeqCoordinator) GetRemoteMsgCount() (arbutil.MessageIndex, error) {
-	return c.getRemoteMsgCountImpl(c.GetContext(), c.client)
 }

--- a/arbnode/redis_coordinator.go
+++ b/arbnode/redis_coordinator.go
@@ -1,0 +1,53 @@
+package arbnode
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/go-redis/redis/v8"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/offchainlabs/nitro/util/redisutil"
+)
+
+type RedisCoordinator struct {
+	client redis.UniversalClient
+	myUrl  string
+}
+
+func NewRedisCoordinator(redisUrl string, myUrl string) (*RedisCoordinator, error) {
+	redisClient, err := redisutil.RedisClientFromURL(redisUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RedisCoordinator{
+		client: redisClient,
+		myUrl:  myUrl,
+	}, nil
+}
+
+func (c *RedisCoordinator) recommendLiveSequencer(ctx context.Context) (string, error) {
+	prioritiesString, err := c.client.Get(ctx, PRIORITIES_KEY).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			err = errors.New("sequencer priorities unset")
+		}
+		return "", err
+	}
+	priorities := strings.Split(prioritiesString, ",")
+	for _, url := range priorities {
+		err := c.client.Get(ctx, livelinessKeyFor(url)).Err()
+		if errors.Is(err, redis.Nil) { // liveliness not set
+			continue
+		}
+		if err != nil {
+			return "", err
+		}
+		return url, nil
+	}
+	log.Info("no sequencer appears live on redis", "priorities", prioritiesString, "self", c.myUrl)
+	return "", nil
+}

--- a/arbnode/redis_coordinator.go
+++ b/arbnode/redis_coordinator.go
@@ -29,7 +29,7 @@ func NewRedisCoordinator(redisUrl string, myUrl string) (*RedisCoordinator, erro
 	}, nil
 }
 
-func (c *RedisCoordinator) recommendLiveSequencer(ctx context.Context) (string, error) {
+func (c *RedisCoordinator) RecommendLiveSequencer(ctx context.Context) (string, error) {
 	prioritiesString, err := c.client.Get(ctx, PRIORITIES_KEY).Result()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {

--- a/arbnode/redis_coordinator.go
+++ b/arbnode/redis_coordinator.go
@@ -2,15 +2,27 @@ package arbnode
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/go-redis/redis/v8"
 
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/util/redisutil"
 )
+
+const CHOSENSEQ_KEY string = "coordinator.chosen"              // Never overwritten. Expires or released only
+const MSG_COUNT_KEY string = "coordinator.msgCount"            // Only written by sequencer holding CHOSEN key
+const PRIORITIES_KEY string = "coordinator.priorities"         // Read only
+const LIVELINESS_KEY_PREFIX string = "coordinator.liveliness." // Per server. Only written by self
+const MESSAGE_KEY_PREFIX string = "coordinator.msg."           // Per Message. Only written by sequencer holding CHOSEN
+const LIVELINESS_VAL string = "OK"
+const INVALID_VAL string = "INVALID"
+const INVALID_URL string = "<?INVALID-URL?>"
 
 type RedisCoordinator struct {
 	client redis.UniversalClient
@@ -50,4 +62,31 @@ func (c *RedisCoordinator) RecommendLiveSequencer(ctx context.Context) (string, 
 	}
 	log.Info("no sequencer appears live on redis", "priorities", prioritiesString, "self", c.myUrl)
 	return "", nil
+}
+
+func messageKeyFor(pos arbutil.MessageIndex) string {
+	return fmt.Sprintf("%s%d", MESSAGE_KEY_PREFIX, pos)
+}
+
+func (c *SeqCoordinator) getRemoteMsgCountImpl(ctx context.Context, r redis.Cmdable) (arbutil.MessageIndex, error) {
+	resStr, err := r.Get(ctx, MSG_COUNT_KEY).Result()
+	if errors.Is(err, redis.Nil) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	resBytes := []byte(resStr)
+	resBytes, err = c.signer.VerifyMessageSignature(nil, resBytes)
+	if err != nil {
+		return 0, err
+	}
+	if len(resBytes) != 8 {
+		return 0, fmt.Errorf("unexpected msg count value length %v", len(resBytes))
+	}
+	return arbutil.MessageIndex(binary.BigEndian.Uint64(resBytes)), nil
+}
+
+func (c *SeqCoordinator) GetRemoteMsgCount() (arbutil.MessageIndex, error) {
+	return c.getRemoteMsgCountImpl(c.GetContext(), c.client)
 }

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -357,7 +357,6 @@ func (c *SeqCoordinator) noRedisError() time.Duration {
 func (c *SeqCoordinator) updatePrevKnownChosen(ctx context.Context, nextChosen string) time.Duration {
 	if nextChosen != c.config.MyUrl() {
 		// was the active sequencer, but no longer
-		isActiveSequencer.Update(0)
 		atomicTimeWrite(&c.lockoutUntil, time.Time{})
 		setPrevChosenTo := nextChosen
 		if c.sequencer != nil {

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -26,15 +26,6 @@ import (
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
-const CHOSENSEQ_KEY string = "coordinator.chosen"              // Never overwritten. Expires or released only
-const MSG_COUNT_KEY string = "coordinator.msgCount"            // Only written by sequencer holding CHOSEN key
-const PRIORITIES_KEY string = "coordinator.priorities"         // Read only
-const LIVELINESS_KEY_PREFIX string = "coordinator.liveliness." // Per server. Only written by self
-const MESSAGE_KEY_PREFIX string = "coordinator.msg."           // Per Message. Only written by sequencer holding CHOSEN
-const LIVELINESS_VAL string = "OK"
-const INVALID_VAL string = "INVALID"
-const INVALID_URL string = "<?INVALID-URL?>"
-
 type SeqCoordinator struct {
 	stopwaiter.StopWaiter
 
@@ -170,10 +161,6 @@ func atomicTimeRead(addr *int64) time.Time {
 
 func livelinessKeyFor(url string) string { return LIVELINESS_KEY_PREFIX + url }
 
-func messageKeyFor(pos arbutil.MessageIndex) string {
-	return fmt.Sprintf("%s%d", MESSAGE_KEY_PREFIX, pos)
-}
-
 func execTestPipe(pipe redis.Pipeliner, ctx context.Context) error {
 	cmders, err := pipe.Exec(ctx)
 	if err != nil {
@@ -256,29 +243,6 @@ func (c *SeqCoordinator) chosenOneUpdate(ctx context.Context, msgCountExpected, 
 	}
 	atomicTimeWrite(&c.lockoutUntil, lockoutUntil.Add(-c.config.LockoutSpare))
 	return nil
-}
-
-func (c *SeqCoordinator) getRemoteMsgCountImpl(ctx context.Context, r redis.Cmdable) (arbutil.MessageIndex, error) {
-	resStr, err := r.Get(ctx, MSG_COUNT_KEY).Result()
-	if errors.Is(err, redis.Nil) {
-		return 0, nil
-	}
-	if err != nil {
-		return 0, err
-	}
-	resBytes := []byte(resStr)
-	resBytes, err = c.signer.VerifyMessageSignature(nil, resBytes)
-	if err != nil {
-		return 0, err
-	}
-	if len(resBytes) != 8 {
-		return 0, fmt.Errorf("unexpected msg count value length %v", len(resBytes))
-	}
-	return arbutil.MessageIndex(binary.BigEndian.Uint64(resBytes)), nil
-}
-
-func (c *SeqCoordinator) GetRemoteMsgCount() (arbutil.MessageIndex, error) {
-	return c.getRemoteMsgCountImpl(c.GetContext(), c.client)
 }
 
 func (c *SeqCoordinator) livelinessUpdate(ctx context.Context) error {

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/metrics"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -19,6 +18,8 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/util/arbmath"

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -109,7 +109,7 @@ var TestSeqCoordinatorConfig = SeqCoordinatorConfig{
 }
 
 func NewSeqCoordinator(streamer *TransactionStreamer, sequencer *Sequencer, sync *SyncMonitor, config SeqCoordinatorConfig) (*SeqCoordinator, error) {
-	redisCoordinator, err := NewRedisCoordinator(config.RedisUrl, config.MyUrlImpl)
+	redisCoordinator, err := NewRedisCoordinator(config.RedisUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -181,7 +181,6 @@ func execTestPipe(pipe redis.Pipeliner, ctx context.Context) error {
 }
 
 func (c *SeqCoordinator) chosenOneUpdate(ctx context.Context, msgCountExpected, msgCountToWrite arbutil.MessageIndex, lastmsg *arbstate.MessageWithMetadata) error {
-	isActiveSequencer.Update(1)
 	var messageData *string
 	if lastmsg != nil {
 		msgBytes, err := json.Marshal(lastmsg)
@@ -248,6 +247,7 @@ func (c *SeqCoordinator) chosenOneUpdate(ctx context.Context, msgCountExpected, 
 	if err != nil {
 		return err
 	}
+	isActiveSequencer.Update(1)
 	atomicTimeWrite(&c.lockoutUntil, lockoutUntil.Add(-c.config.LockoutSpare))
 	return nil
 }

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -402,7 +402,7 @@ func (c *SeqCoordinator) updatePrevKnownChosen(ctx context.Context, nextChosen s
 }
 
 func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
-	chosenSeq, err := c.recommendLiveSequencer(ctx)
+	chosenSeq, err := c.RecommendLiveSequencer(ctx)
 	if err != nil {
 		log.Warn("coordinator failed finding live sequencer", "err", err)
 		return c.retryAfterRedisError()

--- a/arbnode/seq_coordinator_atomic_test.go
+++ b/arbnode/seq_coordinator_atomic_test.go
@@ -117,7 +117,7 @@ func TestRedisSeqCoordinatorAtomic(t *testing.T) {
 	for i := 0; i < NumOfThreads; i++ {
 		config := coordConfig
 		config.MyUrlImpl = fmt.Sprint(i)
-		redisCoordinator, err := NewRedisCoordinator(config.RedisUrl, config.MyUrl())
+		redisCoordinator, err := NewRedisCoordinator(config.RedisUrl)
 		Require(t, err)
 		coordinator := &SeqCoordinator{
 			RedisCoordinator: *redisCoordinator,

--- a/arbnode/seq_coordinator_atomic_test.go
+++ b/arbnode/seq_coordinator_atomic_test.go
@@ -1,6 +1,9 @@
 // Copyright 2021-2022, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
+//go:build redistest
+// +build redistest
+
 package arbnode
 
 import (

--- a/arbnode/seq_coordinator_atomic_test.go
+++ b/arbnode/seq_coordinator_atomic_test.go
@@ -143,7 +143,7 @@ func TestRedisSeqCoordinatorAtomic(t *testing.T) {
 		seqList := ""
 		for i := 0; i < messagesPerRound; i++ {
 			if testData.sequencer[i] == "" {
-				Fail(t, "no sequencer succeded", "round", round, "message", i)
+				Fail(t, "no sequencer succeeded", "round", round, "message", i)
 			}
 			seqList = seqList + testData.sequencer[i] + ","
 		}

--- a/system_tests/seq_coordinator_test.go
+++ b/system_tests/seq_coordinator_test.go
@@ -69,7 +69,7 @@ func TestRedisSeqCoordinatorPriorities(t *testing.T) {
 	initRedisForTest(t, ctx, nodeConfig.SeqCoordinator.RedisUrl, nodeNames)
 
 	createStartNode := func(nodeNum int) {
-		nodeConfig.SeqCoordinator.MyUrl = nodeNames[nodeNum]
+		nodeConfig.SeqCoordinator.MyUrlImpl = nodeNames[nodeNum]
 		_, node, _, l2stack := CreateTestL2WithConfig(t, ctx, l2Info, nodeConfig, false)
 		nodes[nodeNum] = &nodeInfo{n: node, s: l2stack}
 	}
@@ -277,7 +277,7 @@ func TestRedisSeqCoordinatorMessageSync(t *testing.T) {
 
 	initRedisForTest(t, ctx, nodeConfig.SeqCoordinator.RedisUrl, nodeNames)
 
-	nodeConfig.SeqCoordinator.MyUrl = nodeNames[0]
+	nodeConfig.SeqCoordinator.MyUrlImpl = nodeNames[0]
 	l2Info, _, clientA, l2stackA := CreateTestL2WithConfig(t, ctx, nil, nodeConfig, false)
 	defer requireClose(t, l2stackA)
 
@@ -296,7 +296,7 @@ func TestRedisSeqCoordinatorMessageSync(t *testing.T) {
 		break
 	}
 
-	nodeConfig.SeqCoordinator.MyUrl = nodeNames[1]
+	nodeConfig.SeqCoordinator.MyUrlImpl = nodeNames[1]
 	_, _, clientB, l2stackB := CreateTestL2WithConfig(t, ctx, l2Info, nodeConfig, false)
 	defer requireClose(t, l2stackB)
 
@@ -331,7 +331,7 @@ func TestRedisSeqCoordinatorWrongKeyMessageSync(t *testing.T) {
 
 	initRedisForTest(t, ctx, nodeConfig.SeqCoordinator.RedisUrl, nodeNames)
 
-	nodeConfig.SeqCoordinator.MyUrl = nodeNames[0]
+	nodeConfig.SeqCoordinator.MyUrlImpl = nodeNames[0]
 	l2Info, _, clientA, l2stackA := CreateTestL2WithConfig(t, ctx, nil, nodeConfig, false)
 	defer requireClose(t, l2stackA)
 
@@ -352,7 +352,7 @@ func TestRedisSeqCoordinatorWrongKeyMessageSync(t *testing.T) {
 
 	nodeConfigCopy := *nodeConfig
 	nodeConfig = &nodeConfigCopy
-	nodeConfig.SeqCoordinator.MyUrl = nodeNames[1]
+	nodeConfig.SeqCoordinator.MyUrlImpl = nodeNames[1]
 	nodeConfig.SeqCoordinator.Signing.SigningKey = "629b39225c813bf1975fb49bcb6ca2622f2c62509f138ac609f0c048764a95ee"
 	_, _, clientB, l2stackB := CreateTestL2WithConfig(t, ctx, l2Info, nodeConfig, false)
 	defer requireClose(t, l2stackB)


### PR DESCRIPTION
Add `RedisCoordinator` so that `recommendLiveSequencer` can be used outside of the sequencer.