### PR TITLE
Improve nonce failure cache handling on shutdown

### DIFF
--- a/arbnode/sequencer.go
+++ b/arbnode/sequencer.go
@@ -929,6 +929,7 @@ func (s *Sequencer) StopAndWait() {
 				_, failure, _ := s.nonceFailures.GetOldest()
 				failure.revived = true
 				item = failure.queueItem
+				s.nonceFailures.RemoveOldest()
 			} else {
 				select {
 				case item = <-s.txQueue:

--- a/util/stopwaiter/stopwaiter.go
+++ b/util/stopwaiter/stopwaiter.go
@@ -182,7 +182,8 @@ func (s *StopWaiterSafe) LaunchThread(foo func(context.Context)) error {
 	return nil
 }
 
-// This calls go foo() directly, with the benefit of being easily searchable
+// This calls go foo() directly, with the benefit of being easily searchable.
+// Callers may rely on the assumption that foo runs even if this is stopped.
 func (s *StopWaiterSafe) LaunchUntrackedThread(foo func()) {
 	go foo()
 }
@@ -279,6 +280,7 @@ func (s *StopWaiter) StopAndWait() {
 	}
 }
 
+// If stop was already called, thread might silently not be launched
 func (s *StopWaiter) LaunchThread(foo func(context.Context)) {
 	if err := s.StopWaiterSafe.LaunchThread(foo); err != nil {
 		panic(err)


### PR DESCRIPTION
- On eviction, check if a forwarder is enabled and if so forward the tx
- On shutdown, forward anything still in the nonce failure cache