### PR TITLE
Fix the eth_estimateGas RPC gas cap

### DIFF
--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -542,8 +542,9 @@ func makeFakeTxForMessage(message core.Message) *types.Transaction {
 	if gasFeeCap.Sign() == 0 {
 		gasFeeCap = randomGasFeeCap
 	}
+	// During gas estimation, we don't want the gas limit variability to change the L1 cost.
 	gas := message.Gas()
-	if gas == 0 {
+	if gas == 0 || message.RunMode() == types.MessageGasEstimationMode {
 		gas = RandomGas
 	}
 	return types.NewTx(&types.DynamicFeeTx{

--- a/contracts/src/node-interface/NodeInterface.sol
+++ b/contracts/src/node-interface/NodeInterface.sol
@@ -98,8 +98,10 @@ interface NodeInterface {
     /**
      * @notice Estimates a transaction's l1 costs.
      * @dev Use eth_call to call.
-     *      This method is exactly like gasEstimateComponents, but doesn't include the l2 component
+     *      This method is similar to gasEstimateComponents, but doesn't include the l2 component
      *      so that the l1 component can be known even when the tx may fail.
+     *      This method also doesn't pad the estimate as gas estimation normally does.
+     *      If using this value to submit a transaction, we'd recommend first padding it by 10%.
      * @param data the tx's calldata. Everything else like "From" and "Gas" are copied over
      * @param to the tx's "To" (ignored when contractCreation is true)
      * @param contractCreation whether "To" is omitted

--- a/nodeInterface/NodeInterface.go
+++ b/nodeInterface/NodeInterface.go
@@ -155,9 +155,14 @@ func (n NodeInterface) EstimateRetryableTicket(
 
 	// ArbitrumSubmitRetryableTx is unsigned so the following won't panic
 	msg, err := types.NewTx(submitTx).AsMessage(types.NewArbitrumSigner(nil), nil)
+	if err != nil {
+		return err
+	}
+
+	msg.TxRunMode = types.MessageGasEstimationMode
 	*n.returnMessage.message = msg
 	*n.returnMessage.changed = true
-	return err
+	return nil
 }
 
 func (n NodeInterface) ConstructOutboxProof(c ctx, evm mech, size, leaf uint64) (bytes32, bytes32, []bytes32, error) {

--- a/nodeInterface/NodeInterface.go
+++ b/nodeInterface/NodeInterface.go
@@ -509,7 +509,8 @@ func (n NodeInterface) GasEstimateComponents(
 
 	pricing := c.State.L1PricingState()
 
-	// Setting the gas will affect the poster data cost
+	// Setting the gas currently doesn't affect the PosterDataCost,
+	// but we do it anyways for accuracy with potential future changes.
 	args.Gas = &totalRaw
 	msg, err := args.ToMessage(gasCap, n.header, evm.StateDB.(*state.StateDB), types.MessageGasEstimationMode)
 	if err != nil {

--- a/nodeInterface/virtual-contracts.go
+++ b/nodeInterface/virtual-contracts.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/offchainlabs/nitro/arbnode"
+	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/l1pricing"
 	"github.com/offchainlabs/nitro/gethhook"
@@ -138,7 +139,7 @@ func init() {
 		}
 
 		posterCost, _ := state.L1PricingState().PosterDataCost(msg, l1pricing.BatchPosterAddress)
-		posterCostInL2Gas := arbmath.BigToUintSaturating(arbmath.BigDiv(posterCost, header.BaseFee))
+		posterCostInL2Gas := arbos.GetPosterGas(state, header.BaseFee, msg.RunMode(), posterCost)
 		*gascap = arbmath.SaturatingUAdd(*gascap, posterCostInL2Gas)
 	}
 


### PR DESCRIPTION
Depends on https://github.com/OffchainLabs/go-ethereum/pull/213

Previously, the eth_estimateGas gas cap increase to account for L1 fees wasn't taking into account that the L1 gas usage is padded by eth_estimateGas to be more accurate. This PR fixes that to ensure that the EVM gets the full block gas limit available to it.