### PR TITLE
fix: 'node.batch-poster.redis-lock' has invalid keys: redis-url

### DIFF
--- a/testnode-scripts/config.ts
+++ b/testnode-scripts/config.ts
@@ -56,8 +56,8 @@ function writeConfigs(argv: any) {
             },
             "batch-poster": {
                 "enable": false,
+                "redis-url": argv.redisUrl,
                 "redis-lock": {
-                    "redis-url": argv.redisUrl,
                     "key": "batchPosterLock",
                 },
                 "max-interval": "30s",


### PR DESCRIPTION
run sequencer error with tag v2.0.x:

```
docker logs nitro_sequencer_1
version: development, time: development

Sample usage:                  /usr/local/bin/nitro --help
1 error(s) decoding:

* 'node.batch-poster.redis-lock' has invalid keys: redis-url

```

Reason: 

config writer object structure doesn't match the config struct:

https://github.com/OffchainLabs/nitro/blob/v2.0.6/testnode-scripts/config.ts#L59-L61

https://github.com/offchainlabs/nitro/blob/v2.0.6/arbnode/simple_redis_lock.go#L30-L36


