### PR TITLE
Fix sequencer coordinator updateWithLockout backoff

### DIFF
--- a/das/dastree/dastree.go
+++ b/das/dastree/dastree.go
@@ -63,7 +63,7 @@ func RecordHash(record func(bytes32, []byte), preimage ...[]byte) bytes32 {
 	length := uint32(len(unrolled))
 	leaves := []node{}
 	for bin := uint32(0); bin < length; bin += BinSize {
-		end := arbmath.MinUint32(bin+BinSize, length)
+		end := arbmath.MinInt(bin+BinSize, length)
 		hash := keccord(prepend(LeafByte, keccord(unrolled[bin:end]).Bytes()))
 		leaves = append(leaves, node{hash, end - bin})
 	}

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -28,24 +28,30 @@ func Log2ceil(value uint64) uint64 {
 	return uint64(64 - bits.LeadingZeros64(value))
 }
 
+type Signed interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+type Unsigned interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+type Integer interface {
+	Signed | Unsigned
+}
+
+type Float interface {
+	~float32 | ~float64
+}
+
+// Ordered is anything that implements comparison operators such as `<` and `>`.
+// Unfortunately, that doesn't include big ints.
+type Ordered interface {
+	Integer | Float
+}
+
 // MinInt the minimum of two ints
-func MinInt(value, ceiling int64) int64 {
-	if value > ceiling {
-		return ceiling
-	}
-	return value
-}
-
-// MinUint the minimum of two uints
-func MinUint(value, ceiling uint64) uint64 {
-	if value > ceiling {
-		return ceiling
-	}
-	return value
-}
-
-// MinUint32 the minimum of two 32-bit uints
-func MinUint32(value, ceiling uint32) uint32 {
+func MinInt[T Ordered](value, ceiling T) T {
 	if value > ceiling {
 		return ceiling
 	}
@@ -53,7 +59,7 @@ func MinUint32(value, ceiling uint32) uint32 {
 }
 
 // MaxInt the maximum of two ints
-func MaxInt(value, floor int64) int64 {
+func MaxInt[T Ordered](value, floor T) T {
 	if value < floor {
 		return floor
 	}


### PR DESCRIPTION
We don't need to refresh our lockout every update, so we have code to return early if we've recently updated our lockout. Unfortunately, this check was backwards, so it'd never get hit. I've also improved the margin of error.

This PR also adds a generic min/max function for any integers or types based on integers, like `time.Duration`.