### PR TITLE
Docs : Corrected the formatting for a missed header

### DIFF
--- a/docs/tx-lifecycle.md
+++ b/docs/tx-lifecycle.md
@@ -46,7 +46,7 @@ At this phase, the client's acceptance of finality relies on trusting the Sequen
 
 Note that even a malicious/faulty Sequencer can only, at worst, reorder or temporarily delay transactions; it cannot, e.g., forge a client's transaction or propose an invalid state update. Given the degree of trust in the Sequencer at phase 2, we sometimes refer to the "instant" receipt that the Sequencer provides as a "soft confirmation."
 
-#### 3. Sequencer posts transaction in a batch (on-chain)
+### 3. Sequencer posts transaction in a batch (on-chain)
 
 The Sequencer will eventually post a batch of L2 transactions which includes our client's transaction onto the underlying L1 (as calldata); under normal conditions, the Sequencer will post batches [every few minutes](https://arbiscan.io/batches).
 


### PR DESCRIPTION
As seen on https://developer.arbitrum.io/tx-lifecycle, due to incorrect formatting in the MD file, Step 3 is missing in this article. Corrected that.

<img width="394" alt="image" src="https://user-images.githubusercontent.com/7558499/206172521-79b794ef-c04b-4763-8849-d875545f0519.png">
<img width="785" alt="image" src="https://user-images.githubusercontent.com/7558499/206172759-24d93480-eea0-4759-b991-912b7231b6e7.png">
