### PR TITLE
Fix `ClientConnection.StopAndWait`

### DIFF
--- a/broadcaster/sequencenumbercatchupbuffer.go
+++ b/broadcaster/sequencenumbercatchupbuffer.go
@@ -68,7 +68,7 @@ func (b *SequenceNumberCatchupBuffer) OnRegisterClient(ctx context.Context, clie
 		// send the newly connected client the requested messages
 		err := clientConnection.Write(bm)
 		if err != nil {
-			log.Error("error sending client cached messages", err, "client", clientConnection.Name, "elapsed", time.Since(start))
+			log.Error("error sending client cached messages", "error", err, "client", clientConnection.Name, "elapsed", time.Since(start))
 			return err
 		}
 	}

--- a/wsbroadcastserver/clientconnection.go
+++ b/wsbroadcastserver/clientconnection.go
@@ -80,8 +80,9 @@ func (cc *ClientConnection) StopAndWait() {
 	if !cc.Started() {
 		// If client connection never started, need to close channel
 		close(cc.out)
+	} else {
+		cc.StopWaiter.StopAndWait()
 	}
-	cc.StopWaiter.StopAndWait()
 }
 
 func (cc *ClientConnection) RequestedSeqNum() arbutil.MessageIndex {


### PR DESCRIPTION
Issue occurs when feed client disconnects immediately after connecting.