### PR TITLE
Use pointers for precompiles

### DIFF
--- a/nodeInterface/virtual-contracts.go
+++ b/nodeInterface/virtual-contracts.go
@@ -64,6 +64,7 @@ func init() {
 
 			switch *to {
 			case types.NodeInterfaceAddress:
+				address = types.NodeInterfaceAddress
 				duplicate := *nodeInterfaceImpl
 				duplicate.backend = backend
 				duplicate.context = ctx
@@ -71,9 +72,9 @@ func init() {
 				duplicate.sourceMessage = msg
 				duplicate.returnMessage.message = returnMessage
 				duplicate.returnMessage.changed = &swapMessages
-				precompile = nodeInterface.SwapImpl(&duplicate)
-				address = types.NodeInterfaceAddress
+				precompile = nodeInterface.CloneWithImpl(&duplicate)
 			case types.NodeInterfaceDebugAddress:
+				address = types.NodeInterfaceDebugAddress
 				duplicate := *nodeInterfaceDebugImpl
 				duplicate.backend = backend
 				duplicate.context = ctx
@@ -81,8 +82,7 @@ func init() {
 				duplicate.sourceMessage = msg
 				duplicate.returnMessage.message = returnMessage
 				duplicate.returnMessage.changed = &swapMessages
-				precompile = nodeInterfaceDebug.SwapImpl(&duplicate)
-				address = types.NodeInterfaceDebugAddress
+				precompile = nodeInterfaceDebug.CloneWithImpl(&duplicate)
 			default:
 				return msg, nil, nil
 			}

--- a/precompiles/wrapper.go
+++ b/precompiles/wrapper.go
@@ -47,7 +47,7 @@ func (wrapper *DebugPrecompile) Call(
 	}
 }
 
-func (wrapper *DebugPrecompile) Precompile() Precompile {
+func (wrapper *DebugPrecompile) Precompile() *Precompile {
 	return wrapper.precompile.Precompile()
 }
 
@@ -110,7 +110,7 @@ func (wrapper *OwnerPrecompile) Call(
 	return output, gasSupplied, err // we don't deduct gas since we don't want to charge the owner
 }
 
-func (wrapper *OwnerPrecompile) Precompile() Precompile {
+func (wrapper *OwnerPrecompile) Precompile() *Precompile {
 	con := wrapper.precompile
 	return con.Precompile()
 }


### PR DESCRIPTION
Uses pointers for precompiles to make configuration safer.
