### PR TITLE
Don't panic in TxForwarder StopAndWait if not initialized

### DIFF
--- a/arbnode/execution/forwarder.go
+++ b/arbnode/execution/forwarder.go
@@ -191,7 +191,9 @@ func (f *TxForwarder) Start(ctx context.Context) error {
 }
 
 func (f *TxForwarder) StopAndWait() {
-	f.ethClient.Close() // internally closes also the rpc client
+	if f.ethClient != nil {
+		f.ethClient.Close() // internally closes also the rpc client
+	}
 }
 
 func (f *TxForwarder) Started() bool {


### PR DESCRIPTION
The StopAndWait method is called on shutdown, and can be called if there's an error during initialization, in which case ethClient will be nil.