### PR TITLE
staker tests: use empty genesis

### DIFF
--- a/system_tests/arbtrace_test.go
+++ b/system_tests/arbtrace_test.go
@@ -148,7 +148,7 @@ func TestArbTraceForwarding(t *testing.T) {
 	nodeConfig := arbnode.ConfigDefaultL1Test()
 	nodeConfig.RPC.ClassicRedirect = ipcPath
 	nodeConfig.RPC.ClassicRedirectTimeout = time.Second
-	_, _, _, l2stack, _, _, _, l1stack := createTestNodeOnL1WithConfigImpl(t, ctx, true, nodeConfig, nil, nil)
+	_, _, _, l2stack, _, _, _, l1stack := createTestNodeOnL1WithConfigImpl(t, ctx, true, nodeConfig, nil, nil, nil)
 	defer requireClose(t, l1stack)
 	defer requireClose(t, l2stack)
 

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -6,6 +6,7 @@ package arbtest
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"net"
@@ -81,6 +82,65 @@ func TransferBalanceTo(
 	Require(t, err)
 	res, err := EnsureTxSucceeded(ctx, client, tx)
 	Require(t, err)
+	return tx, res
+}
+
+// if l2client is not nil - will wait until balance appears in l2
+func BridgeBalance(
+	t *testing.T, account string, amount *big.Int, l1info info, l2info info, l1client client, l2client client, ctx context.Context,
+) (*types.Transaction, *types.Receipt) {
+	t.Helper()
+
+	// setup or validate the same account on l2info
+	l1acct := l1info.GetInfoWithPrivKey(account)
+	if l2info.Accounts[account] == nil {
+		l2info.SetFullAccountInfo(account, &AccountInfo{
+			Address:    l1acct.Address,
+			PrivateKey: l1acct.PrivateKey,
+			Nonce:      0,
+		})
+	} else {
+		l2acct := l2info.GetInfoWithPrivKey(account)
+		if l2acct.PrivateKey.X.Cmp(l1acct.PrivateKey.X) != 0 ||
+			l2acct.PrivateKey.Y.Cmp(l1acct.PrivateKey.Y) != 0 {
+			Fail(t, "l2 account already exists and not compatible to l1")
+		}
+	}
+
+	// check previous balance
+	var l2Balance *big.Int
+	var err error
+	if l2client != nil {
+		l2Balance, err = l2client.BalanceAt(ctx, l2info.GetAddress("Faucet"), nil)
+		Require(t, err)
+	}
+
+	// send transaction
+	data, err := hex.DecodeString("0f4d14e9000000000000000000000000000000000000000000000000000082f79cd90000")
+	Require(t, err)
+	tx := l1info.PrepareTx(account, "Inbox", l1info.TransferGas*100, amount, data)
+	err = l1client.SendTransaction(ctx, tx)
+	Require(t, err)
+	res, err := EnsureTxSucceeded(ctx, l1client, tx)
+	Require(t, err)
+
+	// wait for balance to appear in l2
+	if l2client != nil {
+		l2Balance.Add(l2Balance, amount)
+		for i := 0; true; i++ {
+			balance, err := l2client.BalanceAt(ctx, l2info.GetAddress("Faucet"), nil)
+			Require(t, err)
+			if balance.Cmp(l2Balance) >= 0 {
+				break
+			}
+			TransferBalance(t, "Faucet", "User", big.NewInt(1), l1info, l1client, ctx)
+			if i > 20 {
+				Fail(t, "bridging failed")
+			}
+			<-time.After(time.Millisecond * 100)
+		}
+	}
+
 	return tx, res
 }
 
@@ -448,7 +508,7 @@ func createTestNodeOnL1WithConfig(
 	l2info info, currentNode *arbnode.Node, l2client *ethclient.Client, l1info info,
 	l1backend *eth.Ethereum, l1client *ethclient.Client, l1stack *node.Node,
 ) {
-	l2info, currentNode, l2client, _, l1info, l1backend, l1client, l1stack = createTestNodeOnL1WithConfigImpl(t, ctx, isSequencer, nodeConfig, chainConfig, stackConfig)
+	l2info, currentNode, l2client, _, l1info, l1backend, l1client, l1stack = createTestNodeOnL1WithConfigImpl(t, ctx, isSequencer, nodeConfig, chainConfig, stackConfig, nil)
 	return
 }
 
@@ -459,6 +519,7 @@ func createTestNodeOnL1WithConfigImpl(
 	nodeConfig *arbnode.Config,
 	chainConfig *params.ChainConfig,
 	stackConfig *node.Config,
+	l2info_in info,
 ) (
 	l2info info, currentNode *arbnode.Node, l2client *ethclient.Client, l2stack *node.Node,
 	l1info info, l1backend *eth.Ethereum, l1client *ethclient.Client, l1stack *node.Node,
@@ -474,7 +535,11 @@ func createTestNodeOnL1WithConfigImpl(
 	var l2chainDb ethdb.Database
 	var l2arbDb ethdb.Database
 	var l2blockchain *core.BlockChain
-	l2info, l2stack, l2chainDb, l2arbDb, l2blockchain = createL2BlockChainWithStackConfig(t, nil, "", chainConfig, stackConfig)
+	l2info = l2info_in
+	if l2info == nil {
+		l2info = NewArbTestInfo(t, chainConfig.ChainID)
+	}
+	_, l2stack, l2chainDb, l2arbDb, l2blockchain = createL2BlockChainWithStackConfig(t, l2info, "", chainConfig, stackConfig)
 	addresses := DeployOnTestL1(t, ctx, l1info, l1client, chainConfig.ChainID)
 	var sequencerTxOptsPtr *bind.TransactOpts
 	var dataSigner signature.DataSignerFunc

--- a/system_tests/debugapi_test.go
+++ b/system_tests/debugapi_test.go
@@ -14,7 +14,7 @@ import (
 func TestDebugAPI(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	_, _, _, l2stack, _, _, _, l1stack := createTestNodeOnL1WithConfigImpl(t, ctx, true, nil, nil, nil)
+	_, _, _, l2stack, _, _, _, l1stack := createTestNodeOnL1WithConfigImpl(t, ctx, true, nil, nil, nil, nil)
 	defer requireClose(t, l1stack)
 	defer requireClose(t, l2stack)
 

--- a/system_tests/staker_test.go
+++ b/system_tests/staker_test.go
@@ -18,15 +18,18 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbnode"
+	"github.com/offchainlabs/nitro/arbos/l2pricing"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/solgen/go/mocksgen"
 	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
 	"github.com/offchainlabs/nitro/staker"
+	"github.com/offchainlabs/nitro/util"
 	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/colors"
 	"github.com/offchainlabs/nitro/validator/valnode"
@@ -65,7 +68,14 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 	t.Parallel()
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
-	l2info, l2nodeA, l2clientA, l1info, _, l1client, l1stack := createTestNodeOnL1(t, ctx, true)
+	var transferGas = util.NormalizeL2GasForL1GasInitial(800_000, params.GWei) // include room for aggregator L1 costs
+	l2chainConfig := params.ArbitrumDevTestChainConfig()
+	l2info := NewBlockChainTestInfo(
+		t,
+		types.NewArbitrumSigner(types.NewLondonSigner(l2chainConfig.ChainID)), big.NewInt(l2pricing.InitialBaseFeeWei*2),
+		transferGas,
+	)
+	_, l2nodeA, l2clientA, _, l1info, _, l1client, l1stack := createTestNodeOnL1WithConfigImpl(t, ctx, true, nil, l2chainConfig, nil, l2info)
 	defer requireClose(t, l1stack)
 	defer l2nodeA.StopAndWait()
 
@@ -86,6 +96,8 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 			Fail(t, "node A L2 genesis hash", nodeAGenesis, "!= node B L2 genesis hash", nodeBGenesis)
 		}
 	}
+
+	BridgeBalance(t, "Faucet", big.NewInt(1).Mul(big.NewInt(params.Ether), big.NewInt(10000)), l1info, l2info, l1client, l2clientA, ctx)
 
 	deployAuth := l1info.GetDefaultTransactOpts("RollupOwner", ctx)
 


### PR DESCRIPTION
Genesis must be empty to be provable.
Test is currently flaky because neither right or wrong staker can prove genesis.

(patch originally created as part of another PR and now cherry-picked)