### PR TITLE
version information for hot config

### DIFF
--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -24,6 +24,7 @@ import (
 )
 
 type InboxReaderConfig struct {
+	Version             int           `reload:"version"`
 	DelayBlocks         uint64        `koanf:"delay-blocks" reload:"hot"`
 	CheckDelay          time.Duration `koanf:"check-delay" reload:"hot"`
 	HardReorg           bool          `koanf:"hard-reorg" reload:"hot"`

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -394,6 +394,7 @@ func DeployOnL1(ctx context.Context, l1client arbutil.L1Interface, deployAuth *b
 }
 
 type Config struct {
+	Version                int                            `reload:"version"`
 	RPC                    arbitrum.Config                `koanf:"rpc"`
 	Sequencer              SequencerConfig                `koanf:"sequencer" reload:"hot"`
 	L1Reader               headerreader.Config            `koanf:"l1-reader" reload:"hot"`

--- a/arbnode/sequencer.go
+++ b/arbnode/sequencer.go
@@ -35,6 +35,7 @@ import (
 const maxTxDataSize = 112065
 
 type SequencerConfig struct {
+	Version                     int                      `reload:"version"`
 	Enable                      bool                     `koanf:"enable"`
 	MaxBlockSpeed               time.Duration            `koanf:"max-block-speed" reload:"hot"`
 	MaxRevertGasReject          uint64                   `koanf:"max-revert-gas-reject" reload:"hot"`

--- a/util/headerreader/header_reader.go
+++ b/util/headerreader/header_reader.go
@@ -37,6 +37,7 @@ type HeaderReader struct {
 }
 
 type Config struct {
+	Version              int           `reload:"version"`
 	Enable               bool          `koanf:"enable"`
 	PollOnly             bool          `koanf:"poll-only" reload:"hot"`
 	PollInterval         time.Duration `koanf:"poll-interval" reload:"hot"`


### PR DESCRIPTION
Allows hot config clients to test if a config update was made by comparing one field (version) against a stored value.