### PR TITLE
Update formula for max fee calculation for batch posting

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -194,13 +194,11 @@ func (p *DataPoster[Meta]) getFeeAndTipCaps(ctx context.Context, lastTipCap *big
 	config := p.config()
 	// MaxFeeCap = (BacklogOfBatches^2 * UrgencyGWei^2 + TargetPriceGWei) * GWei
 	maxFeeCap :=
-		arbmath.BigMulByFloat(
-			arbmath.BigAddByFloat(
-				arbmath.BigMulByFloat(
-					arbmath.UintToBig(arbmath.SquareUint(backlogOfBatches)),
-					arbmath.SquareFloat(config.UrgencyGwei)),
-				config.TargetPriceGwei),
-			params.GWei)
+		arbmath.FloatToBig(
+			(float64(arbmath.SquareUint(backlogOfBatches))*
+				arbmath.SquareFloat(config.UrgencyGwei) +
+				config.TargetPriceGwei) *
+				params.GWei)
 	if arbmath.BigGreaterThan(newFeeCap, maxFeeCap) {
 		log.Error(
 			"reducing proposed fee cap to current maximum",

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -200,7 +200,7 @@ func (p *DataPoster[Meta]) getFeeAndTipCaps(ctx context.Context, lastTipCap *big
 				config.TargetPriceGwei) *
 				params.GWei)
 	if arbmath.BigGreaterThan(newFeeCap, maxFeeCap) {
-		log.Error(
+		log.Warn(
 			"reducing proposed fee cap to current maximum",
 			"proposedFeeCap", newFeeCap,
 			"maxFeeCap", maxFeeCap,

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -46,9 +46,9 @@ type DataPosterConfig struct {
 	RedisSigner           signature.SimpleHmacConfig `koanf:"redis-signer"`
 	ReplacementTimes      string                     `koanf:"replacement-times"`
 	L1LookBehind          uint64                     `koanf:"l1-look-behind" reload:"hot"`
-	MaxFeeCapGwei         float64                    `koanf:"max-fee-cap-gwei" reload:"hot"`
-	MaxFeeCapDoubling     time.Duration              `koanf:"max-fee-cap-doubling" reload:"hot"`
 	MaxQueuedTransactions uint64                     `koanf:"max-queued-transactions" reload:"hot"`
+	TargetPriceGwei       float64                    `koanf:"target-price-gwei" reload:"hot"`
+	UrgencyGwei           float64                    `koanf:"urgency-gwei" reload:"hot"`
 }
 
 type DataPosterConfigFetcher func() *DataPosterConfig
@@ -56,17 +56,17 @@ type DataPosterConfigFetcher func() *DataPosterConfig
 func DataPosterConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".replacement-times", DefaultDataPosterConfig.ReplacementTimes, "comma-separated list of durations since first posting to attempt a replace-by-fee")
 	f.Uint64(prefix+".l1-look-behind", DefaultDataPosterConfig.L1LookBehind, "look at state this many blocks behind the latest (fixes L1 node inconsistencies)")
-	f.Float64(prefix+".max-fee-cap-gwei", DefaultDataPosterConfig.MaxFeeCapGwei, "the maximum fee cap to use, doubled every max-fee-cap-doubling")
-	f.Duration(prefix+".max-fee-cap-doubling", DefaultDataPosterConfig.MaxFeeCapDoubling, "after this duration, double the fee cap (repeats)")
 	f.Uint64(prefix+".max-queued-transactions", DefaultDataPosterConfig.MaxQueuedTransactions, "the maximum number of transactions to have queued in the mempool at once (0 = unlimited)")
+	f.Float64(prefix+".target-price-gwei", DefaultDataPosterConfig.TargetPriceGwei, "the target price to use for maximum fee cap calculation")
+	f.Float64(prefix+".urgency-gwei", DefaultDataPosterConfig.UrgencyGwei, "the urgency to use for maximum fee cap calculation")
 	signature.SimpleHmacConfigAddOptions(prefix+".redis-signer", f)
 }
 
 var DefaultDataPosterConfig = DataPosterConfig{
 	ReplacementTimes:      "5m,10m,20m,30m,1h,2h,4h,6h,8h,12h,16h,18h,20h,22h",
 	L1LookBehind:          2,
-	MaxFeeCapGwei:         105.,
-	MaxFeeCapDoubling:     2 * time.Hour,
+	TargetPriceGwei:       60.,
+	UrgencyGwei:           2.,
 	MaxQueuedTransactions: 64,
 }
 
@@ -74,8 +74,8 @@ var TestDataPosterConfig = DataPosterConfig{
 	ReplacementTimes:      "1s,2s,5s,10s,20s,30s,1m,5m",
 	RedisSigner:           signature.TestSimpleHmacConfig,
 	L1LookBehind:          0,
-	MaxFeeCapGwei:         105.,
-	MaxFeeCapDoubling:     5 * time.Second,
+	TargetPriceGwei:       60.,
+	UrgencyGwei:           2.,
 	MaxQueuedTransactions: 64,
 }
 
@@ -175,7 +175,7 @@ func (p *DataPoster[Meta]) GetNextNonceAndMeta(ctx context.Context) (uint64, Met
 
 const minRbfIncrease = arbmath.OneInBips * 11 / 10
 
-func (p *DataPoster[Meta]) getFeeAndTipCaps(ctx context.Context, lastTipCap *big.Int, dataCreatedAt time.Time) (*big.Int, *big.Int, error) {
+func (p *DataPoster[Meta]) getFeeAndTipCaps(ctx context.Context, lastTipCap *big.Int, dataCreatedAt time.Time, backlogOfBatches uint64) (*big.Int, *big.Int, error) {
 	latestHeader, err := p.headerReader.LastHeader(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -192,22 +192,17 @@ func (p *DataPoster[Meta]) getFeeAndTipCaps(ctx context.Context, lastTipCap *big
 
 	elapsed := time.Since(dataCreatedAt)
 	config := p.config()
-	maxFeeCap := new(big.Int).SetUint64(uint64(config.MaxFeeCapGwei * params.GWei))
-	maxFeeCapDoublings := int64(elapsed / config.MaxFeeCapDoubling)
-	// in tests, this could get way too big
-	if maxFeeCapDoublings > 8 {
-		maxFeeCapDoublings = 8
-	}
-	multiplier := new(big.Int).Exp(big.NewInt(2), big.NewInt(maxFeeCapDoublings), nil)
-	maxFeeCap.Mul(maxFeeCap, multiplier)
+	// MaxFeeCap = (BacklogOfBatches^2 * UrgencyGWei^2 + TargetPriceGWei) * GWei
+	maxFeeCap :=
+		new(big.Int).Mul(
+			new(big.Int).Add(
+				new(big.Int).Mul(
+					new(big.Int).SetUint64(backlogOfBatches*backlogOfBatches),
+					new(big.Int).SetUint64(uint64(config.UrgencyGwei*config.UrgencyGwei))),
+				new(big.Int).SetUint64(uint64(config.TargetPriceGwei))),
+			new(big.Int).SetUint64(uint64(params.GWei)))
 	if arbmath.BigGreaterThan(newFeeCap, maxFeeCap) {
-		logLevel := log.Info
-		if maxFeeCapDoublings >= 3 {
-			logLevel = log.Error
-		} else if maxFeeCapDoublings >= 1 {
-			logLevel = log.Warn
-		}
-		logLevel(
+		log.Error(
 			"reducing proposed fee cap to current maximum",
 			"proposedFeeCap", newFeeCap,
 			"maxFeeCap", maxFeeCap,
@@ -222,7 +217,7 @@ func (p *DataPoster[Meta]) getFeeAndTipCaps(ctx context.Context, lastTipCap *big
 func (p *DataPoster[Meta]) PostTransaction(ctx context.Context, dataCreatedAt time.Time, nonce uint64, meta Meta, to common.Address, calldata []byte, gasLimit uint64) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-	feeCap, tipCap, err := p.getFeeAndTipCaps(ctx, nil, dataCreatedAt)
+	feeCap, tipCap, err := p.getFeeAndTipCaps(ctx, nil, dataCreatedAt, 0)
 	if err != nil {
 		return err
 	}
@@ -283,8 +278,8 @@ func (p *DataPoster[Meta]) sendTx(ctx context.Context, prevTx *queuedTransaction
 }
 
 // the mutex must be held by the caller
-func (p *DataPoster[Meta]) replaceTx(ctx context.Context, prevTx *queuedTransaction[Meta]) error {
-	newFeeCap, newTipCap, err := p.getFeeAndTipCaps(ctx, prevTx.Data.GasTipCap, prevTx.Created)
+func (p *DataPoster[Meta]) replaceTx(ctx context.Context, prevTx *queuedTransaction[Meta], backlogOfBatches uint64) error {
+	newFeeCap, newTipCap, err := p.getFeeAndTipCaps(ctx, prevTx.Data.GasTipCap, prevTx.Created, backlogOfBatches)
 	if err != nil {
 		return err
 	}
@@ -404,11 +399,12 @@ func (p *DataPoster[Meta]) Start(ctxIn context.Context) {
 			log.Warn("failed to get tx queue contents", "err", err)
 			return minWait
 		}
-		for _, tx := range queueContents {
+		for index, tx := range queueContents {
+			backlogOfBatches := len(queueContents) - index - 1
 			replacing := false
 			if now.After(tx.NextReplacement) {
 				replacing = true
-				err := p.replaceTx(ctx, tx)
+				err := p.replaceTx(ctx, tx, uint64(backlogOfBatches))
 				p.maybeLogError(err, tx, "failed to replace-by-fee transaction")
 			}
 			if nextCheck.After(tx.NextReplacement) {

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -194,13 +194,13 @@ func (p *DataPoster[Meta]) getFeeAndTipCaps(ctx context.Context, lastTipCap *big
 	config := p.config()
 	// MaxFeeCap = (BacklogOfBatches^2 * UrgencyGWei^2 + TargetPriceGWei) * GWei
 	maxFeeCap :=
-		new(big.Int).Mul(
-			new(big.Int).Add(
-				new(big.Int).Mul(
-					new(big.Int).SetUint64(backlogOfBatches*backlogOfBatches),
-					new(big.Int).SetUint64(uint64(config.UrgencyGwei*config.UrgencyGwei))),
-				new(big.Int).SetUint64(uint64(config.TargetPriceGwei))),
-			new(big.Int).SetUint64(uint64(params.GWei)))
+		arbmath.BigMulByFloat(
+			arbmath.BigAddByFloat(
+				arbmath.BigMulByFloat(
+					arbmath.UintToBig(arbmath.SquareUint(backlogOfBatches)),
+					arbmath.SquareFloat(config.UrgencyGwei)),
+				config.TargetPriceGwei),
+			params.GWei)
 	if arbmath.BigGreaterThan(newFeeCap, maxFeeCap) {
 		log.Error(
 			"reducing proposed fee cap to current maximum",

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -162,6 +162,11 @@ func BigAddByUint(augend *big.Int, addend uint64) *big.Int {
 	return new(big.Int).Add(augend, UintToBig(addend))
 }
 
+// BigAddByFloat add a float to a huge
+func BigAddByFloat(augend *big.Int, addend float64) *big.Int {
+	return new(big.Int).Add(augend, UintToBig(uint64(addend)))
+}
+
 // BigMulByFrac multiply a huge by a rational
 func BigMulByFrac(value *big.Int, numerator, denominator int64) *big.Int {
 	value = new(big.Int).Set(value)
@@ -181,6 +186,11 @@ func BigMulByUfrac(value *big.Int, numerator, denominator uint64) *big.Int {
 // BigMulByInt multiply a huge by an integer
 func BigMulByInt(multiplicand *big.Int, multiplier int64) *big.Int {
 	return new(big.Int).Mul(multiplicand, big.NewInt(multiplier))
+}
+
+// BigMulByFloat multiply a huge by a float
+func BigMulByFloat(multiplicand *big.Int, multiplier float64) *big.Int {
+	return new(big.Int).Mul(multiplicand, big.NewInt(int64(multiplier)))
 }
 
 // BigMulByUint multiply a huge by a unsigned integer
@@ -341,4 +351,14 @@ func ApproxSquareRoot(value uint64) uint64 {
 		}
 	}
 	return approx
+}
+
+// SquareUint returns square of uint
+func SquareUint(value uint64) uint64 {
+	return value * value
+}
+
+// SquareFloat returns square of float
+func SquareFloat(value float64) float64 {
+	return value * value
 }

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -65,6 +65,11 @@ func UintToBig(value uint64) *big.Int {
 	return new(big.Int).SetUint64(value)
 }
 
+// FloatToBig casts a float to a huge
+func FloatToBig(value float64) *big.Int {
+	return new(big.Int).SetInt64(int64(value))
+}
+
 // UintToBigFloat casts a uint to a big float
 func UintToBigFloat(value uint64) *big.Float {
 	return new(big.Float).SetPrec(53).SetUint64(value)
@@ -162,11 +167,6 @@ func BigAddByUint(augend *big.Int, addend uint64) *big.Int {
 	return new(big.Int).Add(augend, UintToBig(addend))
 }
 
-// BigAddByFloat add a float to a huge
-func BigAddByFloat(augend *big.Int, addend float64) *big.Int {
-	return new(big.Int).Add(augend, UintToBig(uint64(addend)))
-}
-
 // BigMulByFrac multiply a huge by a rational
 func BigMulByFrac(value *big.Int, numerator, denominator int64) *big.Int {
 	value = new(big.Int).Set(value)
@@ -186,11 +186,6 @@ func BigMulByUfrac(value *big.Int, numerator, denominator uint64) *big.Int {
 // BigMulByInt multiply a huge by an integer
 func BigMulByInt(multiplicand *big.Int, multiplier int64) *big.Int {
 	return new(big.Int).Mul(multiplicand, big.NewInt(multiplier))
-}
-
-// BigMulByFloat multiply a huge by a float
-func BigMulByFloat(multiplicand *big.Int, multiplier float64) *big.Int {
-	return new(big.Int).Mul(multiplicand, big.NewInt(int64(multiplier)))
 }
 
 // BigMulByUint multiply a huge by a unsigned integer


### PR DESCRIPTION
New batch pricing formula for the data poster: `P = b^2 * d^2 + Tp`

Where P is our max fee per gas, b is the backlog of batches *after* the batch we're looking at, d(urgency) is a parameter of the algo which the paper seems to find is best at 2, and Tp(target price) is also a parameter of the algo under which a batch will be instantly posted, which the paper seems to find is best at 60