### PR TITLE
fix: run token bridge setup after nodes start

### DIFF
--- a/test-node.bash
+++ b/test-node.bash
@@ -186,18 +186,17 @@ if $force_init; then
 
     docker-compose run testnode-scripts bridge-funds --ethamount 100000
 
-    if $tokenbridge; then
-        echo == Deploying token bridge
-        docker-compose run -e ARB_KEY=$devprivkey -e ETH_KEY=$devprivkey testnode-tokenbridge gen:network
-        docker-compose run --entrypoint sh testnode-tokenbridge -c "cat localNetwork.json"
-        echo 
-    fi
 fi
 
 if $run; then
     UP_FLAG=""
     if $detach; then
         UP_FLAG="-d"
+    else
+        echo == Deploying Token bridge
+        echo Not running in detached mode. To deploy token bridge run the following commands on another terminal or re-run with --detach flag:
+        echo docker-compose run -e ARB_KEY=$devprivkey -e ETH_KEY=$devprivkey testnode-tokenbridge gen:network
+        echo docker-compose run --entrypoint sh testnode-tokenbridge -c "cat localNetwork.json"
     fi
 
     echo == Launching Sequencer
@@ -205,4 +204,11 @@ if $run; then
     echo
 
     docker-compose up $UP_FLAG $NODES
+
+    if $tokenbridge && $detach; then
+        echo == Deploying token bridge
+        docker-compose run -e ARB_KEY=$devprivkey -e ETH_KEY=$devprivkey testnode-tokenbridge gen:network
+        docker-compose run --entrypoint sh testnode-tokenbridge -c "cat localNetwork.json"
+        echo 
+    fi
 fi


### PR DESCRIPTION
Hi! Super glad the token bridge deployment is now included in the testnodes setups in this repo 😄 We've been maintaining our own fork just to include this functionality so thanks for making that easier for us!

However I've found some trouble when trying to run the testnodes with the token bridge deployment. The issue is that running the deployment script from the SDK requires the nodes to be up to succeed, and this is not the case at the moment. The [deployment code](https://github.com/OffchainLabs/nitro/blob/82a5e5ad94e423cbcb1f103d6bcda67717c9cc61/test-node.bash#L189-L194) is ran before the `docker-compose up` brings the nodes up so it fails with the following error:

```
== Deploying token bridge
Creating nitro_sequencer_1 ... done
Creating nitro_testnode-tokenbridge_run ... done
yarn run v1.22.19
$ ts-node ./scripts/genNetwork.ts
Error response from daemon: Container 84bef016867acf62f442a629dcf7755edc76ddb9e97710db587c160a0e087570 is not running
Error: No such container: nitro-sequencer-1
Error: Command failed: docker exec nitro-sequencer-1 cat /config/deployment.json
Error: No such container: nitro-sequencer-1
```

We've fixed this in [our fork](https://github.com/edgeandnode/nitro/commit/33569e1ccfa9c5efc761387f86b2cb1cc38e1955) by deploying the token bridge _after_ the nodes are up (so after `docker-compose up`) however this will only work if you run the script with the detached flag `./test-node.bash --init --detach`. So if the script is being run not in detached mode we don't deploy the token bridge and print out instructions for the user to do it manually. I'm not entirely sold on this idea but haven't come up with something better so far.

I've ported the modifications from our fork (https://github.com/edgeandnode/nitro/commit/33569e1ccfa9c5efc761387f86b2cb1cc38e1955) to this PR for your consideration. 



Signed-off-by: Tomás Migone <tomas@edgeandnode.com>