### PR TITLE
fix(testnode): add redis signer key to batch poster

### DIFF
--- a/testnode-scripts/config.ts
+++ b/testnode-scripts/config.ts
@@ -58,6 +58,11 @@ function writeConfigs(argv: any) {
                 "enable": false,
                 "redis-url": argv.redisUrl,
                 "max-interval": "30s",
+                "data-poster": {
+                    "redis-signer": {
+                      "signing-key": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                    }
+                }
             }
         },
         "init": {


### PR DESCRIPTION
This PR fixes the following error I'm getting when running testnodes on tag `v2.0.6`:

```
poster_1            | INFO [09-27|17:03:16.886] Allocated cache and file handles         database=/home/user/.arbitrum/local/nitro/arbitrumdata cache=16.00MiB handles=16
poster_1            | INFO [09-27|17:03:16.896] Allocated cache and file handles         database=/home/user/.arbitrum/local/nitro/classic-msg cache=16.00MiB handles=16 readonly=true
poster_1            | WARN [09-27|17:03:16.896] Error reading unclean shutdown markers   error="leveldb: not found"
poster_1            | panic: signature verification is enabled but no key is present
poster_1            |
poster_1            | goroutine 1 [running]:
poster_1            | main.main()
poster_1            |   /workspace/cmd/nitro/nitro.go:307 +0x18f4
```

Signed-off-by: Tomás Migone <tomas@edgeandnode.com>