### PR TITLE
only send record from single thread

### DIFF
--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -400,12 +400,6 @@ func (v *BlockValidator) NewBlock(block *types.Block, prevHeader *types.Header, 
 	if present {
 		return
 	}
-	if v.nextBlockToValidate+v.config().PrerecordedBlocks > blockNum {
-		err := v.sendRecord(status, false)
-		if err != nil {
-			log.Error("failed send recording for new block", "err", err)
-		}
-	}
 	v.validations.Store(blockNum, status)
 	if v.lastValidationEntryBlock < blockNum {
 		v.lastValidationEntryBlock = blockNum

--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -128,7 +128,8 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, simpletxloops 
 	finalRefCount := nodeB.BlockValidator.RecordDBReferenceCount()
 	lastBlockNow, err := l2clientB.BlockByNumber(ctx, nil)
 	Require(t, err)
-	largestRefCount := lastBlockNow.NumberU64() + 1 - lastBlock.NumberU64()
+	// up to 3 extra references: awaiting validation, recently valid, lastValidatedHeader
+	largestRefCount := lastBlockNow.NumberU64() - lastBlock.NumberU64() + 3
 	if finalRefCount < 0 || finalRefCount > int64(largestRefCount) {
 		Fail(t, "unexpected refcount:", finalRefCount)
 	}


### PR DESCRIPTION
This avoids unnecessary parallel-calculation of the same state