### PR TITLE
Fix jit validator shutdown cancellation

### DIFF
--- a/validator/block_validator.go
+++ b/validator/block_validator.go
@@ -485,7 +485,10 @@ func (v *BlockValidator) validate(ctx context.Context, validationStatus *validat
 	}
 
 	atomic.StoreUint32(&validationStatus.Status, validationStatusValid) // after that - validation entry could be deleted from map
-	v.checkProgressChan <- struct{}{}
+	select {
+	case v.checkProgressChan <- struct{}{}:
+	default:
+	}
 }
 
 func (v *BlockValidator) sendValidations(ctx context.Context) {

--- a/validator/jit_machine.go
+++ b/validator/jit_machine.go
@@ -111,7 +111,6 @@ func (machine *JitMachine) prove(
 	if err := conn.SetWriteDeadline(timeout); err != nil {
 		return state, err
 	}
-	defer conn.Close()
 
 	// Tell the new process about the global state
 	gsStart := entry.start()

--- a/validator/jit_machine.go
+++ b/validator/jit_machine.go
@@ -4,6 +4,7 @@
 package validator
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -62,8 +63,10 @@ func createJitMachine(config NitroMachineConfig, moduleRoot common.Hash, fatalEr
 }
 
 func (machine *JitMachine) prove(
-	entry *validationEntry, resolver GoPreimageResolver, delayed []byte,
+	ctxIn context.Context, entry *validationEntry, resolver GoPreimageResolver, delayed []byte,
 ) (GoGlobalState, error) {
+	ctx, cancel := context.WithCancel(ctxIn)
+	defer cancel() // ensure our cleanup functions run when we're done
 	state := GoGlobalState{}
 
 	timeout := time.Now().Add(60 * time.Second)
@@ -76,7 +79,13 @@ func (machine *JitMachine) prove(
 	if err := tcp.SetDeadline(timeout); err != nil {
 		return state, err
 	}
-	defer tcp.Close()
+	go func() {
+		<-ctx.Done()
+		err := tcp.Close()
+		if err != nil {
+			log.Warn("error closing JIT validation TCP listener", "err", err)
+		}
+	}()
 	address := fmt.Sprintf("%v\n", tcp.Addr().String())
 
 	// Tell the spawner process about the new tcp port
@@ -89,6 +98,13 @@ func (machine *JitMachine) prove(
 	if err != nil {
 		return state, err
 	}
+	go func() {
+		<-ctx.Done()
+		err := conn.Close()
+		if err != nil && !errors.Is(err, net.ErrClosed) {
+			log.Warn("error closing JIT validation TCP connection", "err", err)
+		}
+	}()
 	if err := conn.SetReadDeadline(timeout); err != nil {
 		return state, err
 	}

--- a/validator/stateless_block_validator.go
+++ b/validator/stateless_block_validator.go
@@ -563,7 +563,7 @@ func (v *StatelessBlockValidator) jitBlock(
 	if err != nil {
 		return empty, nil, err
 	}
-	state, err := machine.prove(entry, resolver, delayed)
+	state, err := machine.prove(ctx, entry, resolver, delayed)
 	return state, delayed, err
 }
 


### PR DESCRIPTION
Particularly it seemed there were issues waiting to accept a connection given that the jit validator binary would've already been killed. I've fixed that by closing the TCP listener on context cancellation.