### PR TITLE
Sequencer: retry txs over the block gas limit

### DIFF
--- a/arbnode/sequencer.go
+++ b/arbnode/sequencer.go
@@ -781,7 +781,7 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 		queueItem := queueItems[i]
 		if errors.Is(err, core.ErrGasLimitReached) {
 			// There's not enough gas left in the block for this tx.
-			if madeBlock && !errors.Is(err, arbos.ErrMaxGasLimitReached) {
+			if madeBlock {
 				// There was already an earlier tx in the block; retry in a fresh block.
 				s.txRetryQueue.Push(queueItem)
 				continue

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -171,7 +171,6 @@ func ProduceBlockAdvanced(
 	// Note: blockGasLeft will diverge from the actual gas left during execution in the event of invalid txs,
 	// but it's only used as block-local representation limiting the amount of work done in a block.
 	blockGasLeft, _ := state.L2PricingState().PerBlockGasLimit()
-	initialBlockGasLeft := blockGasLeft
 	l1BlockNum := l1Info.l1BlockNumber
 
 	// Prepend a tx before all others to touch up the state (update the L1 block num, pricing pools, etc)

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -137,9 +137,6 @@ func ProduceBlock(
 	)
 }
 
-// A marker for the sequencer that an ErrGasLimitReached is permanent
-var ErrMaxGasLimitReached = fmt.Errorf("%w", core.ErrGasLimitReached)
-
 // A bit more flexible than ProduceBlock for use in the sequencer.
 func ProduceBlockAdvanced(
 	l1Header *L1IncomingMessageHeader,
@@ -270,9 +267,6 @@ func ProduceBlockAdvanced(
 			}
 
 			if computeGas > blockGasLeft && isUserTx && userTxsProcessed > 0 {
-				if computeGas > initialBlockGasLeft {
-					return nil, nil, ErrMaxGasLimitReached
-				}
 				return nil, nil, core.ErrGasLimitReached
 			}
 


### PR DESCRIPTION
They'll go through if they're the first tx in a block, in which case the gas available to them is simply limited to the block gas limit. However, if they're not the first tx in a block, the block gas limit is already partially used up so they're not allowed. In that case, we need to put them back in the retry queue, so they'll end up as the first tx in the next block.

When I previously wrote this code I mistakenly thought that such txs could never go through and thus shouldn't be retried.