### PR TITLE
Replace calldatasize() assembly block with msg.data.length

### DIFF
--- a/contracts/src/libraries/IGasRefunder.sol
+++ b/contracts/src/libraries/IGasRefunder.sol
@@ -21,10 +21,7 @@ abstract contract GasRefundEnabled {
         uint256 startGasLeft = gasleft();
         _;
         if (address(gasRefunder) != address(0)) {
-            uint256 calldataSize;
-            assembly {
-                calldataSize := calldatasize()
-            }
+            uint256 calldataSize = msg.data.length;
             uint256 calldataWords = (calldataSize + 31) / 32;
             // account for the CALLDATACOPY cost of the proxy contract, including the memory expansion cost
             startGasLeft += calldataWords * 6 + (calldataWords**2) / 512;


### PR DESCRIPTION
Even with no optimizations `msg.data.length` is compiled to a CALLDATASIZE opcode, so the bytecode should be equivalent and removes some assembly.