### PR TITLE
Fix the pruning check for if the node is running a block validator

### DIFF
--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -320,7 +320,7 @@ func findImportantRoots(ctx context.Context, chainDb ethdb.Database, stack *node
 			}
 		}
 	} else if initConfig.Prune == "full" {
-		if nodeConfig.Node.Staker.Enable || nodeConfig.Node.BlockValidator.Enable {
+		if nodeConfig.Node.ValidatorRequired() {
 			return nil, errors.New("refusing to prune to full-node level when validator is enabled (you should prune in validator mode)")
 		}
 	} else if hashListRegex.MatchString(initConfig.Prune) {


### PR DESCRIPTION
This incorrectly assumed that all stakers, even watchtower stakers, run a block validator when they do not.