### PR TITLE
Add `ChanRateLimiter` 

### DIFF
--- a/util/stopwaiter/stopwaiter.go
+++ b/util/stopwaiter/stopwaiter.go
@@ -225,8 +225,8 @@ func CallIterativelyWith[T any](
 	})
 }
 
-func (s *StopWaiterSafe) ChanRateLimiter(inChan <-chan interface{}, maxRateCallback func() time.Duration) (<-chan interface{}, error) {
-	outChan := make(chan interface{})
+func ChanRateLimiter[T any](s *StopWaiterSafe, inChan <-chan T, maxRateCallback func() time.Duration) (<-chan T, error) {
+	outChan := make(chan T)
 	err := s.LaunchThread(func(ctx context.Context) {
 		nextAllowedTriggerTime := time.Now()
 		for {

--- a/util/stopwaiter/stopwaiter.go
+++ b/util/stopwaiter/stopwaiter.go
@@ -248,7 +248,7 @@ func ChanRateLimiter[T any](s *StopWaiterSafe, inChan <-chan T, maxRateCallback 
 		return nil, err
 	}
 
-	return outChan, err
+	return outChan, nil
 }
 
 // May panic on race conditions instead of returning errors

--- a/util/stopwaiter/stopwaiter.go
+++ b/util/stopwaiter/stopwaiter.go
@@ -179,13 +179,6 @@ func (s *StopWaiterSafe) LaunchUntrackedThread(foo func()) {
 // CallIteratively calls function iteratively in a thread.
 // input param return value is how long to wait before next invocation
 func (s *StopWaiterSafe) CallIteratively(foo func(context.Context) time.Duration) error {
-	return s.CallIterativelyWithTrigger(foo, nil)
-}
-
-// CallIterativelyWithTrigger calls function iteratively in a thread.
-// The return value of foo is how long to wait before next invocation
-// Anything sent to triggerChan parameter triggers call to happen immediately
-func (s *StopWaiterSafe) CallIterativelyWithTrigger(foo func(context.Context) time.Duration, triggerChan chan interface{}) error {
 	return s.LaunchThread(func(ctx context.Context) {
 		for {
 			interval := foo(ctx)
@@ -198,10 +191,60 @@ func (s *StopWaiterSafe) CallIterativelyWithTrigger(foo func(context.Context) ti
 				timer.Stop()
 				return
 			case <-timer.C:
-			case <-triggerChan:
 			}
 		}
 	})
+}
+
+// CallIterativelyWithTrigger calls function iteratively in a thread.
+// The return value of foo is how long to wait before next invocation
+// Anything sent to triggerChan parameter triggers call to happen immediately
+func (s *StopWaiterSafe) CallIterativelyWithTrigger(foo func(context.Context, bool) time.Duration, triggerChan <-chan interface{}) error {
+	return s.LaunchThread(func(ctx context.Context) {
+		triggered := false
+		for {
+			interval := foo(ctx, triggered)
+			triggered = false
+			if ctx.Err() != nil {
+				return
+			}
+			timer := time.NewTimer(interval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			case <-triggerChan:
+				triggered = true
+			}
+		}
+	})
+}
+
+func (s *StopWaiterSafe) ChanRateLimiter(inChan <-chan interface{}, maxRateCallback func() time.Duration) (<-chan interface{}, error) {
+	outChan := make(chan interface{})
+	err := s.LaunchThread(func(ctx context.Context) {
+		nextAllowedTriggerTime := time.Now()
+		for {
+			select {
+			case <-ctx.Done():
+				close(outChan)
+				return
+			case data := <-inChan:
+				now := time.Now()
+				if now.After(nextAllowedTriggerTime) {
+					outChan <- data
+					nextAllowedTriggerTime = now.Add(maxRateCallback())
+				}
+			}
+		}
+	})
+	if err != nil {
+		close(outChan)
+		return nil, err
+	}
+
+	return outChan, err
 }
 
 // May panic on race conditions instead of returning errors


### PR DESCRIPTION
* Add `ChanRateLimiter` to rate limit the number of times an object can be sent through chan.  This can be used to keep `CallIterativelyWithTrigger` from being hit with denial of service.
* Add extra option so that callback knows if call is normal iterative call or if it was manually triggered