### PR TITLE
Use a custom header for our websocket compression

### DIFF
--- a/wsbroadcastserver/utils.go
+++ b/wsbroadcastserver/utils.go
@@ -18,6 +18,11 @@ import (
 	"github.com/gobwas/ws/wsutil"
 )
 
+func init() {
+	// We use a custom dictionary, so our compression isn't compatible with other websocket clients.
+	wsflate.ExtensionNameBytes = append([]byte("Arbitrum-"), wsflate.ExtensionNameBytes...)
+}
+
 type chainedReader struct {
 	readers []io.Reader
 }


### PR DESCRIPTION
Our compression is incompatible with any other client because of our custom dictionary, so this PR hot-swaps out the wsflate library's extension header (hacky).