### PR TITLE
[Configuration Changes] Staker config

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -432,10 +432,16 @@ func (c *Config) Validate() error {
 	if err := c.Feed.Validate(); err != nil {
 		return err
 	}
+	if err := c.Staker.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 
 func (c *Config) Get() *Config {
+	if nil != c.Validate() {
+		panic("invalid config")
+	}
 	return c
 }
 

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -333,7 +333,7 @@ func mainImpl() int {
 			flag.Usage()
 			log.Crit("validator have the L1 reader enabled")
 		}
-		if !nodeConfig.Node.Staker.Dangerous.WithoutBlockValidator {
+		if nodeConfig.Node.Staker.Strategy != "Watchtower" && !nodeConfig.Node.Staker.Dangerous.WithoutBlockValidator {
 			nodeConfig.Node.BlockValidator.Enable = true
 		}
 	}

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -84,7 +84,7 @@ func (c *L1ValidatorConfig) Validate() error {
 }
 
 var DefaultL1ValidatorConfig = L1ValidatorConfig{
-	Enable:                   false,
+	Enable:                   true,
 	Strategy:                 "Watchtower",
 	StakerInterval:           time.Minute,
 	MakeAssertionInterval:    time.Hour,


### PR DESCRIPTION
A few proposed changes to stker config
* using validate for cleaner config parsing
* disabling block validation by default for watchtower stakers
* enabling watchtower by default
This will make a default node keep watch on L1 with very little extra resources.