### PR TITLE
Downgrade Go to 1.19 for Arbitrator CI

### DIFF
--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -35,7 +35,7 @@ jobs:
           sudo add-apt-repository -y ppa:ethereum/ethereum
           sudo add-apt-repository -y ppa:longsleep/golang-backports
           sudo apt-get update && sudo apt-get install -y \
-            build-essential cmake nodejs ethereum lld-14 golang-go libudev-dev
+            build-essential cmake nodejs ethereum lld-14 golang-1.19 libudev-dev
           sudo ln -s /usr/bin/wasm-ld-14 /usr/local/bin/wasm-ld
 
       - name: Install rust stable


### PR DESCRIPTION
Go 1.20 introduces bulk memory opcodes to its WASM builds, which we don't currently support (pending https://github.com/OffchainLabs/nitro/pull/1488).