### PR TITLE
Use a private field to cache config byproducts

### DIFF
--- a/arbutil/cached_computation.go
+++ b/arbutil/cached_computation.go
@@ -1,0 +1,33 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package arbutil
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type CachedComputation[T any] struct {
+	complete int32
+	mutex    sync.Mutex
+	value    T
+}
+
+func (c *CachedComputation[T]) Get(compute func() (T, error)) (T, error) {
+	if atomic.LoadInt32(&c.complete) == 1 {
+		return c.value, nil
+	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if atomic.LoadInt32(&c.complete) == 1 {
+		return c.value, nil
+	}
+	computed, err := compute()
+	if err != nil {
+		return computed, err
+	}
+	c.value = computed
+	atomic.StoreInt32(&c.complete, 1)
+	return computed, err
+}

--- a/cmd/nitro/config_test.go
+++ b/cmd/nitro/config_test.go
@@ -71,11 +71,14 @@ func TestReloads(t *testing.T) {
 	update.Node.Sequencer.MaxBlockSpeed++
 
 	check(reflect.ValueOf(config), false, "config")
-	Require(t, config.CanReload(&config))
-	Require(t, config.CanReload(&update))
+	_, canReload := config.CanReload(&config)
+	Require(t, canReload)
+	_, canReload = config.CanReload(&update)
+	Require(t, canReload)
 
 	testUnsafe := func() {
-		if config.CanReload(&update) == nil {
+		_, canReload = config.CanReload(&update)
+		if canReload == nil {
 			Fail(t, "failed to detect unsafe reload")
 		}
 		update = NodeConfigDefault


### PR DESCRIPTION
I'm creating this PR just to evaluate the approach. One issue is that the `copylock` linter complains everywhere, but I bet we could work around that if needed (or just not copy configs as much which is probably good anyways).