### PR TITLE
Use a common.Hash to represent rollup node hashes

### DIFF
--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -205,7 +205,7 @@ func (v *L1Validator) isRequiredStakeElevated(ctx context.Context) (bool, error)
 type createNodeAction struct {
 	assertion         *Assertion
 	prevInboxMaxCount *big.Int
-	hash              [32]byte
+	hash              common.Hash
 }
 
 type existingNodeAction struct {
@@ -217,7 +217,7 @@ type nodeAction interface{}
 
 type OurStakerInfo struct {
 	LatestStakedNode     uint64
-	LatestStakedNodeHash [32]byte
+	LatestStakedNodeHash common.Hash
 	CanProgress          bool
 	StakeExists          bool
 	*StakerInfo


### PR DESCRIPTION
This fixes the "error advancing stake from node" log line which would previously print the bytes of the hash in decimal instead of hex