### PR TITLE
Fix batch poster failing to estimate gas on restart

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/offchainlabs/nitro/arbnode/dataposter"
 	"github.com/offchainlabs/nitro/arbos"
@@ -46,6 +47,7 @@ type BatchPoster struct {
 	streamer     *TransactionStreamer
 	config       BatchPosterConfigFetcher
 	seqInbox     *bridgegen.SequencerInbox
+	bridge       *bridgegen.Bridge
 	syncMonitor  *SyncMonitor
 	seqInboxABI  *abi.ABI
 	seqInboxAddr common.Address
@@ -127,8 +129,12 @@ var TestBatchPosterConfig = BatchPosterConfig{
 	DataPoster:           dataposter.TestDataPosterConfig,
 }
 
-func NewBatchPoster(l1Reader *headerreader.HeaderReader, inbox *InboxTracker, streamer *TransactionStreamer, syncMonitor *SyncMonitor, config BatchPosterConfigFetcher, contractAddress common.Address, transactOpts *bind.TransactOpts, daWriter das.DataAvailabilityServiceWriter) (*BatchPoster, error) {
-	seqInbox, err := bridgegen.NewSequencerInbox(contractAddress, l1Reader.Client())
+func NewBatchPoster(l1Reader *headerreader.HeaderReader, inbox *InboxTracker, streamer *TransactionStreamer, syncMonitor *SyncMonitor, config BatchPosterConfigFetcher, deployInfo *RollupAddresses, transactOpts *bind.TransactOpts, daWriter das.DataAvailabilityServiceWriter) (*BatchPoster, error) {
+	seqInbox, err := bridgegen.NewSequencerInbox(deployInfo.SequencerInbox, l1Reader.Client())
+	if err != nil {
+		return nil, err
+	}
+	bridge, err := bridgegen.NewBridge(deployInfo.Bridge, l1Reader.Client())
 	if err != nil {
 		return nil, err
 	}
@@ -156,9 +162,10 @@ func NewBatchPoster(l1Reader *headerreader.HeaderReader, inbox *InboxTracker, st
 		streamer:     streamer,
 		syncMonitor:  syncMonitor,
 		config:       config,
+		bridge:       bridge,
 		seqInbox:     seqInbox,
 		seqInboxABI:  seqInboxABI,
-		seqInboxAddr: contractAddress,
+		seqInboxAddr: deployInfo.SequencerInbox,
 		daWriter:     daWriter,
 		redisLock:    redisLock,
 	}
@@ -440,6 +447,31 @@ func (b *BatchPoster) encodeAddBatch(seqNum *big.Int, prevMsgNum arbutil.Message
 }
 
 func (b *BatchPoster) estimateGas(ctx context.Context, sequencerMessage []byte, delayedMessages uint64) (uint64, error) {
+	config := b.config()
+	callOpts := &bind.CallOpts{
+		Context: ctx,
+	}
+	if config.DataPoster.WaitForL1Finality {
+		callOpts.BlockNumber = big.NewInt(int64(rpc.SafeBlockNumber))
+	}
+	safeDelayedMessagesBig, err := b.bridge.DelayedMessageCount(callOpts)
+	if err != nil {
+		return 0, err
+	}
+	if !safeDelayedMessagesBig.IsUint64() {
+		return 0, fmt.Errorf("calling delayedMessageCount() on the bridge returned a non-uint64 result %v", safeDelayedMessagesBig)
+	}
+	safeDelayedMessages := safeDelayedMessagesBig.Uint64()
+	if safeDelayedMessages > delayedMessages {
+		// On restart, we may be trying to estimate gas for a batch whose successor has
+		// already made it into pending state, if not latest state.
+		// In that case, we might get a revert with `DelayedBackwards()`.
+		// To avoid that, we artificially increase the delayed messages to `safeDelayedMessages`.
+		// In theory, this might reduce gas usage, but only by a factor that's already
+		// accounted for in `config.ExtraBatchGas`, as that same factor can appear if a user
+		// posts a new delayed message that we didn't see while gas estimating.
+		delayedMessages = safeDelayedMessages
+	}
 	// Here we set seqNum to MaxUint256, and prevMsgNum to 0, because it disables the smart contracts' consistency checks.
 	// However, we set nextMsgNum to 1 because it is necessary for a correct estimation for the final to be non-zero.
 	// Because we're likely estimating against older state, this might not be the actual next message,
@@ -462,12 +494,13 @@ func (b *BatchPoster) estimateGas(ctx context.Context, sequencerMessage []byte, 
 			"error estimating gas for batch",
 			"err", err,
 			"delayedMessages", delayedMessages,
+			"safeDelayedMessages", safeDelayedMessages,
 			"sequencerMessageHeader", hex.EncodeToString(sequencerMessageHeader),
 			"sequencerMessageLen", len(sequencerMessage),
 		)
 		return 0, fmt.Errorf("error estimating gas for batch: %w", err)
 	}
-	return gas + b.config().ExtraBatchGas, nil
+	return gas + config.ExtraBatchGas, nil
 }
 
 func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error) {

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -358,7 +358,9 @@ func (p *DataPoster[Meta]) updateState(ctx context.Context) error {
 		}
 		p.nonce = nonce
 	}
-	balance, err := p.client.BalanceAt(ctx, p.auth.From, p.lastBlock)
+	// Use the pending (representated as -1) balance because we're looking at batches we'd post,
+	// so we want to see how much gas we could afford with our pending state.
+	balance, err := p.client.BalanceAt(ctx, p.auth.From, big.NewInt(-1))
 	if err != nil {
 		return err
 	}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1083,7 +1083,7 @@ func createNodeImpl(
 		if txOpts == nil {
 			return nil, errors.New("batchposter, but no TxOpts")
 		}
-		batchPoster, err = NewBatchPoster(l1Reader, inboxTracker, txStreamer, syncMonitor, func() *BatchPosterConfig { return &configFetcher.Get().BatchPoster }, deployInfo.SequencerInbox, txOpts, daWriter)
+		batchPoster, err = NewBatchPoster(l1Reader, inboxTracker, txStreamer, syncMonitor, func() *BatchPosterConfig { return &configFetcher.Get().BatchPoster }, deployInfo, txOpts, daWriter)
 		if err != nil {
 			return nil, err
 		}

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -67,7 +67,7 @@ func TestBatchPosterParallel(t *testing.T) {
 	startL1Block, err := l1client.BlockNumber(ctx)
 	Require(t, err)
 	for i := 0; i < parallelBatchPosters; i++ {
-		batchPoster, err := arbnode.NewBatchPoster(nodeA.L1Reader, nodeA.InboxTracker, nodeA.TxStreamer, nodeA.SyncMonitor, func() *arbnode.BatchPosterConfig { return &conf.BatchPoster }, nodeA.DeployInfo.SequencerInbox, &seqTxOpts, nil)
+		batchPoster, err := arbnode.NewBatchPoster(nodeA.L1Reader, nodeA.InboxTracker, nodeA.TxStreamer, nodeA.SyncMonitor, func() *arbnode.BatchPosterConfig { return &conf.BatchPoster }, nodeA.DeployInfo, &seqTxOpts, nil)
 		Require(t, err)
 		batchPoster.Start(ctx)
 		defer batchPoster.StopAndWait()


### PR DESCRIPTION
This PR changes batch gas estimation to now use `max(safeDelayedMessages, delayedMessages)`. This means that if we're trying to re-estimate an old batch, we'll still succeed despite the batch we're trying to estimate having a delayed messages that would go backwards. This condition is more common now that the data poster only respects the latest finalized nonce, which means that on restart the batch poster will begin regenerating batches from about 15 minutes ago.