### PR TITLE
fix polling in FileHandler test

### DIFF
--- a/cmd/nitro/filehandler_test.go
+++ b/cmd/nitro/filehandler_test.go
@@ -36,7 +36,7 @@ Retry:
 			return msgs, nil
 		}
 	}
-	return msgs, nil
+	return msgs, err
 }
 
 func readLogMessagesFromJSONFile(t *testing.T, path string) ([]string, error) {

--- a/cmd/nitro/filehandler_test.go
+++ b/cmd/nitro/filehandler_test.go
@@ -19,12 +19,13 @@ import (
 func pollLogMessagesFromJSONFile(t *testing.T, path string, expected []string) ([]string, error) {
 	t.Helper()
 	var msgs []string
+	var err error
 Retry:
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 30; i++ {
 		time.Sleep(20 * time.Millisecond)
-		msgs, err := readLogMessagesFromJSONFile(t, path)
+		msgs, err = readLogMessagesFromJSONFile(t, path)
 		if err != nil {
-			return []string{}, err
+			continue
 		}
 		if len(msgs) == len(expected) {
 			for i, m := range msgs {
@@ -107,7 +108,7 @@ func testFileHandler(t *testing.T, testCompressed bool) {
 	}
 	var gzFiles int
 	var entries []os.DirEntry
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 60; i++ {
 		time.Sleep(20 * time.Millisecond)
 		gzFiles = 0
 		var err error


### PR DESCRIPTION
The polling for results of FileHandler tests wasn't persistent enough. This PR improves the polling to prevent random test failures. 