### PR TITLE
Add error context everywhere in the validator code

### DIFF
--- a/staker/challenge_manager.go
+++ b/staker/challenge_manager.go
@@ -104,10 +104,10 @@ func NewChallengeManager(
 		Topics:    [][]common.Hash{{initiatedChallengeID}, {uint64ToIndex(challengeIndex)}},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error searching logs for InitiatedChallenge event: %w", err)
+		return nil, fmt.Errorf("error searching logs for InitiatedChallenge event from block %v: %w", startL1Block, err)
 	}
 	if len(logs) == 0 {
-		return nil, errors.New("didn't find InitiatedChallenge event")
+		return nil, fmt.Errorf("didn't find InitiatedChallenge event for challenge %v starting at block %v", challengeIndex, startL1Block)
 	}
 	// Multiple logs are in theory fine, as they should all reveal the same preimage.
 	// We'll use the most recent log to be safe.
@@ -239,10 +239,10 @@ func (m *ChallengeManager) resolveStateHash(ctx context.Context, stateHash commo
 		Topics:    [][]common.Hash{{challengeBisectedID}, {uint64ToIndex(m.challengeIndex)}, {stateHash}},
 	})
 	if err != nil {
-		return ChallengeState{}, fmt.Errorf("error searching logs for Bisected event: %w", err)
+		return ChallengeState{}, fmt.Errorf("error searching logs for Bisected event from block %v: %w", m.startL1Block, err)
 	}
 	if len(logs) == 0 {
-		return ChallengeState{}, errors.New("didn't find Bisected event")
+		return ChallengeState{}, fmt.Errorf("didn't find Bisected event for challenge %v starting at block %v", m.challengeIndex, m.startL1Block)
 	}
 	// Multiple logs are in theory fine, as they should all reveal the same preimage.
 	// We'll use the most recent log to be safe.
@@ -412,10 +412,10 @@ func (m *ChallengeManager) LoadExecChallengeIfExists(ctx context.Context) error 
 		Topics:    [][]common.Hash{{executionChallengeBegunID}, {uint64ToIndex(m.challengeIndex)}},
 	})
 	if err != nil {
-		return fmt.Errorf("error searching challenge %v logs from ExecutionChallengeBegun event: %w", m.challengeIndex, err)
+		return fmt.Errorf("error searching challenge %v logs for ExecutionChallengeBegun event from block %v: %w", m.challengeIndex, m.startL1Block, err)
 	}
 	if len(logs) == 0 {
-		return errors.New("expected ExecutionChallengeBegun event")
+		return fmt.Errorf("didn't find ExecutionChallengeBegun event for challenge %v starting at block %v", m.challengeIndex, m.startL1Block)
 	}
 	if len(logs) > 1 {
 		return errors.New("expected only one ExecutionChallengeBegun event")

--- a/staker/challenge_manager.go
+++ b/staker/challenge_manager.go
@@ -6,6 +6,7 @@ package staker
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -16,9 +17,9 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/offchainlabs/nitro/solgen/go/challengegen"
 	"github.com/offchainlabs/nitro/validator"
-	"github.com/pkg/errors"
 )
 
 const maxBisectionDegree uint64 = 40
@@ -94,7 +95,7 @@ func NewChallengeManager(
 ) (*ChallengeManager, error) {
 	con, err := challengegen.NewChallengeManager(challengeManagerAddr, l1client)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating bindgen ChallengeManager: %w", err)
 	}
 
 	logs, err := l1client.FilterLogs(ctx, ethereum.FilterQuery{
@@ -103,7 +104,7 @@ func NewChallengeManager(
 		Topics:    [][]common.Hash{{initiatedChallengeID}, {uint64ToIndex(challengeIndex)}},
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error searching logs for InitiatedChallenge event: %w", err)
 	}
 	if len(logs) == 0 {
 		return nil, errors.New("didn't find InitiatedChallenge event")
@@ -113,13 +114,13 @@ func NewChallengeManager(
 	evmLog := logs[len(logs)-1]
 	parsedLog, err := con.ParseInitiatedChallenge(evmLog)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing InitiatedChallenge event: %w", err)
 	}
 
 	callOpts := &bind.CallOpts{Context: ctx}
 	challengeInfo, err := con.Challenges(callOpts, new(big.Int).SetUint64(challengeIndex))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting challenge info: %w", err)
 	}
 
 	genesisBlockNum := l2blockChain.Config().ArbitrumChainParams.GenesisBlockNum
@@ -130,7 +131,7 @@ func NewChallengeManager(
 		genesisBlockNum,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating block challenge backend: %w", err)
 	}
 	return &ChallengeManager{
 		challengeCore: &challengeCore{
@@ -204,7 +205,14 @@ func (m *ChallengeManager) latestConfirmedBlock(ctx context.Context) (*big.Int, 
 	}
 	latestBlock, err := m.client.HeaderByNumber(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting latest header from client: %w", err)
+	}
+	if latestBlock.Difficulty.Sign() == 0 {
+		latestConfirmed, err := m.client.HeaderByNumber(ctx, big.NewInt(int64(rpc.FinalizedBlockNumber)))
+		if err != nil {
+			return nil, fmt.Errorf("error getting finalized block from client: %w", err)
+		}
+		return latestConfirmed.Number, nil
 	}
 	block := new(big.Int).Sub(latestBlock.Number, big.NewInt(m.confirmationBlocks))
 	if block.Sign() < 0 {
@@ -231,7 +239,7 @@ func (m *ChallengeManager) resolveStateHash(ctx context.Context, stateHash commo
 		Topics:    [][]common.Hash{{challengeBisectedID}, {uint64ToIndex(m.challengeIndex)}, {stateHash}},
 	})
 	if err != nil {
-		return ChallengeState{}, err
+		return ChallengeState{}, fmt.Errorf("error searching logs for Bisected event: %w", err)
 	}
 	if len(logs) == 0 {
 		return ChallengeState{}, errors.New("didn't find Bisected event")
@@ -241,7 +249,7 @@ func (m *ChallengeManager) resolveStateHash(ctx context.Context, stateHash commo
 	evmLog := logs[len(logs)-1]
 	parsedLog, err := m.con.ParseBisected(evmLog)
 	if err != nil {
-		return ChallengeState{}, err
+		return ChallengeState{}, fmt.Errorf("error parsing Bisected event log: %w", err)
 	}
 	state := ChallengeState{
 		Start:       parsedLog.ChallengedSegmentStart,
@@ -278,7 +286,7 @@ func (m *ChallengeManager) bisect(ctx context.Context, backend ChallengeBackend,
 	newChallengeLength := endSegmentPosition - startSegmentPosition
 	err := backend.SetRange(ctx, startSegmentPosition, endSegmentPosition)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error setting challenge range on backend: %w", err)
 	}
 	bisectionDegree := maxBisectionDegree
 	if newChallengeLength < bisectionDegree {
@@ -296,7 +304,7 @@ func (m *ChallengeManager) bisect(ctx context.Context, backend ChallengeBackend,
 		}
 		newSegments[i], err = backend.GetHashAtStep(ctx, position)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error getting hash at step %v: %w", position, err)
 		}
 		position += normalSegmentLength
 	}
@@ -317,7 +325,7 @@ func (m *ChallengeManager) IsMyTurn(ctx context.Context) (bool, error) {
 	callOpts := &bind.CallOpts{Context: ctx}
 	responder, err := m.con.CurrentResponder(callOpts, m.challengeIndex)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("error getting current responder of challenge %v: %w", m.challengeIndex, err)
 	}
 	if responder != m.actingAs {
 		return false, nil
@@ -329,7 +337,7 @@ func (m *ChallengeManager) IsMyTurn(ctx context.Context) (bool, error) {
 	}
 	responder, err = m.con.CurrentResponder(callOpts, m.challengeIndex)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("error getting confirmed current responder of challenge %v: %w", m.challengeIndex, err)
 	}
 	if responder != m.actingAs {
 		return false, nil
@@ -346,14 +354,14 @@ func (m *ChallengeManager) GetChallengeState(ctx context.Context) (*ChallengeSta
 	}
 	challengeState, err := m.con.ChallengeInfo(callOpts, m.challengeIndex)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, fmt.Errorf("error getting challenge %v info: %w", m.challengeIndex, err)
 	}
 	if challengeState.ChallengeStateHash == (common.Hash{}) {
 		return nil, errors.New("lost challenge (state hash 0)")
 	}
 	state, err := m.resolveStateHash(ctx, challengeState.ChallengeStateHash)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error resolving state hash %v: %w", challengeState.ChallengeStateHash, err)
 	}
 	return &state, nil
 }
@@ -362,12 +370,12 @@ func (m *ChallengeManager) ScanChallengeState(ctx context.Context, backend Chall
 	for i, segment := range state.Segments {
 		ourHash, err := backend.GetHashAtStep(ctx, segment.Position)
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("error getting hash from challenge backend at step %v: %w", segment.Position, err)
 		}
 		log.Debug("checking challenge segment", "challenge", m.challengeIndex, "position", segment.Position, "ourHash", ourHash, "segmentHash", segment.Hash)
 		if segment.Hash != ourHash {
 			if i == 0 {
-				return 0, errors.Errorf(
+				return 0, fmt.Errorf(
 					"first challenge segment doesn't match: at step count %v challenge has %v but resolved %v",
 					segment.Position, segment.Hash, ourHash,
 				)
@@ -375,7 +383,7 @@ func (m *ChallengeManager) ScanChallengeState(ctx context.Context, backend Chall
 			return i - 1, nil
 		}
 	}
-	return 0, errors.Errorf("agreed with entire challenge (start step count %v and end step count %v)", state.Start.String(), state.End.String())
+	return 0, fmt.Errorf("agreed with entire challenge (start step count %v and end step count %v)", state.Start.String(), state.End.String())
 }
 
 func (m *ChallengeManager) LoadExecChallengeIfExists(ctx context.Context) error {
@@ -392,8 +400,11 @@ func (m *ChallengeManager) LoadExecChallengeIfExists(ctx context.Context) error 
 		BlockNumber: latestConfirmedBlock,
 	}
 	challengeState, err := m.con.ChallengeInfo(callOpts, m.challengeIndex)
-	if err != nil || challengeState.Mode != challengeModeExecution {
-		return errors.WithStack(err)
+	if err != nil {
+		return fmt.Errorf("error getting challenge %v info: %w", m.challengeIndex, err)
+	}
+	if challengeState.Mode != challengeModeExecution {
+		return nil
 	}
 	logs, err := m.client.FilterLogs(ctx, ethereum.FilterQuery{
 		FromBlock: m.startL1Block,
@@ -401,7 +412,7 @@ func (m *ChallengeManager) LoadExecChallengeIfExists(ctx context.Context) error 
 		Topics:    [][]common.Hash{{executionChallengeBegunID}, {uint64ToIndex(m.challengeIndex)}},
 	})
 	if err != nil {
-		return errors.WithStack(err)
+		return fmt.Errorf("error searching challenge %v logs from ExecutionChallengeBegun event: %w", m.challengeIndex, err)
 	}
 	if len(logs) == 0 {
 		return errors.New("expected ExecutionChallengeBegun event")
@@ -411,7 +422,7 @@ func (m *ChallengeManager) LoadExecChallengeIfExists(ctx context.Context) error 
 	}
 	ev, err := m.con.ParseExecutionChallengeBegun(logs[0])
 	if err != nil {
-		return errors.WithStack(err)
+		return fmt.Errorf("error parsing ExecutionChallengeBegun event: %w", err)
 	}
 	blockNum, tooFar := m.blockChallengeBackend.GetBlockNrAtStep(ev.BlockSteps.Uint64())
 	return m.createExecutionBackend(ctx, uint64(blockNum), tooFar)
@@ -422,9 +433,10 @@ func (m *ChallengeManager) IssueOneStepProof(
 	oldState *ChallengeState,
 	startSegment int,
 ) (*types.Transaction, error) {
-	proof, err := m.executionChallengeBackend.GetProofAt(ctx, oldState.Segments[startSegment].Position)
+	position := oldState.Segments[startSegment].Position
+	proof, err := m.executionChallengeBackend.GetProofAt(ctx, position)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting OSP from challenge backend at step %v: %w", position, err)
 	}
 	return m.challengeCore.con.OneStepProveExecution(
 		m.challengeCore.auth,
@@ -451,18 +463,18 @@ func (m *ChallengeManager) createExecutionBackend(ctx context.Context, blockNum 
 	}
 	entry, err := m.validator.CreateReadyValidationEntry(ctx, nextHeader)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating validation entry for block %v for execution challenge: %w", blockNum, err)
 	}
 	input, err := entry.ToInput()
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting validation entry input of block %v: %w", blockNum, err)
 	}
 	if tooFar {
 		input.BatchInfo = []validator.BatchInfo{}
 	}
 	m.executionChallengeBackend, err = m.validator.validationSpawner.CreateExecutionBackend(ctx, m.wasmModuleRoot, input, m.targetNumMachines)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating execution backend for block %v: %w", blockNum, err)
 	}
 	m.initialMachineBlockNr = int64(blockNum)
 	return nil
@@ -471,15 +483,15 @@ func (m *ChallengeManager) createExecutionBackend(ctx context.Context, blockNum 
 func (m *ChallengeManager) Act(ctx context.Context) (*types.Transaction, error) {
 	err := m.LoadExecChallengeIfExists(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error loading execution challenge: %w", err)
 	}
 	myTurn, err := m.IsMyTurn(ctx)
 	if !myTurn || (err != nil) {
-		return nil, err
+		return nil, fmt.Errorf("error checking if it's our turn: %w", err)
 	}
 	state, err := m.GetChallengeState(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting challenge state: %w", err)
 	}
 
 	var backend ChallengeBackend
@@ -491,12 +503,12 @@ func (m *ChallengeManager) Act(ctx context.Context) (*types.Transaction, error) 
 
 	err = backend.SetRange(ctx, state.Start.Uint64(), state.End.Uint64())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error setting challenge range on backend: %w", err)
 	}
 
 	nextMovePos, err := m.ScanChallengeState(ctx, backend, state)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error scanning challenge state: %w", err)
 	}
 	startPosition := state.Segments[nextMovePos].Position
 	endPosition := state.Segments[nextMovePos+1].Position
@@ -515,15 +527,15 @@ func (m *ChallengeManager) Act(ctx context.Context) (*types.Transaction, error) 
 	blockNum, tooFar := m.blockChallengeBackend.GetBlockNrAtStep(uint64(nextMovePos))
 	expectedState, expectedStatus, err := m.blockChallengeBackend.GetInfoAtStep(uint64(nextMovePos + 1))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting info from block challenge backend: %w", err)
 	}
 	err = m.createExecutionBackend(ctx, uint64(blockNum), tooFar)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating execution backend: %w", err)
 	}
 	stepCount, computedState, computedStatus, err := m.executionChallengeBackend.GetFinalState(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting execution challenge final state: %w", err)
 	}
 	if expectedStatus != computedStatus {
 		return nil, fmt.Errorf("after block %v expected status %v but got %v", blockNum, expectedStatus, computedStatus)

--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -255,12 +255,12 @@ func (v *L1Validator) blockNumberFromGlobalState(gs validator.GoGlobalState) (in
 func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurStakerInfo, strategy StakerStrategy, makeAssertionInterval time.Duration) (nodeAction, bool, error) {
 	startState, prevInboxMaxCount, startStateProposed, err := lookupNodeStartState(ctx, v.rollup, stakerInfo.LatestStakedNode, stakerInfo.LatestStakedNodeHash)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("error looking up node start state: %w", err)
 	}
 
 	startStateProposedHeader, err := v.client.HeaderByNumber(ctx, new(big.Int).SetUint64(startStateProposed))
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("error looking up L1 header of block %v of node start state: %w", startStateProposed, err)
 	}
 	startStateProposedTime := time.Unix(int64(startStateProposedHeader.Time), 0)
 
@@ -269,7 +269,7 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 
 	localBatchCount, err := v.inboxTracker.GetBatchCount()
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("error getting batch count from inbox tracker: %w", err)
 	}
 	if localBatchCount < startState.RequiredBatches() {
 		log.Info("catching up to chain batches", "localBatches", localBatchCount, "target", startState.RequiredBatches())
@@ -280,7 +280,7 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 	if startBlock == nil && (startState.GlobalState != validator.GoGlobalState{}) {
 		expectedBlockHeight, inboxPositionInvalid, err := v.blockNumberFromGlobalState(startState.GlobalState)
 		if err != nil {
-			return nil, false, err
+			return nil, false, fmt.Errorf("error getting block number from global state: %w", err)
 		}
 		if inboxPositionInvalid {
 			log.Error("invalid start global state inbox position", startState.GlobalState.BlockHash, "batch", startState.GlobalState.Batch, "pos", startState.GlobalState.PosInBatch)
@@ -306,7 +306,7 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 			return nil, false, fmt.Errorf("block validator validated block %v as hash %v but blockchain has hash %v", lastBlockValidated, expectedHash, haveHash)
 		}
 		if err := v.updateBlockValidatorModuleRoot(ctx); err != nil {
-			return nil, false, err
+			return nil, false, fmt.Errorf("error updating block validator module root: %w", err)
 		}
 		wasmRootValid := false
 		for _, root := range validRoots {
@@ -324,7 +324,7 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 		if localBatchCount > 0 {
 			messageCount, err := v.inboxTracker.GetBatchMessageCount(localBatchCount - 1)
 			if err != nil {
-				return nil, false, err
+				return nil, false, fmt.Errorf("error getting latest batch %v message count: %w", localBatchCount-1, err)
 			}
 			// Must be non-negative as a batch must contain at least one message
 			lastBatchBlock := uint64(arbutil.MessageCountToBlockNumber(messageCount, v.genesisBlockNumber))
@@ -338,12 +338,12 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 
 	currentL1BlockNum, err := v.client.BlockNumber(ctx)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("error getting latest L1 block number: %w", err)
 	}
 
 	minAssertionPeriod, err := v.rollup.MinimumAssertionPeriod(v.getCallOpts(ctx))
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("error getting rollup minimum assertion period: %w", err)
 	}
 
 	timeSinceProposed := big.NewInt(int64(currentL1BlockNum) - int64(startStateProposed))
@@ -354,7 +354,7 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 
 	successorNodes, err := v.rollup.LookupNodeChildren(ctx, stakerInfo.LatestStakedNode, stakerInfo.LatestStakedNodeHash)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("error looking up node %v (hash %v) children: %w", stakerInfo.LatestStakedNode, stakerInfo.LatestStakedNodeHash, err)
 	}
 
 	var correctNode nodeAction
@@ -376,7 +376,7 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 			if requiredBatches > 0 {
 				haveAcc, err := v.inboxTracker.GetBatchAcc(requiredBatches - 1)
 				if err != nil {
-					return nil, false, err
+					return nil, false, fmt.Errorf("error getting batch %v accumulator: %w", requiredBatches-1, err)
 				}
 				if haveAcc != nd.AfterInboxBatchAcc {
 					return nil, false, fmt.Errorf("missed sequencer batches reorg: at seq num %v have acc %v but assertion has acc %v", requiredBatches-1, haveAcc, nd.AfterInboxBatchAcc)
@@ -384,7 +384,7 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 			}
 			lastBlockNum, inboxPositionInvalid, err := v.blockNumberFromGlobalState(afterGs)
 			if err != nil {
-				return nil, false, err
+				return nil, false, fmt.Errorf("error getting block number from global state: %w", err)
 			}
 			if int64(lastBlockValidated) < lastBlockNum {
 				return nil, false, fmt.Errorf("waiting for validator to catch up to assertion blocks: %v/%v", lastBlockValidated, lastBlockNum)
@@ -398,7 +398,7 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 				}
 				lastBlockExtra, err := types.DeserializeHeaderExtraInformation(lastBlock.Header())
 				if err != nil {
-					return nil, false, err
+					return nil, false, fmt.Errorf("error getting block %v header extra info: %w", lastBlockNum, err)
 				}
 				expectedBlockHash = lastBlock.Hash()
 				expectedSendRoot = lastBlockExtra.SendRoot
@@ -458,7 +458,10 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 			lastNodeHashIfExists = &successorNodes[len(successorNodes)-1].NodeHash
 		}
 		action, err := v.createNewNodeAction(ctx, stakerInfo, lastBlockValidated, localBatchCount, prevInboxMaxCount, startBlock, startState, lastNodeHashIfExists)
-		return action, wrongNodesExist, err
+		if err != nil {
+			return nil, wrongNodesExist, fmt.Errorf("error generating create new node action: %w", err)
+		}
+		return action, wrongNodesExist, nil
 	}
 
 	return nil, wrongNodesExist, nil
@@ -497,11 +500,11 @@ func (v *L1Validator) createNewNodeAction(
 	for i := localBatchCount - 1; i+1 >= minBatchCount && i > 0; i-- {
 		batchMessageCount, err := v.inboxTracker.GetBatchMessageCount(i)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error getting batch %v message count: %w", i, err)
 		}
 		prevBatchMessageCount, err := v.inboxTracker.GetBatchMessageCount(i - 1)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error getting previous batch %v message count: %w", i-1, err)
 		}
 		// Must be non-negative as a batch must contain at least one message
 		lastBlockNum := uint64(arbutil.MessageCountToBlockNumber(batchMessageCount, v.genesisBlockNumber))
@@ -532,7 +535,7 @@ func (v *L1Validator) createNewNodeAction(
 	}
 	validatedBatchAcc, err := v.inboxTracker.GetBatchAcc(assertionCoversBatch)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting batch %v accumulator: %w", assertionCoversBatch, err)
 	}
 
 	assertingBlock := v.l2Blockchain.GetBlockByNumber(lastBlockValidated)
@@ -541,7 +544,7 @@ func (v *L1Validator) createNewNodeAction(
 	}
 	assertingBlockExtra, err := types.DeserializeHeaderExtraInformation(assertingBlock.Header())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting asserting block %v header extra info: %w", assertingBlock.Number(), err)
 	}
 
 	hasSiblingByte := [1]byte{0}
@@ -575,7 +578,7 @@ func (v *L1Validator) createNewNodeAction(
 	if v.blockValidator == nil {
 		wasmModuleRoot, err = v.rollup.WasmModuleRoot(v.getCallOpts(ctx))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error rollup wasm module root: %w", err)
 		}
 	}
 

--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -255,7 +255,7 @@ func (v *L1Validator) blockNumberFromGlobalState(gs validator.GoGlobalState) (in
 func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurStakerInfo, strategy StakerStrategy, makeAssertionInterval time.Duration) (nodeAction, bool, error) {
 	startState, prevInboxMaxCount, startStateProposed, err := lookupNodeStartState(ctx, v.rollup, stakerInfo.LatestStakedNode, stakerInfo.LatestStakedNodeHash)
 	if err != nil {
-		return nil, false, fmt.Errorf("error looking up node start state: %w", err)
+		return nil, false, fmt.Errorf("error looking up node %v (hash %v) start state: %w", stakerInfo.LatestStakedNode, stakerInfo.LatestStakedNodeHash, err)
 	}
 
 	startStateProposedHeader, err := v.client.HeaderByNumber(ctx, new(big.Int).SetUint64(startStateProposed))
@@ -459,7 +459,7 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 		}
 		action, err := v.createNewNodeAction(ctx, stakerInfo, lastBlockValidated, localBatchCount, prevInboxMaxCount, startBlock, startState, lastNodeHashIfExists)
 		if err != nil {
-			return nil, wrongNodesExist, fmt.Errorf("error generating create new node action: %w", err)
+			return nil, wrongNodesExist, fmt.Errorf("error generating create new node action (from start block %v to last block validated %v): %w", startBlock, lastBlockValidated, err)
 		}
 		return action, wrongNodesExist, nil
 	}

--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -599,7 +599,7 @@ func lookupNodeStartState(ctx context.Context, rollup *RollupWatcher, nodeNum ui
 	if nodeNum == 0 {
 		creationEvent, err := rollup.LookupCreation(ctx)
 		if err != nil {
-			return nil, nil, 0, err
+			return nil, nil, 0, fmt.Errorf("error looking up rollup creation event: %w", err)
 		}
 		return &validator.ExecutionState{
 			GlobalState:   validator.GoGlobalState{},

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -616,7 +616,10 @@ func (s *Staker) advanceStake(ctx context.Context, info *OurStakerInfo, effectiv
 		// We'll return early if we already havea stake
 		if info.StakeExists {
 			_, err = s.rollup.StakeOnExistingNode(s.builder.Auth(ctx), action.number, action.hash)
-			return fmt.Errorf("error staking on existing node: %w", err)
+			if err != nil {
+				return fmt.Errorf("error staking on existing node: %w", err)
+			}
+			return nil
 		}
 
 		// If we have no stake yet, we'll put one down

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -315,7 +315,7 @@ func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {
 	if s.strategy != WatchtowerStrategy {
 		whitelisted, err := s.IsWhitelisted(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error checking if whitelisted: %w", err)
 		}
 		if !whitelisted {
 			log.Warn("validator address isn't whitelisted", "address", s.wallet.Address(), "txSender", s.wallet.TxSenderAddress())
@@ -333,7 +333,7 @@ func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {
 		var err error
 		rawInfo, err = s.rollup.StakerInfo(ctx, walletAddressOrZero)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error getting own staker info: %w", err)
 		}
 	}
 	// If the wallet address is zero, or the wallet address isn't staked,
@@ -342,7 +342,7 @@ func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {
 		callOpts, s.rollupAddress, walletAddressOrZero,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting latest staked node: %w", err)
 	}
 	if rawInfo != nil {
 		rawInfo.LatestStakedNode = latestStakedNodeNum
@@ -358,7 +358,7 @@ func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {
 	effectiveStrategy := s.strategy
 	nodesLinear, err := s.validatorUtils.AreUnresolvedNodesLinear(callOpts, s.rollupAddress)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error checking for rollup assertion fork: %w", err)
 	}
 	if !nodesLinear {
 		log.Warn("rollup assertion fork detected")
@@ -385,12 +385,12 @@ func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {
 
 	latestConfirmedNode, err := s.rollup.LatestConfirmed(callOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting latest confirmed node: %w", err)
 	}
 
 	requiredStakeElevated, err := s.isRequiredStakeElevated(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error checking if required stake is elevated: %w", err)
 	}
 	// Resolve nodes if either we're on the make nodes strategy,
 	// or we're on the stake latest strategy but don't have a stake
@@ -400,12 +400,15 @@ func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {
 	resolvingNode := false
 	if shouldResolveNodes {
 		arbTx, err := s.resolveTimedOutChallenges(ctx)
-		if err != nil || arbTx != nil {
-			return arbTx, err
+		if err != nil {
+			return nil, fmt.Errorf("error resolving timed out challenges: %w", err)
+		}
+		if arbTx != nil {
+			return arbTx, nil
 		}
 		resolvingNode, err = s.resolveNextNode(ctx, rawInfo, &latestConfirmedNode)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error resolving nodes: %w", err)
 		}
 		if resolvingNode && rawInfo == nil && latestConfirmedNode > info.LatestStakedNode {
 			// If we hit this condition, we've resolved what was previously the latest confirmed node,
@@ -414,7 +417,7 @@ func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {
 			// to indicate that we're now entering the rollup on the newly confirmed node.
 			nodeInfo, err := s.rollup.GetNode(callOpts, latestConfirmedNode)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error getting latest confirmed node info: %w", err)
 			}
 			info.LatestStakedNode = latestConfirmedNode
 			info.LatestStakedNodeHash = nodeInfo.NodeHash
@@ -434,11 +437,11 @@ func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {
 			// Note: we must have an address if rawInfo != nil
 			_, err = s.rollup.ReturnOldDeposit(s.builder.Auth(ctx), walletAddressOrZero)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error returning old deposit: %w", err)
 			}
 			_, err = s.rollup.WithdrawStakerFunds(s.builder.Auth(ctx))
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error withdrawing staker funds: %w", err)
 			}
 			log.Info("removing old stake and withdrawing funds")
 			return s.wallet.ExecuteTransactions(ctx, s.builder, common.HexToAddress(s.config.GasRefunderAddress))
@@ -448,19 +451,19 @@ func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {
 	if walletAddressOrZero != (common.Address{}) && canActFurther() {
 		withdrawable, err := s.rollup.WithdrawableFunds(callOpts, walletAddressOrZero)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error checking withdrawable funds: %w", err)
 		}
 		if withdrawable.Sign() > 0 {
 			_, err = s.rollup.WithdrawStakerFunds(s.builder.Auth(ctx))
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error withdrawing staker funds: %w", err)
 			}
 		}
 	}
 
 	if rawInfo != nil && canActFurther() {
 		if err = s.handleConflict(ctx, rawInfo); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error handling conflict: %w", err)
 		}
 	}
 
@@ -470,7 +473,7 @@ func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {
 		// Advance stake up to 20 times in one transaction
 		for i := 0; info.CanProgress && i < 20; i++ {
 			if err := s.advanceStake(ctx, &info, effectiveStrategy); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error advancing stake: %w", err)
 			}
 			if !s.wallet.CanBatchTxs() && effectiveStrategy >= StakeLatestStrategy {
 				info.CanProgress = false
@@ -480,7 +483,7 @@ func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {
 
 	if rawInfo != nil && s.builder.BuildingTransactionCount() == 0 && canActFurther() {
 		if err := s.createConflict(ctx, rawInfo); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error creating conflict: %w", err)
 		}
 	}
 
@@ -505,7 +508,7 @@ func (s *Staker) handleConflict(ctx context.Context, info *StakerInfo) error {
 
 		latestConfirmedCreated, err := s.rollup.LatestConfirmedCreationBlock(ctx)
 		if err != nil {
-			return err
+			return fmt.Errorf("error getting latest confirmed creation block: %w", err)
 		}
 
 		newChallengeManager, err := NewChallengeManager(
@@ -523,7 +526,7 @@ func (s *Staker) handleConflict(ctx context.Context, info *StakerInfo) error {
 			s.config.ConfirmationBlocks,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("error creating challenge manager: %w", err)
 		}
 
 		s.activeChallenge = newChallengeManager
@@ -537,7 +540,7 @@ func (s *Staker) advanceStake(ctx context.Context, info *OurStakerInfo, effectiv
 	active := effectiveStrategy >= StakeLatestStrategy
 	action, wrongNodesExist, err := s.generateNodeAction(ctx, info, effectiveStrategy, s.config.MakeAssertionInterval)
 	if err != nil {
-		return err
+		return fmt.Errorf("error generating node action: %w", err)
 	}
 	if wrongNodesExist && effectiveStrategy == WatchtowerStrategy {
 		log.Error("found incorrect assertion in watchtower mode")
@@ -568,16 +571,19 @@ func (s *Staker) advanceStake(ctx context.Context, info *OurStakerInfo, effectiv
 		info.LatestStakedNode = 0
 		info.LatestStakedNodeHash = action.hash
 
-		// We'll return early if we already havea stake
+		// We'll return early if we already have a stake
 		if info.StakeExists {
 			_, err = s.rollup.StakeOnNewNode(s.builder.Auth(ctx), action.assertion.AsSolidityStruct(), action.hash, action.prevInboxMaxCount)
-			return err
+			if err != nil {
+				return fmt.Errorf("error staking on new node: %w", err)
+			}
+			return nil
 		}
 
 		// If we have no stake yet, we'll put one down
 		stakeAmount, err := s.rollup.CurrentRequiredStake(s.getCallOpts(ctx))
 		if err != nil {
-			return err
+			return fmt.Errorf("error getting current required stake: %w", err)
 		}
 		_, err = s.rollup.NewStakeOnNewNode(
 			s.builder.AuthWithAmount(ctx, stakeAmount),
@@ -586,7 +592,7 @@ func (s *Staker) advanceStake(ctx context.Context, info *OurStakerInfo, effectiv
 			action.prevInboxMaxCount,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("error placing new stake on new node: %w", err)
 		}
 		info.StakeExists = true
 		return nil
@@ -610,13 +616,13 @@ func (s *Staker) advanceStake(ctx context.Context, info *OurStakerInfo, effectiv
 		// We'll return early if we already havea stake
 		if info.StakeExists {
 			_, err = s.rollup.StakeOnExistingNode(s.builder.Auth(ctx), action.number, action.hash)
-			return err
+			return fmt.Errorf("error staking on existing node: %w", err)
 		}
 
 		// If we have no stake yet, we'll put one down
 		stakeAmount, err := s.rollup.CurrentRequiredStake(s.getCallOpts(ctx))
 		if err != nil {
-			return err
+			return fmt.Errorf("error getting current required stake: %w", err)
 		}
 		_, err = s.rollup.NewStakeOnExistingNode(
 			s.builder.AuthWithAmount(ctx, stakeAmount),
@@ -624,7 +630,7 @@ func (s *Staker) advanceStake(ctx context.Context, info *OurStakerInfo, effectiv
 			action.hash,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("error placing new stake on existing node: %w", err)
 		}
 		info.StakeExists = true
 		return nil
@@ -641,13 +647,13 @@ func (s *Staker) createConflict(ctx context.Context, info *StakerInfo) error {
 	callOpts := s.getCallOpts(ctx)
 	stakers, moreStakers, err := s.validatorUtils.GetStakers(callOpts, s.rollupAddress, 0, 1024)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting stakers list: %w", err)
 	}
 	for moreStakers {
 		var newStakers []common.Address
 		newStakers, moreStakers, err = s.validatorUtils.GetStakers(callOpts, s.rollupAddress, uint64(len(stakers)), 1024)
 		if err != nil {
-			return err
+			return fmt.Errorf("error getting more stakers: %w", err)
 		}
 		stakers = append(stakers, newStakers...)
 	}
@@ -660,14 +666,14 @@ func (s *Staker) createConflict(ctx context.Context, info *StakerInfo) error {
 	for _, staker := range stakers {
 		stakerInfo, err := s.rollup.StakerInfo(ctx, staker)
 		if err != nil {
-			return err
+			return fmt.Errorf("error getting staker %v info: %w", staker, err)
 		}
 		if stakerInfo.CurrentChallenge != nil {
 			continue
 		}
 		conflictInfo, err := s.validatorUtils.FindStakerConflict(callOpts, s.rollupAddress, walletAddr, staker, big.NewInt(1024))
 		if err != nil {
-			return err
+			return fmt.Errorf("error finding conflict with staker %v: %w", staker, err)
 		}
 		if ConflictType(conflictInfo.Ty) != CONFLICT_TYPE_FOUND {
 			continue
@@ -685,13 +691,13 @@ func (s *Staker) createConflict(ctx context.Context, info *StakerInfo) error {
 
 		node1Info, err := s.rollup.LookupNode(ctx, conflictInfo.Node1)
 		if err != nil {
-			return err
+			return fmt.Errorf("error looking up node %v: %w", conflictInfo.Node1, err)
 		}
 		node2Info, err := s.rollup.LookupNode(ctx, conflictInfo.Node2)
 		if err != nil {
-			return err
+			return fmt.Errorf("error looking up node %v: %w", conflictInfo.Node2, err)
 		}
-		log.Warn("creating challenge", "node1", conflictInfo.Node1, "node2", conflictInfo.Node2, "otherStaker", staker2)
+		log.Warn("creating challenge", "node1", conflictInfo.Node1, "node2", conflictInfo.Node2, "otherStaker", staker)
 		_, err = s.rollup.CreateChallenge(
 			s.builder.Auth(ctx),
 			[2]common.Address{staker1, staker2},
@@ -704,7 +710,7 @@ func (s *Staker) createConflict(ctx context.Context, info *StakerInfo) error {
 			[2][32]byte{node1Info.WasmModuleRoot, node2Info.WasmModuleRoot},
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("error creating challenge: %w", err)
 		}
 	}
 	// No conflicts exist


### PR DESCRIPTION
This avoids a generic and extremely vague "execution reverted" error that leaves no trace as to its source.