### PR TITLE
Increase number of simultaneous initial feed connections handled

### DIFF
--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -75,7 +75,7 @@ var DefaultBroadcasterConfig = BroadcasterConfig{
 	Ping:           5 * time.Second,
 	ClientTimeout:  15 * time.Second,
 	Queue:          100,
-	Workers:        100,
+	Workers:        1000,
 	MaxSendQueue:   4096,
 	RequireVersion: false,
 	DisableSigning: true,


### PR DESCRIPTION
Increase the number of threads allotted for broadcast feed HTTP to websocket upgrades.  This means a larger number of connections can be initiated at the same time.