### PR TITLE
Update default prechecker conditional tx requirements

### DIFF
--- a/arbnode/tx_pre_checker.go
+++ b/arbnode/tx_pre_checker.go
@@ -44,8 +44,8 @@ type TxPreCheckerConfigFetcher func() *TxPreCheckerConfig
 
 var DefaultTxPreCheckerConfig = TxPreCheckerConfig{
 	Strictness:             TxPreCheckerStrictnessNone,
-	RequiredStateAge:       1,
-	RequiredStateMaxBlocks: 0,
+	RequiredStateAge:       2,
+	RequiredStateMaxBlocks: 4,
 }
 
 func TxPreCheckerConfigAddOptions(prefix string, f *flag.FlagSet) {


### PR DESCRIPTION
As mentioned in https://github.com/OffchainLabs/nitro/pull/1474#discussion_r1163424187 I think due to the coarseness of the block timestamp, having the required state age at 1 doesn't make much sense, so we need to increase it to 2 and set the max blocks to 4 to make it practically a 1 second delay anyways.