### PR TITLE
Fix Shadowed Variables

### DIFF
--- a/arbcompress/compress_common.go
+++ b/arbcompress/compress_common.go
@@ -7,8 +7,8 @@ const LEVEL_FAST = 0
 const LEVEL_WELL = 11
 const WINDOW_SIZE = 22 // BROTLI_DEFAULT_WINDOW
 
-func compressedBufferSizeFor(len int) int {
-	return len + (len>>10)*8 + 64 // actual limit is: len + (len >> 14) * 4 + 6
+func compressedBufferSizeFor(length int) int {
+	return length + (length>>10)*8 + 64 // actual limit is: length + (length >> 14) * 4 + 6
 }
 
 func CompressFast(input []byte) ([]byte, error) {

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -335,8 +335,8 @@ func mainImpl() int {
 		log.Error("failed to create node", "err", err)
 		return 1
 	}
-	liveNodeConfig.setOnReloadHook(func(old *NodeConfig, new *NodeConfig) error {
-		return currentNode.OnConfigReload(&old.Node, &new.Node)
+	liveNodeConfig.setOnReloadHook(func(oldCfg *NodeConfig, newCfg *NodeConfig) error {
+		return currentNode.OnConfigReload(&oldCfg.Node, &newCfg.Node)
 	})
 
 	if nodeConfig.Node.Dangerous.NoL1Listener && nodeConfig.Init.DevInit {


### PR DESCRIPTION
The naming of some of the added variables collide with internal golang keywords. To prevent the internal keywords
from being overshadowed, the variable names are changed so that these do not collide anymore. 