### PR TITLE
IPFS Backend for daserver

### DIFF
--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -174,8 +174,9 @@ func RecoverPayloadFromDasBatch(
 		return nil, nil
 	}
 	version := cert.Version
-	recordPreimage := func(key common.Hash, value []byte) {
+	recordPreimage := func(key common.Hash, value []byte) error {
 		preimages[key] = value
+		return nil
 	}
 
 	if version >= 2 {
@@ -217,7 +218,10 @@ func RecoverPayloadFromDasBatch(
 		return nil, err
 	}
 	if preimages != nil {
-		dastree.RecordHash(recordPreimage, keysetPreimage)
+		_, err = dastree.RecordHash(recordPreimage, keysetPreimage)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	keyset, err := DeserializeKeyset(bytes.NewReader(keysetPreimage), keysetValidationMode == KeysetDontValidate)
@@ -254,7 +258,10 @@ func RecoverPayloadFromDasBatch(
 			preimages[dataHash] = payload
 			preimages[crypto.Keccak256Hash(treeLeaf)] = treeLeaf
 		} else {
-			dastree.RecordHash(recordPreimage, payload)
+			_, err := dastree.RecordHash(recordPreimage, payload)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/cmd/ipfshelper/ipfshelper.go
+++ b/cmd/ipfshelper/ipfshelper.go
@@ -228,3 +228,8 @@ func CanBeIpfsPath(pathString string) bool {
 	_, err := ipfspath.ParsePath(pathString)
 	return err == nil || prefix == "/ipfs/" || prefix == "/ipld/" || prefix == "/ipns/"
 }
+
+// TODO break abstraction for now til we figure out what fns are needed
+func (h *IpfsHelper) GetAPI() icore.CoreAPI {
+	return h.api
+}

--- a/cmd/ipfshelper/ipfshelper.go
+++ b/cmd/ipfshelper/ipfshelper.go
@@ -171,8 +171,8 @@ func (h *IpfsHelper) AddFile(ctx context.Context, filePath string, includeHidden
 	return h.api.Unixfs().Add(ctx, fileNode)
 }
 
-func CreateIpfsHelper(ctx context.Context, repoDirectory string, clientOnly bool) (*IpfsHelper, error) {
-	return createIpfsHelperImpl(ctx, repoDirectory, clientOnly, []string{}, "")
+func CreateIpfsHelper(ctx context.Context, repoDirectory string, clientOnly bool, profiles string) (*IpfsHelper, error) {
+	return createIpfsHelperImpl(ctx, repoDirectory, clientOnly, []string{}, profiles)
 }
 
 func (h *IpfsHelper) Close() error {

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -81,7 +81,7 @@ func downloadInit(ctx context.Context, initConfig *InitConfig) (string, error) {
 		return initConfig.Url[5:], nil
 	}
 	if ipfshelper.CanBeIpfsPath(initConfig.Url) {
-		ipfsNode, err := ipfshelper.CreateIpfsHelper(ctx, initConfig.DownloadPath, false)
+		ipfsNode, err := ipfshelper.CreateIpfsHelper(ctx, initConfig.DownloadPath, false, "nitro")
 		if err != nil {
 			return "", err
 		}

--- a/cmd/replay/db.go
+++ b/cmd/replay/db.go
@@ -34,7 +34,7 @@ func (db PreimageDb) Get(key []byte) ([]byte, error) {
 	} else {
 		return nil, fmt.Errorf("preimage DB attempted to access non-hash key %v", hex.EncodeToString(key))
 	}
-	return wavmio.ResolvePreImage(hash), nil
+	return wavmio.ResolvePreImage(hash)
 }
 
 func (db PreimageDb) Put(key []byte, value []byte) error {

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -27,11 +27,14 @@ import (
 )
 
 func getBlockHeaderByHash(hash common.Hash) *types.Header {
-	enc := wavmio.ResolvePreImage(hash)
-	header := &types.Header{}
-	err := rlp.DecodeBytes(enc, &header)
+	enc, err := wavmio.ResolvePreImage(hash)
 	if err != nil {
-		panic(fmt.Sprintf("Error parsing resolved block header: %v", err))
+		panic(fmt.Errorf("Error resolving preimage: %w", err))
+	}
+	header := &types.Header{}
+	err = rlp.DecodeBytes(enc, &header)
+	if err != nil {
+		panic(fmt.Errorf("Error parsing resolved block header: %w", err))
 	}
 	return header
 }

--- a/das/das.go
+++ b/das/das.go
@@ -45,9 +45,10 @@ type DataAvailabilityConfig struct {
 	LocalCacheConfig BigCacheConfig `koanf:"local-cache"`
 	RedisCacheConfig RedisConfig    `koanf:"redis-cache"`
 
-	LocalDBStorageConfig   LocalDBStorageConfig   `koanf:"local-db-storage"`
-	LocalFileStorageConfig LocalFileStorageConfig `koanf:"local-file-storage"`
-	S3StorageServiceConfig S3StorageServiceConfig `koanf:"s3-storage"`
+	LocalDBStorageConfig     LocalDBStorageConfig     `koanf:"local-db-storage"`
+	LocalFileStorageConfig   LocalFileStorageConfig   `koanf:"local-file-storage"`
+	S3StorageServiceConfig   S3StorageServiceConfig   `koanf:"s3-storage"`
+	IpfsStorageServiceConfig IpfsStorageServiceConfig `koanf:"ipfs-storage"`
 
 	KeyConfig KeyConfig `koanf:"key"`
 
@@ -100,6 +101,7 @@ func DataAvailabilityConfigAddOptions(prefix string, f *flag.FlagSet) {
 	LocalDBStorageConfigAddOptions(prefix+".local-db-storage", f)
 	LocalFileStorageConfigAddOptions(prefix+".local-file-storage", f)
 	S3ConfigAddOptions(prefix+".s3-storage", f)
+	IpfsStorageServiceConfigAddOptions(prefix+".ipfs-storage", f)
 
 	// Key config for storage
 	KeyConfigAddOptions(prefix+".key", f)

--- a/das/dastree/dastree.go
+++ b/das/dastree/dastree.go
@@ -129,7 +129,7 @@ func Content(root bytes32, oracle func(bytes32) []byte) ([]byte, error) {
 	//     2. For any canonical dastree, there exists a degenerate single-leaf equivalent that we accept.
 	//     3. We also accept old-style flat hashes
 	//     4. Only the committee can produce trees unwrapped by this function
-	//     5. Only the replay binary calls this
+	//     5. Only the replay binary calls this - TODO remove this note
 	//
 
 	unpeal := func(hash bytes32) (byte, []byte, error) {

--- a/das/dastree/dastree_test.go
+++ b/das/dastree/dastree_test.go
@@ -25,14 +25,15 @@ func TestDASTree(t *testing.T) {
 		tests = append(tests, large)
 	}
 
-	record := func(key bytes32, value []byte) {
+	record := func(key bytes32, value []byte) error {
 		colors.PrintGrey("storing ", key, " ", pretty.PrettyBytes(value))
 		store[key] = value
 		if crypto.Keccak256Hash(value) != key {
 			Fail(t, "key not the hash of value")
 		}
+		return nil
 	}
-	oracle := func(key bytes32) []byte {
+	oracle := func(key bytes32) ([]byte, error) {
 		preimage, ok := store[key]
 		if !ok {
 			Fail(t, "no preimage for key", key)
@@ -41,12 +42,13 @@ func TestDASTree(t *testing.T) {
 			Fail(t, "key not the hash of preimage")
 		}
 		colors.PrintBlue("loading ", key, " ", pretty.PrettyBytes(preimage))
-		return preimage
+		return preimage, nil
 	}
 
 	hashes := map[bytes32][]byte{}
 	for _, test := range tests {
-		hash := RecordHash(record, test)
+		hash, err := RecordHash(record, test)
+		Require(t, err)
 		hashes[hash] = test
 	}
 

--- a/das/factory.go
+++ b/das/factory.go
@@ -48,6 +48,15 @@ func CreatePersistentStorageService(
 		storageServices = append(storageServices, s)
 	}
 
+	if config.IpfsStorageServiceConfig.Enable {
+		s, err := NewIpfsStorageService(ctx, config.IpfsStorageServiceConfig)
+		if err != nil {
+			return nil, nil, err
+		}
+		lifecycleManager.Register(s)
+		storageServices = append(storageServices, s)
+	}
+
 	if len(storageServices) > 1 {
 		s, err := NewRedundantStorageService(ctx, storageServices)
 		if err != nil {

--- a/das/ipfs_storage_service.go
+++ b/das/ipfs_storage_service.go
@@ -1,0 +1,111 @@
+// Copyright 2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package das
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ipfs/go-cid"
+	icore "github.com/ipfs/interface-go-ipfs-core"
+	"github.com/ipfs/interface-go-ipfs-core/options"
+	path "github.com/ipfs/interface-go-ipfs-core/path"
+	"github.com/multiformats/go-multihash"
+	"github.com/offchainlabs/nitro/arbstate"
+	"github.com/offchainlabs/nitro/cmd/ipfshelper"
+)
+
+type IpfsStorageServiceConfig struct {
+	Enable  bool   `koanf:"enable"`
+	RepoDir string `koanf:"repo-dir"`
+	// Something about expiry
+}
+
+var DefaultIpfsStorageServiceConfig = IpfsStorageServiceConfig{
+	Enable:  false,
+	RepoDir: "",
+}
+
+type IpfsStorageService struct {
+	ipfsHelper *ipfshelper.IpfsHelper
+	ipfsApi    icore.CoreAPI
+}
+
+func NewIpfsStorageService(ctx context.Context, repoDirectory string, profiles string) (*IpfsStorageService, error) {
+	ipfsHelper, err := ipfshelper.CreateIpfsHelper(ctx, repoDirectory, false, profiles)
+	if err != nil {
+		return nil, err
+	}
+	return &IpfsStorageService{
+		ipfsHelper: ipfsHelper,
+		ipfsApi:    ipfsHelper.GetAPI(),
+	}, nil
+}
+
+func hashToCid(hash common.Hash) (cid.Cid, error) {
+	multiEncodedHashBytes, err := multihash.Encode(hash[:], multihash.KECCAK_256)
+	if err != nil {
+		return cid.Cid{}, err
+	}
+
+	_, multiHash, err := multihash.MHFromBytes(multiEncodedHashBytes)
+	if err != nil {
+		return cid.Cid{}, err
+	}
+
+	return cid.NewCidV1(cid.Raw, multiHash), nil
+
+}
+
+func (s *IpfsStorageService) GetByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
+	thisCid, err := hashToCid(hash)
+	if err != nil {
+		return nil, err
+	}
+
+	ipfsPath := path.IpfsPath(thisCid)
+	log.Info("Retrieving path", "path", ipfsPath.String())
+
+	rdr, err := s.ipfsApi.Block().Get(ctx, ipfsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := ioutil.ReadAll(rdr)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (s *IpfsStorageService) Put(ctx context.Context, data []byte, expirationTime uint64) error {
+	_ = expirationTime // TODO do something with this
+
+	blockStat, err := s.ipfsApi.Block().Put(ctx, bytes.NewReader(data), options.Block.CidCodec("raw"), options.Block.Hash(multihash.KECCAK_256, -1), options.Block.Pin(true))
+	if err != nil {
+		return err
+	}
+	log.Info("Written path", "path", blockStat.Path().String())
+	return nil
+}
+
+func (s *IpfsStorageService) ExpirationPolicy(ctx context.Context) (arbstate.ExpirationPolicy, error) {
+	return arbstate.KeepForever, nil
+}
+
+func (s *IpfsStorageService) Sync(ctx context.Context) error {
+	return nil
+}
+func (s *IpfsStorageService) Close(ctx context.Context) error {
+	return nil
+}
+func (s *IpfsStorageService) String() string {
+	return "IpfsStorageService"
+}
+func (s *IpfsStorageService) HealthCheck(ctx context.Context) error {
+	return nil
+}

--- a/das/ipfs_storage_service.go
+++ b/das/ipfs_storage_service.go
@@ -17,17 +17,28 @@ import (
 	"github.com/multiformats/go-multihash"
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/cmd/ipfshelper"
+	flag "github.com/spf13/pflag"
 )
 
 type IpfsStorageServiceConfig struct {
-	Enable  bool   `koanf:"enable"`
-	RepoDir string `koanf:"repo-dir"`
-	// Something about expiry
+	Enable              bool   `koanf:"enable"`
+	RepoDir             string `koanf:"repo-dir"`
+	DiscardAfterTimeout bool   `koanf:"discard-after-timeout"`
+	Profiles            string `koanf:"profiles"`
 }
 
 var DefaultIpfsStorageServiceConfig = IpfsStorageServiceConfig{
-	Enable:  false,
-	RepoDir: "",
+	Enable:              false,
+	RepoDir:             "",
+	DiscardAfterTimeout: false,
+	Profiles:            "test",
+}
+
+func IpfsStorageServiceConfigAddOptions(prefix string, f *flag.FlagSet) {
+	f.Bool(prefix+".enable", DefaultIpfsStorageServiceConfig.Enable, "enable storage/retrieval of sequencer batch data from IPFS")
+	f.String(prefix+".repo-dir", DefaultIpfsStorageServiceConfig.RepoDir, "directory to use to store the local IPFS repo")
+	f.Bool(prefix+".discard-after-timeout", DefaultIpfsStorageServiceConfig.DiscardAfterTimeout, "discard data after its expiry timeout")
+	f.String(prefix+".profiles", DefaultIpfsStorageServiceConfig.Profiles, "comma separated list of IPFS profiles to use")
 }
 
 type IpfsStorageService struct {
@@ -35,8 +46,8 @@ type IpfsStorageService struct {
 	ipfsApi    icore.CoreAPI
 }
 
-func NewIpfsStorageService(ctx context.Context, repoDirectory string, profiles string) (*IpfsStorageService, error) {
-	ipfsHelper, err := ipfshelper.CreateIpfsHelper(ctx, repoDirectory, false, profiles)
+func NewIpfsStorageService(ctx context.Context, config IpfsStorageServiceConfig) (*IpfsStorageService, error) {
+	ipfsHelper, err := ipfshelper.CreateIpfsHelper(ctx, config.RepoDir, false, config.Profiles)
 	if err != nil {
 		return nil, err
 	}

--- a/das/ipfs_storage_service_test.go
+++ b/das/ipfs_storage_service_test.go
@@ -1,0 +1,31 @@
+// Copyright 2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package das
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestIpfsStorageServiceAddAndGet(t *testing.T) {
+	enableLogging()
+	ctx := context.Background()
+	svc, err := NewIpfsStorageService(ctx, "/tmp/ipfstest", "test")
+	Require(t, err)
+	data := []byte("hello world")
+
+	err = svc.Put(ctx, data, 0)
+	Require(t, err)
+
+	hash := crypto.Keccak256(data)
+	returnedData, err := svc.GetByHash(ctx, common.BytesToHash(hash))
+	Require(t, err)
+	if bytes.Compare(data, returnedData) != 0 {
+		Fail(t, "Returned data didn't match!")
+	}
+}

--- a/das/ipfs_storage_service_test.go
+++ b/das/ipfs_storage_service_test.go
@@ -6,26 +6,47 @@ package das
 import (
 	"bytes"
 	"context"
+	"math"
+	"math/rand"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/offchainlabs/nitro/das/dastree"
 )
 
-func TestIpfsStorageServiceAddAndGet(t *testing.T) {
-	enableLogging()
-	ctx := context.Background()
-	svc, err := NewIpfsStorageService(ctx, IpfsStorageServiceConfig{true, "/tmp/ipfstest", false, "test"})
-	Require(t, err)
-	data := []byte("hello world")
+func runAddAndGetTest(t *testing.T, ctx context.Context, svc *IpfsStorageService, size int) {
 
-	err = svc.Put(ctx, data, 0)
+	src := rand.NewSource(87432489732)
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(src.Int63() & 0xff)
+	}
+
+	err := svc.Put(ctx, data, 0)
 	Require(t, err)
 
-	hash := crypto.Keccak256(data)
+	hash := dastree.Hash(data).Bytes()
 	returnedData, err := svc.GetByHash(ctx, common.BytesToHash(hash))
 	Require(t, err)
 	if bytes.Compare(data, returnedData) != 0 {
 		Fail(t, "Returned data didn't match!")
+	}
+
+}
+
+func TestIpfsStorageServiceAddAndGet(t *testing.T) {
+	enableLogging()
+	ctx := context.Background()
+	svc, err := NewIpfsStorageService(ctx, IpfsStorageServiceConfig{true, t.TempDir(), "test"})
+	defer svc.Close(ctx)
+	Require(t, err)
+
+	pow2Size := 1 << 16 // 64kB
+	for i := 1; i < 8; i++ {
+		runAddAndGetTest(t, ctx, svc, int(math.Pow10(i)))
+		runAddAndGetTest(t, ctx, svc, pow2Size)
+		runAddAndGetTest(t, ctx, svc, pow2Size-1)
+		runAddAndGetTest(t, ctx, svc, pow2Size+1)
+		pow2Size = pow2Size << 1
 	}
 }

--- a/das/ipfs_storage_service_test.go
+++ b/das/ipfs_storage_service_test.go
@@ -15,7 +15,7 @@ import (
 func TestIpfsStorageServiceAddAndGet(t *testing.T) {
 	enableLogging()
 	ctx := context.Background()
-	svc, err := NewIpfsStorageService(ctx, "/tmp/ipfstest", "test")
+	svc, err := NewIpfsStorageService(ctx, IpfsStorageServiceConfig{true, "/tmp/ipfstest", false, "test"})
 	Require(t, err)
 	data := []byte("hello world")
 

--- a/wavmio/higher.go
+++ b/wavmio/higher.go
@@ -61,10 +61,10 @@ func AdvanceInboxMessage() {
 	setGlobalStateU64(IDX_INBOX_POSITION, pos+1)
 }
 
-func ResolvePreImage(hash common.Hash) []byte {
+func ResolvePreImage(hash common.Hash) ([]byte, error) {
 	return readBuffer(func(offset uint32, buf []byte) uint32 {
 		return resolvePreImage(hash[:], offset, buf)
-	})
+	}), nil
 }
 
 func SetLastBlockHash(hash [32]byte) {

--- a/wavmio/stub.go
+++ b/wavmio/stub.go
@@ -133,12 +133,12 @@ func AdvanceInboxMessage() {
 	seqAdvanced++
 }
 
-func ResolvePreImage(hash common.Hash) []byte {
+func ResolvePreImage(hash common.Hash) ([]byte, error) {
 	val, ok := preimages[hash]
 	if !ok {
 		panic("preimage not found")
 	}
-	return val
+	return val, nil
 }
 
 func SetLastBlockHash(hash [32]byte) {


### PR DESCRIPTION
IPFS DAS backend

It takes advantage of IPFS' content addressing scheme to be able to directly retrieve the batches from IPFS using their root hash from the L1 sequencer inbox contract.

Retrieval from IPFS from nitro nodes will be done in a separate PR.

# Testing done

Unit tests pass.

## Manual testing

Generate committee member keys.
```
./target/bin/datool keygen --dir datestconf/ipfs-keys/
```

Make a config file `datestconf/ipfs-daserver.conf`
```
{
  "data-availability": {
    "disable-signature-checking": true,
    "enable": true,
    "ipfs-storage": {
      "enable": true,
      "repo-dir": "/tmp/ipfs-daserver"
    },
    "key": {
      "key-dir": "/home/tristan/offchain/nitro/datestconf/ipfs-keys/"
    },
	"l1-node-url": "none",
	"sequencer-inbox-address": "none"
  },
  "enable-rest": true,
  "enable-rpc": true,
  "log-level": 3,
  "metrics": true,
  "metrics-server": {
    "addr": "127.0.0.1",
    "port": 6070,
    "pprof": false,
    "update-interval": "3s"
  },
  "rest-addr": "localhost",
  "rest-port": "9877",
  "rpc-addr": "localhost",
  "rpc-port": "9876"
}
```

Start `daserver`
```
./target/bin/daserver --conf.file datestconf/ipfs-daserver.conf --log-level 5
```

Store and retrieve some data
```
tristan@ramona ~/offchain/nitro 0
Wed Nov 23 08:52:15
$ ./target/bin/datool client rpc store --message "das test 123" --url http://localhost:9876
Hex Encoded Cert: 0x88e23728e830d08e2ac5906465907117b9fa1b4f340c69887d8e0c3501fb0004717c6872c0ffa16d56336e55564a973cb531f6cc3fdf374b0bf054b1a0792cde9f00000000637fa14501000000000000000111ffa1048b223c8737f75da8c59a1c8c989614c24cf509c36b2ec67b2f26b20415488094b8de362be38c5610254424fa0e22a5018d8a1a09de41840ed40a38316cc1288ced84e85dd94115216023a8c98a5c6eec1b90e5e0619cdded0dbb6179
Hex Encoded Data Hash: 0x7c6872c0ffa16d56336e55564a973cb531f6cc3fdf374b0bf054b1a0792cde9f
tristan@ramona ~/offchain/nitro 0
Wed Nov 23 08:52:21
$ ./target/bin/datool client rest getbyhash --url http://localhost:9877 --data-hash 0x7c6872c0ffa16d56336e55564a973cb531f6cc3fdf374b0bf054b1a0792cde9f
Message: das test 123
```

Note multiple stages of retrieval in logs since even small data chunks need 2 preimages in the dastree format:
```
INFO [11-23|08:52:21.808] Written path                             path=/ipld/bafkrwie6edkjxxecucldrorsysevob5iez6n3ie5n4ne4jtcuyzuiufdgi
INFO [11-23|08:52:21.808] Written path                             path=/ipld/bafkrwih4nbzmb75bnvldg3svkzfjopfvgh3myp67g5fqx4cuwgqhslg6t4
DEBUG[11-23|08:52:21.808] Served das_store                         conn=127.0.0.1:41718 reqid=1 duration=1.308383ms
DEBUG[11-23|08:52:33.626] Got request                              requestPath=/get-by-hash/7c6872c0ffa16d56336e55564a973cb531f6cc3fdf374b0bf054b1a0792cde9f
DEBUG[11-23|08:52:33.627] Got request                              requestPath=/get-by-hash/7c6872c0ffa16d56336e55564a973cb531f6cc3fdf374b0bf054b1a0792cde9f
INFO [11-23|08:52:33.627] Retrieving path                          path=/ipfs/bafkrwih4nbzmb75bnvldg3svkzfjopfvgh3myp67g5fqx4cuwgqhslg6t4
INFO [11-23|08:52:33.627] Retrieving path                          path=/ipfs/bafkrwie6edkjxxecucldrorsysevob5iez6n3ie5n4ne4jtcuyzuiufdgi
```

Store large random data that needs multiple chunks
```
$ ./target/bin/datool client rpc store --url http://localhost:9876 --random-message-size 1234657
Hex Encoded Cert: 0x88e23728e830d08e2ac5906465907117b9fa1b4f340c69887d8e0c3501fb000471586bbce8c455b0de39e53cc4257762f5575c1f672505efa9ff77487cff1130b200000000637fa1a901000000000000000114d1dd6b88e7e90e81f19b9043f4f86aee5f3ef48684127bf59f25b83c145c10cdd1655eb8842c77272116753420bf060737deec925bc746f3ec43e40dc0142a28484ae4cbf88d555beb1ffaeea8c0bc88cbe44f8ebe43026216bedc9beb3a0c
Hex Encoded Data Hash: 0x586bbce8c455b0de39e53cc4257762f5575c1f672505efa9ff77487cff1130b2
```

Retrieve it and observe logging of many chunks being stored (not shown)
```
$ ./target/bin/datool client rest getbyhash --url http://localhost:9877 --data-hash 0x586bbce8c455b0de39e53cc4257762f5575c1f672505efa9ff77487cff1130b2
```

