### PR TITLE
Reduce InOutInfo struct from 2 storage slots to 1

### DIFF
--- a/contracts/src/mocks/BridgeStub.sol
+++ b/contracts/src/mocks/BridgeStub.sol
@@ -11,8 +11,9 @@ import "../bridge/IBridge.sol";
 
 contract BridgeStub is IBridge {
     struct InOutInfo {
-        uint256 index;
+        uint8 version;
         bool allowed;
+        uint240 index;
     }
 
     mapping(address => InOutInfo) private allowedDelayedInboxesMap;
@@ -143,7 +144,11 @@ contract BridgeStub is IBridge {
             return;
         }
         if (enabled) {
-            allowedDelayedInboxesMap[inbox] = InOutInfo(allowedDelayedInboxList.length, true);
+            allowedDelayedInboxesMap[inbox] = InOutInfo({
+                version: 1,
+                allowed: true,
+                index: uint240(allowedDelayedInboxList.length)
+            });
             allowedDelayedInboxList.push(inbox);
         } else {
             allowedDelayedInboxList[info.index] = allowedDelayedInboxList[


### PR DESCRIPTION
(Unfinished/Untested) I saw `InOutInfo` was using 2 storage slots unnecessarily. To maintain backwards compatibility with old `InOutInfo`'s a version parameter was added (will be 0 in all existing structs as the index is right aligned) and also supports further upgrades into the same storage slot. Putting this as a draft as it's untested and there's probably more that needs doing.