### PR TITLE
[Instrumentation] Add Pprof Support to Nitro

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -414,9 +414,7 @@ type Config struct {
 	Dangerous              DangerousConfig                `koanf:"dangerous"`
 	Caching                CachingConfig                  `koanf:"caching"`
 	Archive                bool                           `koanf:"archive"`
-	EnablePprof            bool                           `koanf:"pprof"`
-	PprofPort              uint64                         `koanf:"pprof-port"`
-	PprofHost              string                         `koanf:"pprof-host"`
+	Pprof                  PprofConfig                    `koanf:"pprof"`
 	TxLookupLimit          uint64                         `koanf:"tx-lookup-limit"`
 }
 
@@ -474,13 +472,11 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet, feedInputEnable bool, feed
 	SyncMonitorConfigAddOptions(prefix+".sync-monitor", f)
 	DangerousConfigAddOptions(prefix+".dangerous", f)
 	CachingConfigAddOptions(prefix+".caching", f)
+	PProfConfigAddOptions(prefix+".pprof", f)
 	f.Uint64(prefix+".tx-lookup-limit", ConfigDefault.TxLookupLimit, "retain the ability to lookup transactions by hash for the past N blocks (0 = all blocks)")
 
 	archiveMsg := fmt.Sprintf("retain past block state (deprecated, please use %v.caching.archive)", prefix)
 	f.Bool(prefix+".archive", ConfigDefault.Archive, archiveMsg)
-	f.Bool(prefix+".pprof", ConfigDefault.EnablePprof, "enable pprof profiling for Go")
-	f.Uint64(prefix+".pprof-port", ConfigDefault.PprofPort, "port for profiling in Go")
-	f.String(prefix+".pprof-host", ConfigDefault.PprofHost, "host for profiling in Go")
 }
 
 var ConfigDefault = Config{
@@ -498,14 +494,24 @@ var ConfigDefault = Config{
 	SeqCoordinator:         DefaultSeqCoordinatorConfig,
 	DataAvailability:       das.DefaultDataAvailabilityConfig,
 	Wasm:                   DefaultWasmConfig,
+	Pprof:                  DefaultPProfConfig,
 	SyncMonitor:            DefaultSyncMonitorConfig,
 	Dangerous:              DefaultDangerousConfig,
 	Archive:                false,
 	TxLookupLimit:          40_000_000,
 	Caching:                DefaultCachingConfig,
-	EnablePprof:            false,
-	PprofPort:              6060,
-	PprofHost:              "127.0.0.1",
+}
+
+type PprofConfig struct {
+	Enable bool   `koanf:"enable"`
+	Port   uint64 `koanf:"port"`
+	Host   string `koanf:"host"`
+}
+
+var DefaultPProfConfig = PprofConfig{
+	Enable: false,
+	Port:   6060,
+	Host:   "127.0.0.1",
 }
 
 func ConfigDefaultL1Test() *Config {
@@ -652,6 +658,12 @@ var DefaultCachingConfig = CachingConfig{
 	BlockCount:    128,
 	BlockAge:      30 * time.Minute,
 	TrieTimeLimit: time.Hour,
+}
+
+func PProfConfigAddOptions(prefix string, f *flag.FlagSet) {
+	f.Bool(prefix+".enable", ConfigDefault.Pprof.Enable, "enable pprof profiling for Go")
+	f.Uint64(prefix+".port", ConfigDefault.Pprof.Port, "port for profiling in Go")
+	f.String(prefix+".host", ConfigDefault.Pprof.Host, "host for profiling in Go")
 }
 
 type Node struct {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -414,6 +414,9 @@ type Config struct {
 	Dangerous              DangerousConfig                `koanf:"dangerous"`
 	Caching                CachingConfig                  `koanf:"caching"`
 	Archive                bool                           `koanf:"archive"`
+	EnablePprof            bool                           `koanf:"pprof"`
+	PprofPort              uint64                         `koanf:"pprof-port"`
+	PprofHost              string                         `koanf:"pprof-host"`
 	TxLookupLimit          uint64                         `koanf:"tx-lookup-limit"`
 }
 
@@ -475,6 +478,9 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet, feedInputEnable bool, feed
 
 	archiveMsg := fmt.Sprintf("retain past block state (deprecated, please use %v.caching.archive)", prefix)
 	f.Bool(prefix+".archive", ConfigDefault.Archive, archiveMsg)
+	f.Bool(prefix+".pprof", ConfigDefault.EnablePprof, "enable pprof profiling for Go")
+	f.Uint64(prefix+".pprof-port", ConfigDefault.PprofPort, "port for profiling in Go")
+	f.String(prefix+".pprof-host", ConfigDefault.PprofHost, "host for profiling in Go")
 }
 
 var ConfigDefault = Config{
@@ -497,6 +503,9 @@ var ConfigDefault = Config{
 	Archive:                false,
 	TxLookupLimit:          40_000_000,
 	Caching:                DefaultCachingConfig,
+	EnablePprof:            false,
+	PprofPort:              6060,
+	PprofHost:              "127.0.0.1",
 }
 
 func ConfigDefaultL1Test() *Config {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -414,7 +414,6 @@ type Config struct {
 	Dangerous              DangerousConfig                `koanf:"dangerous"`
 	Caching                CachingConfig                  `koanf:"caching"`
 	Archive                bool                           `koanf:"archive"`
-	Pprof                  PprofConfig                    `koanf:"pprof"`
 	TxLookupLimit          uint64                         `koanf:"tx-lookup-limit"`
 }
 
@@ -476,7 +475,6 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet, feedInputEnable bool, feed
 	SyncMonitorConfigAddOptions(prefix+".sync-monitor", f)
 	DangerousConfigAddOptions(prefix+".dangerous", f)
 	CachingConfigAddOptions(prefix+".caching", f)
-	PProfConfigAddOptions(prefix+".pprof", f)
 	f.Uint64(prefix+".tx-lookup-limit", ConfigDefault.TxLookupLimit, "retain the ability to lookup transactions by hash for the past N blocks (0 = all blocks)")
 
 	archiveMsg := fmt.Sprintf("retain past block state (deprecated, please use %v.caching.archive)", prefix)
@@ -498,24 +496,11 @@ var ConfigDefault = Config{
 	SeqCoordinator:         DefaultSeqCoordinatorConfig,
 	DataAvailability:       das.DefaultDataAvailabilityConfig,
 	Wasm:                   DefaultWasmConfig,
-	Pprof:                  DefaultPProfConfig,
 	SyncMonitor:            DefaultSyncMonitorConfig,
 	Dangerous:              DefaultDangerousConfig,
 	Archive:                false,
 	TxLookupLimit:          40_000_000,
 	Caching:                DefaultCachingConfig,
-}
-
-type PprofConfig struct {
-	Enable bool   `koanf:"enable"`
-	Port   uint64 `koanf:"port"`
-	Host   string `koanf:"host"`
-}
-
-var DefaultPProfConfig = PprofConfig{
-	Enable: false,
-	Port:   6060,
-	Host:   "127.0.0.1",
 }
 
 func ConfigDefaultL1Test() *Config {
@@ -662,12 +647,6 @@ var DefaultCachingConfig = CachingConfig{
 	BlockCount:    128,
 	BlockAge:      30 * time.Minute,
 	TrieTimeLimit: time.Hour,
-}
-
-func PProfConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Bool(prefix+".enable", ConfigDefault.Pprof.Enable, "enable pprof profiling for Go")
-	f.Uint64(prefix+".port", ConfigDefault.Pprof.Port, "port for profiling in Go")
-	f.String(prefix+".host", ConfigDefault.Pprof.Host, "host for profiling in Go")
 }
 
 type Node struct {

--- a/cmd/genericconf/server.go
+++ b/cmd/genericconf/server.go
@@ -155,17 +155,20 @@ func GraphQLConfigAddOptions(prefix string, f *flag.FlagSet) {
 type MetricsServerConfig struct {
 	Addr           string        `koanf:"addr"`
 	Port           int           `koanf:"port"`
+	Pprof          bool          `koanf:"pprof"`
 	UpdateInterval time.Duration `koanf:"update-interval"`
 }
 
 var MetricsServerConfigDefault = MetricsServerConfig{
 	Addr:           "127.0.0.1",
 	Port:           6070,
+	Pprof:          false,
 	UpdateInterval: 3 * time.Second,
 }
 
 func MetricsServerAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".addr", MetricsServerConfigDefault.Addr, "metrics server address")
 	f.Int(prefix+".port", MetricsServerConfigDefault.Port, "metrics server port")
+	f.Bool(prefix+".pprof", MetricsServerConfigDefault.Pprof, "enable profiling for Go")
 	f.Duration(prefix+".update-interval", MetricsServerConfigDefault.UpdateInterval, "metrics server update interval")
 }

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -300,6 +300,11 @@ func mainImpl() int {
 		return 1
 	}
 
+	if nodeConfig.MetricsServer.Pprof && !nodeConfig.Metrics {
+		flag.Usage()
+		log.Error("--metrics must be enabled in order to use pprof with the metrics server")
+		return 1
+	}
 	if nodeConfig.Metrics {
 		go metrics.CollectProcessMetrics(nodeConfig.MetricsServer.UpdateInterval)
 

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -821,7 +821,7 @@ func startPprof(address string) {
 	exp.Exp(metrics.DefaultRegistry)
 	log.Info("Starting pprof server", "addr", fmt.Sprintf("http://%s/debug/pprof", address))
 	go func() {
-		if err := http.ListenAndServe(address, nil); err != nil {
+		if err := http.ListenAndServe(address, http.DefaultServeMux); err != nil {
 			log.Error("Failure in running pprof server", "err", err)
 		}
 	}()

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -129,9 +129,8 @@ func main() {
 
 		return
 	}
-	if nodeConfig.Node.EnablePprof {
-		addr := fmt.Sprintf("%s:%d", nodeConfig.Node.PprofHost, nodeConfig.Node.PprofPort)
-		startPProf(addr)
+	if nodeConfig.Node.Pprof.Enable {
+		startPProf(nodeConfig.Node.Pprof)
 	}
 	if nodeConfig.Node.Archive {
 		log.Warn("--node.archive has been deprecated. Please use --node.caching.archive instead.")
@@ -801,10 +800,11 @@ func (f *NodeConfigFetcher) Start(ctx context.Context) {
 func (f *NodeConfigFetcher) StopAndWait() {
 	f.LiveNodeConfig.StopAndWait()
 }
-func startPProf(address string) {
-	log.Info("Starting pprof", "addr", fmt.Sprintf("http://%s/debug/pprof", address))
+func startPProf(cfg arbnode.PprofConfig) {
+	addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+	log.Info("Starting pprof", "addr", fmt.Sprintf("http://%s/debug/pprof", addr))
 	go func() {
-		if err := http.ListenAndServe(address, nil); err != nil {
+		if err := http.ListenAndServe(addr, nil); err != nil {
 			log.Error("Failure in running pprof server", "err", err)
 		}
 	}()

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -819,7 +819,8 @@ func (f *NodeConfigFetcher) Get() *arbnode.Config {
 
 func startPprof(address string) {
 	exp.Exp(metrics.DefaultRegistry)
-	log.Info("Starting pprof server", "addr", fmt.Sprintf("http://%s/debug/pprof", address))
+	log.Info("Starting metrics server with pprof", "addr", fmt.Sprintf("http://%s/debug/metrics", address))
+	log.Info("Pprof endpoint", "addr", fmt.Sprintf("http://%s/debug/pprof", address))
 	go func() {
 		if err := http.ListenAndServe(address, http.DefaultServeMux); err != nil {
 			log.Error("Failure in running pprof server", "err", err)

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -306,7 +306,7 @@ func mainImpl() int {
 		if nodeConfig.MetricsServer.Addr != "" {
 			address := fmt.Sprintf("%v:%v", nodeConfig.MetricsServer.Addr, nodeConfig.MetricsServer.Port)
 			if nodeConfig.MetricsServer.Pprof {
-				startPprof(address, true /* with metrics */)
+				startPprof(address)
 			} else {
 				exp.Setup(address)
 			}
@@ -817,18 +817,8 @@ func (f *NodeConfigFetcher) Get() *arbnode.Config {
 	return &f.LiveNodeConfig.get().Node
 }
 
-func (f *NodeConfigFetcher) Start(ctx context.Context) {
-	f.LiveNodeConfig.Start(ctx)
-}
-
-func (f *NodeConfigFetcher) StopAndWait() {
-	f.LiveNodeConfig.StopAndWait()
-}
-
-func startPprof(address string, withMetrics bool) {
-	if withMetrics {
-		exp.Exp(metrics.DefaultRegistry)
-	}
+func startPprof(address string) {
+	exp.Exp(metrics.DefaultRegistry)
 	log.Info("Starting pprof server", "addr", fmt.Sprintf("http://%s/debug/pprof", address))
 	go func() {
 		if err := http.ListenAndServe(address, nil); err != nil {

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -300,11 +300,6 @@ func mainImpl() int {
 		return 1
 	}
 
-	if nodeConfig.MetricsServer.Pprof && !nodeConfig.Metrics {
-		flag.Usage()
-		log.Error("--metrics must be enabled in order to use pprof with the metrics server")
-		return 1
-	}
 	if nodeConfig.Metrics {
 		go metrics.CollectProcessMetrics(nodeConfig.MetricsServer.UpdateInterval)
 
@@ -316,6 +311,10 @@ func mainImpl() int {
 				exp.Setup(address)
 			}
 		}
+	} else if nodeConfig.MetricsServer.Pprof {
+		flag.Usage()
+		log.Error("--metrics must be enabled in order to use pprof with the metrics server")
+		return 1
 	}
 
 	fatalErrChan := make(chan error, 10)

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -11,7 +11,7 @@ import (
 	"math"
 	"math/big"
 	"net/http"
-	_ "net/http/pprof"
+	_ "net/http/pprof" // #nosec G108
 	"os"
 	"os/signal"
 	"reflect"
@@ -826,6 +826,7 @@ func startPprof(address string) {
 	log.Info("Starting metrics server with pprof", "addr", fmt.Sprintf("http://%s/debug/metrics", address))
 	log.Info("Pprof endpoint", "addr", fmt.Sprintf("http://%s/debug/pprof", address))
 	go func() {
+		// #nosec G114
 		if err := http.ListenAndServe(address, http.DefaultServeMux); err != nil {
 			log.Error("Failure in running pprof server", "err", err)
 		}


### PR DESCRIPTION
Although Nitro seems quite light on resource use, [pprof](https://jvns.ca/blog/2017/09/24/profiling-go-with-pprof/) can be a useful tool in development when new features are introduced that could add new bottlenecks to the software. Flame graphs to understand the heap and CPU profiles can help find important optimization targets.

This PR adds the following flags to the Nitro command
```
--metrics-server.pprof   enable pprof profiling for Go
```

This attaches profiling to the metrics server to not require any additional configuration.

Upon enabling them, one can extract CPU and mem profiles by navigating to http://localhost:6060/debug/pprof or via CURL as follows:
```
curl -X GET  http://localhost:6070/debug/pprof/heap --output heap.pprof
curl -X GET  http://localhost:6070/debug/pprof/profile --output cpu.pprof
```
and then opening these via the pprof tool:

```
go install github.com/google/pprof@latest
pprof -http=localhost:7777 cpu.pprof
```

A sample flame graph extracted from Nitro running in non-sequencer mode shows most activity is geth, as expected

<img width="1599" alt="Screen Shot 2022-10-11 at 1 59 54 PM" src="https://user-images.githubusercontent.com/5572669/195174823-2c60b265-c05b-49e4-abe5-c6ce0e34486f.png">
