### PR TITLE
Fix a race in the parallel batch poster test

### DIFF
--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -80,7 +80,9 @@ func testBatchPosterParallel(t *testing.T, useRedis bool) {
 	startL1Block, err := l1client.BlockNumber(ctx)
 	Require(t, err)
 	for i := 0; i < parallelBatchPosters; i++ {
-		batchPoster, err := arbnode.NewBatchPoster(nodeA.L1Reader, nodeA.InboxTracker, nodeA.TxStreamer, nodeA.SyncMonitor, func() *arbnode.BatchPosterConfig { return &conf.BatchPoster }, nodeA.DeployInfo, &seqTxOpts, nil)
+		// Make a copy of the batch poster config so NewBatchPoster calling Validate() on it doesn't race
+		batchPosterConfig := conf.BatchPoster
+		batchPoster, err := arbnode.NewBatchPoster(nodeA.L1Reader, nodeA.InboxTracker, nodeA.TxStreamer, nodeA.SyncMonitor, func() *arbnode.BatchPosterConfig { return &batchPosterConfig }, nodeA.DeployInfo, &seqTxOpts, nil)
 		Require(t, err)
 		batchPoster.Start(ctx)
 		defer batchPoster.StopAndWait()


### PR DESCRIPTION
In this test, we create multiple batch posters, but giving the same config means that writing the gas refunder address in the config `Validate()` function races with another batch poster reading the gas refunder address when creating a batch. To fix this, we just create a copy of the batch poster config for each batch poster in the test.