### PR TITLE
Make relay requested sequence number limit configurable

### DIFF
--- a/broadcaster/broadcaster.go
+++ b/broadcaster/broadcaster.go
@@ -61,7 +61,7 @@ type ConfirmedSequenceNumberMessage struct {
 }
 
 func NewBroadcaster(config wsbroadcastserver.BroadcasterConfigFetcher, chainId uint64, feedErrChan chan error, dataSigner signature.DataSignerFunc) *Broadcaster {
-	catchupBuffer := NewSequenceNumberCatchupBuffer()
+	catchupBuffer := NewSequenceNumberCatchupBuffer(func() bool { return config().LimitCatchup })
 	return &Broadcaster{
 		server:        wsbroadcastserver.NewWSBroadcastServer(config, catchupBuffer, chainId, feedErrChan),
 		catchupBuffer: catchupBuffer,

--- a/broadcaster/sequencenumbercatchupbuffer_test.go
+++ b/broadcaster/sequencenumbercatchupbuffer_test.go
@@ -28,6 +28,7 @@ func TestGetEmptyCacheMessages(t *testing.T) {
 	buffer := SequenceNumberCatchupBuffer{
 		messages:     nil,
 		messageCount: 0,
+		limitCatchup: func() bool { return false },
 	}
 
 	// Get everything
@@ -58,6 +59,7 @@ func TestGetCacheMessages(t *testing.T) {
 	buffer := SequenceNumberCatchupBuffer{
 		messages:     createDummyBroadcastMessages(indexes),
 		messageCount: int32(len(indexes)),
+		limitCatchup: func() bool { return false },
 	}
 
 	// Get everything
@@ -107,6 +109,7 @@ func TestDeleteConfirmedNil(t *testing.T) {
 	buffer := SequenceNumberCatchupBuffer{
 		messages:     nil,
 		messageCount: 0,
+		limitCatchup: func() bool { return false },
 	}
 
 	buffer.deleteConfirmed(0)
@@ -120,6 +123,7 @@ func TestDeleteConfirmInvalidOrder(t *testing.T) {
 	buffer := SequenceNumberCatchupBuffer{
 		messages:     createDummyBroadcastMessages(indexes),
 		messageCount: int32(len(indexes)),
+		limitCatchup: func() bool { return false },
 	}
 
 	// Confirm before cache
@@ -134,6 +138,7 @@ func TestDeleteConfirmed(t *testing.T) {
 	buffer := SequenceNumberCatchupBuffer{
 		messages:     createDummyBroadcastMessages(indexes),
 		messageCount: int32(len(indexes)),
+		limitCatchup: func() bool { return false },
 	}
 
 	// Confirm older than cache
@@ -148,6 +153,7 @@ func TestDeleteFreeMem(t *testing.T) {
 	buffer := SequenceNumberCatchupBuffer{
 		messages:     createDummyBroadcastMessagesImpl(indexes, len(indexes)*10+1),
 		messageCount: int32(len(indexes)),
+		limitCatchup: func() bool { return false },
 	}
 
 	// Confirm older than cache
@@ -162,6 +168,7 @@ func TestBroadcastBadMessage(t *testing.T) {
 	buffer := SequenceNumberCatchupBuffer{
 		messages:     nil,
 		messageCount: 0,
+		limitCatchup: func() bool { return false },
 	}
 
 	var foo int
@@ -179,6 +186,7 @@ func TestBroadcastPastSeqNum(t *testing.T) {
 	buffer := SequenceNumberCatchupBuffer{
 		messages:     createDummyBroadcastMessagesImpl(indexes, len(indexes)*10+1),
 		messageCount: int32(len(indexes)),
+		limitCatchup: func() bool { return false },
 	}
 
 	bm := BroadcastMessage{

--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -55,6 +55,7 @@ type BroadcasterConfig struct {
 	LogDisconnect      bool          `koanf:"log-disconnect"`
 	EnableCompression  bool          `koanf:"enable-compression" reload:"hot"`  // if reloaded to false will cause disconnection of clients with enabled compression on next broadcast
 	RequireCompression bool          `koanf:"require-compression" reload:"hot"` // if reloaded to true will cause disconnection of clients with disabled compression on next broadcast
+	LimitCatchup       bool          `koanf:"limit-catchup" reload:"hot"`
 }
 
 func (bc *BroadcasterConfig) Validate() error {
@@ -85,6 +86,7 @@ func BroadcasterConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".log-disconnect", DefaultBroadcasterConfig.LogDisconnect, "log every client disconnect")
 	f.Bool(prefix+".enable-compression", DefaultBroadcasterConfig.EnableCompression, "enable per message deflate compression support")
 	f.Bool(prefix+".require-compression", DefaultBroadcasterConfig.RequireCompression, "require clients to use compression")
+	f.Bool(prefix+".limit-catchup", DefaultBroadcasterConfig.LimitCatchup, "only supply catchup buffer if requested sequence number is reasonable")
 }
 
 var DefaultBroadcasterConfig = BroadcasterConfig{
@@ -106,6 +108,7 @@ var DefaultBroadcasterConfig = BroadcasterConfig{
 	LogDisconnect:      false,
 	EnableCompression:  true,
 	RequireCompression: false,
+	LimitCatchup:       false,
 }
 
 var DefaultTestBroadcasterConfig = BroadcasterConfig{
@@ -127,6 +130,7 @@ var DefaultTestBroadcasterConfig = BroadcasterConfig{
 	LogDisconnect:      false,
 	EnableCompression:  true,
 	RequireCompression: false,
+	LimitCatchup:       false,
 }
 
 type WSBroadcastServer struct {


### PR DESCRIPTION
Before this change, downstream relays wouldn't be initialized with the catchup buffer.