### PR TITLE
Only cache messages since last batch

### DIFF
--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -610,15 +610,15 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L
 	}
 
 	if t.txStreamer.broadcastServer != nil && pos > 1 {
-		prevprevbatchmeta, err := t.GetBatchMetadata(pos - 2)
+		prevbatchmeta, err := t.GetBatchMetadata(pos - 1)
 		if errors.Is(err, AccumulatorNotFoundErr) {
-			return errors.New("missing previous previous sequencer batch")
+			return errors.New("missing previous sequencer batch")
 		} else if err != nil {
 			return err
 		}
-		if prevprevbatchmeta.MessageCount > 0 {
-			// Confirm messages from batch before last batch
-			t.txStreamer.broadcastServer.Confirm(prevprevbatchmeta.MessageCount - 1)
+		if prevbatchmeta.MessageCount > 0 {
+			// Confirm messages from last batch
+			t.txStreamer.broadcastServer.Confirm(prevbatchmeta.MessageCount - 1)
 		}
 	}
 


### PR DESCRIPTION
Previously caching messages from last batch as well as messages since the last batch.  At the time, the concern was that messages would be missed if node started getting messages right after a batch was posted and the node hadn't read the batch from L1 yet.  A recent change added caching such that node would keep feed messages until L1 caught up, so this is no longer a concern.