### PR TITLE
Add missing timer.Stop() to util/stopwaiter

### DIFF
--- a/util/stopwaiter/stopwaiter.go
+++ b/util/stopwaiter/stopwaiter.go
@@ -117,11 +117,11 @@ func getAllStackTraces() string {
 
 func (s *StopWaiterSafe) stopAndWaitImpl(warningTimeout time.Duration) error {
 	s.StopOnly()
-	timer := time.NewTimer(warningTimeout)
 	waitChan, err := s.GetWaitChannel()
 	if err != nil {
 		return err
 	}
+	timer := time.NewTimer(warningTimeout)
 
 	select {
 	case <-timer.C:
@@ -129,6 +129,7 @@ func (s *StopWaiterSafe) stopAndWaitImpl(warningTimeout time.Duration) error {
 		log.Warn("taking too long to stop", "name", s.name, "delay[s]", warningTimeout.Seconds())
 		log.Warn(traces)
 	case <-waitChan:
+		timer.Stop()
 		return nil
 	}
 	<-waitChan


### PR DESCRIPTION
When reviewing the code, I've noticed that `timer.Stop()` call is missing in `stopAndWaitImpl()`. Although goroutine firing a timer will go away after the timer fires, usually the `time.NewTimer()` call has the corresponding instruction of `timer.Stop()` (either as deferred or inline call). If it is ok for goroutine to go away after the timer fires, the `time.After(delay)` can be used.

I've also moved call to `time.NewTimer()`, so that hanging goroutine is not created if `s.GetWaitChannel()` returns an error, and function is returned.

I've also checked to make sure that all other usages of `time.NewTimer()` and `time.NewTicker()` do indeed stop timers once they are not needed -- all is great in the rest of the codebase!