### PR TITLE
Fix precompiles using all gas on non-solidity errors

### DIFF
--- a/arbnode/dataposter/redis_storage.go
+++ b/arbnode/dataposter/redis_storage.go
@@ -178,7 +178,8 @@ func (s *RedisStorage[Item]) Put(ctx context.Context, index uint64, prevItem *It
 		_, err = pipe.Exec(ctx)
 		if errors.Is(err, redis.TxFailedErr) {
 			// Unfortunately, we can't wrap two errors.
-			err = fmt.Errorf("%w: %w", ErrStorageRace, err)
+			//nolint:errorlint
+			err = fmt.Errorf("%w: %v", ErrStorageRace, err.Error())
 		}
 		return err
 	}

--- a/arbnode/dataposter/redis_storage.go
+++ b/arbnode/dataposter/redis_storage.go
@@ -178,7 +178,7 @@ func (s *RedisStorage[Item]) Put(ctx context.Context, index uint64, prevItem *It
 		_, err = pipe.Exec(ctx)
 		if errors.Is(err, redis.TxFailedErr) {
 			// Unfortunately, we can't wrap two errors.
-			err = fmt.Errorf("%w: %v", ErrStorageRace, err.Error())
+			err = fmt.Errorf("%w: %w", ErrStorageRace, err)
 		}
 		return err
 	}

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -281,6 +281,8 @@ func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool, s
 			// no state changes needed
 		case 9:
 			ensure(state.l1PricingState.SetL1FeesAvailable(stateDB.GetBalance(l1pricing.L1PricerFundsPoolAddress)))
+		case 10:
+			// no state changes needed
 		default:
 			return fmt.Errorf("unrecognized ArbOS version %v, %w", state.arbosVersion, ErrFatalNodeOutOfDate)
 		}

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -237,7 +237,9 @@ func InitializeArbosState(stateDB vm.StateDB, burner burn.Burner, chainConfig *p
 	return aState, nil
 }
 
-func (state *ArbosState) UpgradeArbosVersionIfNecessary(currentTimestamp uint64, stateDB vm.StateDB, chainConfig *params.ChainConfig) error {
+func (state *ArbosState) UpgradeArbosVersionIfNecessary(
+	currentTimestamp uint64, stateDB vm.StateDB, chainConfig *params.ChainConfig,
+) error {
 	upgradeTo, err := state.upgradeVersion.Get()
 	state.Restrict(err)
 	flagday, _ := state.upgradeTimestamp.Get()
@@ -249,7 +251,9 @@ func (state *ArbosState) UpgradeArbosVersionIfNecessary(currentTimestamp uint64,
 
 var ErrFatalNodeOutOfDate = errors.New("please upgrade to the latest version of the node software")
 
-func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool, stateDB vm.StateDB, chainConfig *params.ChainConfig) error {
+func (state *ArbosState) UpgradeArbosVersion(
+	upgradeTo uint64, firstTime bool, stateDB vm.StateDB, chainConfig *params.ChainConfig,
+) error {
 	for state.arbosVersion < upgradeTo {
 		ensure := func(err error) {
 			if err != nil {
@@ -280,15 +284,25 @@ func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool, s
 		case 8:
 			// no state changes needed
 		case 9:
-			ensure(state.l1PricingState.SetL1FeesAvailable(stateDB.GetBalance(l1pricing.L1PricerFundsPoolAddress)))
+			ensure(state.l1PricingState.SetL1FeesAvailable(stateDB.GetBalance(
+				l1pricing.L1PricerFundsPoolAddress,
+			)))
 		case 10:
-			if !chainConfig.ArbitrumChainParams.AllowDebugPrecompiles {
+			if !chainConfig.DebugMode() {
 				// This upgrade isn't finalized so we only want to support it for testing
-				return fmt.Errorf("the chain is upgrading to unsupported ArbOS version %v, %w", state.arbosVersion+1, ErrFatalNodeOutOfDate)
+				return fmt.Errorf(
+					"the chain is upgrading to unsupported ArbOS version %v, %w",
+					state.arbosVersion+1,
+					ErrFatalNodeOutOfDate,
+				)
 			}
 			// no state changes needed
 		default:
-			return fmt.Errorf("the chain is upgrading to unsupported ArbOS version %v, %w", state.arbosVersion+1, ErrFatalNodeOutOfDate)
+			return fmt.Errorf(
+				"the chain is upgrading to unsupported ArbOS version %v, %w",
+				state.arbosVersion+1,
+				ErrFatalNodeOutOfDate,
+			)
 		}
 		state.arbosVersion++
 	}

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -229,7 +229,7 @@ func InitializeArbosState(stateDB vm.StateDB, burner burn.Burner, chainConfig *p
 		return nil, err
 	}
 	if desiredArbosVersion > 1 {
-		err = aState.UpgradeArbosVersion(desiredArbosVersion, true, stateDB)
+		err = aState.UpgradeArbosVersion(desiredArbosVersion, true, stateDB, chainConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -237,19 +237,19 @@ func InitializeArbosState(stateDB vm.StateDB, burner burn.Burner, chainConfig *p
 	return aState, nil
 }
 
-func (state *ArbosState) UpgradeArbosVersionIfNecessary(currentTimestamp uint64, stateDB vm.StateDB) error {
+func (state *ArbosState) UpgradeArbosVersionIfNecessary(currentTimestamp uint64, stateDB vm.StateDB, chainConfig *params.ChainConfig) error {
 	upgradeTo, err := state.upgradeVersion.Get()
 	state.Restrict(err)
 	flagday, _ := state.upgradeTimestamp.Get()
 	if state.arbosVersion < upgradeTo && currentTimestamp >= flagday {
-		return state.UpgradeArbosVersion(upgradeTo, false, stateDB)
+		return state.UpgradeArbosVersion(upgradeTo, false, stateDB, chainConfig)
 	}
 	return nil
 }
 
-var ErrFatalNodeOutOfDate = errors.New("please upgrade to latest version of node software")
+var ErrFatalNodeOutOfDate = errors.New("please upgrade to the latest version of the node software")
 
-func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool, stateDB vm.StateDB) error {
+func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool, stateDB vm.StateDB, chainConfig *params.ChainConfig) error {
 	for state.arbosVersion < upgradeTo {
 		ensure := func(err error) {
 			if err != nil {
@@ -282,9 +282,13 @@ func (state *ArbosState) UpgradeArbosVersion(upgradeTo uint64, firstTime bool, s
 		case 9:
 			ensure(state.l1PricingState.SetL1FeesAvailable(stateDB.GetBalance(l1pricing.L1PricerFundsPoolAddress)))
 		case 10:
+			if !chainConfig.ArbitrumChainParams.AllowDebugPrecompiles {
+				// This upgrade isn't finalized so we only want to support it for testing
+				return fmt.Errorf("the chain is upgrading to unsupported ArbOS version %v, %w", state.arbosVersion+1, ErrFatalNodeOutOfDate)
+			}
 			// no state changes needed
 		default:
-			return fmt.Errorf("unrecognized ArbOS version %v, %w", state.arbosVersion, ErrFatalNodeOutOfDate)
+			return fmt.Errorf("the chain is upgrading to unsupported ArbOS version %v, %w", state.arbosVersion+1, ErrFatalNodeOutOfDate)
 		}
 		state.arbosVersion++
 	}

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -88,7 +88,7 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 
 		state.L2PricingState().UpdatePricingModel(l2BaseFee, timePassed, false)
 
-		return state.UpgradeArbosVersionIfNecessary(currentTime, evm.StateDB)
+		return state.UpgradeArbosVersionIfNecessary(currentTime, evm.StateDB, evm.ChainConfig())
 	case InternalTxBatchPostingReportMethodID:
 		inputs, err := util.UnpackInternalTxDataBatchPostingReport(tx.Data)
 		if err != nil {

--- a/contracts/src/mocks/Simple.sol
+++ b/contracts/src/mocks/Simple.sol
@@ -104,4 +104,10 @@ contract Simple {
         (success, ) = address(this).call(data);
         require(success, "CALL_FAILED");
     }
+
+    function checkGasUsed(address to, bytes calldata input) external view returns (uint256) {
+        uint256 before = gasleft();
+        to.staticcall{gas: before - 10000}(input);
+        return before - gasleft();
+    }
 }

--- a/contracts/src/precompiles/ArbDebug.sol
+++ b/contracts/src/precompiles/ArbDebug.sol
@@ -34,6 +34,8 @@ interface ArbDebug {
 
     function customRevert(uint64 number) external pure;
 
+    function legacyError() external pure;
+
     error Custom(uint64, string, bool);
     error Unused();
 }

--- a/contracts/src/precompiles/ArbSys.sol
+++ b/contracts/src/precompiles/ArbSys.sol
@@ -147,4 +147,6 @@ interface ArbSys {
         bytes32 indexed hash,
         uint256 indexed position
     );
+
+    error InvalidBlockNumber(uint256 requested, uint256 current);
 }

--- a/das/aggregator.go
+++ b/das/aggregator.go
@@ -348,7 +348,7 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64, 
 
 	verified, err := blsSignatures.VerifySignature(aggCert.Sig, aggCert.SerializeSignableFields(), aggPubKey)
 	if err != nil {
-		return nil, fmt.Errorf("%s. %w", err.Error(), BatchToDasFailed)
+		return nil, fmt.Errorf("%w. %w", err, BatchToDasFailed)
 	}
 	if !verified {
 		return nil, fmt.Errorf("failed aggregate signature check. %w", BatchToDasFailed)

--- a/das/aggregator.go
+++ b/das/aggregator.go
@@ -348,7 +348,8 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64, 
 
 	verified, err := blsSignatures.VerifySignature(aggCert.Sig, aggCert.SerializeSignableFields(), aggPubKey)
 	if err != nil {
-		return nil, fmt.Errorf("%w. %w", err, BatchToDasFailed)
+		//nolint:errorlint
+		return nil, fmt.Errorf("%s. %w", err.Error(), BatchToDasFailed)
 	}
 	if !verified {
 		return nil, fmt.Errorf("failed aggregate signature check. %w", BatchToDasFailed)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ replace github.com/VictoriaMetrics/fastcache => ./fastcache
 replace github.com/ethereum/go-ethereum => ./go-ethereum
 
 require (
-	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/alicebob/miniredis/v2 v2.21.0
 	github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156
 	github.com/andybalholm/brotli v1.0.3
@@ -17,11 +16,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.10
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.26.9
 	github.com/cavaliergopher/grab/v3 v3.0.1
-	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/codeclysm/extract/v3 v3.0.2
 	github.com/dgraph-io/badger/v3 v3.2103.2
 	github.com/ethereum/go-ethereum v1.10.13-0.20211112145008-abc74a5ffeb7
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
+	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-ipfs-files v0.1.1
 	github.com/ipfs/go-path v0.3.0
@@ -62,6 +60,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/ceramicnetwork/go-dag-jose v0.1.0 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/containerd/cgroups v1.0.4 // indirect
@@ -91,9 +90,9 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/golang/glog v1.0.0 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/gomodule/redigo v1.8.9 // indirect
 	github.com/google/flatbuffers v1.12.1 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/graph-gophers/graphql-go v1.3.0 // indirect
@@ -102,7 +101,6 @@ require (
 	github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.1 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
 	github.com/ipfs/go-bitfield v1.0.0 // indirect
 	github.com/ipfs/go-bitswap v0.10.2 // indirect
@@ -264,7 +262,7 @@ require (
 
 require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/gobwas/httphead v0.1.0 // indirect
+	github.com/gobwas/httphead v0.1.0
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.1.0
 	github.com/gobwas/ws-examples v0.0.0-20190625122829-a9e8908d9484

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,6 @@ github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5 h1:iW0a5
 github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5/go.mod h1:Y2QMoi1vgtOIfc+6DhrMOGkLoGzqSV2rKp4Sm+opsyA=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZpUGpz5+4FfNmIU+FmZg2P3Xaj2v2bfNWmk=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
-github.com/alicebob/miniredis v2.5.0+incompatible h1:yBHoLpsyjupjz3NL3MhKMVkR41j82Yjf3KFv7ApYzUI=
-github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+DxYx+6BMjkBbe5ONFIF1MXffk=
 github.com/alicebob/miniredis/v2 v2.21.0 h1:CdmwIlKUWFBDS+4464GtQiQ0R1vpzOgu4Vnd74rBL7M=
 github.com/alicebob/miniredis/v2 v2.21.0/go.mod h1:XNqvJdQJv5mSuVMc0ynneafpnL/zv52acZ6kqeS0t88=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
@@ -432,8 +430,6 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gomodule/redigo v1.8.9 h1:Sl3u+2BI/kk+VEatbj0scLdrFhjPmbxOc1myhDP41ws=
-github.com/gomodule/redigo v1.8.9/go.mod h1:7ArFNvsTjH8GMMzB4uy1snslv2BwmginuMs06a1uzZE=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v1.12.1 h1:MVlul7pQNoDzWRLTw5imwYsl+usrS1TXG2H4jg6ImGw=

--- a/precompiles/ArbDebug.go
+++ b/precompiles/ArbDebug.go
@@ -3,6 +3,8 @@
 
 package precompiles
 
+import "errors"
+
 // All calls to this precompile are authorized by the DebugPrecompile wrapper,
 // which ensures these methods are not accessible in production.
 type ArbDebug struct {
@@ -43,4 +45,8 @@ func (con ArbDebug) CustomRevert(c ctx, number uint64) error {
 // Caller becomes a chain owner
 func (con ArbDebug) BecomeChainOwner(c ctx, evm mech) error {
 	return c.State.ChainOwners().Add(c.caller)
+}
+
+func (con ArbDebug) LegacyError(c ctx) error {
+	return errors.New("example legacy error")
 }

--- a/precompiles/ArbSys.go
+++ b/precompiles/ArbSys.go
@@ -22,13 +22,12 @@ type ArbSys struct {
 	L2ToL1TxGasCost         func(addr, addr, huge, huge, huge, huge, huge, huge, []byte) (uint64, error)
 	SendMerkleUpdate        func(ctx, mech, huge, bytes32, huge) error
 	SendMerkleUpdateGasCost func(huge, bytes32, huge) (uint64, error)
+	InvalidBlockNumberError func(huge, huge) error
 
 	// deprecated event
 	L2ToL1Transaction        func(ctx, mech, addr, addr, huge, huge, huge, huge, huge, huge, huge, []byte) error
 	L2ToL1TransactionGasCost func(addr, addr, huge, huge, huge, huge, huge, huge, huge, []byte) (uint64, error)
 }
-
-var InvalidBlockNum = errors.New("invalid block number")
 
 // ArbBlockNumber gets the current L2 block number
 func (con *ArbSys) ArbBlockNumber(c ctx, evm mech) (huge, error) {
@@ -38,13 +37,21 @@ func (con *ArbSys) ArbBlockNumber(c ctx, evm mech) (huge, error) {
 // ArbBlockHash gets the L2 block hash, if sufficiently recent
 func (con *ArbSys) ArbBlockHash(c ctx, evm mech, arbBlockNumber *big.Int) (bytes32, error) {
 	if !arbBlockNumber.IsUint64() {
-		return bytes32{}, InvalidBlockNum
+		if c.State.ArbOSVersion() >= 11 {
+			return bytes32{}, con.InvalidBlockNumberError(arbBlockNumber, evm.Context.BlockNumber)
+		} else {
+			return bytes32{}, errors.New("invalid block number")
+		}
 	}
 	requestedBlockNum := arbBlockNumber.Uint64()
 
 	currentNumber := evm.Context.BlockNumber.Uint64()
 	if requestedBlockNum >= currentNumber || requestedBlockNum+256 < currentNumber {
-		return common.Hash{}, errors.New("invalid block number for ArbBlockHAsh")
+		if c.State.ArbOSVersion() >= 11 {
+			return common.Hash{}, con.InvalidBlockNumberError(arbBlockNumber, evm.Context.BlockNumber)
+		} else {
+			return common.Hash{}, errors.New("invalid block number for ArbBlockHAsh")
+		}
 	}
 
 	return evm.Context.GetHash(requestedBlockNum), nil

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -725,7 +725,9 @@ func (p *Precompile) Call(
 			}
 			return solErr.data, callerCtx.gasLeft, vm.ErrExecutionReverted
 		}
-		log.Debug("precompile reverted with non-solidity error", "precompile", precompileAddress, "input", input, "err", errRet)
+		if !errors.Is(errRet, vm.ErrOutOfGas) {
+			log.Debug("precompile reverted with non-solidity error", "precompile", precompileAddress, "input", input, "err", errRet)
+		}
 		// nolint:errorlint
 		if arbosVersion >= 11 || errRet == vm.ErrExecutionReverted {
 			return nil, callerCtx.gasLeft, vm.ErrExecutionReverted

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -725,7 +725,14 @@ func (p *Precompile) Call(
 			}
 			return solErr.data, callerCtx.gasLeft, vm.ErrExecutionReverted
 		}
-		return nil, callerCtx.gasLeft, errRet
+		log.Debug("precompile reverted with non-solidity error", "precompile", precompileAddress, "input", input, "err", errRet)
+		// nolint:errorlint
+		if arbosVersion >= 11 || errRet == vm.ErrExecutionReverted {
+			return nil, callerCtx.gasLeft, vm.ErrExecutionReverted
+		} else {
+			// Preserve behavior with old versions which would zero out gas on this type of error
+			return nil, 0, errRet
+		}
 	}
 	result := make([]interface{}, resultCount)
 	for i := 0; i < resultCount; i++ {

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -5,12 +5,16 @@ package arbtest
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/offchainlabs/nitro/arbos"
+	"github.com/offchainlabs/nitro/solgen/go/mocksgen"
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
+	"github.com/offchainlabs/nitro/util/arbmath"
 )
 
 func TestPurePrecompileMethodCalls(t *testing.T) {
@@ -36,15 +40,63 @@ func TestCustomSolidityErrors(t *testing.T) {
 	_, node, client := CreateTestL2(t, ctx)
 	defer node.StopAndWait()
 
+	callOpts := &bind.CallOpts{Context: ctx}
 	arbDebug, err := precompilesgen.NewArbDebug(common.HexToAddress("0xff"), client)
-	Require(t, err, "could not deploy ArbDebug contract")
-	customError := arbDebug.CustomRevert(&bind.CallOpts{}, 1024)
+	Require(t, err, "could not bind ArbDebug contract")
+	customError := arbDebug.CustomRevert(callOpts, 1024)
 	if customError == nil {
-		Fail(t, "should have errored")
+		Fail(t, "customRevert call should have errored")
 	}
 	observedMessage := customError.Error()
 	expectedMessage := "execution reverted: error Custom(1024, This spider family wards off bugs: /\\oo/\\ //\\(oo)/\\ /\\oo/\\, true)"
 	if observedMessage != expectedMessage {
 		Fail(t, observedMessage)
 	}
+
+	arbSys, err := precompilesgen.NewArbSys(arbos.ArbSysAddress, client)
+	Require(t, err, "could not bind ArbSys contract")
+	_, customError = arbSys.ArbBlockHash(callOpts, big.NewInt(1e9))
+	if customError == nil {
+		Fail(t, "out of range ArbBlockHash call have errored")
+	}
+	observedMessage = customError.Error()
+	expectedMessage = "execution reverted: error InvalidBlockNumber(1000000000, 1)"
+	if observedMessage != expectedMessage {
+		Fail(t, observedMessage)
+	}
+}
+
+func TestPrecompileErrorGasLeft(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	info, node, client := CreateTestL2(t, ctx)
+	defer node.StopAndWait()
+
+	auth := info.GetDefaultTransactOpts("Faucet", ctx)
+	_, _, simple, err := mocksgen.DeploySimple(&auth, client)
+	Require(t, err)
+
+	assertNotAllGasConsumed := func(to common.Address, input []byte) {
+		gas, err := simple.CheckGasUsed(&bind.CallOpts{Context: ctx}, to, input)
+		Require(t, err, "Failed to call CheckGasUsed to precompile", to)
+		maxGas := big.NewInt(100_000)
+		if arbmath.BigGreaterThan(gas, maxGas) {
+			Fail(t, "Precompile", to, "used", gas, "gas reverting, greater than max expected", maxGas)
+		}
+	}
+
+	arbSys, err := precompilesgen.ArbSysMetaData.GetAbi()
+	Require(t, err)
+
+	arbBlockHash := arbSys.Methods["arbBlockHash"]
+	data, err := arbBlockHash.Inputs.Pack(big.NewInt(1e9))
+	Require(t, err)
+	input := append([]byte{}, arbBlockHash.ID...)
+	input = append(input, data...)
+	assertNotAllGasConsumed(arbos.ArbSysAddress, input)
+
+	arbDebug, err := precompilesgen.ArbDebugMetaData.GetAbi()
+	Require(t, err)
+	assertNotAllGasConsumed(common.HexToAddress("0xff"), arbDebug.Methods["legacyError"].ID)
 }

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -57,7 +57,7 @@ func TestCustomSolidityErrors(t *testing.T) {
 	Require(t, err, "could not bind ArbSys contract")
 	_, customError = arbSys.ArbBlockHash(callOpts, big.NewInt(1e9))
 	if customError == nil {
-		Fail(t, "out of range ArbBlockHash call have errored")
+		Fail(t, "out of range ArbBlockHash call should have errored")
 	}
 	observedMessage = customError.Error()
 	expectedMessage = "execution reverted: error InvalidBlockNumber(1000000000, 1)"


### PR DESCRIPTION
Pulls in https://github.com/OffchainLabs/go-ethereum/pull/199

This PR also adds a nice Solidity error for out of bound ArbSys arbBlockHash calls :) 