### PR TITLE
Fix CI failing due to lld-10 not existing

### DIFF
--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -35,8 +35,8 @@ jobs:
           sudo add-apt-repository -y ppa:ethereum/ethereum
           sudo add-apt-repository -y ppa:longsleep/golang-backports
           sudo apt-get update && sudo apt-get install -y \
-            build-essential cmake nodejs ethereum lld-10 golang-go libudev-dev
-          sudo ln -s /usr/bin/wasm-ld-10 /usr/local/bin/wasm-ld
+            build-essential cmake nodejs ethereum lld-14 golang-go libudev-dev
+          sudo ln -s /usr/bin/wasm-ld-14 /usr/local/bin/wasm-ld
 
       - name: Install rust stable
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Install wasm-ld
         run: |
-          sudo apt-get update && sudo apt-get install -y lld-10
-          sudo ln -s /usr/bin/wasm-ld-10 /usr/local/bin/wasm-ld
+          sudo apt-get update && sudo apt-get install -y lld-14
+          sudo ln -s /usr/bin/wasm-ld-14 /usr/local/bin/wasm-ld
 
       - name: Install rust wasm32-unknown-unknown
         uses: actions-rs/toolchain@v1

--- a/arbitrator/jit/src/machine.rs
+++ b/arbitrator/jit/src/machine.rs
@@ -54,7 +54,7 @@ pub fn create(opts: &Opts, env: WasmEnv) -> (Instance, FunctionEnv<WasmEnv>, Sto
         }
     };
 
-    let module = match Module::new(&store, &wasm) {
+    let module = match Module::new(&store, wasm) {
         Ok(module) => module,
         Err(err) => panic!("{}", err),
     };

--- a/arbitrator/jit/src/wavmio.rs
+++ b/arbitrator/jit/src/wavmio.rs
@@ -134,7 +134,7 @@ fn inbox_message_impl(sp: &GoStack, inbox: &Inbox, name: &str) -> MaybeEscape {
         Err(_) => error!("bad offset {offset} in {name}"),
     };
 
-    let len = std::cmp::min(32, message.len().saturating_sub(offset)) as usize;
+    let len = std::cmp::min(32, message.len().saturating_sub(offset));
     let read = message.get(offset..(offset + len)).unwrap_or_default();
     sp.write_slice(out_ptr, read);
     sp.write_u64(5, read.len() as u64);
@@ -207,7 +207,7 @@ pub fn resolve_preimage(mut env: WasmEnvMut, sp: u32) -> MaybeEscape {
         Err(_) => error!("bad offset {offset} in {name}"),
     };
 
-    let len = std::cmp::min(32, preimage.len().saturating_sub(offset)) as usize;
+    let len = std::cmp::min(32, preimage.len().saturating_sub(offset));
     let read = preimage.get(offset..(offset + len)).unwrap_or_default();
     sp.write_slice(out_ptr, read);
     sp.write_u64(7, read.len() as u64);

--- a/arbitrator/prover/src/console.rs
+++ b/arbitrator/prover/src/console.rs
@@ -78,8 +78,8 @@ impl Color {
     /// Color a bool one of two colors depending on its value.
     pub fn color_if(cond: bool, true_color: &str, false_color: &str) -> String {
         match cond {
-            true => Color::color(true_color, &format!("{}", cond)),
-            false => Color::color(false_color, &format!("{}", cond)),
+            true => Color::color(true_color, format!("{}", cond)),
+            false => Color::color(false_color, format!("{}", cond)),
         }
     }
 }

--- a/arbitrator/prover/src/value.rs
+++ b/arbitrator/prover/src/value.rs
@@ -90,9 +90,9 @@ compile_error!("Architectures with less than a 32 bit pointer width are not supp
 impl ProgramCounter {
     pub fn serialize(self) -> Bytes32 {
         let mut b = [0u8; 32];
-        b[28..].copy_from_slice(&(self.inst as u32).to_be_bytes());
-        b[24..28].copy_from_slice(&(self.func as u32).to_be_bytes());
-        b[20..24].copy_from_slice(&(self.module as u32).to_be_bytes());
+        b[28..].copy_from_slice(&self.inst.to_be_bytes());
+        b[24..28].copy_from_slice(&self.func.to_be_bytes());
+        b[20..24].copy_from_slice(&self.module.to_be_bytes());
         Bytes32(b)
     }
 


### PR DESCRIPTION
It seems that our CI Ubuntu version has been upgraded to 22.04, which doesn't have lld-10: https://packages.ubuntu.com/search?suite=jammy&searchon=names&keywords=lld-

Example CI failure: https://github.com/OffchainLabs/nitro/actions/runs/3708762924/jobs/6286667891

I've upgraded our CI to LLD 14 as a replacement, which is what I'm using locally.