### PR TITLE
Pin rustc 1.66.1 in CI

### DIFF
--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -43,7 +43,7 @@ jobs:
         id: install-rust
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: "1.66.1"
           override: true
           components: 'llvm-tools-preview, rustfmt, clippy'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,14 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: "1.66.1"
           target: wasm32-unknown-unknown
 
       - name: Install rust wasm32-wasi
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: "1.66.1"
           target: wasm32-wasi
 
       - name: Install rust stable
@@ -70,7 +70,7 @@ jobs:
         id: install-rust
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: "1.66.1"
           override: true
 
       - name: Cache Build Products

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,7 +52,7 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        
+
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
         config-file: ./.github/codeql/codeql-config.yml
@@ -74,7 +74,7 @@ jobs:
       id: install-rust
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: "1.66.1"
         override: true
 
     - name: Cache Rust Build Products
@@ -122,7 +122,7 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     # - run: |


### PR DESCRIPTION
The new rust version 1.67.0 enables bulk memory support in WASM by default, which we don't support yet (it's part of WASM 1.1 IIRC). It shouldn't be too bad to add support, but until we do, we'll just pin the old version in CI.