### PR TITLE
Fix wsbroadcastserver connection name logging

### DIFF
--- a/wsbroadcastserver/clientconnection.go
+++ b/wsbroadcastserver/clientconnection.go
@@ -7,10 +7,10 @@ import (
 	"compress/flate"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"math/rand"
 	"net"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -60,7 +60,7 @@ func NewClientConnection(
 		clientIp:        connectingIP,
 		desc:            desc,
 		creation:        time.Now(),
-		Name:            string(connectingIP) + "@" + conn.RemoteAddr().String() + strconv.Itoa(rand.Intn(10)),
+		Name:            fmt.Sprintf("%s@%s-%d", connectingIP, conn.RemoteAddr().String(), rand.Intn(10)),
 		clientManager:   clientManager,
 		requestedSeqNum: requestedSeqNum,
 		lastHeardUnix:   time.Now().Unix(),

--- a/wsbroadcastserver/clientconnection.go
+++ b/wsbroadcastserver/clientconnection.go
@@ -60,7 +60,7 @@ func NewClientConnection(
 		clientIp:        connectingIP,
 		desc:            desc,
 		creation:        time.Now(),
-		Name:            fmt.Sprintf("%s@%s-%d", connectingIP, conn.RemoteAddr().String(), rand.Intn(10)),
+		Name:            fmt.Sprintf("%s@%s-%d", connectingIP, conn.RemoteAddr(), rand.Intn(10)),
 		clientManager:   clientManager,
 		requestedSeqNum: requestedSeqNum,
 		lastHeardUnix:   time.Now().Unix(),

--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -274,6 +274,7 @@ func (s *WSBroadcastServer) StartWithHeader(ctx context.Context, header ws.Hands
 					requestedSeqNum = arbutil.MessageIndex(num)
 				} else if headerName == HTTPHeaderCloudflareConnectingIP {
 					connectingIP = net.ParseIP(string(value))
+					log.Trace("Client IP parsed from header", "ip", connectingIP, "header", headerName, "value", string(value))
 				}
 
 				return nil
@@ -288,6 +289,9 @@ func (s *WSBroadcastServer) StartWithHeader(ctx context.Context, header ws.Hands
 				if connectingIP == nil {
 					if addr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
 						connectingIP = addr.IP
+						log.Trace("Client IP taken from socket", "ip", connectingIP, "remoteAddr", conn.RemoteAddr())
+					} else {
+						log.Warn("No client IP could be determined from socket", "remoteAddr", conn.RemoteAddr())
 					}
 				}
 


### PR DESCRIPTION
# Testing done

Start relay:
```
./target/bin/relay --node.feed.input.url wss://nova.arbitrum.io/feed --l2.chain-id 42170 --node.feed.output.connection-limits.enable --node.feed.output.connection-limits.per-ip-limit 1 --metrics --log-level 5 --node.feed.output.log-connect
```

## Test with no cloudflare ip set and from an internal IP

```
wscat -P -c ws://127.0.0.1:9642/feed
```

```
INFO [02-17|09:40:34.785] client registered                        client=127.0.0.1@127.0.0.1:56646-5 r
equestedSeqNum=0 sentCount=1208 elapsed=2.468061ms                                                     
WARN [02-17|09:40:39.598] Ignoring private, looback, or unparseable IP. Please check relay and network 
configuration to ensure client IP addresses are detected correctly ip=127.0.0.1                        
```

## Test with cloudflare ip set

```
wscat -H "CF-Connecting-IP:1.2.3.4" -P -c ws://127.0.0.1:9642/feed
```

```
INFO [02-17|09:40:41.936] client registered                        client=1.2.3.4@127.0.0.1:42446-0   r
equestedSeqNum=0 sentCount=1210 elapsed=1.887199ms                
```

## Extra trace logging

```
TRACE[02-17|09:50:52.587] Client IP taken from socket              ip=127.0.0.1 remoteAddr=127.0.0.1:48780                                                                                                    
     
TRACE[02-17|09:50:55.425] Client IP parsed from header             ip=1.2.3.4   header=Cf-Connecting-Ip  value=1.2.3.4                                                                                         
```