### PR TITLE
Fix block hash in receipts in ws log subscription

### DIFF
--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -398,7 +398,8 @@ func ProduceBlockAdvanced(
 	}
 
 	binary.BigEndian.PutUint64(header.Nonce[:], delayedMessagesRead)
-	header.Root = statedb.IntermediateRoot(true)
+
+	FinalizeBlock(header, complete, statedb, chainConfig)
 
 	// Touch up the block hashes in receipts
 	tmpBlock := types.NewBlock(header, complete, nil, receipts, trie.NewStackTrie(nil))
@@ -410,9 +411,6 @@ func ProduceBlockAdvanced(
 			txLog.BlockHash = blockHash
 		}
 	}
-
-	FinalizeBlock(header, complete, statedb, chainConfig)
-	header.Root = statedb.IntermediateRoot(true)
 
 	block := types.NewBlock(header, complete, nil, receipts, trie.NewStackTrie(nil))
 
@@ -434,6 +432,7 @@ func ProduceBlockAdvanced(
 	return block, receipts, nil
 }
 
+// Also sets header.Root
 func FinalizeBlock(header *types.Header, txs types.Transactions, statedb *state.StateDB, chainConfig *params.ChainConfig) {
 	if header != nil {
 		if header.Number.Uint64() < chainConfig.ArbitrumChainParams.GenesisBlockNum {
@@ -467,5 +466,6 @@ func FinalizeBlock(header *types.Header, txs types.Transactions, statedb *state.
 			ArbOSFormatVersion: arbosVersion,
 		}
 		arbitrumHeader.UpdateHeaderWithInfo(header)
+		header.Root = statedb.IntermediateRoot(true)
 	}
 }

--- a/arbos/engine.go
+++ b/arbos/engine.go
@@ -50,7 +50,6 @@ func (e Engine) Prepare(chain consensus.ChainHeaderReader, header *types.Header)
 
 func (e Engine) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header) {
 	FinalizeBlock(header, txs, state, chain.Config())
-	header.Root = state.IntermediateRoot(true)
 }
 
 func (e Engine) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,

--- a/system_tests/log_subscription_test.go
+++ b/system_tests/log_subscription_test.go
@@ -1,0 +1,57 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package arbtest
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
+)
+
+func TestLogSubscription(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	l2info, node, client := CreateTestL2(t, ctx)
+	defer node.StopAndWait()
+
+	auth := l2info.GetDefaultTransactOpts("Owner", ctx)
+	arbSys, err := precompilesgen.NewArbSys(types.ArbSysAddress, client)
+	Require(t, err)
+
+	logChan := make(chan types.Log, 128)
+	subscription, err := client.SubscribeFilterLogs(ctx, ethereum.FilterQuery{}, logChan)
+	Require(t, err)
+	defer subscription.Unsubscribe()
+
+	tx, err := arbSys.WithdrawEth(&auth, common.Address{})
+	Require(t, err)
+	receipt, err := EnsureTxSucceeded(ctx, client, tx)
+	Require(t, err)
+
+	if len(receipt.Logs) != 1 {
+		Fail(t, "Unexpected number of logs", len(receipt.Logs))
+	}
+
+	var receiptLog types.Log = *receipt.Logs[0]
+	var subscriptionLog types.Log
+	timer := time.NewTimer(time.Second * 5)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		Fail(t, "Hit timeout waiting for log from subscription")
+	case subscriptionLog = <-logChan:
+	}
+	if !reflect.DeepEqual(receiptLog, subscriptionLog) {
+		Fail(t, "Receipt log", receiptLog, "is different than subscription log", subscriptionLog)
+	}
+	_, err = client.BlockByHash(ctx, subscriptionLog.BlockHash)
+	Require(t, err)
+}


### PR DESCRIPTION
Previously, we were setting the log's block hash before we updated the state root.