### PR TITLE
Add support for database format versions

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -676,20 +676,20 @@ type ConfigFetcher interface {
 	StopAndWait()
 }
 
-func checkArbDbVersion(arbDb ethdb.Database) error {
+func checkArbDbSchemaVersion(arbDb ethdb.Database) error {
 	var version uint64
-	hasVersion, err := arbDb.Has(dbFormatVersionKey)
+	hasVersion, err := arbDb.Has(dbSchemaVersion)
 	if err != nil {
 		return err
 	}
 	if hasVersion {
-		versionBytes, err := arbDb.Get(dbFormatVersionKey)
+		versionBytes, err := arbDb.Get(dbSchemaVersion)
 		if err != nil {
 			return err
 		}
 		version = binary.BigEndian.Uint64(versionBytes)
 	}
-	for version != currentDbFormatVersion {
+	for version != currentDbSchemaVersion {
 		batch := arbDb.NewBatch()
 		switch version {
 		case ^uint64(0):
@@ -703,7 +703,7 @@ func checkArbDbVersion(arbDb ethdb.Database) error {
 		version++
 		versionBytes := make([]uint8, 8)
 		binary.BigEndian.PutUint64(versionBytes, version)
-		err = batch.Put(dbFormatVersionKey, versionBytes)
+		err = batch.Put(dbSchemaVersion, versionBytes)
 		if err != nil {
 			return err
 		}
@@ -731,7 +731,7 @@ func createNodeImpl(
 	config := configFetcher.Get()
 	var reorgingToBlock *types.Block
 
-	err := checkArbDbVersion(arbDb)
+	err := checkArbDbSchemaVersion(arbDb)
 	if err != nil {
 		return nil, err
 	}

--- a/arbnode/schema.go
+++ b/arbnode/schema.go
@@ -13,4 +13,7 @@ var (
 	messageCountKey        []byte = []byte("_messageCount")        // contains the current message count
 	delayedMessageCountKey []byte = []byte("_delayedMessageCount") // contains the current delayed message count
 	sequencerBatchCountKey []byte = []byte("_sequencerBatchCount") // contains the current sequencer message count
+	dbFormatVersionKey     []byte = []byte("_version")             // contains a uint64 representing the database format version
 )
+
+const currentDbFormatVersion uint64 = 0

--- a/arbnode/schema.go
+++ b/arbnode/schema.go
@@ -13,7 +13,7 @@ var (
 	messageCountKey        []byte = []byte("_messageCount")        // contains the current message count
 	delayedMessageCountKey []byte = []byte("_delayedMessageCount") // contains the current delayed message count
 	sequencerBatchCountKey []byte = []byte("_sequencerBatchCount") // contains the current sequencer message count
-	dbFormatVersionKey     []byte = []byte("_version")             // contains a uint64 representing the database format version
+	dbSchemaVersion        []byte = []byte("_schemaVersion")       // contains a uint64 representing the database schema version
 )
 
-const currentDbFormatVersion uint64 = 0
+const currentDbSchemaVersion uint64 = 0


### PR DESCRIPTION
In particular, databases that have been running on https://github.com/OffchainLabs/nitro/pull/1214 will be incompatible with older versions. To avoid this silently breaking things, this PR adds an explicit version field to the database.