### PR TITLE
Validator shouldn't require deprecated parameter

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -127,6 +127,10 @@ func main() {
 
 		return
 	}
+	if nodeConfig.Node.Archive {
+		log.Warn("node.archive has been deprecated. Please use node.caching.archive instead.")
+		nodeConfig.Node.Caching.Archive = true
+	}
 	err = initLog(nodeConfig.LogType, log.Lvl(nodeConfig.LogLevel))
 	if err != nil {
 		panic(err)
@@ -185,8 +189,8 @@ func main() {
 	}
 
 	if nodeConfig.Node.Validator.Enable {
-		if !nodeConfig.Node.Archive {
-			panic("validator requires --node.archive")
+		if !nodeConfig.Node.Caching.Archive {
+			panic("validator requires --node.caching.archive")
 		}
 		if !nodeConfig.Node.L1Reader.Enable {
 			flag.Usage()
@@ -217,10 +221,6 @@ func main() {
 		return
 	}
 
-	if nodeConfig.Node.Archive {
-		log.Warn("node.archive has been deprecated. Please use node.caching.archive instead.")
-		nodeConfig.Node.Caching.Archive = true
-	}
 	if nodeConfig.Node.Caching.Archive && nodeConfig.Node.TxLookupLimit != 0 {
 		log.Info("retaining ability to lookup full transaction history as archive mode is enabled")
 		nodeConfig.Node.TxLookupLimit = 0


### PR DESCRIPTION
Validator requires node to be run in archive mode, but was requiring the deprecated parameter `--node.archive`.  Changed to require `--node.cachine.archive` instead, as well as move deprecated parameter check earlier in the code.