### PR TITLE
Fix eth_syncing lastl1BlockHash field

### DIFF
--- a/arbnode/sync_monitor.go
+++ b/arbnode/sync_monitor.go
@@ -116,7 +116,7 @@ func (s *SyncMonitor) SyncProgressMap() map[string]interface{} {
 			}
 			if header != nil {
 				res["lastL1BlockNum"] = header.Number
-				res["lastl1BlockHash"] = header.Hash
+				res["lastl1BlockHash"] = header.Hash()
 			}
 		}
 	}


### PR DESCRIPTION
This previously resulted in the error:
```
{
  "error": {
    "code": -32000,
    "message": "json: unsupported type: func() common.Hash"
  }
}
```