### PR TITLE
Bump the database schema version

### DIFF
--- a/arbnode/schema.go
+++ b/arbnode/schema.go
@@ -17,4 +17,4 @@ var (
 	dbSchemaVersion        []byte = []byte("_schemaVersion")       // contains a uint64 representing the database schema version
 )
 
-const currentDbSchemaVersion uint64 = 0
+const currentDbSchemaVersion uint64 = 1


### PR DESCRIPTION
This follows https://github.com/OffchainLabs/nitro/pull/1214 which changed the new database format but where I forgot to bump the database schema version