### PR TITLE
Update test-node.bash to nitro v2.0.14

### DIFF
--- a/test-node.bash
+++ b/test-node.bash
@@ -2,7 +2,7 @@
 
 set -e
 
-NITRO_NODE_VERSION=offchainlabs/nitro-node:v2.0.13-174496c-dev
+NITRO_NODE_VERSION=offchainlabs/nitro-node:v2.0.14-2baa834-dev
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.0.0-c8db5b1
 
 mydir=`dirname $0`


### PR DESCRIPTION
This fixes the max-delay option for the batch poster that `testnode-scripts/config.ts` sets not being available on previous versions.