### PR TITLE
Move config helpers from cmd/util to their own pkg

### DIFF
--- a/cmd/daserver/daserver.go
+++ b/cmd/daserver/daserver.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
-	"github.com/offchainlabs/nitro/cmd/util"
+	"github.com/offchainlabs/nitro/cmd/util/confighelpers"
 	"github.com/offchainlabs/nitro/das"
 )
 
@@ -91,17 +91,17 @@ func parseDAServer(args []string) (*DAServerConfig, error) {
 	das.DataAvailabilityConfigAddOptions("data-availability", f)
 	genericconf.ConfConfigAddOptions("conf", f)
 
-	k, err := util.BeginCommonParse(f, args)
+	k, err := confighelpers.BeginCommonParse(f, args)
 	if err != nil {
 		return nil, err
 	}
 
 	var serverConfig DAServerConfig
-	if err := util.EndCommonParse(k, &serverConfig); err != nil {
+	if err := confighelpers.EndCommonParse(k, &serverConfig); err != nil {
 		return nil, err
 	}
 	if serverConfig.ConfConfig.Dump {
-		err = util.DumpConfig(k, map[string]interface{}{
+		err = confighelpers.DumpConfig(k, map[string]interface{}{
 			"data-availability.key.priv-key": "",
 		})
 		if err != nil {
@@ -126,11 +126,11 @@ func startup() error {
 
 	serverConfig, err := parseDAServer(os.Args[1:])
 	if err != nil {
-		util.HandleError(err, printSampleUsage)
+		confighelpers.HandleError(err, printSampleUsage)
 		return nil
 	}
 	if !(serverConfig.EnableRPC || serverConfig.EnableREST) {
-		util.HandleError(nil, printSampleUsage)
+		confighelpers.HandleError(nil, printSampleUsage)
 		fmt.Printf("Please specify at least one of --enable-rest or --enable-rpc\n")
 		return nil
 	}
@@ -162,7 +162,7 @@ func startup() error {
 		return err
 	}
 
-	vcsRevision, vcsTime := util.GetVersion()
+	vcsRevision, vcsTime := confighelpers.GetVersion()
 	var rpcServer *http.Server
 	if serverConfig.EnableRPC {
 		log.Info("Starting HTTP-RPC server", "addr", serverConfig.RPCAddr, "port", serverConfig.RPCPort, "revision", vcsRevision, "vcs.time", vcsTime)

--- a/cmd/datool/datool.go
+++ b/cmd/datool/datool.go
@@ -23,8 +23,9 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
-
 	"github.com/offchainlabs/nitro/cmd/util"
+
+	"github.com/offchainlabs/nitro/cmd/util/confighelpers"
 	"github.com/offchainlabs/nitro/das"
 	"github.com/offchainlabs/nitro/das/dastree"
 	"github.com/offchainlabs/nitro/util/signature"
@@ -101,13 +102,13 @@ func parseClientStoreConfig(args []string) (*ClientStoreConfig, error) {
 	f.Duration("das-retention-period", 24*time.Hour, "The period which DASes are requested to retain the stored batches.")
 	genericconf.ConfConfigAddOptions("conf", f)
 
-	k, err := util.BeginCommonParse(f, args)
+	k, err := confighelpers.BeginCommonParse(f, args)
 	if err != nil {
 		return nil, err
 	}
 
 	var config ClientStoreConfig
-	if err := util.EndCommonParse(k, &config); err != nil {
+	if err := confighelpers.EndCommonParse(k, &config); err != nil {
 		return nil, err
 	}
 	return &config, nil
@@ -204,13 +205,13 @@ func parseRESTClientGetByHashConfig(args []string) (*RESTClientGetByHashConfig, 
 
 	genericconf.ConfConfigAddOptions("conf", f)
 
-	k, err := util.BeginCommonParse(f, args)
+	k, err := confighelpers.BeginCommonParse(f, args)
 	if err != nil {
 		return nil, err
 	}
 
 	var config RESTClientGetByHashConfig
-	if err := util.EndCommonParse(k, &config); err != nil {
+	if err := confighelpers.EndCommonParse(k, &config); err != nil {
 		return nil, err
 	}
 	return &config, nil
@@ -266,13 +267,13 @@ func parseKeyGenConfig(args []string) (*KeyGenConfig, error) {
 	f.Bool("wallet", false, "generate the ECDSA keypair in a wallet file")
 	genericconf.ConfConfigAddOptions("conf", f)
 
-	k, err := util.BeginCommonParse(f, args)
+	k, err := confighelpers.BeginCommonParse(f, args)
 	if err != nil {
 		return nil, err
 	}
 
 	var config KeyGenConfig
-	if err := util.EndCommonParse(k, &config); err != nil {
+	if err := confighelpers.EndCommonParse(k, &config); err != nil {
 		return nil, err
 	}
 	return &config, nil

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -40,6 +40,7 @@ import (
 	"github.com/offchainlabs/nitro/cmd/conf"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/cmd/util"
+	"github.com/offchainlabs/nitro/cmd/util/confighelpers"
 	_ "github.com/offchainlabs/nitro/nodeInterface"
 	"github.com/offchainlabs/nitro/util/colors"
 	"github.com/offchainlabs/nitro/util/headerreader"
@@ -122,7 +123,7 @@ func main() {
 	args := os.Args[1:]
 	nodeConfig, l1Wallet, l2DevWallet, l1Client, l1ChainId, err := ParseNode(ctx, args)
 	if err != nil {
-		util.HandleError(err, printSampleUsage)
+		confighelpers.HandleError(err, printSampleUsage)
 
 		return
 	}
@@ -131,7 +132,7 @@ func main() {
 		panic(err)
 	}
 
-	vcsRevision, vcsTime := util.GetVersion()
+	vcsRevision, vcsTime := confighelpers.GetVersion()
 	log.Info("Running Arbitrum nitro node", "revision", vcsRevision, "vcs.time", vcsTime)
 
 	if nodeConfig.Node.Dangerous.NoL1Listener {
@@ -255,7 +256,7 @@ func main() {
 
 	chainDb, l2BlockChain, err := openInitializeChainDb(ctx, stack, nodeConfig, new(big.Int).SetUint64(nodeConfig.L2.ChainID), arbnode.DefaultCacheConfigFor(stack, &nodeConfig.Node.Caching))
 	if err != nil {
-		util.HandleError(err, printSampleUsage)
+		confighelpers.HandleError(err, printSampleUsage)
 		return
 	}
 
@@ -447,7 +448,7 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 
 	NodeConfigAddOptions(f)
 
-	k, err := util.BeginCommonParse(f, args)
+	k, err := confighelpers.BeginCommonParse(f, args)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
@@ -552,19 +553,19 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 		}
 	}
 
-	err = util.ApplyOverrides(f, k)
+	err = confighelpers.ApplyOverrides(f, k)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
 
 	var nodeConfig NodeConfig
-	if err := util.EndCommonParse(k, &nodeConfig); err != nil {
+	if err := confighelpers.EndCommonParse(k, &nodeConfig); err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
 
 	// Don't print wallet passwords
 	if nodeConfig.Conf.Dump {
-		err = util.DumpConfig(k, map[string]interface{}{
+		err = confighelpers.DumpConfig(k, map[string]interface{}{
 			"l1.wallet.password":        "",
 			"l1.wallet.private-key":     "",
 			"l2.dev-wallet.password":    "",

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/offchainlabs/nitro/broadcastclient"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
-	"github.com/offchainlabs/nitro/cmd/util"
+	"github.com/offchainlabs/nitro/cmd/util/confighelpers"
 	"github.com/offchainlabs/nitro/relay"
 )
 
@@ -43,7 +43,7 @@ func startup() error {
 
 	relayConfig, err := ParseRelay(ctx, os.Args[1:])
 	if err != nil || len(relayConfig.Node.Feed.Input.URLs) == 0 || relayConfig.Node.Feed.Input.URLs[0] == "" || relayConfig.L2.ChainId == 0 {
-		util.HandleError(err, printSampleUsage)
+		confighelpers.HandleError(err, printSampleUsage)
 
 		return nil
 	}
@@ -57,7 +57,7 @@ func startup() error {
 	glogger.Verbosity(log.Lvl(relayConfig.LogLevel))
 	log.Root().SetHandler(glogger)
 
-	vcsRevision, vcsTime := util.GetVersion()
+	vcsRevision, vcsTime := confighelpers.GetVersion()
 	log.Info("Running Arbitrum nitro relay", "revision", vcsRevision, "vcs.time", vcsTime)
 
 	defer log.Info("Cleanly shutting down relay")
@@ -153,18 +153,18 @@ func ParseRelay(_ context.Context, args []string) (*RelayConfig, error) {
 
 	RelayConfigAddOptions(f)
 
-	k, err := util.BeginCommonParse(f, args)
+	k, err := confighelpers.BeginCommonParse(f, args)
 	if err != nil {
 		return nil, err
 	}
 
 	var relayConfig RelayConfig
-	if err := util.EndCommonParse(k, &relayConfig); err != nil {
+	if err := confighelpers.EndCommonParse(k, &relayConfig); err != nil {
 		return nil, err
 	}
 
 	if relayConfig.Conf.Dump {
-		err = util.DumpConfig(k, map[string]interface{}{})
+		err = confighelpers.DumpConfig(k, map[string]interface{}{})
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/util/confighelpers/configuration.go
+++ b/cmd/util/confighelpers/configuration.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2022, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-package util
+package confighelpers
 
 import (
 	"fmt"


### PR DESCRIPTION
This stops inclusion of unneccessary dependencies when using Nitro from other projects.