### PR TITLE
Feed connection limit

### DIFF
--- a/wsbroadcastserver/clientconnection.go
+++ b/wsbroadcastserver/clientconnection.go
@@ -33,6 +33,7 @@ type ClientConnection struct {
 	ioMutex  sync.Mutex
 	conn     net.Conn
 	creation time.Time
+	clientIp net.IP
 
 	desc            *netpoll.Desc
 	Name            string
@@ -51,14 +52,15 @@ func NewClientConnection(
 	desc *netpoll.Desc,
 	clientManager *ClientManager,
 	requestedSeqNum arbutil.MessageIndex,
-	connectingIP string,
+	connectingIP net.IP,
 	compression bool,
 ) *ClientConnection {
 	return &ClientConnection{
 		conn:            conn,
+		clientIp:        connectingIP,
 		desc:            desc,
 		creation:        time.Now(),
-		Name:            connectingIP + "@" + conn.RemoteAddr().String() + strconv.Itoa(rand.Intn(10)),
+		Name:            string(connectingIP) + "@" + conn.RemoteAddr().String() + strconv.Itoa(rand.Intn(10)),
 		clientManager:   clientManager,
 		requestedSeqNum: requestedSeqNum,
 		lastHeardUnix:   time.Now().Unix(),

--- a/wsbroadcastserver/clientmanager.go
+++ b/wsbroadcastserver/clientmanager.go
@@ -91,7 +91,7 @@ func (cm *ClientManager) registerClient(ctx context.Context, clientConnection *C
 	}()
 
 	if cm.config().ConnectionLimits.Enable && !cm.connectionLimiter.Register(clientConnection.clientIp) {
-		return fmt.Errorf("Rate limited %s", clientConnection.clientIp)
+		return fmt.Errorf("Connection limited %s", clientConnection.clientIp)
 	}
 
 	clientsCurrentGauge.Inc(1)

--- a/wsbroadcastserver/clientmanager.go
+++ b/wsbroadcastserver/clientmanager.go
@@ -8,6 +8,7 @@ import (
 	"compress/flate"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -57,6 +58,8 @@ type ClientManager struct {
 	config        BroadcasterConfigFetcher
 	catchupBuffer CatchupBuffer
 	flateWriter   *flate.Writer
+
+	connectionLimiter *ConnectionLimiter
 }
 
 type ClientConnectionAction struct {
@@ -67,13 +70,14 @@ type ClientConnectionAction struct {
 func NewClientManager(poller netpoll.Poller, configFetcher BroadcasterConfigFetcher, catchupBuffer CatchupBuffer) *ClientManager {
 	config := configFetcher()
 	return &ClientManager{
-		poller:        poller,
-		pool:          gopool.NewPool(config.Workers, config.Queue, 1),
-		clientPtrMap:  make(map[*ClientConnection]bool),
-		broadcastChan: make(chan interface{}, 1),
-		clientAction:  make(chan ClientConnectionAction, 128),
-		config:        configFetcher,
-		catchupBuffer: catchupBuffer,
+		poller:            poller,
+		pool:              gopool.NewPool(config.Workers, config.Queue, 1),
+		clientPtrMap:      make(map[*ClientConnection]bool),
+		broadcastChan:     make(chan interface{}, 1),
+		clientAction:      make(chan ClientConnectionAction, 128),
+		config:            configFetcher,
+		catchupBuffer:     catchupBuffer,
+		connectionLimiter: NewConnectionLimiter(func() *ConnectionLimiterConfig { return &configFetcher().ConnectionLimits }),
 	}
 }
 
@@ -84,11 +88,18 @@ func (cm *ClientManager) registerClient(ctx context.Context, clientConnection *C
 		}
 	}()
 
+	if cm.config().ConnectionLimits.Enable && !cm.connectionLimiter.Register(clientConnection.clientIp) {
+		return fmt.Errorf("Rate limited %s", clientConnection.clientIp)
+	}
+
 	clientsConnectedGauge.Inc(1)
 	atomic.AddInt32(&cm.clientCount, 1)
 	err, sent, elapsed := cm.catchupBuffer.OnRegisterClient(clientConnection)
 	if err != nil {
 		clientsTotalFailedRegisterCounter.Inc(1)
+		if cm.config().ConnectionLimits.Enable {
+			cm.connectionLimiter.Release(clientConnection.clientIp)
+		}
 		return err
 	}
 	if cm.config().LogConnect {
@@ -107,7 +118,7 @@ func (cm *ClientManager) Register(
 	conn net.Conn,
 	desc *netpoll.Desc,
 	requestedSeqNum arbutil.MessageIndex,
-	connectingIP string,
+	connectingIP net.IP,
 	compression bool,
 ) *ClientConnection {
 	createClient := ClientConnectionAction{
@@ -143,6 +154,7 @@ func (cm *ClientManager) removeClientImpl(clientConnection *ClientConnection) {
 	if cm.config().LogDisconnect {
 		log.Info("client removed", "client", clientConnection.Name, "age", clientConnection.Age())
 	}
+
 	clientsDurationHistogram.Update(clientConnection.Age().Microseconds())
 	clientsConnectedGauge.Dec(1)
 	atomic.AddInt32(&cm.clientCount, -1)
@@ -154,6 +166,9 @@ func (cm *ClientManager) removeClient(clientConnection *ClientConnection) {
 	}
 
 	cm.removeClientImpl(clientConnection)
+	if cm.config().ConnectionLimits.Enable {
+		cm.connectionLimiter.Release(clientConnection.clientIp)
+	}
 
 	delete(cm.clientPtrMap, clientConnection)
 }

--- a/wsbroadcastserver/connectionlimiter.go
+++ b/wsbroadcastserver/connectionlimiter.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	clientsLimitedGauge = metrics.NewRegisteredGauge("arb/feed/clients/limited", nil)
+	clientsLimitedCounter = metrics.NewRegisteredCounter("arb/feed/clients/limited", nil)
 )
 
 type ConnectionLimiterConfig struct {
@@ -103,7 +103,7 @@ func (l *ConnectionLimiter) getIpStringsAndLimits(ip net.IP) []ipStringAndLimit 
 func (l *ConnectionLimiter) isAllowedImpl(ip net.IP) bool {
 	for _, item := range l.getIpStringsAndLimits(ip) {
 		if res := l.ipConnectionCounts[item.ipString]; res >= item.limit {
-			clientsLimitedGauge.Inc(1)
+			clientsLimitedCounter.Inc(1)
 			return false
 		}
 	}

--- a/wsbroadcastserver/connectionlimiter.go
+++ b/wsbroadcastserver/connectionlimiter.go
@@ -8,7 +8,12 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	flag "github.com/spf13/pflag"
+)
+
+var (
+	clientsLimitedGauge = metrics.NewRegisteredGauge("arb/feed/clients/limited", nil)
 )
 
 type ConnectionLimiterConfig struct {
@@ -98,6 +103,7 @@ func (l *ConnectionLimiter) getIpStringsAndLimits(ip net.IP) []ipStringAndLimit 
 func (l *ConnectionLimiter) isAllowedImpl(ip net.IP) bool {
 	for _, item := range l.getIpStringsAndLimits(ip) {
 		if res := l.ipConnectionCounts[item.ipString]; res >= item.limit {
+			clientsLimitedGauge.Inc(1)
 			return false
 		}
 	}

--- a/wsbroadcastserver/connectionlimiter.go
+++ b/wsbroadcastserver/connectionlimiter.go
@@ -1,0 +1,153 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package wsbroadcastserver
+
+import (
+	"net"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/log"
+	flag "github.com/spf13/pflag"
+)
+
+type ConnectionLimiterConfig struct {
+	Enable             bool `koanf:"enable" reload:"hot"`
+	PerIpLimit         int  `koanf:"per-ip-limit" reload:"hot"`
+	PerIpv6Cidr48Limit int  `koanf:"per-ipv6-cidr-48-limit" reload:"hot"`
+	PerIpv6Cidr64Limit int  `koanf:"per-ipv6-cidr-64-limit" reload:"hot"`
+}
+
+var DefaultConnectionLimiterConfig = ConnectionLimiterConfig{
+	Enable:             false,
+	PerIpLimit:         5,
+	PerIpv6Cidr48Limit: 20,
+	PerIpv6Cidr64Limit: 10,
+}
+
+func ConnectionLimiterConfigAddOptions(prefix string, f *flag.FlagSet) {
+	f.Bool(prefix+".enable", DefaultConnectionLimiterConfig.Enable, "enable broadcaster per-client connection limiting")
+	f.Int(prefix+".per-ip-limit", DefaultConnectionLimiterConfig.PerIpLimit, "limit clients, as identified by IPv4/v6 address, to this many connections to this relay")
+	f.Int(prefix+".per-ipv6-cidr-48-limit", DefaultConnectionLimiterConfig.PerIpv6Cidr48Limit, "limit ipv6 clients, as identified by IPv6 address masked with /48, to this many connections to this relay")
+	f.Int(prefix+".per-ipv6-cidr-64-limit", DefaultConnectionLimiterConfig.PerIpv6Cidr64Limit, "limit ipv6 clients, as identified by IPv6 address masked with /64, to this many connections to this relay")
+}
+
+type ConnectionLimiterConfigFetcher func() *ConnectionLimiterConfig
+
+type ConnectionLimiter struct {
+	sync.RWMutex
+
+	ipConnectionCounts map[string]int
+	config             ConnectionLimiterConfigFetcher
+}
+
+func NewConnectionLimiter(configFetcher ConnectionLimiterConfigFetcher) *ConnectionLimiter {
+	return &ConnectionLimiter{
+		ipConnectionCounts: make(map[string]int),
+		config:             configFetcher,
+	}
+}
+
+func (l *ConnectionLimiter) IsAllowed(ip net.IP) bool {
+	l.RLock()
+	defer l.RUnlock()
+	return l.isAllowedImpl(ip)
+}
+
+func isIpv6(ip net.IP) bool {
+	// This seems to be the canonical way to distinguish IPv4 from IPv6 in Go
+	// https://stackoverflow.com/questions/22751035/golang-distinguish-ipv4-ipv6
+	// We don't care about the case where it is an IPv4 address in IPv6
+	// representation, we'll just treat that as IPv4.
+	return ip.To4() == nil
+}
+
+func (l *ConnectionLimiter) isAllowedImpl(ip net.IP) bool {
+	if ip == nil || ip.IsPrivate() || ip.IsLoopback() {
+		log.Warn("Ignoring private, looback, or unparseable IP. Please check relay and network configuration to ensure client IP addresses are detected correctly", "ip", ip)
+		return true
+	}
+
+	config := l.config()
+
+	if res := l.ipConnectionCounts[string(ip)]; res >= config.PerIpLimit {
+		return false
+	}
+
+	if isIpv6(ip) {
+		ipv6Slash48 := ip.Mask(net.CIDRMask(48, 128))
+		if ipv6Slash48 == nil {
+			log.Warn("Error taking /48 mask of ipv6 client address", "ip", ip)
+		} else if res := l.ipConnectionCounts[string(ipv6Slash48)+"/48"]; res >= config.PerIpv6Cidr48Limit {
+			return false
+		}
+
+		ipv6Slash64 := ip.Mask(net.CIDRMask(64, 128))
+		if ipv6Slash64 == nil {
+			log.Warn("Error taking /64 mask of ipv6 client address", "ip", ip)
+		} else if res := l.ipConnectionCounts[string(ipv6Slash64)+"/64"]; res >= config.PerIpv6Cidr64Limit {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (l *ConnectionLimiter) updateUsage(ip net.IP, increment bool) {
+	if ip == nil {
+		return
+	}
+
+	updateAmount := -1
+	if increment {
+		updateAmount = 1
+	}
+
+	config := l.config()
+	updateAndCheckBounds := func(ipString string, bound int) {
+		l.ipConnectionCounts[ipString] += updateAmount
+		if l.ipConnectionCounts[ipString] < 0 {
+			log.Error("BUG: Unbalanced ConnectionLimiter.updateUsage(..., false) calls")
+			l.ipConnectionCounts[ipString] = 0
+		} else if l.ipConnectionCounts[ipString] > bound {
+			log.Error("BUG: Unbalanced ConnectionLimiter.updateUsage(..., true) calls")
+			l.ipConnectionCounts[ipString] = bound
+		}
+	}
+
+	updateAndCheckBounds(string(ip), config.PerIpLimit)
+
+	if isIpv6(ip) {
+		ipv6Slash48 := ip.Mask(net.CIDRMask(48, 128))
+		if ipv6Slash48 != nil {
+			updateAndCheckBounds(string(ipv6Slash48)+"/48", config.PerIpv6Cidr48Limit)
+		}
+
+		ipv6Slash64 := ip.Mask(net.CIDRMask(64, 128))
+		if ipv6Slash64 != nil {
+			updateAndCheckBounds(string(ipv6Slash64)+"/64", config.PerIpv6Cidr64Limit)
+		}
+	}
+}
+
+func (l *ConnectionLimiter) Register(ip net.IP) bool {
+	l.Lock()
+	defer l.Unlock()
+
+	// First check if allowed without modifying counts so that we don't need to roll back partial counts.
+	if !l.isAllowedImpl(ip) {
+		return false
+	}
+
+	l.updateUsage(ip, true)
+
+	return true
+}
+
+func (l *ConnectionLimiter) Release(ip net.IP) {
+	l.Lock()
+	defer l.Unlock()
+
+	l.updateUsage(ip, false)
+
+}

--- a/wsbroadcastserver/connectionlimiter_test.go
+++ b/wsbroadcastserver/connectionlimiter_test.go
@@ -1,0 +1,201 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package wsbroadcastserver
+
+import (
+	"net"
+	"runtime"
+	"testing"
+
+	"github.com/offchainlabs/nitro/util/testhelpers"
+)
+
+func TestIpv4BasicConnectionLimiting(t *testing.T) {
+	configFetcher := func() *ConnectionLimiterConfig {
+		return &ConnectionLimiterConfig{
+			Enable:             true,
+			PerIpLimit:         3,
+			PerIpv6Cidr48Limit: 1,
+			PerIpv6Cidr64Limit: 1,
+		}
+	}
+	l := NewConnectionLimiter(configFetcher)
+
+	ip1 := net.ParseIP("1.2.3.4")
+
+	Expect(t, l.IsAllowed(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, !l.Register(ip1))
+	Expect(t, !l.IsAllowed(ip1))
+
+	l.Release(ip1)
+	Expect(t, l.IsAllowed(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, !l.IsAllowed(ip1))
+	Expect(t, !l.Register(ip1))
+
+	l.Release(ip1)
+	l.Release(ip1)
+	Expect(t, l.IsAllowed(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, l.IsAllowed(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, !l.IsAllowed(ip1))
+	Expect(t, !l.Register(ip1))
+
+	l.Release(ip1)
+	l.Release(ip1)
+	l.Release(ip1)
+	Expect(t, l.IsAllowed(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, l.IsAllowed(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, l.IsAllowed(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, !l.IsAllowed(ip1))
+	Expect(t, !l.Register(ip1))
+}
+
+func TestTooManyReleases(t *testing.T) {
+	configFetcher := func() *ConnectionLimiterConfig {
+		return &ConnectionLimiterConfig{
+			Enable:             true,
+			PerIpLimit:         3,
+			PerIpv6Cidr48Limit: 1,
+			PerIpv6Cidr64Limit: 1,
+		}
+	}
+	l := NewConnectionLimiter(configFetcher)
+
+	ip1 := net.ParseIP("1.2.3.4")
+
+	Expect(t, l.IsAllowed(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, !l.Register(ip1))
+	Expect(t, !l.IsAllowed(ip1))
+
+	// Make sure the count doesn't go negative and allow too many connections.
+	l.Release(ip1)
+	l.Release(ip1)
+	l.Release(ip1)
+	l.Release(ip1)
+	l.Release(ip1)
+	l.Release(ip1)
+
+	Expect(t, l.IsAllowed(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, l.IsAllowed(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, l.IsAllowed(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, !l.IsAllowed(ip1))
+	Expect(t, !l.Register(ip1))
+}
+
+func TestIpv6Masks(t *testing.T) {
+	configFetcher := func() *ConnectionLimiterConfig {
+		return &ConnectionLimiterConfig{
+			Enable:             true,
+			PerIpLimit:         3,
+			PerIpv6Cidr48Limit: 5,
+			PerIpv6Cidr64Limit: 2,
+		}
+	}
+	l := NewConnectionLimiter(configFetcher)
+
+	ip1 := net.ParseIP("1:2:3:4:5:5:5:5")
+	ip2 := net.ParseIP("1:2:3:4:6:6:6:6")
+	ip3 := net.ParseIP("1:2:3:4:7:7:7:7")
+
+	ip4 := net.ParseIP("1:2:3:5:5:5:5:5")
+	ip5 := net.ParseIP("1:2:3:6:6:6:6:6")
+	ip6 := net.ParseIP("1:2:3:7:7:7:7:7")
+
+	ip7 := net.ParseIP("1:2:4:5:5:5:5:5")
+	ip8 := net.ParseIP("1:2:4:6:6:6:6:6")
+	ip9 := net.ParseIP("1:2:4:7:7:7:7:7")
+
+	// /64 limit blocks
+	Expect(t, l.Register(ip1))  // 1:2:3:4/64 1, 1:2:3/48 1
+	Expect(t, l.Register(ip2))  // 1:2:3:4/64 2, 1:2:3/48 2
+	Expect(t, !l.Register(ip2)) // 1:2:3:4/64 2*, 1:2:3/48 2
+	Expect(t, !l.Register(ip3)) // 1:2:3:4/64 2*, 1:2:3/48 2
+
+	// /48 limit blocks
+	Expect(t, l.Register(ip4))  // 1:2:3:5/64 1, 1:2:3/48 3
+	Expect(t, l.Register(ip5))  // 1:2:3:6/64 1, 1:2:3/48 4
+	Expect(t, l.Register(ip4))  // 1:2:3:5/64 2, 1:2:3/48 5
+	Expect(t, !l.Register(ip5)) // 1:2:3:6/64 1, 1:2:3/48 5*
+
+	// /64 limit blocks after releasing from the /48 that would've blocked
+	l.Release(ip1)              // 1:2:3:4/64 1, 1:2:3/48 4
+	Expect(t, l.Register(ip5))  // 1:2:3:6/64 2, 1:2:3/48 5
+	l.Release(ip2)              // 1:2:3:4/64 0, 1:2:3/48 4
+	Expect(t, !l.Register(ip5)) // 1:2:3:6/64 2*, 1:2:3/48 4
+
+	// /48 limit blocks a new /64 IP
+	Expect(t, l.Register(ip6))  // 1:2:3:7/64 1, 1:2:3/48 5
+	Expect(t, !l.Register(ip6)) // 1:2:3:7/64 1, 1:2:3/48 5*
+
+	// IPs in different range to above have separate counts
+	Expect(t, l.Register(ip7))  // 1:2:4:5/64 1, 1:2:4/48 1
+	Expect(t, l.Register(ip7))  // 1:2:4:5/64 2, 1:2:4/48 2
+	Expect(t, !l.Register(ip7)) // 1:2:4:5/64 2*, 1:2:4/48 2
+	Expect(t, l.Register(ip8))  // 1:2:4:6/64 1, 1:2:4/48 3
+	Expect(t, l.Register(ip8))  // 1:2:4:6/64 2, 1:2:4/48 4
+	Expect(t, !l.Register(ip8)) // 1:2:4:6/64 2*, 1:2:4/48 4
+	Expect(t, l.Register(ip9))  // 1:2:4:7/64 1, 1:2:4/48 5
+	Expect(t, !l.Register(ip9)) // 1:2:4:7/64 1, 1:2:4/48 5
+
+}
+
+func TestPrivateAddresses(t *testing.T) {
+	configFetcher := func() *ConnectionLimiterConfig {
+		return &ConnectionLimiterConfig{
+			Enable:             true,
+			PerIpLimit:         1,
+			PerIpv6Cidr48Limit: 1,
+			PerIpv6Cidr64Limit: 1,
+		}
+	}
+	l := NewConnectionLimiter(configFetcher)
+	ip1 := net.ParseIP("fc00:0:0:0:0:0:0:1")
+	ip2 := net.ParseIP("fc00:0:0:0:1:0:0:1")
+
+	ip3 := net.ParseIP("10.0.0.1")
+	Expect(t, l.Register(ip1))
+	Expect(t, l.Register(ip1))
+	Expect(t, l.Register(ip1))
+
+	Expect(t, l.Register(ip2))
+	Expect(t, l.Register(ip2))
+	Expect(t, l.Register(ip2))
+
+	Expect(t, l.Register(ip3))
+	Expect(t, l.Register(ip3))
+	Expect(t, l.Register(ip3))
+}
+
+func Expect(t *testing.T, res bool, text ...interface{}) {
+	t.Helper()
+	if !res {
+		buf := make([]byte, 1<<16)
+		stackSize := runtime.Stack(buf, false)
+		testhelpers.FailImpl(t, string(buf[0:stackSize]))
+	}
+}
+
+func Require(t *testing.T, err error, text ...interface{}) {
+	t.Helper()
+	testhelpers.RequireImpl(t, err, text...)
+}
+
+func Fail(t *testing.T, printables ...interface{}) {
+	t.Helper()
+	testhelpers.FailImpl(t, printables...)
+}

--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -247,7 +247,7 @@ func (s *WSBroadcastServer) StartWithHeader(ctx context.Context, header ws.Hands
 				return nil
 			},
 			OnHeader: func(key []byte, value []byte) error {
-				headerName := string(key)
+				headerName := textproto.CanonicalMIMEHeaderKey(string(key))
 				if headerName == HTTPHeaderFeedClientVersion {
 					feedClientVersion, err := strconv.ParseUint(string(value), 0, 64)
 					if err != nil {
@@ -294,7 +294,7 @@ func (s *WSBroadcastServer) StartWithHeader(ctx context.Context, header ws.Hands
 				if config.ConnectionLimits.Enable && !s.clientManager.connectionLimiter.IsAllowed(connectingIP) {
 					return nil, ws.RejectConnectionError(
 						ws.RejectionStatus(http.StatusTooManyRequests),
-						ws.RejectionReason("Too many open websocket connections."),
+						ws.RejectionReason("Too many open feed connections."),
 					)
 				}
 

--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -294,7 +294,7 @@ func (s *WSBroadcastServer) StartWithHeader(ctx context.Context, header ws.Hands
 				if config.ConnectionLimits.Enable && !s.clientManager.connectionLimiter.IsAllowed(connectingIP) {
 					return nil, ws.RejectConnectionError(
 						ws.RejectionStatus(http.StatusTooManyRequests),
-						ws.RejectionReason(fmt.Sprintf("Too many open websocket connections.")),
+						ws.RejectionReason("Too many open websocket connections."),
 					)
 				}
 


### PR DESCRIPTION
This change adds four new configuration options to the relay executable.
`--node.feed.output.connection-limits.enable`
`--node.feed.output.connection-limits.per-ip-limit`
`--node.feed.output.connection-limits.per-ipv6-cidr-48-limit`
`--node.feed.output.connection-limits.per-ipv6-cidr-64-limit`
The `per-ip-limit` option controls the number of times a single IP may be connected to this relay. The `ipv6-cidr` options control how many times any CIDR block either /48 or /64 can be connected to this relay.
All connection-limit configuration is hot reloadable.

The metric `arb_feed_clients_limited` shows how many times connections were rejected due to the connection limit.

Websocket connection requests will almost always be rejected at the handshake request to upgrade to websockets from the client by returning a 429 response. In the event of a race where two or more handshakes are completed when one of them should be rejected, whichever one gets registered by the ClientManager last will be rejected by closing the connection.

Private and loopback IP ranges are not blocked, and a Warning message is printed for them since it indicates a misconfiguration if they are seen.

This change also fixes client IP detection for Cloudflare, we had not canonicalized the header we were looking for. Arbitrary client IP header support will be added in a follow up PR.


# Testing done
New unit tests pass.

Manual testing with wscat. Basic scenario shown below.
```
$ ./target/bin/relay --node.feed.input.url wss://nova.arbitrum.io/feed --l2.chain-id 42170 --node.feed.output.connection-limits.enable --node.feed.output.connection-limits.per-ip-limit 2
INFO [02-06|16:03:38.219] Running Arbitrum nitro relay             revision=936cfa2-modified vcs.time=2023-01-31T19:17:34Z
INFO [02-06|16:03:38.220] arbitrum websocket broadcast server is listening address=[::]:9642
INFO [02-06|16:03:38.220] connecting to arbitrum inbox message broadcaster url=wss://nova.arbitrum.io/feed
INFO [02-06|16:03:38.356] Feed connected                           feedServerVersion=2 chainId=42170 requestedSeqNum=0

tristan@ramona ~/offchain/nitro/wsbroadcastserver 0
Mon Feb 06 16:01:58
$ wscat -H "CF-Connecting-IP:1.2.3.4" -P -c ws://127.0.0.1:9642/feed
Connected (press CTRL+C to quit)
< Received ping

Mon Feb 06 16:01:58
$ wscat -H "CF-Connecting-IP:1.2.3.4" -P -c ws://127.0.0.1:9642/feed
Connected (press CTRL+C to quit)
< Received ping

Mon Feb 06 16:01:23
$ wscat -H "CF-Connecting-IP:1.2.3.4" -P -c ws://127.0.0.1:9642/feed
error: Unexpected server response: 429
 ```

Additionally manually tested the race condition where two handshakes succeed when there is only one connection allowed by removing the check in the handshake, and observed that the second connection is dropped and the client exits with the error message shown below.

```
$ wscat -H "CF-Connecting-IP:1.2.3.4" -P -c ws://127.0.0.1:9642/feed
Connected (press CTRL+C to quit)
Disconnected (code: 1006, reason: "")
```

Also tested with wscat: that IPv6 CIDR ranges are counted correctly, and internal IP ranges are ignored. 

Checked the metric is produced correctly
```
$ curl -s localhost:6070/debug/metrics/prometheus | grep _limit

# TYPE arb_feed_clients_limited gauge
arb_feed_clients_limited 3
```
