### PR TITLE
Fix case for cloudflare http header

### DIFF
--- a/wsbroadcastserver/clientconnection.go
+++ b/wsbroadcastserver/clientconnection.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,12 +44,6 @@ func NewClientConnection(
 	requestedSeqNum arbutil.MessageIndex,
 	connectingIP string,
 ) *ClientConnection {
-	if len(connectingIP) == 0 {
-		parts := strings.Split(conn.RemoteAddr().String(), ":")
-		if len(parts) > 0 {
-			connectingIP = parts[0]
-		}
-	}
 	return &ClientConnection{
 		conn:            conn,
 		desc:            desc,

--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	HTTPHeaderCloudflareConnectingIP  = "cf-connecting-ip"
+	HTTPHeaderCloudflareConnectingIP  = "CF-Connecting-IP"
 	HTTPHeaderFeedServerVersion       = "Arbitrum-Feed-Server-Version"
 	HTTPHeaderFeedClientVersion       = "Arbitrum-Feed-Client-Version"
 	HTTPHeaderRequestedSequenceNumber = "Arbitrum-Requested-Sequence-Number"


### PR DESCRIPTION
Get cloudflare connecting IP if available, and use consistent naming when logging feed connection states