### PR TITLE
Add nonce cache to sequencer

### DIFF
--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -480,6 +480,7 @@ func messageFromTxes(header *arbos.L1IncomingMessageHeader, txes types.Transacti
 	}, nil
 }
 
+// Must be called inside a transaction filter hook (meaning the reorg mutex is held)
 func (s *TransactionStreamer) CheckNonceWithCache(statedb *state.StateDB, sender common.Address, nonce uint64) error {
 	if s.nonceCache.GetMaxEntries() > 0 {
 		stateNonce, ok := s.nonceCache.Get(sender)
@@ -495,6 +496,7 @@ func (s *TransactionStreamer) CheckNonceWithCache(statedb *state.StateDB, sender
 	return nil
 }
 
+// Must be called inside a transaction filter hook (meaning the reorg mutex is held)
 func (s *TransactionStreamer) UpdateNonceCache(sender common.Address, newNonce uint64) {
 	if s.nonceCache.GetMaxEntries() > 0 {
 		s.nonceCache.Add(sender, newNonce)

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -535,11 +535,9 @@ func (s *TransactionStreamer) SequenceTransactions(header *arbos.L1IncomingMessa
 				stateNonce = statedb.GetNonce(sender)
 				s.nonceCache.Add(sender, stateNonce)
 			}
-			txNonce := tx.Nonce()
-			if txNonce < stateNonce {
-				return fmt.Errorf("%w: address %v, tx: %d state: %d", core.ErrNonceTooLow, sender, txNonce, stateNonce)
-			} else if txNonce > stateNonce {
-				return fmt.Errorf("%w: address %v, tx: %d state: %d", core.ErrNonceTooHigh, sender, txNonce, stateNonce)
+			err := MakeNonceError(sender, tx.Nonce(), stateNonce)
+			if err != nil {
+				return err
 			}
 			return oldPreTxFilter(config, header, statedb, arbos, tx, sender)
 		}

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -81,7 +81,7 @@ type SequencingHooks struct {
 	TxErrors               []error
 	DiscardInvalidTxsEarly bool
 	PreTxFilter            func(*params.ChainConfig, *types.Header, *state.StateDB, *arbosState.ArbosState, *types.Transaction, common.Address) error
-	PostTxFilter           func(*arbosState.ArbosState, *types.Transaction, common.Address, uint64, *core.ExecutionResult) error
+	PostTxFilter           func(*types.Header, *arbosState.ArbosState, *types.Transaction, common.Address, uint64, *core.ExecutionResult) error
 }
 
 func noopSequencingHooks() *SequencingHooks {
@@ -91,7 +91,7 @@ func noopSequencingHooks() *SequencingHooks {
 		func(*params.ChainConfig, *types.Header, *state.StateDB, *arbosState.ArbosState, *types.Transaction, common.Address) error {
 			return nil
 		},
-		func(*arbosState.ArbosState, *types.Transaction, common.Address, uint64, *core.ExecutionResult) error {
+		func(*types.Header, *arbosState.ArbosState, *types.Transaction, common.Address, uint64, *core.ExecutionResult) error {
 			return nil
 		},
 	}
@@ -285,7 +285,7 @@ func ProduceBlockAdvanced(
 				&header.GasUsed,
 				vm.Config{},
 				func(result *core.ExecutionResult) error {
-					return hooks.PostTxFilter(state, tx, sender, dataGas, result)
+					return hooks.PostTxFilter(header, state, tx, sender, dataGas, result)
 				},
 			)
 			if err != nil {

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -80,7 +80,7 @@ func createNewHeader(prevHeader *types.Header, l1info *L1Info, state *arbosState
 type SequencingHooks struct {
 	TxErrors               []error
 	DiscardInvalidTxsEarly bool
-	PreTxFilter            func(*params.ChainConfig, *types.Header, *state.StateDB, *arbosState.ArbosState, *types.Transaction) error
+	PreTxFilter            func(*params.ChainConfig, *types.Header, *state.StateDB, *arbosState.ArbosState, *types.Transaction, common.Address) error
 	PostTxFilter           func(*arbosState.ArbosState, *types.Transaction, common.Address, uint64, *core.ExecutionResult) error
 }
 
@@ -88,7 +88,7 @@ func noopSequencingHooks() *SequencingHooks {
 	return &SequencingHooks{
 		[]error{},
 		false,
-		func(*params.ChainConfig, *types.Header, *state.StateDB, *arbosState.ArbosState, *types.Transaction) error {
+		func(*params.ChainConfig, *types.Header, *state.StateDB, *arbosState.ArbosState, *types.Transaction, common.Address) error {
 			return nil
 		},
 		func(*arbosState.ArbosState, *types.Transaction, common.Address, uint64, *core.ExecutionResult) error {
@@ -228,12 +228,12 @@ func ProduceBlockAdvanced(
 				return nil, nil, core.ErrGasLimitReached
 			}
 
-			if err := hooks.PreTxFilter(chainConfig, header, statedb, state, tx); err != nil {
+			sender, err = signer.Sender(tx)
+			if err != nil {
 				return nil, nil, err
 			}
 
-			sender, err = signer.Sender(tx)
-			if err != nil {
+			if err := hooks.PreTxFilter(chainConfig, header, statedb, state, tx, sender); err != nil {
 				return nil, nil, err
 			}
 

--- a/util/containers/lru.go
+++ b/util/containers/lru.go
@@ -1,0 +1,57 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package containers
+
+import "github.com/golang/groupcache/lru"
+
+// Not thread safe!
+type LruCache[K comparable, V any] struct {
+	inner lru.Cache
+}
+
+func NewLruCache[K comparable, V any](size int) *LruCache[K, V] {
+	inner := lru.New(size)
+	return &LruCache[K, V]{inner: *inner}
+}
+
+func (c *LruCache[K, V]) Add(key K, value V) {
+	c.inner.Add(key, value)
+}
+
+func (c *LruCache[K, V]) Get(key K) (V, bool) {
+	value, ok := c.inner.Get(key)
+	if !ok {
+		var empty V
+		return empty, false
+	}
+	casted, ok := value.(V)
+	if !ok {
+		panic("LRU cache has value of wrong type")
+	}
+	return casted, true
+}
+
+func (c *LruCache[K, V]) Remove(key K) {
+	c.inner.Remove(key)
+}
+
+func (c *LruCache[K, V]) RemoveOldest() {
+	c.inner.RemoveOldest()
+}
+
+func (c *LruCache[K, V]) Len() int {
+	return c.inner.Len()
+}
+
+func (c *LruCache[K, V]) Clear() {
+	c.inner.Clear()
+}
+
+func (c *LruCache[K, V]) GetMaxEntries() int {
+	return c.inner.MaxEntries
+}
+
+func (c *LruCache[K, V]) SetMaxEntries(maxEntries int) {
+	c.inner.MaxEntries = maxEntries
+}

--- a/util/containers/queue.go
+++ b/util/containers/queue.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2022, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-package arbutil
+package containers
 
 // A queue of an arbitrary type backed by a slice which is shrinked when it grows too large
 type Queue[T any] struct {


### PR DESCRIPTION
Adds an in-memory LRU cache to the sequencer which efficiently remembers account nonces