### PR TITLE
Don't use sequencing hooks when resequencing reorg'd messages

### DIFF
--- a/arbnode/sequencer.go
+++ b/arbnode/sequencer.go
@@ -286,7 +286,7 @@ func NewSequencer(txStreamer *TransactionStreamer, l1Reader *headerreader.Header
 		l1Timestamp:     0,
 		pauseChan:       nil,
 	}
-	txStreamer.SetReorgSequencingPolicy(s.makeSequencingHooks)
+	txStreamer.EnableReorgSequencing()
 	return s, nil
 }
 

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -68,7 +68,7 @@ type TransactionStreamer struct {
 	latestBlock                *types.Block
 	latestMessage              *arbos.L1IncomingMessage
 	newBlockNotifier           chan struct{}
-	reorgSequencing            func() *arbos.SequencingHooks
+	reorgSequencing            bool
 
 	coordinator     *SeqCoordinator
 	broadcastServer *broadcaster.Broadcaster
@@ -156,14 +156,14 @@ func (s *TransactionStreamer) SetInboxReader(inboxReader *InboxReader) {
 	s.inboxReader = inboxReader
 }
 
-func (s *TransactionStreamer) SetReorgSequencingPolicy(reorgSequencing func() *arbos.SequencingHooks) {
+func (s *TransactionStreamer) EnableReorgSequencing() {
 	if s.Started() {
-		panic("trying to set reorg sequencing policy after start")
+		panic("trying to enable reorg sequencing after start")
 	}
-	if s.reorgSequencing != nil {
-		panic("trying to set reorg sequencing policy when already set")
+	if s.reorgSequencing {
+		panic("trying to enable reorg sequencing when already set")
 	}
-	s.reorgSequencing = reorgSequencing
+	s.reorgSequencing = true
 }
 
 func (s *TransactionStreamer) cleanupInconsistentState() error {
@@ -224,7 +224,7 @@ func (s *TransactionStreamer) reorgToInternal(batch ethdb.Batch, count arbutil.M
 		return nil, errors.New("cannot reorg out init message")
 	}
 	var oldMessages []*arbstate.MessageWithMetadata
-	if s.reorgSequencing != nil {
+	if s.reorgSequencing {
 		targetMsgCount, err := s.GetMessageCount()
 		if err != nil {
 			return nil, err
@@ -830,7 +830,9 @@ func (s *TransactionStreamer) resequenceReorgedMessages(messages []*arbstate.Mes
 			log.Warn("failed to parse sequencer message found from reorg", "err", err)
 			continue
 		}
-		_, err = s.sequenceTransactionsWithInsertionMutex(msg.Message.Header, txes, s.reorgSequencing())
+		hooks := arbos.NoopSequencingHooks()
+		hooks.DiscardInvalidTxsEarly = true
+		_, err = s.sequenceTransactionsWithInsertionMutex(msg.Message.Header, txes, hooks)
 		if err != nil {
 			log.Error("failed to re-sequence old user message removed by reorg", "err", err)
 			return

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -85,7 +85,7 @@ type SequencingHooks struct {
 	PostTxFilter           func(*types.Header, *arbosState.ArbosState, *types.Transaction, common.Address, uint64, *core.ExecutionResult) error
 }
 
-func noopSequencingHooks() *SequencingHooks {
+func NoopSequencingHooks() *SequencingHooks {
 	return &SequencingHooks{
 		[]error{},
 		false,
@@ -131,7 +131,7 @@ func ProduceBlock(
 		txes = types.Transactions{}
 	}
 
-	hooks := noopSequencingHooks()
+	hooks := NoopSequencingHooks()
 	return ProduceBlockAdvanced(
 		message.Header, txes, delayedMessagesRead, lastBlockHeader, statedb, chainContext, chainConfig, hooks,
 	)
@@ -196,7 +196,7 @@ func ProduceBlockAdvanced(
 		// repeatedly process the next tx, doing redeems created along the way in FIFO order
 
 		var tx *types.Transaction
-		hooks := noopSequencingHooks()
+		hooks := NoopSequencingHooks()
 		isUserTx := false
 		if len(redeems) > 0 {
 			tx = redeems[0]


### PR DESCRIPTION
This should fix the race condition uncovered in https://github.com/OffchainLabs/nitro/pull/1369