### PR TITLE
Cleanup: non-capitalized error strings

### DIFF
--- a/arbnode/delayed_sequencer.go
+++ b/arbnode/delayed_sequencer.go
@@ -109,7 +109,7 @@ func (d *DelayedSequencer) update(ctx context.Context, lastBlockHeader *types.He
 			header, err = d.l1Reader.LatestSafeHeader()
 		}
 		if err != nil {
-			return fmt.Errorf("Failed to get latest header: %w", err)
+			return fmt.Errorf("failed to get latest header: %w", err)
 		}
 		finalized = header.Number
 	}

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -417,14 +417,14 @@ func ProduceBlockAdvanced(
 	block := types.NewBlock(header, complete, nil, receipts, trie.NewStackTrie(nil))
 
 	if len(block.Transactions()) != len(receipts) {
-		return nil, nil, fmt.Errorf("Block has %d txes but %d receipts", len(block.Transactions()), len(receipts))
+		return nil, nil, fmt.Errorf("block has %d txes but %d receipts", len(block.Transactions()), len(receipts))
 	}
 
 	balanceDelta := statedb.GetUnexpectedBalanceDelta()
 	if !arbmath.BigEquals(balanceDelta, expectedBalanceDelta) {
 		// Fail if funds have been minted or debug mode is enabled (i.e. this is a test)
 		if balanceDelta.Cmp(expectedBalanceDelta) > 0 || chainConfig.DebugMode() {
-			return nil, nil, fmt.Errorf("Unexpected total balance delta %v (expected %v)", balanceDelta, expectedBalanceDelta)
+			return nil, nil, fmt.Errorf("unexpected total balance delta %v (expected %v)", balanceDelta, expectedBalanceDelta)
 		} else {
 			// This is a real chain and funds were burnt, not minted, so only log an error and don't panic
 			log.Error("Unexpected total balance delta", "delta", balanceDelta, "expected", expectedBalanceDelta)

--- a/arbos/util/transfer.go
+++ b/arbos/util/transfer.go
@@ -43,7 +43,7 @@ func TransferBalance(
 		if evm.Depth() != 0 && scenario != TracingDuringEVM {
 			// A non-zero depth implies this transfer is occuring inside EVM execution
 			log.Error("Tracing scenario mismatch", "scenario", scenario, "depth", evm.Depth())
-			return errors.New("Tracing scenario mismatch")
+			return errors.New("tracing scenario mismatch")
 		}
 
 		if scenario != TracingDuringEVM {

--- a/arbos/util/util.go
+++ b/arbos/util/util.go
@@ -78,7 +78,7 @@ func init() {
 		}
 		unpack := func(data []byte) (map[string]interface{}, error) {
 			if len(data) < 4 {
-				return nil, errors.New("Data not long enough")
+				return nil, errors.New("data not long enough")
 			}
 			args := make(map[string]interface{})
 			return args, method.Inputs.UnpackIntoMap(args, data[4:])

--- a/arbstate/das_reader.go
+++ b/arbstate/das_reader.go
@@ -25,7 +25,7 @@ type DataAvailabilityReader interface {
 	ExpirationPolicy(ctx context.Context) (ExpirationPolicy, error)
 }
 
-var ErrHashMismatch = errors.New("Result does not match expected hash")
+var ErrHashMismatch = errors.New("result does not match expected hash")
 
 // DASMessageHeaderFlag indicates that this data is a certificate for the data availability service,
 // which will retrieve the full batch data.
@@ -78,7 +78,7 @@ func DeserializeDASCertFrom(rd io.Reader) (c *DataAvailabilityCertificate, err e
 		return nil, err
 	}
 	if !IsDASMessageHeaderByte(header) {
-		return nil, errors.New("Tried to deserialize a message that doesn't have the DAS header.")
+		return nil, errors.New("tried to deserialize a message that doesn't have the DAS header")
 	}
 
 	_, err = io.ReadFull(r, c.KeysetHash[:])

--- a/cmd/daserver/daserver.go
+++ b/cmd/daserver/daserver.go
@@ -130,7 +130,7 @@ func startup() error {
 		confighelpers.PrintErrorAndExit(err, printSampleUsage)
 	}
 	if !(serverConfig.EnableRPC || serverConfig.EnableREST) {
-		confighelpers.PrintErrorAndExit(errors.New("Please specify at least one of --enable-rest or --enable-rpc"), printSampleUsage)
+		confighelpers.PrintErrorAndExit(errors.New("please specify at least one of --enable-rest or --enable-rpc"), printSampleUsage)
 	}
 
 	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))

--- a/cmd/replay/db.go
+++ b/cmd/replay/db.go
@@ -20,7 +20,7 @@ func (db PreimageDb) Has(key []byte) (bool, error) {
 	if len(key) != 32 {
 		return false, nil
 	}
-	return false, errors.New("Preimage DB doesn't support Has")
+	return false, errors.New("preimage DB doesn't support Has")
 }
 
 func (db PreimageDb) Get(key []byte) ([]byte, error) {
@@ -38,11 +38,11 @@ func (db PreimageDb) Get(key []byte) ([]byte, error) {
 }
 
 func (db PreimageDb) Put(key []byte, value []byte) error {
-	return errors.New("Preimage DB doesn't support Put")
+	return errors.New("preimage DB doesn't support Put")
 }
 
 func (db PreimageDb) Delete(key []byte) error {
-	return errors.New("Preimage DB doesn't support Delete")
+	return errors.New("preimage DB doesn't support Delete")
 }
 
 func (db PreimageDb) NewBatch() ethdb.Batch {
@@ -58,7 +58,7 @@ func (db PreimageDb) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
 }
 
 func (db PreimageDb) Stat(property string) (string, error) {
-	return "", errors.New("Preimage DB doesn't support Stat")
+	return "", errors.New("preimage DB doesn't support Stat")
 }
 
 func (db PreimageDb) Compact(start []byte, limit []byte) error {
@@ -102,7 +102,7 @@ func (i ErrorIterator) Next() bool {
 }
 
 func (i ErrorIterator) Error() error {
-	return errors.New("Preimage DB doesn't support iterators")
+	return errors.New("preimage DB doesn't support iterators")
 }
 
 func (i ErrorIterator) Key() []byte {

--- a/das/aggregator.go
+++ b/das/aggregator.go
@@ -74,7 +74,7 @@ func (this *ServiceDetails) String() string {
 
 func NewServiceDetails(service DataAvailabilityServiceWriter, pubKey blsSignatures.PublicKey, signersMask uint64, metricName string) (*ServiceDetails, error) {
 	if bits.OnesCount64(signersMask) != 1 {
-		return nil, fmt.Errorf("Tried to configure backend DAS %v with invalid signersMask %X", service, signersMask)
+		return nil, fmt.Errorf("tried to configure backend DAS %v with invalid signersMask %X", service, signersMask)
 	}
 	return &ServiceDetails{
 		service:     service,
@@ -124,13 +124,13 @@ func NewAggregatorWithSeqInboxCaller(
 	pubKeys := []blsSignatures.PublicKey{}
 	for _, d := range services {
 		if bits.OnesCount64(d.signersMask) != 1 {
-			return nil, fmt.Errorf("Tried to configure backend DAS %v with invalid signersMask %X", d.service, d.signersMask)
+			return nil, fmt.Errorf("tried to configure backend DAS %v with invalid signersMask %X", d.service, d.signersMask)
 		}
 		aggSignersMask |= d.signersMask
 		pubKeys = append(pubKeys, d.pubKey)
 	}
 	if bits.OnesCount64(aggSignersMask) != len(services) {
-		return nil, errors.New("At least two signers share a mask")
+		return nil, errors.New("at least two signers share a mask")
 	}
 
 	keyset := &arbstate.DataAvailabilityKeyset{
@@ -246,7 +246,7 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64, 
 			if !verified {
 				incFailureMetric()
 				metrics.GetOrRegisterCounter(metricWithServiceName+"/error/bad_response/total", nil).Inc(1)
-				responses <- storeResponse{d, nil, errors.New("Signature verification failed.")}
+				responses <- storeResponse{d, nil, errors.New("signature verification failed")}
 				return
 			}
 
@@ -255,13 +255,13 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64, 
 			if cert.DataHash != expectedHash {
 				incFailureMetric()
 				metrics.GetOrRegisterCounter(metricWithServiceName+"/error/bad_response/total", nil).Inc(1)
-				responses <- storeResponse{d, nil, errors.New("Hash verification failed.")}
+				responses <- storeResponse{d, nil, errors.New("hash verification failed")}
 				return
 			}
 			if cert.Timeout != timeout {
 				incFailureMetric()
 				metrics.GetOrRegisterCounter(metricWithServiceName+"/error/bad_response/total", nil).Inc(1)
-				responses <- storeResponse{d, nil, fmt.Errorf("Timeout was %d, expected %d", cert.Timeout, timeout)}
+				responses <- storeResponse{d, nil, fmt.Errorf("timeout was %d, expected %d", cert.Timeout, timeout)}
 				return
 			}
 
@@ -320,7 +320,7 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64, 
 					returned = true
 				} else if storeFailures > a.maxAllowedServiceStoreFailures {
 					cd := certDetails{}
-					cd.err = fmt.Errorf("Aggregator failed to store message to at least %d out of %d DASes (assuming %d are honest)", a.requiredServicesForStore, len(a.services), a.config.AssumedHonest)
+					cd.err = fmt.Errorf("aggregator failed to store message to at least %d out of %d DASes (assuming %d are honest)", a.requiredServicesForStore, len(a.services), a.config.AssumedHonest)
 					certDetailsChan <- cd
 					returned = true
 				}
@@ -349,7 +349,7 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64, 
 		return nil, err
 	}
 	if !verified {
-		return nil, errors.New("Failed aggregate signature check")
+		return nil, errors.New("failed aggregate signature check")
 	}
 	return &aggCert, nil
 }

--- a/das/archiving_storage_service.go
+++ b/das/archiving_storage_service.go
@@ -16,7 +16,7 @@ import (
 	"github.com/offchainlabs/nitro/util/pretty"
 )
 
-var ErrArchiveTimeout = errors.New("Archiver timed out")
+var ErrArchiveTimeout = errors.New("archiver timed out")
 
 type ArchivingStorageService struct {
 	inner                  StorageService

--- a/das/factory.go
+++ b/das/factory.go
@@ -74,15 +74,15 @@ func CreateBatchPosterDAS(
 	}
 
 	if !config.AggregatorConfig.Enable || !config.RestfulClientAggregatorConfig.Enable {
-		return nil, nil, nil, errors.New("--node.data-availabilty.rpc-aggregator.enable and rest-aggregator.enable must be set when running a Batch Poster in AnyTrust mode.")
+		return nil, nil, nil, errors.New("--node.data-availabilty.rpc-aggregator.enable and rest-aggregator.enable must be set when running a Batch Poster in AnyTrust mode")
 	}
 
 	if config.LocalDBStorageConfig.Enable || config.LocalFileStorageConfig.Enable || config.S3StorageServiceConfig.Enable {
-		return nil, nil, nil, errors.New("--node.data-availability.local-db-storage.enable, local-file-storage.enable, s3-storage.enable may not be set when running a Batch Poster in AnyTrust mode.")
+		return nil, nil, nil, errors.New("--node.data-availability.local-db-storage.enable, local-file-storage.enable, s3-storage.enable may not be set when running a Batch Poster in AnyTrust mode")
 	}
 
 	if config.KeyConfig.KeyDir != "" || config.KeyConfig.PrivKey != "" {
-		return nil, nil, nil, errors.New("--node.data-availability.key.key-dir, priv-key may not be set when running a Batch Poster in AnyTrust mode.")
+		return nil, nil, nil, errors.New("--node.data-availability.key.key-dir, priv-key may not be set when running a Batch Poster in AnyTrust mode")
 	}
 
 	var daWriter DataAvailabilityServiceWriter

--- a/das/local_file_storage_service.go
+++ b/das/local_file_storage_service.go
@@ -41,7 +41,7 @@ type LocalFileStorageService struct {
 
 func NewLocalFileStorageService(dataDir string) (StorageService, error) {
 	if unix.Access(dataDir, unix.W_OK|unix.R_OK) != nil {
-		return nil, fmt.Errorf("Couldn't start LocalFileStorageService, directory '%s' must be readable and writeable", dataDir)
+		return nil, fmt.Errorf("couldn't start LocalFileStorageService, directory '%s' must be readable and writeable", dataDir)
 	}
 	return &LocalFileStorageService{dataDir: dataDir}, nil
 }

--- a/das/reader_aggregator_strategies.go
+++ b/das/reader_aggregator_strategies.go
@@ -13,7 +13,7 @@ import (
 	"github.com/offchainlabs/nitro/arbstate"
 )
 
-var ErrNoReadersResponded = errors.New("No DAS readers responded successfully.")
+var ErrNoReadersResponded = errors.New("no DAS readers responded successfully")
 
 type aggregatorStrategy interface {
 	newInstance() aggregatorStrategyInstance

--- a/das/rest_server_list.go
+++ b/das/rest_server_list.go
@@ -62,7 +62,7 @@ func restfulServerURLsFromList(
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Recieved error response (%d) fetching online-url-list at %s", resp.StatusCode, listUrl)
+		return nil, fmt.Errorf("recieved error response (%d) fetching online-url-list at %s", resp.StatusCode, listUrl)
 	}
 	scanner := bufio.NewScanner(resp.Body)
 	scanner.Split(bufio.ScanWords)

--- a/das/restful_client.go
+++ b/das/restful_client.go
@@ -31,7 +31,7 @@ func NewRestfulDasClient(protocol string, host string, port int) *RestfulDasClie
 
 func NewRestfulDasClientFromURL(url string) (*RestfulDasClient, error) {
 	if !(strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://")) {
-		return nil, fmt.Errorf("Protocol prefix 'http://' or 'https://' must be specified for RestfulDasClient; got '%s'", url)
+		return nil, fmt.Errorf("protocol prefix 'http://' or 'https://' must be specified for RestfulDasClient; got '%s'", url)
 
 	}
 	return &RestfulDasClient{

--- a/das/simple_das_reader_aggregator.go
+++ b/das/simple_das_reader_aggregator.go
@@ -97,7 +97,7 @@ func NewRestfulClientAggregator(ctx context.Context, config *RestfulClientAggreg
 		}
 	}
 	if len(combinedUrls) == 0 {
-		return nil, errors.New("No URLs were specified with either of rest-aggregator.urls or rest-aggregator.online-url-list")
+		return nil, errors.New("no URLs were specified with either of rest-aggregator.urls or rest-aggregator.online-url-list")
 	}
 
 	urls := make([]string, 0, len(combinedUrls))
@@ -126,7 +126,7 @@ func NewRestfulClientAggregator(ctx context.Context, config *RestfulClientAggreg
 	case "testing-sequential":
 		a.strategy = &testingSequentialStrategy{}
 	default:
-		return nil, fmt.Errorf("Unknown RestfulClientAggregator strategy '%s', use --help to see available strategies.", config.Strategy)
+		return nil, fmt.Errorf("unknown RestfulClientAggregator strategy '%s', use --help to see available strategies", config.Strategy)
 	}
 	a.strategy.update(a.readers, a.stats)
 	return &a, nil
@@ -239,7 +239,7 @@ func (a *SimpleDASReaderAggregator) GetByHash(ctx context.Context, hash common.H
 		}
 	}
 
-	return nil, fmt.Errorf("Data wasn't able to be retrieved from any DAS Reader: %v", errorCollection)
+	return nil, fmt.Errorf("data wasn't able to be retrieved from any DAS Reader: %v", errorCollection)
 }
 
 func (a *SimpleDASReaderAggregator) tryGetByHash(

--- a/das/storage_service.go
+++ b/das/storage_service.go
@@ -14,7 +14,7 @@ import (
 	"github.com/offchainlabs/nitro/arbstate"
 )
 
-var ErrNotFound = errors.New("Not found")
+var ErrNotFound = errors.New("not found")
 
 type StorageService interface {
 	arbstate.DataAvailabilityReader

--- a/precompiles/ArbAggregator.go
+++ b/precompiles/ArbAggregator.go
@@ -83,7 +83,7 @@ func (con ArbAggregator) SetFeeCollector(c ctx, evm mech, batchPoster addr, newF
 			return err
 		}
 		if !isOwner {
-			return errors.New("Only a batch poster (or its fee collector / chain owner) may change its fee collector")
+			return errors.New("only a batch poster (or its fee collector / chain owner) may change its fee collector")
 		}
 	}
 	return posterInfo.SetPayTo(newFeeCollector)

--- a/precompiles/ArbSys.go
+++ b/precompiles/ArbSys.go
@@ -28,7 +28,7 @@ type ArbSys struct {
 	L2ToL1TransactionGasCost func(addr, addr, huge, huge, huge, huge, huge, huge, huge, []byte) (uint64, error)
 }
 
-var InvalidBlockNum = errors.New("Invalid block number")
+var InvalidBlockNum = errors.New("invalid block number")
 
 // ArbBlockNumber gets the current L2 block number
 func (con *ArbSys) ArbBlockNumber(c ctx, evm mech) (huge, error) {

--- a/precompiles/ArbosTest.go
+++ b/precompiles/ArbosTest.go
@@ -15,7 +15,7 @@ type ArbosTest struct {
 // BurnArbGas unproductively burns the amount of L2 ArbGas
 func (con ArbosTest) BurnArbGas(c ctx, gasAmount huge) error {
 	if !gasAmount.IsUint64() {
-		return errors.New("Not a uint64")
+		return errors.New("not a uint64")
 	}
 	//nolint:errcheck
 	c.Burn(gasAmount.Uint64()) // burn the amount, even if it's more than the user has

--- a/precompiles/wrapper.go
+++ b/precompiles/wrapper.go
@@ -43,7 +43,7 @@ func (wrapper *DebugPrecompile) Call(
 		return con.Call(input, precompileAddress, actingAsAddress, caller, value, readOnly, gasSupplied, evm)
 	} else {
 		// take all gas
-		return nil, 0, errors.New("Debug precompiles are disabled")
+		return nil, 0, errors.New("debug precompiles are disabled")
 	}
 }
 

--- a/validator/jit_machine.go
+++ b/validator/jit_machine.go
@@ -62,7 +62,7 @@ func createJitMachine(config NitroMachineConfig, moduleRoot common.Hash, fatalEr
 	process.Stderr = os.Stderr
 	go func() {
 		if err := process.Run(); err != nil {
-			fatalErrChan <- fmt.Errorf("Lost jit block validator process: %w", err)
+			fatalErrChan <- fmt.Errorf("lost jit block validator process: %w", err)
 		}
 	}()
 

--- a/validator/rollup_watcher.go
+++ b/validator/rollup_watcher.go
@@ -150,7 +150,7 @@ func (r *RollupWatcher) LookupNodeChildren(ctx context.Context, nodeNum uint64, 
 		return nil, nil
 	}
 	if node.NodeHash != nodeHash {
-		return nil, fmt.Errorf("Got unexpected node hash %v looking for node number %v with expected hash %v (reorg?)", node.NodeHash, nodeNum, nodeHash)
+		return nil, fmt.Errorf("got unexpected node hash %v looking for node number %v with expected hash %v (reorg?)", node.NodeHash, nodeNum, nodeHash)
 	}
 	latestChild, err := r.RollupUserLogic.GetNode(r.getCallOpts(ctx), node.LatestChildNumber)
 	if err != nil {


### PR DESCRIPTION
Per [Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#error-strings) error strings should not be capitalized (unless beginning with acronyms or proper nouns) -- this helps concatenating several errors (using ':') w/o losing the readability. This PR updates the error strings.