### PR TITLE
Don't install emsdk in non-arbitrator CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,21 +112,9 @@ jobs:
         if: steps.cache-cbrotli.outputs.cache-hit != 'true'
         run: ./build-brotli.sh -l
 
-      - name: Setup emsdk
+      - name: Build cbrotli-wasm in docker
         if: steps.cache-cbrotli.outputs.cache-hit != 'true'
-        uses: mymindstorm/setup-emsdk@v11
-        with:
-          # Make sure to set a version number!
-          version: 3.1.6
-          # This is the name of the cache folder.
-          # The cache folder will be placed in the build directory,
-          #  so make sure it doesn't conflict with anything!
-          actions-cache-folder: 'emsdk-cache'
-          no-cache: true
-
-      - name: Build cbrotli-wasm
-        if: steps.cache-cbrotli.outputs.cache-hit != 'true'
-        run: ./build-brotli.sh -w
+        run: ./build-brotli.sh -w -d
 
       - name: Build
         run: make build test-go-deps -j


### PR DESCRIPTION
Unfortunately its caching system keeps resulting in failed CI runs such as https://github.com/OffchainLabs/nitro/actions/runs/4249234348/jobs/7389186616 , so this PR just installs cbrotli-wasm in docker to avoid needing emsdk outside of docker.

The arbitrator build should make sure that our non-docker brotli build keeps working.

Thanks @rachel-bousfield for the suggestion!