### PR TITLE
Close connection before calling stop

### DIFF
--- a/wsbroadcastserver/clientconnection.go
+++ b/wsbroadcastserver/clientconnection.go
@@ -70,8 +70,14 @@ func (cc *ClientConnection) Start(parentCtx context.Context) {
 }
 
 func (cc *ClientConnection) StopAndWait() {
-	close(cc.out)
-	cc.StopWaiter.StopAndWait()
+	// Ignore errors from conn.Close since we are just shutting down
+	_ = cc.conn.Close()
+	if !cc.Started() {
+		// If client connection never started, need to close channel
+		close(cc.out)
+	} else {
+		cc.StopWaiter.StopAndWait()
+	}
 }
 
 func (cc *ClientConnection) RequestedSeqNum() arbutil.MessageIndex {

--- a/wsbroadcastserver/clientconnection.go
+++ b/wsbroadcastserver/clientconnection.go
@@ -62,14 +62,7 @@ func (cc *ClientConnection) Start(parentCtx context.Context) {
 				if err != nil {
 					logWarn(err, "error writing data to client")
 					cc.clientManager.Remove(cc)
-					for {
-						// Consume and ignore channel data until client properly stopped to prevent deadlock
-						select {
-						case <-ctx.Done():
-							return
-						case <-cc.out:
-						}
-					}
+					return
 				}
 			}
 		}
@@ -77,12 +70,8 @@ func (cc *ClientConnection) Start(parentCtx context.Context) {
 }
 
 func (cc *ClientConnection) StopAndWait() {
-	if !cc.Started() {
-		// If client connection never started, need to close channel
-		close(cc.out)
-	} else {
-		cc.StopWaiter.StopAndWait()
-	}
+	close(cc.out)
+	cc.StopWaiter.StopAndWait()
 }
 
 func (cc *ClientConnection) RequestedSeqNum() arbutil.MessageIndex {


### PR DESCRIPTION
To prevent deadlocks, close client connection before calling `StopWaiter.StopAndWait()`, and don't flush channel because sender already detects channel full. 