### PR TITLE
Retry block validation if we fail to add the sequencer message

### DIFF
--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -586,11 +586,13 @@ func (v *BlockValidator) sendValidations(ctx context.Context) {
 			validationStatus.Cancel = cancel
 			err := v.ValidationEntryAddSeqMessage(ctx, validationStatus.Entry, startPos, endPos, seqMsg)
 			if err != nil && validationCtx.Err() == nil {
+				validationStatus.replaceStatus(Prepared, RecordFailed)
 				log.Error("error preparing validation", "err", err)
 				return
 			}
 			input, err := validationStatus.Entry.ToInput()
 			if err != nil && validationCtx.Err() == nil {
+				validationStatus.replaceStatus(Prepared, RecordFailed)
 				log.Error("error preparing validation", "err", err)
 				return
 			}


### PR DESCRIPTION
This can happen because we fail to fetch the DAS batch, which is definitely an error we want to retry. Setting the validation status to RecordFailed will let it get cleaned up in sendRecords and then retried.