### PR TITLE
Allow validator smart contract wallet to be specified

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -940,7 +940,16 @@ func createNodeImpl(
 	var staker *validator.Staker
 	if config.Validator.Enable {
 		// TODO: remember validator wallet in JSON instead of querying it from L1 every time
-		wallet, err := validator.NewValidatorWallet(nil, deployInfo.ValidatorWalletCreator, deployInfo.Rollup, l1Reader, txOpts, int64(deployInfo.DeployedAt), func(common.Address) {})
+		var existingWalletAddress *common.Address
+		if len(config.Validator.ContractWalletAddress) > 0 {
+			if !common.IsHexAddress(config.Validator.ContractWalletAddress) {
+				log.Error("invalid validator smart contract wallet", "addr", config.Validator.ContractWalletAddress
+				return nil, errors.New("invalid validator smart contract wallet address")
+			}
+			tmpAddress := common.HexToAddress(config.Validator.ContractWalletAddress)
+			existingWalletAddress = &tmpAddress
+		}
+		wallet, err := validator.NewValidatorWallet(ctx, existingWalletAddress, deployInfo.ValidatorWalletCreator, deployInfo.Rollup, l1Reader, txOpts, int64(deployInfo.DeployedAt), func(common.Address) {})
 		if err != nil {
 			return nil, err
 		}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -943,7 +943,7 @@ func createNodeImpl(
 		var existingWalletAddress *common.Address
 		if len(config.Validator.ContractWalletAddress) > 0 {
 			if !common.IsHexAddress(config.Validator.ContractWalletAddress) {
-				log.Error("invalid validator smart contract wallet", "addr", config.Validator.ContractWalletAddress
+				log.Error("invalid validator smart contract wallet", "addr", config.Validator.ContractWalletAddress)
 				return nil, errors.New("invalid validator smart contract wallet address")
 			}
 			tmpAddress := common.HexToAddress(config.Validator.ContractWalletAddress)

--- a/system_tests/staker_test.go
+++ b/system_tests/staker_test.go
@@ -121,7 +121,7 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 		TargetMachineCount: 4,
 	}
 
-	valWalletA, err := validator.NewValidatorWallet(nil, l2nodeA.DeployInfo.ValidatorWalletCreator, l2nodeA.DeployInfo.Rollup, l2nodeA.L1Reader, &l1authA, 0, func(common.Address) {})
+	valWalletA, err := validator.NewValidatorWallet(ctx, nil, l2nodeA.DeployInfo.ValidatorWalletCreator, l2nodeA.DeployInfo.Rollup, l2nodeA.L1Reader, &l1authA, 0, func(common.Address) {})
 	Require(t, err)
 	if honestStakerInactive {
 		valConfig.Strategy = "Defensive"
@@ -147,7 +147,7 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 	err = stakerA.Initialize(ctx)
 	Require(t, err)
 
-	valWalletB, err := validator.NewValidatorWallet(nil, l2nodeB.DeployInfo.ValidatorWalletCreator, l2nodeB.DeployInfo.Rollup, l2nodeB.L1Reader, &l1authB, 0, func(common.Address) {})
+	valWalletB, err := validator.NewValidatorWallet(ctx, nil, l2nodeB.DeployInfo.ValidatorWalletCreator, l2nodeB.DeployInfo.Rollup, l2nodeB.L1Reader, &l1authB, 0, func(common.Address) {})
 	Require(t, err)
 	valConfig.Strategy = "MakeNodes"
 	stakerB, err := validator.NewStaker(
@@ -168,7 +168,7 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 	err = stakerB.Initialize(ctx)
 	Require(t, err)
 
-	valWalletC, err := validator.NewValidatorWallet(nil, l2nodeA.DeployInfo.ValidatorWalletCreator, l2nodeA.DeployInfo.Rollup, l2nodeA.L1Reader, nil, 0, func(common.Address) {})
+	valWalletC, err := validator.NewValidatorWallet(ctx, nil, l2nodeA.DeployInfo.ValidatorWalletCreator, l2nodeA.DeployInfo.Rollup, l2nodeA.L1Reader, nil, 0, func(common.Address) {})
 	Require(t, err)
 	valConfig.Strategy = "Watchtower"
 	stakerC, err := validator.NewStaker(

--- a/validator/staker.go
+++ b/validator/staker.go
@@ -91,7 +91,7 @@ func L1ValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Int(prefix+".target-machine-count", DefaultL1ValidatorConfig.TargetMachineCount, "target machine count")
 	f.Int64(prefix+".confirmation-blocks", DefaultL1ValidatorConfig.ConfirmationBlocks, "confirmation blocks")
 	f.Bool(prefix+".only-create-wallet-contract", DefaultL1ValidatorConfig.OnlyCreateWalletContract, "only create smart wallet contract and exit")
-	f.String(prefix+".validator.contract-wallet-address", "", "validator smart contract wallet public address")
+	f.String(prefix+".contract-wallet-address", DefaultL1ValidatorConfig.ContractWalletAddress, "validator smart contract wallet public address")
 	f.String(prefix+".gas-refunder-address", DefaultL1ValidatorConfig.GasRefunderAddress, "The gas refunder contract address (optional)")
 	DangerousConfigAddOptions(prefix+".dangerous", f)
 }

--- a/validator/staker.go
+++ b/validator/staker.go
@@ -61,6 +61,7 @@ type L1ValidatorConfig struct {
 	TargetMachineCount       int               `koanf:"target-machine-count"`
 	ConfirmationBlocks       int64             `koanf:"confirmation-blocks"`
 	OnlyCreateWalletContract bool              `koanf:"only-create-wallet-contract"`
+	ContractWalletAddress    string            `koanf:"contract-wallet-address"`
 	GasRefunderAddress       string            `koanf:"gas-refunder-address"`
 	Dangerous                DangerousConfig   `koanf:"dangerous"`
 }
@@ -75,6 +76,7 @@ var DefaultL1ValidatorConfig = L1ValidatorConfig{
 	TargetMachineCount:       4,
 	ConfirmationBlocks:       12,
 	OnlyCreateWalletContract: false,
+	ContractWalletAddress:    "",
 	GasRefunderAddress:       "",
 	Dangerous:                DefaultDangerousConfig,
 }
@@ -89,6 +91,7 @@ func L1ValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Int(prefix+".target-machine-count", DefaultL1ValidatorConfig.TargetMachineCount, "target machine count")
 	f.Int64(prefix+".confirmation-blocks", DefaultL1ValidatorConfig.ConfirmationBlocks, "confirmation blocks")
 	f.Bool(prefix+".only-create-wallet-contract", DefaultL1ValidatorConfig.OnlyCreateWalletContract, "only create smart wallet contract and exit")
+	f.String(prefix+".validator.contract-wallet-address", "", "validator smart contract wallet public address")
 	f.String(prefix+".gas-refunder-address", DefaultL1ValidatorConfig.GasRefunderAddress, "The gas refunder contract address (optional)")
 	DangerousConfigAddOptions(prefix+".dangerous", f)
 }

--- a/validator/validator_wallet.go
+++ b/validator/validator_wallet.go
@@ -72,6 +72,9 @@ func NewValidatorWallet(ctx context.Context, address *common.Address, walletFact
 }
 
 func (v *ValidatorWallet) validateWallet(ctx context.Context) error {
+	if v.con == nil || v.auth == nil {
+		return nil
+	}
 	callOpts := &bind.CallOpts{Context: ctx}
 	owner, err := v.con.Owner(callOpts)
 	if err != nil {

--- a/validator/validator_wallet.go
+++ b/validator/validator_wallet.go
@@ -46,7 +46,7 @@ type ValidatorWallet struct {
 	rollupFromBlock   int64
 }
 
-func NewValidatorWallet(address *common.Address, walletFactoryAddr, rollupAddress common.Address, l1Reader L1ReaderInterface, auth *bind.TransactOpts, rollupFromBlock int64, onWalletCreated func(common.Address)) (*ValidatorWallet, error) {
+func NewValidatorWallet(ctx context.Context, address *common.Address, walletFactoryAddr, rollupAddress common.Address, l1Reader L1ReaderInterface, auth *bind.TransactOpts, rollupFromBlock int64, onWalletCreated func(common.Address)) (*ValidatorWallet, error) {
 	var con *rollupgen.ValidatorWallet
 	if address != nil {
 		var err error
@@ -55,7 +55,7 @@ func NewValidatorWallet(address *common.Address, walletFactoryAddr, rollupAddres
 			return nil, err
 		}
 	}
-	return &ValidatorWallet{
+	v := &ValidatorWallet{
 		con:               con,
 		address:           address,
 		onWalletCreated:   onWalletCreated,
@@ -64,7 +64,27 @@ func NewValidatorWallet(address *common.Address, walletFactoryAddr, rollupAddres
 		rollupAddress:     rollupAddress,
 		walletFactoryAddr: walletFactoryAddr,
 		rollupFromBlock:   rollupFromBlock,
-	}, nil
+	}
+	if err := v.validateWallet(ctx); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (v *ValidatorWallet) validateWallet(ctx context.Context) error {
+	callOpts := &bind.CallOpts{Context: ctx}
+	owner, err := v.con.Owner(callOpts)
+	if err != nil {
+		return err
+	}
+	isExecutor, err := v.con.Executors(callOpts, v.auth.From)
+	if err != nil {
+		return err
+	}
+	if v.auth.From != owner && !isExecutor {
+		return errors.New("specified unauthorized smart contract wallet")
+	}
+	return nil
 }
 
 func (v *ValidatorWallet) Initialize(ctx context.Context) error {
@@ -131,6 +151,10 @@ func (v *ValidatorWallet) populateWallet(ctx context.Context, createIfMissing bo
 		return err
 	}
 	v.con = con
+
+	if err := v.validateWallet(ctx); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
- `node.validator.validator.contract-wallet-address` can be used to specify the wallet address of the validator
- Check that the validator is authorized to make transactions through the smart contract wallet that it wants to use