### PR TITLE
Initialize validator wallet early

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -969,6 +969,12 @@ func createNodeImpl(
 		if err != nil {
 			return nil, err
 		}
+		if staker.Strategy() != validator.WatchtowerStrategy {
+			err := wallet.Initialize(ctx)
+			if err != nil {
+				return nil, err
+			}
+		}
 		var txSenderPtr *common.Address
 		if txOpts != nil {
 			txSenderPtr = &txOpts.From

--- a/validator/staker.go
+++ b/validator/staker.go
@@ -186,12 +186,6 @@ func NewStaker(
 }
 
 func (s *Staker) Initialize(ctx context.Context) error {
-	if s.strategy != WatchtowerStrategy {
-		err := s.wallet.Initialize(ctx)
-		if err != nil {
-			return err
-		}
-	}
 	err := s.L1Validator.Initialize(ctx)
 	if err != nil {
 		return err
@@ -716,4 +710,8 @@ func (s *Staker) createConflict(ctx context.Context, info *StakerInfo) error {
 	}
 	// No conflicts exist
 	return nil
+}
+
+func (s *Staker) Strategy() StakerStrategy {
+	return s.strategy
 }


### PR DESCRIPTION
This fixes the "running as validator" log line, which previously didn't have the wallet populated at the time of logging.