### PR TITLE
Add client registration delay to relay

### DIFF
--- a/wsbroadcastserver/clientmanager.go
+++ b/wsbroadcastserver/clientmanager.go
@@ -129,8 +129,11 @@ func (cm *ClientManager) Register(
 		NewClientConnection(conn, desc, cm, requestedSeqNum, connectingIP, compression),
 		true,
 	}
-	cm.clientAction <- createClient
 
+	go func() {
+		time.Sleep(cm.config().RegistrationDelay)
+		cm.clientAction <- createClient
+	}()
 	return createClient.cc
 }
 

--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -61,6 +61,7 @@ type BroadcasterConfig struct {
 	RequireCompression bool                    `koanf:"require-compression" reload:"hot"` // if reloaded to true will cause disconnection of clients with disabled compression on next broadcast
 	LimitCatchup       bool                    `koanf:"limit-catchup" reload:"hot"`
 	ConnectionLimits   ConnectionLimiterConfig `koanf:"connection-limits" reload:"hot"`
+	RegistrationDelay  time.Duration           `koanf:"registration-delay" reload:"hot"`
 }
 
 func (bc *BroadcasterConfig) Validate() error {
@@ -93,6 +94,7 @@ func BroadcasterConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".require-compression", DefaultBroadcasterConfig.RequireCompression, "require clients to use compression")
 	f.Bool(prefix+".limit-catchup", DefaultBroadcasterConfig.LimitCatchup, "only supply catchup buffer if requested sequence number is reasonable")
 	ConnectionLimiterConfigAddOptions(prefix+".connection-limits", f)
+	f.Duration(prefix+".registration-delay", DefaultBroadcasterConfig.RegistrationDelay, "time to wait after client connection has been accepted before registering it and serving feed data")
 }
 
 var DefaultBroadcasterConfig = BroadcasterConfig{
@@ -116,6 +118,7 @@ var DefaultBroadcasterConfig = BroadcasterConfig{
 	RequireCompression: false,
 	LimitCatchup:       false,
 	ConnectionLimits:   DefaultConnectionLimiterConfig,
+	RegistrationDelay:  0,
 }
 
 var DefaultTestBroadcasterConfig = BroadcasterConfig{
@@ -139,6 +142,7 @@ var DefaultTestBroadcasterConfig = BroadcasterConfig{
 	RequireCompression: false,
 	LimitCatchup:       false,
 	ConnectionLimits:   DefaultConnectionLimiterConfig,
+	RegistrationDelay:  0,
 }
 
 type WSBroadcastServer struct {


### PR DESCRIPTION
# Testing done

```
$ ./target/bin/relay --node.feed.input.url wss://goerli-rollup.arbitrum.io/feed --l2.chain-id 421613 --node.feed.output.connection-limits.enable --node.feed.output.connection-limits.per-ip-limit 2 --metrics --log-level 5 --node.feed.output.log-connect --node.feed.output.connection-limits.reconnect-cooldown-period 15s --node.feed.output.registration-delay 5s
```

```
$ wscat -H "CF-Connecting-IP:1.2.3.4" -P -c ws://127.0.0.1:9642/feed
... feed output 5s later```
```

Tested creating multiple connections, and how it combines with connection limiting.

Note: When there are multiple connections pending registration that would exceed the connection limit, the ones that are rejected are rejected with this error instead of 429 since the websocket connection is already established.
```
Disconnected (code: 1006, reason: "")
```
This was already the case before, but adding in the delay makes this condition more likely to occur. The connection is still rejected but the error message is not ideal. Once all pending connections are registered then clients get 429 errors.