### PR TITLE
Feature-gate llvm

### DIFF
--- a/arbitrator/jit/Cargo.toml
+++ b/arbitrator/jit/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 wasmer = "2.3.0"
 wasmer-compiler-cranelift = "2.3.0"
-wasmer-compiler-llvm = "2.3.0"
+wasmer-compiler-llvm = { version = "2.3.0", optional = true }
 eyre = "0.6.5"
 parking_lot = "0.12.1"
 rand = { version = "0.8.4", default-features = false }
@@ -16,3 +16,6 @@ hex = "0.4.3"
 structopt = "0.3.26"
 sha3 = "0.9.1"
 libc = "0.2.132"
+
+[features]
+llvm = ["dep:wasmer-compiler-llvm"]

--- a/arbitrator/jit/src/machine.rs
+++ b/arbitrator/jit/src/machine.rs
@@ -15,7 +15,6 @@ use wasmer::{
     RuntimeError, Store, Universal, WasmerEnv,
 };
 use wasmer_compiler_cranelift::Cranelift;
-use wasmer_compiler_llvm::LLVM;
 
 use std::{
     collections::BTreeMap,
@@ -44,11 +43,16 @@ pub fn create(opts: &Opts, env: WasmEnvArc) -> (Instance, WasmEnvArc) {
             Universal::new(compiler).engine()
         }
         false => {
-            let mut compiler = LLVM::new();
-            compiler.canonicalize_nans(true);
-            compiler.opt_level(wasmer_compiler_llvm::LLVMOptLevel::Aggressive);
-            compiler.enable_verifier();
-            Universal::new(compiler).engine()
+            #[cfg(not(feature = "llvm"))]
+            panic!("Please rebuild with the \"llvm\" feature for LLVM support");
+            #[cfg(feature = "llvm")]
+            {
+                let mut compiler = wasmer_compiler_llvm::LLVM::new();
+                compiler.canonicalize_nans(true);
+                compiler.opt_level(wasmer_compiler_llvm::LLVMOptLevel::Aggressive);
+                compiler.enable_verifier();
+                Universal::new(compiler).engine()
+            }
         }
     };
 
@@ -183,6 +187,8 @@ pub struct WasmEnv {
     pub sequencer_messages: Inbox,
     /// The delayed inbox's messages
     pub delayed_messages: Inbox,
+    /// The first inbox message number knowably out of bounds
+    pub first_too_far: u64,
     /// The purpose and connections of this process
     pub process: ProcessEnv,
 }

--- a/arbitrator/jit/src/machine.rs
+++ b/arbitrator/jit/src/machine.rs
@@ -187,8 +187,6 @@ pub struct WasmEnv {
     pub sequencer_messages: Inbox,
     /// The delayed inbox's messages
     pub delayed_messages: Inbox,
-    /// The first inbox message number knowably out of bounds
-    pub first_too_far: u64,
     /// The purpose and connections of this process
     pub process: ProcessEnv,
 }


### PR DESCRIPTION
Puts LLVM behind a rust feature to avoid issues in local LLVM configurations when not using it