### PR TITLE
Staker config fix

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -448,7 +448,7 @@ func (c *Config) ValidatorRequired() bool {
 		return true
 	}
 	if c.Staker.Enable {
-		return !c.Staker.Dangerous.WithoutBlockValidator
+		return c.Staker.ValidatorRequired()
 	}
 	return false
 }
@@ -852,7 +852,7 @@ func createNodeImpl(
 	}
 
 	var blockValidator *staker.BlockValidator
-	if config.BlockValidator.Enable {
+	if config.ValidatorRequired() {
 		blockValidator, err = staker.NewBlockValidator(
 			statelessBlockValidator,
 			inboxTracker,
@@ -892,6 +892,7 @@ func createNodeImpl(
 				return nil, err
 			}
 		}
+
 		stakerObj, err = staker.NewStaker(l1Reader, wallet, bind.CallOpts{}, config.Staker, blockValidator, statelessBlockValidator, deployInfo.ValidatorUtils)
 		if err != nil {
 			return nil, err

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -843,7 +843,7 @@ func createNodeImpl(
 		err = errors.New("no validator url specified")
 	}
 	if err != nil {
-		if config.ValidatorRequired() {
+		if config.ValidatorRequired() || config.Staker.Enable {
 			return nil, fmt.Errorf("%w: failed to init block validator", err)
 		} else {
 			log.Warn("validation not supported", "err", err)

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -98,6 +98,19 @@ func (c *L1ValidatorConfig) ParseStrategy() (StakerStrategy, error) {
 	}
 }
 
+func (c *L1ValidatorConfig) ValidatorRequired() bool {
+	if !c.Enable {
+		return false
+	}
+	if c.Dangerous.WithoutBlockValidator {
+		return false
+	}
+	if c.strategy == WatchtowerStrategy {
+		return false
+	}
+	return true
+}
+
 func (c *L1ValidatorConfig) Validate() error {
 	strategy, err := c.ParseStrategy()
 	if err != nil {


### PR DESCRIPTION
Validator is not required for watchtower-staker unless enabled by user.
We still need a stateless validator for watchtower staker, meaning eg. we need a defined validation URL, but this exists by default as loopback. solving that requires some more code restructure.