### PR TITLE
Generally saturate and log a warning instead of erroring on overflow

### DIFF
--- a/arbos/l2pricing/l2pricing.go
+++ b/arbos/l2pricing/l2pricing.go
@@ -13,8 +13,8 @@ type L2PricingState struct {
 	storage             *storage.Storage
 	speedLimitPerSecond storage.StorageBackedUint64
 	perBlockGasLimit    storage.StorageBackedUint64
-	baseFeeWei          storage.StorageBackedBigInt
-	minBaseFeeWei       storage.StorageBackedBigInt
+	baseFeeWei          storage.StorageBackedBigUint
+	minBaseFeeWei       storage.StorageBackedBigUint
 	gasBacklog          storage.StorageBackedUint64
 	pricingInertia      storage.StorageBackedUint64
 	backlogTolerance    storage.StorageBackedUint64
@@ -47,8 +47,8 @@ func OpenL2PricingState(sto *storage.Storage) *L2PricingState {
 		sto,
 		sto.OpenStorageBackedUint64(speedLimitPerSecondOffset),
 		sto.OpenStorageBackedUint64(perBlockGasLimitOffset),
-		sto.OpenStorageBackedBigInt(baseFeeWeiOffset),
-		sto.OpenStorageBackedBigInt(minBaseFeeWeiOffset),
+		sto.OpenStorageBackedBigUint(baseFeeWeiOffset),
+		sto.OpenStorageBackedBigUint(minBaseFeeWeiOffset),
 		sto.OpenStorageBackedUint64(gasBacklogOffset),
 		sto.OpenStorageBackedUint64(pricingInertiaOffset),
 		sto.OpenStorageBackedUint64(backlogToleranceOffset),
@@ -60,7 +60,7 @@ func (ps *L2PricingState) BaseFeeWei() (*big.Int, error) {
 }
 
 func (ps *L2PricingState) SetBaseFeeWei(val *big.Int) error {
-	return ps.baseFeeWei.Set(val)
+	return ps.baseFeeWei.SetSaturatingWithWarning(val, "L2 base fee")
 }
 
 func (ps *L2PricingState) MinBaseFeeWei() (*big.Int, error) {
@@ -71,7 +71,7 @@ func (ps *L2PricingState) SetMinBaseFeeWei(val *big.Int) error {
 	// This modifies the "minimum basefee" parameter, but doesn't modify the current basefee.
 	// If this increases the minimum basefee, then the basefee might be below the minimum for a little while.
 	// If so, the basefee will increase by up to a factor of two per block, until it reaches the minimum.
-	return ps.minBaseFeeWei.Set(val)
+	return ps.minBaseFeeWei.SetChecked(val)
 }
 
 func (ps *L2PricingState) SpeedLimitPerSecond() (uint64, error) {

--- a/arbos/retryables/retryable.go
+++ b/arbos/retryables/retryable.go
@@ -47,7 +47,7 @@ type Retryable struct {
 	numTries           storage.StorageBackedUint64
 	from               storage.StorageBackedAddress
 	to                 storage.StorageBackedAddressOrNil
-	callvalue          storage.StorageBackedBigInt
+	callvalue          storage.StorageBackedBigUint
 	beneficiary        storage.StorageBackedAddress
 	calldata           storage.StorageBackedBytes
 	timeout            storage.StorageBackedUint64
@@ -80,7 +80,7 @@ func (rs *RetryableState) CreateRetryable(
 		sto.OpenStorageBackedUint64(numTriesOffset),
 		sto.OpenStorageBackedAddress(fromOffset),
 		sto.OpenStorageBackedAddressOrNil(toOffset),
-		sto.OpenStorageBackedBigInt(callvalueOffset),
+		sto.OpenStorageBackedBigUint(callvalueOffset),
 		sto.OpenStorageBackedAddress(beneficiaryOffset),
 		sto.OpenStorageBackedBytes(calldataKey),
 		sto.OpenStorageBackedUint64(timeoutOffset),
@@ -89,7 +89,7 @@ func (rs *RetryableState) CreateRetryable(
 	_ = ret.numTries.Set(0)
 	_ = ret.from.Set(from)
 	_ = ret.to.Set(to)
-	_ = ret.callvalue.Set(callvalue)
+	_ = ret.callvalue.SetChecked(callvalue)
 	_ = ret.beneficiary.Set(beneficiary)
 	_ = ret.calldata.Set(calldata)
 	_ = ret.timeout.Set(timeout)
@@ -115,7 +115,7 @@ func (rs *RetryableState) OpenRetryable(id common.Hash, currentTimestamp uint64)
 		numTries:           sto.OpenStorageBackedUint64(numTriesOffset),
 		from:               sto.OpenStorageBackedAddress(fromOffset),
 		to:                 sto.OpenStorageBackedAddressOrNil(toOffset),
-		callvalue:          sto.OpenStorageBackedBigInt(callvalueOffset),
+		callvalue:          sto.OpenStorageBackedBigUint(callvalueOffset),
 		beneficiary:        sto.OpenStorageBackedAddress(beneficiaryOffset),
 		calldata:           sto.OpenStorageBackedBytes(calldataKey),
 		timeout:            timeoutStorage,

--- a/arbos/storage/storage_test.go
+++ b/arbos/storage/storage_test.go
@@ -39,7 +39,7 @@ func TestStorageBackedBigInt(t *testing.T) {
 		maxUint256,
 		minUint256,
 	} {
-		err := sbbi.Set(in)
+		err := sbbi.SetChecked(in)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -87,7 +87,7 @@ func TestStorageBackedBigInt(t *testing.T) {
 		new(big.Int).Exp(minUint256, big.NewInt(1025), nil),
 	} {
 		requirePanic(t, in, func() {
-			_ = sbbi.Set(in)
+			_ = sbbi.SetChecked(in)
 		})
 	}
 }


### PR DESCRIPTION
None of this should be reachable in practice, e.g. it'd be impossible to get a surplus of 2^256 wei, but this is useful for fuzzing campaigns where extreme values can enter the system. The places where we still use the old method are either setting an initialization value, or being directly called from an ArbOwner method where the solidity ABI guarantees we have an in-bounds value (and any error would be returned to the caller).