### PR TITLE
Update bridge enabled condition

### DIFF
--- a/contracts/src/bridge/Bridge.sol
+++ b/contracts/src/bridge/Bridge.sol
@@ -230,8 +230,11 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
         InOutInfo storage info = allowedDelayedInboxesMap[inbox];
         bool alreadyEnabled = info.allowed;
         emit InboxToggle(inbox, enabled);
-        if ((alreadyEnabled && enabled) || (!alreadyEnabled && !enabled)) {
-            return;
+        /// @solidity memory-safe-assembly
+        assembly {
+            if eq(alreadyEnabled, enabled) {
+                stop()
+            }
         }
         if (enabled) {
             allowedDelayedInboxesMap[inbox] = InOutInfo(allowedDelayedInboxList.length, true);
@@ -252,8 +255,11 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
         InOutInfo storage info = allowedOutboxesMap[outbox];
         bool alreadyEnabled = info.allowed;
         emit OutboxToggle(outbox, enabled);
-        if ((alreadyEnabled && enabled) || (!alreadyEnabled && !enabled)) {
-            return;
+        /// @solidity memory-safe-assembly
+        assembly {
+            if eq(alreadyEnabled, enabled) {
+                stop()
+            }
         }
         if (enabled) {
             allowedOutboxesMap[outbox] = InOutInfo(allowedOutboxList.length, true);

--- a/contracts/src/bridge/Bridge.sol
+++ b/contracts/src/bridge/Bridge.sol
@@ -230,11 +230,8 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
         InOutInfo storage info = allowedDelayedInboxesMap[inbox];
         bool alreadyEnabled = info.allowed;
         emit InboxToggle(inbox, enabled);
-        /// @solidity memory-safe-assembly
-        assembly {
-            if eq(alreadyEnabled, enabled) {
-                stop()
-            }
+        if (alreadyEnabled == enabled) {
+            return;
         }
         if (enabled) {
             allowedDelayedInboxesMap[inbox] = InOutInfo(allowedDelayedInboxList.length, true);
@@ -255,11 +252,8 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
         InOutInfo storage info = allowedOutboxesMap[outbox];
         bool alreadyEnabled = info.allowed;
         emit OutboxToggle(outbox, enabled);
-        /// @solidity memory-safe-assembly
-        assembly {
-            if eq(alreadyEnabled, enabled) {
-                stop()
-            }
+        if (alreadyEnabled == enabled) {
+            return;
         }
         if (enabled) {
             allowedOutboxesMap[outbox] = InOutInfo(allowedOutboxList.length, true);

--- a/contracts/src/mocks/BridgeStub.sol
+++ b/contracts/src/mocks/BridgeStub.sol
@@ -139,8 +139,11 @@ contract BridgeStub is IBridge {
         InOutInfo storage info = allowedDelayedInboxesMap[inbox];
         bool alreadyEnabled = info.allowed;
         emit InboxToggle(inbox, enabled);
-        if ((alreadyEnabled && enabled) || (!alreadyEnabled && !enabled)) {
-            return;
+        /// @solidity memory-safe-assembly
+        assembly {
+            if eq(alreadyEnabled, enabled) {
+                stop()
+            }
         }
         if (enabled) {
             allowedDelayedInboxesMap[inbox] = InOutInfo(allowedDelayedInboxList.length, true);

--- a/contracts/src/mocks/BridgeStub.sol
+++ b/contracts/src/mocks/BridgeStub.sol
@@ -139,11 +139,8 @@ contract BridgeStub is IBridge {
         InOutInfo storage info = allowedDelayedInboxesMap[inbox];
         bool alreadyEnabled = info.allowed;
         emit InboxToggle(inbox, enabled);
-        /// @solidity memory-safe-assembly
-        assembly {
-            if eq(alreadyEnabled, enabled) {
-                stop()
-            }
+        if (alreadyEnabled == enabled) {
+            return;
         }
         if (enabled) {
             allowedDelayedInboxesMap[inbox] = InOutInfo(allowedDelayedInboxList.length, true);


### PR DESCRIPTION
I saw that the `(alreadyEnabled && enabled) || (!alreadyEnabled && !enabled)` condition is used in a few places in the Bridge code for setting the delayed inbox and outbox, this is just the opposite of an XOR boolean operation. I did some gas tests with v0.8.17 and the optimizer with 100 runs, using just the condition in isolation I found that the gas went up in the `true`/`true` case. However gas was saved in the `true`/`false` case, if that is the more common case then it's probably ok to just use that to reduce the code complexity a bit. However gas can be saved in both cases by using inline assembly. This PR opts for the `==` variant for readability as these functions are not called that often. 

Testing results shown below in comments:

```solidity
contract Bridge {

  struct InOutInfo {
    uint256 index;
    bool allowed;
  }

  InOutInfo info = InOutInfo(1, true);

  // Base case (original code)
  // alreadyEnabled = true, enabled = true
  // gas: 23611 
  // alreadyEnabled = true, enabled = false
  // gas: 23627
  function inbox(bool enabled) external view {
    bool alreadyEnabled = info.allowed;
    if ((alreadyEnabled && enabled) || (!alreadyEnabled && !enabled)) {
      return;
    }
  }

  // Using == comparison
  // alreadyEnabled = true, enabled = true
  // gas: 23628 (+17)
  // alreadyEnabled = true, enabled = false
  // gas: 23617 (-10)
  function inboxEQ(bool enabled) external view {
    bool alreadyEnabled = info.allowed;
    if (alreadyEnabled == enabled) {
      return;
    }
  }

  // Using assembly
  // alreadyEnabled = true, enabled = true
  // gas: 23581 (-30)
  // alreadyEnabled = true, enabled = false
  // gas: 23583 (-44)
  function inboxASM(bool enabled) external view {
    bool alreadyEnabled = info.allowed;
    /// @solidity memory-safe-assembly
    assembly {
      if eq(alreadyEnabled, enabled) { stop() }
    }
  }
}
```