### PR TITLE
Track l1 gas receipts

### DIFF
--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -229,7 +229,7 @@ func InitializeArbosState(stateDB vm.StateDB, burner burn.Burner, chainConfig *p
 		return nil, err
 	}
 	if desiredArbosVersion > 1 {
-		err = aState.UpgradeArbosVersion(desiredArbosVersion, true)
+		err = aState.UpgradeArbosVersion(desiredArbosVersion, true, stateDB)
 		if err != nil {
 			return nil, err
 		}
@@ -237,19 +237,19 @@ func InitializeArbosState(stateDB vm.StateDB, burner burn.Burner, chainConfig *p
 	return aState, nil
 }
 
-func (state *ArbosState) UpgradeArbosVersionIfNecessary(currentTimestamp uint64) error {
+func (state *ArbosState) UpgradeArbosVersionIfNecessary(currentTimestamp uint64, stateDB vm.StateDB) error {
 	upgradeTo, err := state.upgradeVersion.Get()
 	state.Restrict(err)
 	flagday, _ := state.upgradeTimestamp.Get()
 	if state.arbosVersion < upgradeTo && currentTimestamp >= flagday {
-		return state.UpgradeArbosVersion(upgradeTo, false)
+		return state.UpgradeArbosVersion(upgradeTo, false, stateDB)
 	}
 	return nil
 }
 
 var ErrFatalNodeOutOfDate error = errors.New("please upgrade to latest version of node software")
 
-func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool) error {
+func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool, stateDB vm.StateDB) error {
 	for state.arbosVersion < upgradeTo {
 		ensure := func(err error) {
 			if err != nil {
@@ -278,7 +278,9 @@ func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool) e
 		case 7:
 			// no state changes needed
 		case 8:
-			// no state changes needed
+		// no state changes needed
+		case 9:
+			ensure(state.l1PricingState.SetL1FeesAvailable(stateDB.GetBalance(l1pricing.L1PricerFundsPoolAddress)))
 		default:
 			return fmt.Errorf("unrecognized ArbOS version %v, %w", state.arbosVersion, ErrFatalNodeOutOfDate)
 		}

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -278,7 +278,7 @@ func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool, s
 		case 7:
 			// no state changes needed
 		case 8:
-		// no state changes needed
+			// no state changes needed
 		case 9:
 			ensure(state.l1PricingState.SetL1FeesAvailable(stateDB.GetBalance(l1pricing.L1PricerFundsPoolAddress)))
 		default:

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -88,7 +88,7 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 
 		state.L2PricingState().UpdatePricingModel(l2BaseFee, timePassed, false)
 
-		return state.UpgradeArbosVersionIfNecessary(currentTime)
+		return state.UpgradeArbosVersionIfNecessary(currentTime, evm.StateDB)
 	case InternalTxBatchPostingReportMethodID:
 		inputs, err := util.UnpackInternalTxDataBatchPostingReport(tx.Data)
 		if err != nil {

--- a/arbos/l1pricing/l1PricingOldVersions.go
+++ b/arbos/l1pricing/l1PricingOldVersions.go
@@ -1,0 +1,393 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package l1pricing
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/offchainlabs/nitro/arbos/util"
+	am "github.com/offchainlabs/nitro/util/arbmath"
+	"math"
+	"math/big"
+)
+
+func (ps *L1PricingState) _preversion10_UpdateForBatchPosterSpending(
+	statedb vm.StateDB,
+	evm *vm.EVM,
+	arbosVersion uint64,
+	updateTime, currentTime uint64,
+	batchPoster common.Address,
+	weiSpent *big.Int,
+	l1Basefee *big.Int,
+	scenario util.TracingScenario,
+) error {
+	if arbosVersion < 2 {
+		return ps._preVersion2_UpdateForBatchPosterSpending(statedb, evm, updateTime, currentTime, batchPoster, weiSpent, scenario)
+	}
+
+	batchPosterTable := ps.BatchPosterTable()
+	posterState, err := batchPosterTable.OpenPoster(batchPoster, true)
+	if err != nil {
+		return err
+	}
+
+	fundsDueForRewards, err := ps.FundsDueForRewards()
+	if err != nil {
+		return err
+	}
+
+	// compute allocation fraction -- will allocate updateTimeDelta/timeDelta fraction of units and funds to this update
+	lastUpdateTime, err := ps.LastUpdateTime()
+	if err != nil {
+		return err
+	}
+	if lastUpdateTime == 0 && updateTime > 0 { // it's the first update, so there isn't a last update time
+		lastUpdateTime = updateTime - 1
+	}
+	if updateTime > currentTime || updateTime < lastUpdateTime {
+		return ErrInvalidTime
+	}
+	allocationNumerator := updateTime - lastUpdateTime
+	allocationDenominator := currentTime - lastUpdateTime
+	if allocationDenominator == 0 {
+		allocationNumerator = 1
+		allocationDenominator = 1
+	}
+
+	// allocate units to this update
+	unitsSinceUpdate, err := ps.UnitsSinceUpdate()
+	if err != nil {
+		return err
+	}
+	unitsAllocated := am.SaturatingUMul(unitsSinceUpdate, allocationNumerator) / allocationDenominator
+	unitsSinceUpdate -= unitsAllocated
+	if err := ps.SetUnitsSinceUpdate(unitsSinceUpdate); err != nil {
+		return err
+	}
+
+	// impose cap on amortized cost, if there is one
+	if arbosVersion >= 3 {
+		amortizedCostCapBips, err := ps.AmortizedCostCapBips()
+		if err != nil {
+			return err
+		}
+		if amortizedCostCapBips != 0 {
+			weiSpentCap := am.BigMulByBips(
+				am.BigMulByUint(l1Basefee, unitsAllocated),
+				am.SaturatingCastToBips(amortizedCostCapBips),
+			)
+			if am.BigLessThan(weiSpentCap, weiSpent) {
+				// apply the cap on assignment of amortized cost;
+				// the difference will be a loss for the batch poster
+				weiSpent = weiSpentCap
+			}
+		}
+	}
+
+	dueToPoster, err := posterState.FundsDue()
+	if err != nil {
+		return err
+	}
+	err = posterState.SetFundsDue(am.BigAdd(dueToPoster, weiSpent))
+	if err != nil {
+		return err
+	}
+	perUnitReward, err := ps.PerUnitReward()
+	if err != nil {
+		return err
+	}
+	fundsDueForRewards = am.BigAdd(fundsDueForRewards, am.BigMulByUint(am.UintToBig(unitsAllocated), perUnitReward))
+	if err := ps.SetFundsDueForRewards(fundsDueForRewards); err != nil {
+		return err
+	}
+
+	// pay rewards, as much as possible
+	paymentForRewards := am.BigMulByUint(am.UintToBig(perUnitReward), unitsAllocated)
+	availableFunds := statedb.GetBalance(L1PricerFundsPoolAddress)
+	if am.BigLessThan(availableFunds, paymentForRewards) {
+		paymentForRewards = availableFunds
+	}
+	fundsDueForRewards = am.BigSub(fundsDueForRewards, paymentForRewards)
+	if err := ps.SetFundsDueForRewards(fundsDueForRewards); err != nil {
+		return err
+	}
+	payRewardsTo, err := ps.PayRewardsTo()
+	if err != nil {
+		return err
+	}
+	err = util.TransferBalance(
+		&L1PricerFundsPoolAddress, &payRewardsTo, paymentForRewards, evm, scenario, "batchPosterReward",
+	)
+	if err != nil {
+		return err
+	}
+	availableFunds = statedb.GetBalance(L1PricerFundsPoolAddress)
+
+	// settle up payments owed to the batch poster, as much as possible
+	balanceDueToPoster, err := posterState.FundsDue()
+	if err != nil {
+		return err
+	}
+	balanceToTransfer := balanceDueToPoster
+	if am.BigLessThan(availableFunds, balanceToTransfer) {
+		balanceToTransfer = availableFunds
+	}
+	if balanceToTransfer.Sign() > 0 {
+		addrToPay, err := posterState.PayTo()
+		if err != nil {
+			return err
+		}
+		err = util.TransferBalance(
+			&L1PricerFundsPoolAddress, &addrToPay, balanceToTransfer, evm, scenario, "batchPosterRefund",
+		)
+		if err != nil {
+			return err
+		}
+		balanceDueToPoster = am.BigSub(balanceDueToPoster, balanceToTransfer)
+		err = posterState.SetFundsDue(balanceDueToPoster)
+		if err != nil {
+			return err
+		}
+	}
+
+	// update time
+	if err := ps.SetLastUpdateTime(updateTime); err != nil {
+		return err
+	}
+
+	// adjust the price
+	if unitsAllocated > 0 {
+		totalFundsDue, err := batchPosterTable.TotalFundsDue()
+		if err != nil {
+			return err
+		}
+		fundsDueForRewards, err = ps.FundsDueForRewards()
+		if err != nil {
+			return err
+		}
+		surplus := am.BigSub(statedb.GetBalance(L1PricerFundsPoolAddress), am.BigAdd(totalFundsDue, fundsDueForRewards))
+
+		inertia, err := ps.Inertia()
+		if err != nil {
+			return err
+		}
+		equilUnits, err := ps.EquilibrationUnits()
+		if err != nil {
+			return err
+		}
+		inertiaUnits := am.BigDivByUint(equilUnits, inertia)
+		price, err := ps.PricePerUnit()
+		if err != nil {
+			return err
+		}
+
+		allocPlusInert := am.BigAddByUint(inertiaUnits, unitsAllocated)
+		oldSurplus, err := ps.LastSurplus()
+		if err != nil {
+			return err
+		}
+
+		desiredDerivative := am.BigDiv(new(big.Int).Neg(surplus), equilUnits)
+		actualDerivative := am.BigDivByUint(am.BigSub(surplus, oldSurplus), unitsAllocated)
+		changeDerivativeBy := am.BigSub(desiredDerivative, actualDerivative)
+		priceChange := am.BigDiv(am.BigMulByUint(changeDerivativeBy, unitsAllocated), allocPlusInert)
+
+		if err := ps.SetLastSurplus(surplus, arbosVersion); err != nil {
+			return err
+		}
+		newPrice := am.BigAdd(price, priceChange)
+		if newPrice.Sign() < 0 {
+			newPrice = common.Big0
+		}
+		if err := ps.SetPricePerUnit(newPrice); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ps *L1PricingState) _preVersion2_UpdateForBatchPosterSpending(
+	statedb vm.StateDB,
+	evm *vm.EVM,
+	updateTime, currentTime uint64,
+	batchPoster common.Address,
+	weiSpent *big.Int,
+	scenario util.TracingScenario,
+) error {
+	batchPosterTable := ps.BatchPosterTable()
+	posterState, err := batchPosterTable.OpenPoster(batchPoster, true)
+	if err != nil {
+		return err
+	}
+
+	// compute previous shortfall
+	totalFundsDue, err := batchPosterTable.TotalFundsDue()
+	if err != nil {
+		return err
+	}
+	fundsDueForRewards, err := ps.FundsDueForRewards()
+	if err != nil {
+		return err
+	}
+	oldSurplus := am.BigSub(statedb.GetBalance(L1PricerFundsPoolAddress), am.BigAdd(totalFundsDue, fundsDueForRewards))
+
+	// compute allocation fraction -- will allocate updateTimeDelta/timeDelta fraction of units and funds to this update
+	lastUpdateTime, err := ps.LastUpdateTime()
+	if err != nil {
+		return err
+	}
+	if lastUpdateTime == 0 && currentTime > 0 { // it's the first update, so there isn't a last update time
+		lastUpdateTime = updateTime - 1
+	}
+	if updateTime >= currentTime || updateTime < lastUpdateTime {
+		return nil // historically this returned an error
+	}
+	allocationNumerator := updateTime - lastUpdateTime
+	allocationDenominator := currentTime - lastUpdateTime
+	if allocationDenominator == 0 {
+		allocationNumerator = 1
+		allocationDenominator = 1
+	}
+
+	// allocate units to this update
+	unitsSinceUpdate, err := ps.UnitsSinceUpdate()
+	if err != nil {
+		return err
+	}
+	unitsAllocated := unitsSinceUpdate * allocationNumerator / allocationDenominator
+	unitsSinceUpdate -= unitsAllocated
+	if err := ps.SetUnitsSinceUpdate(unitsSinceUpdate); err != nil {
+		return err
+	}
+
+	dueToPoster, err := posterState.FundsDue()
+	if err != nil {
+		return err
+	}
+	err = posterState.SetFundsDue(am.BigAdd(dueToPoster, weiSpent))
+	if err != nil {
+		return err
+	}
+	perUnitReward, err := ps.PerUnitReward()
+	if err != nil {
+		return err
+	}
+	fundsDueForRewards = am.BigAdd(fundsDueForRewards, am.BigMulByUint(am.UintToBig(unitsAllocated), perUnitReward))
+	if err := ps.SetFundsDueForRewards(fundsDueForRewards); err != nil {
+		return err
+	}
+
+	// allocate funds to this update
+	collectedSinceUpdate := statedb.GetBalance(L1PricerFundsPoolAddress)
+	availableFunds := am.BigDivByUint(am.BigMulByUint(collectedSinceUpdate, allocationNumerator), allocationDenominator)
+
+	// pay rewards, as much as possible
+	paymentForRewards := am.BigMulByUint(am.UintToBig(perUnitReward), unitsAllocated)
+	if am.BigLessThan(availableFunds, paymentForRewards) {
+		paymentForRewards = availableFunds
+	}
+	fundsDueForRewards = am.BigSub(fundsDueForRewards, paymentForRewards)
+	if err := ps.SetFundsDueForRewards(fundsDueForRewards); err != nil {
+		return err
+	}
+	payRewardsTo, err := ps.PayRewardsTo()
+	if err != nil {
+		return err
+	}
+	err = util.TransferBalance(
+		&L1PricerFundsPoolAddress, &payRewardsTo, paymentForRewards, evm, scenario, "batchPosterReward",
+	)
+	if err != nil {
+		return err
+	}
+	availableFunds = am.BigSub(availableFunds, paymentForRewards)
+
+	// settle up our batch poster payments owed, as much as possible
+	allPosterAddrs, err := batchPosterTable.AllPosters(math.MaxUint64)
+	if err != nil {
+		return err
+	}
+	for _, posterAddr := range allPosterAddrs {
+		poster, err := batchPosterTable.OpenPoster(posterAddr, false)
+		if err != nil {
+			return err
+		}
+		balanceDueToPoster, err := poster.FundsDue()
+		if err != nil {
+			return err
+		}
+		balanceToTransfer := balanceDueToPoster
+		if am.BigLessThan(availableFunds, balanceToTransfer) {
+			balanceToTransfer = availableFunds
+		}
+		if balanceToTransfer.Sign() > 0 {
+			addrToPay, err := poster.PayTo()
+			if err != nil {
+				return err
+			}
+			err = util.TransferBalance(
+				&L1PricerFundsPoolAddress, &addrToPay, balanceToTransfer, evm, scenario, "batchPosterRefund",
+			)
+			if err != nil {
+				return err
+			}
+			availableFunds = am.BigSub(availableFunds, balanceToTransfer)
+			balanceDueToPoster = am.BigSub(balanceDueToPoster, balanceToTransfer)
+			err = poster.SetFundsDue(balanceDueToPoster)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// update time
+	if err := ps.SetLastUpdateTime(updateTime); err != nil {
+		return err
+	}
+
+	// adjust the price
+	if unitsAllocated > 0 {
+		totalFundsDue, err = batchPosterTable.TotalFundsDue()
+		if err != nil {
+			return err
+		}
+		fundsDueForRewards, err = ps.FundsDueForRewards()
+		if err != nil {
+			return err
+		}
+		surplus := am.BigSub(statedb.GetBalance(L1PricerFundsPoolAddress), am.BigAdd(totalFundsDue, fundsDueForRewards))
+
+		inertia, err := ps.Inertia()
+		if err != nil {
+			return err
+		}
+		equilUnits, err := ps.EquilibrationUnits()
+		if err != nil {
+			return err
+		}
+		inertiaUnits := am.BigDivByUint(equilUnits, inertia)
+		price, err := ps.PricePerUnit()
+		if err != nil {
+			return err
+		}
+
+		allocPlusInert := am.BigAddByUint(inertiaUnits, unitsAllocated)
+		priceChange := am.BigDiv(
+			am.BigSub(
+				am.BigMul(surplus, am.BigSub(equilUnits, common.Big1)),
+				am.BigMul(oldSurplus, equilUnits),
+			),
+			am.BigMul(equilUnits, allocPlusInert),
+		)
+
+		newPrice := am.BigAdd(price, priceChange)
+		if newPrice.Sign() < 0 {
+			newPrice = common.Big0
+		}
+		if err := ps.SetPricePerUnit(newPrice); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/arbos/l1pricing_test.go
+++ b/arbos/l1pricing_test.go
@@ -203,6 +203,11 @@ func _testL1PricingFundsDue(t *testing.T, testParams *l1PricingTest, expectedRes
 	if !arbmath.BigEquals(fundsStillHeld, expectedResults.fundsStillHeld) {
 		Fail(t, fundsStillHeld, expectedResults.fundsStillHeld)
 	}
+	fundsAvail, err := l1p.L1FeesAvailable()
+	Require(t, err)
+	if fundsStillHeld.Cmp(fundsAvail) != 0 {
+		Fail(t, fundsStillHeld, fundsAvail)
+	}
 }
 
 func TestUpdateTimeUpgradeBehavior(t *testing.T) {

--- a/arbos/l1pricing_test.go
+++ b/arbos/l1pricing_test.go
@@ -172,6 +172,8 @@ func _testL1PricingFundsDue(t *testing.T, testParams *l1PricingTest, expectedRes
 	balanceAdded := big.NewInt(int64(testParams.fundsCollectedPerSecond * 3))
 	unitsAdded := uint64(testParams.unitsPerSecond * 3)
 	evm.StateDB.AddBalance(l1pricing.L1PricerFundsPoolAddress, balanceAdded)
+	err = l1p.SetL1FeesAvailable(balanceAdded)
+	Require(t, err)
 	err = l1p.SetUnitsSinceUpdate(unitsAdded)
 	Require(t, err)
 

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -536,6 +536,11 @@ func (p *TxProcessor) EndTxHook(gasLeft uint64, success bool) {
 		posterFeeDestination = p.evm.Context.Coinbase
 	}
 	util.MintBalance(&posterFeeDestination, p.PosterFee, p.evm, scenario, purpose)
+	if p.state.ArbOSVersion() >= 10 {
+		if _, err := p.state.L1PricingState().AddToL1FeesAvailable(p.PosterFee); err != nil {
+			log.Error("failed to update L1FeesAvailable: "+err.Error(), "err", err)
+		}
+	}
 
 	if p.msg.GasPrice().Sign() > 0 { // in tests, gas price could be 0
 		// ArbOS's gas pool is meant to enforce the computational speed-limit.

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -538,7 +538,7 @@ func (p *TxProcessor) EndTxHook(gasLeft uint64, success bool) {
 	util.MintBalance(&posterFeeDestination, p.PosterFee, p.evm, scenario, purpose)
 	if p.state.ArbOSVersion() >= 10 {
 		if _, err := p.state.L1PricingState().AddToL1FeesAvailable(p.PosterFee); err != nil {
-			log.Error("failed to update L1FeesAvailable: "+err.Error(), "err", err)
+			log.Error("failed to update L1FeesAvailable: ", "err", err)
 		}
 	}
 

--- a/contracts/src/precompiles/ArbGasInfo.sol
+++ b/contracts/src/precompiles/ArbGasInfo.sol
@@ -118,4 +118,7 @@ interface ArbGasInfo {
 
     /// @notice Returns the cost amortization cap in basis points
     function getAmortizedCostCapBips() external view returns (uint64);
+
+    /// @notice Returns the available funds from L1 fees
+    function getL1FeesAvailable() external view returns (uint256);
 }

--- a/contracts/src/precompiles/ArbOwner.sol
+++ b/contracts/src/precompiles/ArbOwner.sol
@@ -81,6 +81,9 @@ interface ArbOwner {
     /// @notice Sets the cost amortization cap in basis points
     function setAmortizedCostCapBips(uint64 cap) external;
 
+    /// @notice Releases surplus funds from L1PricerFundsPoolAddress for use
+    function releaseL1PricerSurplusFunds(uint256 maxWeiToRelease) external returns (uint256);
+
     // Emitted when a successful call is made to this precompile
     event OwnerActs(bytes4 indexed method, address indexed owner, bytes data);
 }

--- a/precompiles/ArbGasInfo.go
+++ b/precompiles/ArbGasInfo.go
@@ -209,3 +209,7 @@ func (con ArbGasInfo) GetPerBatchGasCharge(c ctx, evm mech) (int64, error) {
 func (con ArbGasInfo) GetAmortizedCostCapBips(c ctx, evm mech) (uint64, error) {
 	return c.State.L1PricingState().AmortizedCostCapBips()
 }
+
+func (con ArbGasInfo) GetL1FeesAvailable(c ctx, evm mech) (huge, error) {
+	return c.State.L1PricingState().L1FeesAvailable()
+}

--- a/precompiles/ArbGasInfo.go
+++ b/precompiles/ArbGasInfo.go
@@ -188,6 +188,27 @@ func (con ArbGasInfo) GetGasBacklogTolerance(c ctx, evm mech) (uint64, error) {
 }
 
 func (con ArbGasInfo) GetL1PricingSurplus(c ctx, evm mech) (*big.Int, error) {
+	if c.State.ArbOSVersion() < 10 {
+		return con._preversion10_GetL1PricingSurplus(c, evm)
+	}
+	ps := c.State.L1PricingState()
+	fundsDueForRefunds, err := ps.BatchPosterTable().TotalFundsDue()
+	if err != nil {
+		return nil, err
+	}
+	fundsDueForRewards, err := ps.FundsDueForRewards()
+	if err != nil {
+		return nil, err
+	}
+	haveFunds, err := ps.L1FeesAvailable()
+	if err != nil {
+		return nil, err
+	}
+	needFunds := arbmath.BigAdd(fundsDueForRefunds, fundsDueForRewards)
+	return arbmath.BigSub(haveFunds, needFunds), nil
+}
+
+func (con ArbGasInfo) _preversion10_GetL1PricingSurplus(c ctx, evm mech) (*big.Int, error) {
 	ps := c.State.L1PricingState()
 	fundsDueForRefunds, err := ps.BatchPosterTable().TotalFundsDue()
 	if err != nil {

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -529,7 +529,8 @@ func Precompiles() map[addr]ArbosPrecompile {
 	insert(MakePrecompile(templates.ArbBLSMetaData, &ArbBLS{Address: hex("67")}))
 	insert(MakePrecompile(templates.ArbFunctionTableMetaData, &ArbFunctionTable{Address: hex("68")}))
 	insert(MakePrecompile(templates.ArbosTestMetaData, &ArbosTest{Address: hex("69")}))
-	insert(MakePrecompile(templates.ArbGasInfoMetaData, &ArbGasInfo{Address: hex("6c")}))
+	ArbGasInfo := insert(MakePrecompile(templates.ArbGasInfoMetaData, &ArbGasInfo{Address: hex("6c")}))
+	ArbGasInfo.methodsByName["GetL1FeesAvailable"].arbosVersion = 10
 	insert(MakePrecompile(templates.ArbAggregatorMetaData, &ArbAggregator{Address: hex("6d")}))
 	insert(MakePrecompile(templates.ArbStatisticsMetaData, &ArbStatistics{Address: hex("6f")}))
 
@@ -573,6 +574,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 	_, ArbOwner := MakePrecompile(templates.ArbOwnerMetaData, ArbOwnerImpl)
 	ArbOwner.methodsByName["GetInfraFeeAccount"].arbosVersion = 5
 	ArbOwner.methodsByName["SetInfraFeeAccount"].arbosVersion = 5
+	ArbOwner.methodsByName["ReleaseL1PricerSurplusFunds"].arbosVersion = 10
 
 	insert(ownerOnly(ArbOwnerImpl.Address, ArbOwner, emitOwnerActs))
 	insert(debugOnly(MakePrecompile(templates.ArbDebugMetaData, &ArbDebug{Address: hex("ff")})))


### PR DESCRIPTION
This updates how the L1 data pricer tracks the amount of fees received. All L1 data fees are deposited in a special account, and previously the balance in that account was used to track fee collections. This allowed someone to manipulate the pricer's behavior by depositing funds into the special account -- essentially driving the price down by subsidizing future transactions.

In some scenarios we want to avoid that manipulation, so this PR adds a new state variable in the L1 pricer that tracks the actual fees collected (minus amounts transferred out to reimburse costs). The new variable will always be less than or equal to the balance of the special account.  Now if someone transfers funds into the special account, the L1 pricer "won't notice" and the extra funds will just sit in the special account.

Also added two precompile methods: one in `ArbGasInfo` to get the value of the new variable, and one in `ArbOwner` that allows any extra funds that have been deposited into the special account to be made available to the L1 pricer.

Includes new tests.

Linked to go-ethereum PR https://github.com/OffchainLabs/go-ethereum/pull/176