### PR TITLE
When acquiring the lockout, populate the feed backlog

### DIFF
--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -91,13 +91,6 @@ func (t *InboxTracker) Initialize() error {
 		return err
 	}
 
-	if t.txStreamer.broadcastServer != nil {
-		err = t.populateFeedBacklog(t.txStreamer.broadcastServer)
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -202,7 +195,7 @@ func (t *InboxTracker) GetBatchCount() (uint64, error) {
 	return count, nil
 }
 
-func (t *InboxTracker) populateFeedBacklog(broadcastServer *broadcaster.Broadcaster) error {
+func (t *InboxTracker) PopulateFeedBacklog(broadcastServer *broadcaster.Broadcaster) error {
 	batchCount, err := t.GetBatchCount()
 	if err != nil {
 		return fmt.Errorf("error getting batch count: %w", err)
@@ -234,7 +227,7 @@ func (t *InboxTracker) populateFeedBacklog(broadcastServer *broadcaster.Broadcas
 		}
 		feedMessages = append(feedMessages, feedMessage)
 	}
-	broadcastServer.PopulateBacklog(feedMessages)
+	broadcastServer.BroadcastFeedMessages(feedMessages)
 	return nil
 }
 

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -591,6 +591,13 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 		messages = append(messages, message)
 		msgToRead++
 	}
+	if len(messages) > 0 {
+		if err := c.streamer.AddMessages(localMsgCount, false, messages); err != nil {
+			log.Warn("coordinator failed to add messages", "err", err, "pos", localMsgCount, "length", len(messages))
+		} else {
+			localMsgCount = msgToRead
+		}
+	}
 
 	if c.config.MyUrl() == redisutil.INVALID_URL {
 		return c.noRedisError()

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/offchainlabs/nitro/arbnode/execution"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/broadcaster"
 	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/contracts"
 	"github.com/offchainlabs/nitro/util/redisutil"
@@ -592,10 +593,27 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 		msgToRead++
 	}
 	if len(messages) > 0 {
-		if err := c.streamer.AddMessages(localMsgCount, false, messages); err != nil {
-			log.Warn("coordinator failed to add messages", "err", err, "pos", localMsgCount, "length", len(messages))
+		startMessageCount := localMsgCount
+		if err := c.streamer.AddMessages(startMessageCount, false, messages); err != nil {
+			log.Warn("coordinator failed to add messages", "err", err, "pos", startMessageCount, "length", len(messages))
 		} else {
 			localMsgCount = msgToRead
+		}
+		if c.streamer.broadcastServer != nil {
+			broadcastServer := c.streamer.broadcastServer
+			var feedMessages []*broadcaster.BroadcastFeedMessage
+			for i, msg := range messages {
+				pos := startMessageCount + arbutil.MessageIndex(i)
+				msg, err := broadcastServer.NewBroadcastFeedMessage(msg, pos)
+				if err != nil {
+					log.Error("failed to create broadcast feed message from redis message", "pos", pos, "msg", msg)
+					break
+				}
+				feedMessages = append(feedMessages, msg)
+			}
+			if len(feedMessages) > 0 {
+				broadcastServer.BroadcastFeedMessages(feedMessages)
+			}
 		}
 	}
 

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -798,6 +798,13 @@ func (s *TransactionStreamer) ResumeReorgs() {
 	s.reorgMutex.RUnlock()
 }
 
+func (s *TransactionStreamer) PopulateFeedBacklog() error {
+	if s.broadcastServer == nil {
+		return nil
+	}
+	return s.inboxReader.tracker.PopulateFeedBacklog(s.broadcastServer)
+}
+
 func (s *TransactionStreamer) writeMessage(pos arbutil.MessageIndex, msg arbostypes.MessageWithMetadata, batch ethdb.Batch) error {
 	key := dbKey(messagePrefix, uint64(pos))
 	msgBytes, err := rlp.EncodeToBytes(msg)

--- a/broadcaster/broadcaster.go
+++ b/broadcaster/broadcaster.go
@@ -161,8 +161,3 @@ func (b *Broadcaster) StopAndWait() {
 func (b *Broadcaster) Started() bool {
 	return b.server.Started()
 }
-
-// Not thread safe
-func (b *Broadcaster) PopulateBacklog(messages []*BroadcastFeedMessage) {
-	b.catchupBuffer.Reset(messages)
-}

--- a/broadcaster/broadcaster.go
+++ b/broadcaster/broadcaster.go
@@ -110,9 +110,14 @@ func (b *Broadcaster) BroadcastSingleFeedMessage(bfm *BroadcastFeedMessage) {
 
 	broadcastFeedMessages = append(broadcastFeedMessages, bfm)
 
+	b.BroadcastFeedMessages(broadcastFeedMessages)
+}
+
+func (b *Broadcaster) BroadcastFeedMessages(messages []*BroadcastFeedMessage) {
+
 	bm := BroadcastMessage{
 		Version:  1,
-		Messages: broadcastFeedMessages,
+		Messages: messages,
 	}
 
 	b.server.Broadcast(bm)

--- a/broadcaster/sequencenumbercatchupbuffer.go
+++ b/broadcaster/sequencenumbercatchupbuffer.go
@@ -174,9 +174,3 @@ func (b *SequenceNumberCatchupBuffer) OnDoBroadcast(bmi interface{}) error {
 func (b *SequenceNumberCatchupBuffer) GetMessageCount() int {
 	return int(atomic.LoadInt32(&b.messageCount))
 }
-
-// Not thread safe
-func (b *SequenceNumberCatchupBuffer) Reset(messages []*BroadcastFeedMessage) {
-	b.messages = messages
-	atomic.StoreInt32(&b.messageCount, int32(len(messages)))
-}


### PR DESCRIPTION
On startup, the nitro node reads in messages from the last batch and publishes them to the feed, but if it's the inactive sequencer a gap can form between it and the new messages it sequences. This PR fixes that by rebroadcasting any messages since the last batch when acquiring the lockout.