### PR TITLE
Don't send feed cache if requested seqnum is too old

### DIFF
--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -170,10 +170,9 @@ func (s *WSBroadcastServer) StartWithHeader(ctx context.Context, header ws.Hands
 
 		safeConn := deadliner{conn, s.config().IOTimeout}
 
-		// Set requestedSeqNum to max if client doesn't provide it
-		requestedSeqNum := arbutil.MessageIndex(^uint64(0))
 		var feedClientVersionSeen bool
 		var connectingIP string
+		var requestedSeqNum arbutil.MessageIndex
 		upgrader := ws.Upgrader{
 			OnRequest: func(uri []byte) error {
 				if strings.Contains(string(uri), LivenessProbeURI) {


### PR DESCRIPTION
If node is far enough behind, any cached feed values would already be on-chain by the time the node catches up