### PR TITLE
Harden the batch poster

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -597,7 +597,7 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 		if err != nil {
 			b.building = nil
 			logLevel := log.Error
-			if errors.Is(err, AccumulatorNotFoundErr) || errors.Is(err, dataposter.StorageRaceErr) {
+			if errors.Is(err, AccumulatorNotFoundErr) || errors.Is(err, dataposter.ErrStorageRace) {
 				// Likely the inbox tracker just isn't caught up.
 				// Let's see if this error disappears naturally.
 				if b.firstAccErr == (time.Time{}) {

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/go-redis/redis/v8"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/util/arbmath"
@@ -45,7 +46,7 @@ type QueueStorage[Item any] interface {
 type DataPosterConfig struct {
 	RedisSigner           signature.SimpleHmacConfig `koanf:"redis-signer"`
 	ReplacementTimes      string                     `koanf:"replacement-times"`
-	L1LookBehind          uint64                     `koanf:"l1-look-behind" reload:"hot"`
+	WaitForL1Finality     bool                       `koanf:"wait-for-l1-finality" reload:"hot"`
 	MaxQueuedTransactions uint64                     `koanf:"max-queued-transactions" reload:"hot"`
 	TargetPriceGwei       float64                    `koanf:"target-price-gwei" reload:"hot"`
 	UrgencyGwei           float64                    `koanf:"urgency-gwei" reload:"hot"`
@@ -55,7 +56,7 @@ type DataPosterConfigFetcher func() *DataPosterConfig
 
 func DataPosterConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".replacement-times", DefaultDataPosterConfig.ReplacementTimes, "comma-separated list of durations since first posting to attempt a replace-by-fee")
-	f.Uint64(prefix+".l1-look-behind", DefaultDataPosterConfig.L1LookBehind, "look at state this many blocks behind the latest (fixes L1 node inconsistencies)")
+	f.Bool(prefix+".wait-for-l1-finality", DefaultDataPosterConfig.WaitForL1Finality, "only treat a transaction as confirmed after L1 finality has been achieved (recommended)")
 	f.Uint64(prefix+".max-queued-transactions", DefaultDataPosterConfig.MaxQueuedTransactions, "the maximum number of transactions to have queued in the mempool at once (0 = unlimited)")
 	f.Float64(prefix+".target-price-gwei", DefaultDataPosterConfig.TargetPriceGwei, "the target price to use for maximum fee cap calculation")
 	f.Float64(prefix+".urgency-gwei", DefaultDataPosterConfig.UrgencyGwei, "the urgency to use for maximum fee cap calculation")
@@ -64,7 +65,7 @@ func DataPosterConfigAddOptions(prefix string, f *flag.FlagSet) {
 
 var DefaultDataPosterConfig = DataPosterConfig{
 	ReplacementTimes:      "5m,10m,20m,30m,1h,2h,4h,6h,8h,12h,16h,18h,20h,22h",
-	L1LookBehind:          2,
+	WaitForL1Finality:     true,
 	TargetPriceGwei:       60.,
 	UrgencyGwei:           2.,
 	MaxQueuedTransactions: 64,
@@ -73,7 +74,7 @@ var DefaultDataPosterConfig = DataPosterConfig{
 var TestDataPosterConfig = DataPosterConfig{
 	ReplacementTimes:      "1s,2s,5s,10s,20s,30s,1m,5m",
 	RedisSigner:           signature.TestSimpleHmacConfig,
-	L1LookBehind:          0,
+	WaitForL1Finality:     false,
 	TargetPriceGwei:       60.,
 	UrgencyGwei:           2.,
 	MaxQueuedTransactions: 64,
@@ -221,6 +222,15 @@ func (p *DataPoster[Meta]) getFeeAndTipCaps(ctx context.Context, gasLimit uint64
 		newFeeCap = balanceFeeCap
 	}
 
+	if arbmath.BigGreaterThan(newFeeCap, newTipCap) {
+		log.Warn(
+			"reducing new tip cap to new fee cap",
+			"proposedTipCap", newTipCap,
+			"newFeeCap", newFeeCap,
+		)
+		newTipCap = new(big.Int).Set(newFeeCap)
+	}
+
 	return newFeeCap, newTipCap, nil
 }
 
@@ -322,16 +332,21 @@ func (p *DataPoster[Meta]) replaceTx(ctx context.Context, prevTx *queuedTransact
 
 // the mutex must be held by the caller
 func (p *DataPoster[Meta]) updateState(ctx context.Context) error {
-	header, err := p.client.HeaderByNumber(ctx, nil)
+	var blockNumQuery *big.Int
+	if p.config().WaitForL1Finality {
+		blockNumQuery = big.NewInt(int64(rpc.FinalizedBlockNumber))
+	}
+	header, err := p.client.HeaderByNumber(ctx, blockNumQuery)
 	if err != nil {
 		return err
 	}
-	p.lastBlock = arbmath.BigSub(header.Number, new(big.Int).SetUint64(p.config().L1LookBehind))
+	p.lastBlock = header.Number
 	nonce, err := p.client.NonceAt(ctx, p.auth.From, p.lastBlock)
 	if err != nil {
 		return err
 	}
 	if nonce > p.nonce {
+		log.Info("data poster transactions confirmed", "previousNonce", p.nonce, "newNonce", nonce, "l1Block", p.lastBlock)
 		if len(p.errorCount) > 0 {
 			for x := p.nonce; x < nonce; x++ {
 				delete(p.errorCount, x)
@@ -359,7 +374,7 @@ func (p *DataPoster[Meta]) maybeLogError(err error, tx *queuedTransaction[Meta],
 		delete(p.errorCount, nonce)
 		return
 	}
-	if errors.Is(err, StorageRaceErr) {
+	if errors.Is(err, ErrStorageRace) {
 		p.errorCount[nonce]++
 		if p.errorCount[nonce] <= maxConsecutiveIntermittentErrors {
 			log.Debug(msg, "err", err, "nonce", nonce)
@@ -392,7 +407,15 @@ func (p *DataPoster[Meta]) Start(ctxIn context.Context) {
 		if maxTxsToRbf == 0 {
 			maxTxsToRbf = 512
 		}
-		queueContents, err := p.queue.GetContents(ctx, p.nonce, maxTxsToRbf)
+		unconfirmedNonce, err := p.client.NonceAt(ctx, p.auth.From, nil)
+		if err != nil {
+			log.Warn("failed to get latest nonce", "err", err)
+			return minWait
+		}
+		// We use unconfirmedNonce here to replace-by-fee transactions that aren't in a block,
+		// excluding those that are in an unconfirmed block. If a reorg occurs, we'll continue
+		// replacing them by fee.
+		queueContents, err := p.queue.GetContents(ctx, unconfirmedNonce, maxTxsToRbf)
 		if err != nil {
 			log.Warn("failed to get tx queue contents", "err", err)
 			return minWait

--- a/arbnode/dataposter/redis_storage.go
+++ b/arbnode/dataposter/redis_storage.go
@@ -112,7 +112,7 @@ func (s *RedisStorage[Item]) Prune(ctx context.Context, keepStartingAt uint64) e
 	return nil
 }
 
-var StorageRaceErr = errors.New("storage race error")
+var ErrStorageRace = errors.New("storage race error")
 
 func (s *RedisStorage[Item]) Put(ctx context.Context, index uint64, prevItem *Item, newItem *Item) error {
 	if newItem == nil {
@@ -132,11 +132,11 @@ func (s *RedisStorage[Item]) Put(ctx context.Context, index uint64, prevItem *It
 		pipe := tx.TxPipeline()
 		if len(haveItems) == 0 {
 			if prevItem != nil {
-				return fmt.Errorf("%w: tried to replace item at index %v but no item exists there", StorageRaceErr, index)
+				return fmt.Errorf("%w: tried to replace item at index %v but no item exists there", ErrStorageRace, index)
 			}
 		} else if len(haveItems) == 1 {
 			if prevItem == nil {
-				return fmt.Errorf("%w: tried to insert new item at index %v but an item exists there", StorageRaceErr, index)
+				return fmt.Errorf("%w: tried to insert new item at index %v but an item exists there", ErrStorageRace, index)
 			}
 			verifiedItem, err := s.peelVerifySignature([]byte(haveItems[0]))
 			if err != nil {
@@ -147,7 +147,7 @@ func (s *RedisStorage[Item]) Put(ctx context.Context, index uint64, prevItem *It
 				return err
 			}
 			if !bytes.Equal(verifiedItem, prevItemEncoded) {
-				return fmt.Errorf("%w: replacing different item than expected at index %v", StorageRaceErr, index)
+				return fmt.Errorf("%w: replacing different item than expected at index %v", ErrStorageRace, index)
 			}
 			err = pipe.ZRem(ctx, s.key, haveItems[0]).Err()
 			if err != nil {
@@ -178,7 +178,7 @@ func (s *RedisStorage[Item]) Put(ctx context.Context, index uint64, prevItem *It
 		_, err = pipe.Exec(ctx)
 		if errors.Is(err, redis.TxFailedErr) {
 			// Unfortunately, we can't wrap two errors.
-			err = fmt.Errorf("%w: %v", StorageRaceErr, err.Error())
+			err = fmt.Errorf("%w: %v", ErrStorageRace, err.Error())
 		}
 		return err
 	}


### PR DESCRIPTION
- Don't post a tx with a higher tip cap than fee cap (geth doesn't like this, so we lower the tip cap if necessary, which is equivalent anyways)
- Wait for L1 finality before discarding transactions that made it into a block (we previously waited for 3 confirmations)
  - Don't replace by fee transactions in an unconfirmed block
- Rename StorageRaceErr to ErrStorageRace to match go error naming conventions