### PR TITLE
Ensure test keys are deterministic

### DIFF
--- a/system_tests/test_info.go
+++ b/system_tests/test_info.go
@@ -73,7 +73,7 @@ func GetTestKeyForAccountName(t *testing.T, name string) *ecdsa.PrivateKey {
 	// For simplicity, make a larger than necessary buffer so copies always work
 	keyBytes := make([]byte, 32+len(name))
 	// We start at byte 1 to make sure the key isn't greater than the scalar modulus
-	for i := 1; i < 32; i++ {
+	for i := 1; i < 32; i += len(name) {
 		copy(keyBytes[i:i+len(name)], name)
 	}
 	keyBytes = keyBytes[:32]


### PR DESCRIPTION
`ecdsa.GenerateKey` is not guaranteed to be deterministic, and as of Go 1.20, it no longer is, which causes `TestSequencerWhitelist` to become flaky. This PR replaces it with geth's `crypto.ToECDSA` function which is deterministic.