### PR TITLE
Free queue elements as soon as they are popped

### DIFF
--- a/util/containers/queue.go
+++ b/util/containers/queue.go
@@ -31,6 +31,7 @@ func (q *Queue[T]) Pop() T {
 		return empty
 	}
 	item := q.slice[0]
+	q.slice[0] = empty
 	q.slice = q.slice[1:]
 	q.shrink()
 	return item


### PR DESCRIPTION
This is a small optimization that potentially frees anything pointed to by a popped slice element earlier than the shrink.