### PR TITLE
Fix precheckNonces which previously assumed txs would succeed

### DIFF
--- a/arbnode/sequencer.go
+++ b/arbnode/sequencer.go
@@ -603,13 +603,13 @@ func (s *Sequencer) precheckNonces(queueItems []txQueueItem) []txQueueItem {
 			queueItem.returnResult(err)
 			continue
 		}
-		stateNonce, pending := pendingNonces[sender]
+		stateNonce := s.nonceCache.Get(latestHeader, latestState, sender)
+		pendingNonce, pending := pendingNonces[sender]
 		if !pending {
-			stateNonce = s.nonceCache.Get(latestHeader, latestState, sender)
+			pendingNonce = stateNonce
 		}
 		txNonce := tx.Nonce()
-		err = MakeNonceError(sender, txNonce, stateNonce)
-		if err == nil {
+		if txNonce == pendingNonce {
 			pendingNonces[sender] = txNonce + 1
 			nextKey := addressAndNonce{sender, txNonce + 1}
 			revivingFailure, exists := s.nonceFailures.Get(nextKey)
@@ -625,7 +625,11 @@ func (s *Sequencer) precheckNonces(queueItems []txQueueItem) []txQueueItem {
 					nextQueueItem = &revivingFailure.queueItem
 				}
 			}
-		} else {
+		} else if txNonce < stateNonce || txNonce > pendingNonce {
+			// It's impossible for this tx to succeed so far,
+			// because its nonce is lower than the state nonce
+			// or higher than the highest tx nonce we've seen.
+			err := MakeNonceError(sender, txNonce, stateNonce)
 			if errors.Is(err, core.ErrNonceTooHigh) {
 				// Retry this transaction if its predecessor appears
 				key := addressAndNonce{sender, txNonce}
@@ -643,11 +647,18 @@ func (s *Sequencer) precheckNonces(queueItems []txQueueItem) []txQueueItem {
 						nonceFailureCacheOverflowCounter.Inc(1)
 					}
 				}
-			} else {
+				continue
+			} else if err != nil {
+				nonceCacheRejectedCounter.Inc(1)
 				queueItem.returnResult(err)
+				continue
+			} else {
+				log.Warn("unreachable nonce err == nil condition hit in precheckNonces")
 			}
-			continue
 		}
+		// If neither if condition was hit, then txNonce >= stateNonce && txNonce < pendingNonce
+		// This tx might still go through if previous txs fail.
+		// We'll include it in the output queue in case that happens.
 		outputQueueItems = append(outputQueueItems, queueItem)
 	}
 	nonceFailureCacheSizeGauge.Update(int64(s.nonceFailures.Len()))


### PR DESCRIPTION
E.g. if two txs from the same address with nonce 5 were submitted, the old precheckNonces would immediately issue a nonce too low error for the second tx, even though the first tx might fail causing the second tx to have otherwise succeeded.