### PR TITLE
Do not connect to feed until node caught up to L1

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1485,6 +1485,7 @@ func (n *Node) Start(ctx context.Context) error {
 				select {
 				case <-n.InboxReader.CaughtUp():
 				case <-ctx.Done():
+					return
 				}
 			}
 			n.BroadcastClients.Start(ctx)

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1480,7 +1480,15 @@ func (n *Node) Start(ctx context.Context) error {
 		}
 	}
 	if n.BroadcastClients != nil {
-		n.BroadcastClients.Start(ctx)
+		go func() {
+			if n.InboxReader != nil {
+				select {
+				case <-n.InboxReader.CaughtUp():
+				case <-ctx.Done():
+				}
+			}
+			n.BroadcastClients.Start(ctx)
+		}()
 	}
 	if n.configFetcher != nil {
 		n.configFetcher.Start(ctx)

--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -162,6 +162,10 @@ func NewBroadcastClient(
 
 func (bc *BroadcastClient) Start(ctxIn context.Context) {
 	bc.StopWaiter.Start(ctxIn, bc)
+	if bc.StopWaiter.Stopped() {
+		log.Info("broadcast client has already been stopped, not starting")
+		return
+	}
 	bc.LaunchThread(func(ctx context.Context) {
 		backoffDuration := bc.config.ReconnectInitialBackoff
 		for {

--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -443,9 +443,11 @@ func (bc *BroadcastClient) StopAndWait() {
 	bc.connMutex.Lock()
 	defer bc.connMutex.Unlock()
 
-	bc.shuttingDown = true
-	if bc.conn != nil {
-		_ = bc.conn.Close()
+	if !bc.shuttingDown {
+		bc.shuttingDown = true
+		if bc.conn != nil {
+			_ = bc.conn.Close()
+		}
 	}
 }
 

--- a/broadcastclients/broadcastclients.go
+++ b/broadcastclients/broadcastclients.go
@@ -77,8 +77,6 @@ func (bcs *BroadcastClients) Start(ctx context.Context) {
 }
 func (bcs *BroadcastClients) StopAndWait() {
 	for _, client := range bcs.clients {
-		if client.Started() {
-			client.StopAndWait()
-		}
+		client.StopAndWait()
 	}
 }

--- a/util/stopwaiter/stopwaiter_test.go
+++ b/util/stopwaiter/stopwaiter_test.go
@@ -47,3 +47,28 @@ func TestStopWaiterStopAndWaitTimeoutShouldNotWarn(t *testing.T) {
 		testhelpers.FailImpl(t, "Incorrectly logged about waiting long on StopAndWait")
 	}
 }
+
+func TestStopWaiterStopAndWaitBeforeStart(t *testing.T) {
+	sw := StopWaiter{}
+	sw.StopAndWait()
+}
+
+func TestStopWaiterStopAndWaitAfterStop(t *testing.T) {
+	sw := StopWaiter{}
+	sw.Start(context.Background(), &TestStruct{})
+	ctx := sw.GetContext()
+	sw.StopOnly()
+	<-ctx.Done()
+	sw.StopAndWait()
+}
+
+func TestStopWaiterStopAndWaitMultipleTimes(t *testing.T) {
+	sw := StopWaiter{}
+	sw.StopAndWait()
+	sw.StopAndWait()
+	sw.StopAndWait()
+	sw.Start(context.Background(), &TestStruct{})
+	sw.StopAndWait()
+	sw.StopAndWait()
+	sw.StopAndWait()
+}


### PR DESCRIPTION
* adds postponing `BroadcastClients` start until `InboxReader` is caught up with L1
* fix `StopWaiter.StopAndWait` behavior when called before `StopWaiter` is started