### PR TITLE
Remove non-prom allowed chars from das agg metrics

### DIFF
--- a/das/aggregator.go
+++ b/das/aggregator.go
@@ -218,17 +218,17 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64, 
 			var metricWithServiceName string = metricBase + "/" + d.metricName
 			defer cancel()
 			incFailureMetric := func() {
-				metrics.GetOrRegisterCounter(metricWithServiceName+"/failure", nil).Inc(1)
-				metrics.GetOrRegisterCounter(metricBase+"/all/failure", nil).Inc(1)
+				metrics.GetOrRegisterCounter(metricWithServiceName+"/error/total", nil).Inc(1)
+				metrics.GetOrRegisterCounter(metricBase+"/error/all/total", nil).Inc(1)
 			}
 
 			cert, err := d.service.Store(storeCtx, message, timeout, sig)
 			if err != nil {
 				incFailureMetric()
 				if errors.Is(err, context.DeadlineExceeded) {
-					metrics.GetOrRegisterCounter(metricWithServiceName+"/timeout", nil).Inc(1)
+					metrics.GetOrRegisterCounter(metricWithServiceName+"/error/timeout/total", nil).Inc(1)
 				} else {
-					metrics.GetOrRegisterCounter(metricWithServiceName+"/client_error", nil).Inc(1)
+					metrics.GetOrRegisterCounter(metricWithServiceName+"/error/client/total", nil).Inc(1)
 				}
 				responses <- storeResponse{d, nil, err}
 				return
@@ -239,13 +239,13 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64, 
 			)
 			if err != nil {
 				incFailureMetric()
-				metrics.GetOrRegisterCounter(metricWithServiceName+"/bad_response", nil).Inc(1)
+				metrics.GetOrRegisterCounter(metricWithServiceName+"/error/bad_response/total", nil).Inc(1)
 				responses <- storeResponse{d, nil, err}
 				return
 			}
 			if !verified {
 				incFailureMetric()
-				metrics.GetOrRegisterCounter(metricWithServiceName+"/bad_response", nil).Inc(1)
+				metrics.GetOrRegisterCounter(metricWithServiceName+"/error/bad_response/total", nil).Inc(1)
 				responses <- storeResponse{d, nil, errors.New("Signature verification failed.")}
 				return
 			}
@@ -254,19 +254,19 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64, 
 
 			if cert.DataHash != expectedHash {
 				incFailureMetric()
-				metrics.GetOrRegisterCounter(metricWithServiceName+"/bad_response", nil).Inc(1)
+				metrics.GetOrRegisterCounter(metricWithServiceName+"/error/bad_response/total", nil).Inc(1)
 				responses <- storeResponse{d, nil, errors.New("Hash verification failed.")}
 				return
 			}
 			if cert.Timeout != timeout {
 				incFailureMetric()
-				metrics.GetOrRegisterCounter(metricWithServiceName+"/bad_response", nil).Inc(1)
+				metrics.GetOrRegisterCounter(metricWithServiceName+"/error/bad_response/total", nil).Inc(1)
 				responses <- storeResponse{d, nil, fmt.Errorf("Timeout was %d, expected %d", cert.Timeout, timeout)}
 				return
 			}
 
-			metrics.GetOrRegisterCounter(metricWithServiceName+"/success", nil).Inc(1)
-			metrics.GetOrRegisterCounter(metricBase+"/all/success", nil).Inc(1)
+			metrics.GetOrRegisterCounter(metricWithServiceName+"/success/total", nil).Inc(1)
+			metrics.GetOrRegisterCounter(metricBase+"/success/all/total", nil).Inc(1)
 			responses <- storeResponse{d, cert.Sig, nil}
 		}(ctx, d)
 	}

--- a/das/rpc_aggregator.go
+++ b/das/rpc_aggregator.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
-	"strings"
+	"regexp"
 
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 
@@ -60,7 +60,8 @@ func setUpServices(config DataAvailabilityConfig) ([]ServiceDetails, error) {
 			return nil, err
 		}
 		// Prometheus metric names must contain only chars [a-zA-Z0-9:_]
-		metricName := strings.ReplaceAll(url.Hostname(), ".", "_")
+		invalidPromCharRegex := regexp.MustCompile(`[^a-zA-Z0-9:_]+`)
+		metricName := invalidPromCharRegex.ReplaceAllString(url.Hostname(), "_")
 
 		service, err := NewDASRPCClient(b.URL)
 		if err != nil {


### PR DESCRIPTION
Also set metrics to be counters not gauges.

# Testing done

Tested various strings manually with https://go.dev/play/ 
```
// You can edit this code!
// Click here and start typing.
package main

import (
	"fmt"
	"regexp"
)

func main() {
	invalidPromCharRegex := regexp.MustCompile(`[^a-zA-Z0-9:_]+`)
	metricName := invalidPromCharRegex.ReplaceAllString("a c-b    c", "_")
	fmt.Println(metricName)
}
```