### PR TITLE
Set new TxLookupLimit to better target 1 year

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -503,7 +503,7 @@ var ConfigDefault = Config{
 	SyncMonitor:            DefaultSyncMonitorConfig,
 	Dangerous:              DefaultDangerousConfig,
 	Archive:                false,
-	TxLookupLimit:          40_000_000,
+	TxLookupLimit:          126_100_000, // 1 year at 4 blocks per second
 	Caching:                DefaultCachingConfig,
 	TransactionStreamer:    DefaultTransactionStreamerConfig,
 }

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -503,7 +503,7 @@ var ConfigDefault = Config{
 	SyncMonitor:            DefaultSyncMonitorConfig,
 	Dangerous:              DefaultDangerousConfig,
 	Archive:                false,
-	TxLookupLimit:          126_100_000, // 1 year at 4 blocks per second
+	TxLookupLimit:          126_230_400, // 1 year at 4 blocks per second
 	Caching:                DefaultCachingConfig,
 	TransactionStreamer:    DefaultTransactionStreamerConfig,
 }


### PR DESCRIPTION
The new value is set according to our current max block speed of 4 per second times 1 year of tx lookup memory