### PR TITLE
Support L2.chain-name, ifps and base64 encoded l2Chain configs

### DIFF
--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -1,6 +1,6 @@
 [
   {
-    "chain-id": "42161",
+    "chain-id": 42161,
     "chain-name": "arb1",
     "parent-chain-id": 1,
     "chain-parameters":
@@ -69,7 +69,7 @@
     }
   },
   {
-    "chain-id": "42170",
+    "chain-id": 42170,
     "chain-name": "nova",
     "parent-chain-id": 1,
     "chain-parameters":
@@ -151,7 +151,7 @@
     }
   },
   {
-    "chain-id": "421611",
+    "chain-id": 421611,
     "chain-name": "rinkeby-nitro",
     "parent-chain-id": 4,
     "chain-parameters":
@@ -220,7 +220,7 @@
     }
   },
   {
-    "chain-id": "421613",
+    "chain-id": 421613,
     "chain-name": "goerli-rollup",
     "parent-chain-id": 5,
     "chain-parameters":
@@ -293,7 +293,7 @@
     }
   },
   {
-    "chain-id": "421703",
+    "chain-id": 421703,
     "chain-name": "goerli-anytrust",
     "parent-chain-id": 5,
     "chain-parameters":
@@ -337,7 +337,7 @@
     }
   },
   {
-    "chain-id": "412346",
+    "chain-id": 412346,
     "chain-name": "arb-dev-test",
     "chain-config":
     {
@@ -373,7 +373,7 @@
     }
   },
   {
-    "chain-id": "412347",
+    "chain-id": 412347,
     "chain-name": "anytrust-dev-test",
     "chain-config":
     {

--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -1,6 +1,6 @@
-{
-  "42161":
+[
   {
+    "chain-id": "42161",
     "chain-name": "arb1",
     "parent-chain-id": 1,
     "chain-parameters":
@@ -68,8 +68,8 @@
       "deployed-at": 15411056
     }
   },
-  "42170":
   {
+    "chain-id": "42170",
     "chain-name": "nova",
     "parent-chain-id": 1,
     "chain-parameters":
@@ -150,8 +150,8 @@
       "deployed-at": 15016829
     }
   },
-  "421611":
   {
+    "chain-id": "421611",
     "chain-name": "rinkeby-nitro",
     "parent-chain-id": 4,
     "chain-parameters":
@@ -219,8 +219,8 @@
       "deployed-at": 11088567
     }
   },
-  "421613":
   {
+    "chain-id": "421613",
     "chain-name": "goerli-rollup",
     "parent-chain-id": 5,
     "chain-parameters":
@@ -292,8 +292,8 @@
       "deployed-at": 7217526
     }
   },
-  "421703":
   {
+    "chain-id": "421703",
     "chain-name": "goerli-anytrust",
     "parent-chain-id": 5,
     "chain-parameters":
@@ -336,8 +336,8 @@
       }
     }
   },
-  "412346":
   {
+    "chain-id": "412346",
     "chain-name": "arb-dev-test",
     "chain-config":
     {
@@ -372,8 +372,8 @@
       }
     }
   },
-  "412347":
   {
+    "chain-id": "412347",
     "chain-name": "anytrust-dev-test",
     "chain-config":
     {
@@ -408,4 +408,4 @@
       }
     }
   }
-}
+]

--- a/cmd/chaininfo/chain_info.go
+++ b/cmd/chaininfo/chain_info.go
@@ -79,7 +79,7 @@ func ProcessChainInfo(chainId uint64, chainName string, l2ChainInfoFiles []strin
 			}
 		}
 		for _, chainInfo := range chainsInfo {
-			if chainInfo.ChainId == chainId || chainInfo.ChainName == chainName {
+			if (chainInfo.ChainId == 0 || chainInfo.ChainId == chainId) && (chainInfo.ChainName == "" || chainInfo.ChainName == chainName) {
 				return &chainInfo, nil
 			}
 		}
@@ -91,7 +91,7 @@ func ProcessChainInfo(chainId uint64, chainName string, l2ChainInfoFiles []strin
 		return nil, err
 	}
 	for _, chainInfo := range chainsInfo {
-		if chainInfo.ChainId == chainId || chainInfo.ChainName == chainName {
+		if (chainInfo.ChainId == 0 || chainInfo.ChainId == chainId) && (chainInfo.ChainName == "" || chainInfo.ChainName == chainName) {
 			return &chainInfo, nil
 		}
 	}

--- a/cmd/chaininfo/chain_info.go
+++ b/cmd/chaininfo/chain_info.go
@@ -4,12 +4,9 @@
 package chaininfo
 
 import (
-	"bytes"
 	_ "embed"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"math/big"
 	"os"
 
@@ -69,14 +66,7 @@ func ProcessChainInfo(chainId uint64, chainName string, l2ChainInfoFiles []strin
 		var chainsInfo []ChainInfo
 		err = json.Unmarshal(chainsInfoBytes, &chainsInfo)
 		if err != nil {
-			decodedChainsInfoBytes, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding, bytes.NewReader(chainsInfoBytes)))
-			if err != nil {
-				return nil, err
-			}
-			err = json.Unmarshal(decodedChainsInfoBytes, &chainsInfo)
-			if err != nil {
-				return nil, err
-			}
+			return nil, err
 		}
 		for _, chainInfo := range chainsInfo {
 			if (chainInfo.ChainId == 0 || chainInfo.ChainId == chainId) && (chainInfo.ChainName == "" || chainInfo.ChainName == chainName) {

--- a/cmd/chaininfo/chain_info.go
+++ b/cmd/chaininfo/chain_info.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
-	"github.com/offchainlabs/nitro/cmd/conf"
 	"github.com/offchainlabs/nitro/cmd/ipfshelper"
 )
 
@@ -50,18 +49,18 @@ func GetChainConfig(ctx context.Context, chainId *big.Int, chainName string, gen
 	}
 }
 
-func GetRollupAddressesConfig(ctx context.Context, l2Config conf.L2Config) (RollupAddresses, error) {
-	chainInfo, err := ProcessChainInfo(ctx, l2Config.ChainID, l2Config.ChainName, l2Config.ChainInfoFiles, l2Config.ChainInfoIpfsUrl, l2Config.ChainInfoIpfsDownloadPath)
+func GetRollupAddressesConfig(ctx context.Context, chainId uint64, chainName string, l2ChainInfoFiles []string, l2ChainInfoIpfsUrl string, l2ChainInfoIpfsDownloadPath string) (RollupAddresses, error) {
+	chainInfo, err := ProcessChainInfo(ctx, chainId, chainName, l2ChainInfoFiles, l2ChainInfoIpfsUrl, l2ChainInfoIpfsDownloadPath)
 	if err != nil {
 		return RollupAddresses{}, err
 	}
 	if chainInfo.RollupAddresses != nil {
 		return *chainInfo.RollupAddresses, nil
 	}
-	if l2Config.ChainID != 0 {
-		return RollupAddresses{}, fmt.Errorf("missing rollup addresses for L2 chain ID %v", l2Config.ChainID)
+	if chainId != 0 {
+		return RollupAddresses{}, fmt.Errorf("missing rollup addresses for L2 chain ID %v", chainId)
 	} else {
-		return RollupAddresses{}, fmt.Errorf("missing rollup addresses for L2 chain name %v", l2Config.ChainName)
+		return RollupAddresses{}, fmt.Errorf("missing rollup addresses for L2 chain name %v", chainName)
 	}
 }
 

--- a/cmd/chaininfo/chain_info.go
+++ b/cmd/chaininfo/chain_info.go
@@ -93,7 +93,7 @@ func findChainInfo(chainId uint64, chainName string, chainsInfoBytes []byte) (*C
 		return nil, err
 	}
 	for _, chainInfo := range chainsInfo {
-		if (chainInfo.ChainId == 0 || chainInfo.ChainId == chainId) && (chainInfo.ChainName == "" || chainInfo.ChainName == chainName) {
+		if (chainId == 0 || chainInfo.ChainId == chainId) && (chainName == "" || chainInfo.ChainName == chainName) {
 			return &chainInfo, nil
 		}
 	}

--- a/cmd/conf/chain.go
+++ b/cmd/conf/chain.go
@@ -34,17 +34,21 @@ func (c *L1Config) ResolveDirectoryNames(chain string) {
 }
 
 type L2Config struct {
-	ChainID        uint64                   `koanf:"chain-id"`
-	ChainName      string                   `koanf:"chain-name"`
-	ChainInfoFiles []string                 `koanf:"chain-info-files"`
-	DevWallet      genericconf.WalletConfig `koanf:"dev-wallet"`
+	ChainID                   uint64                   `koanf:"chain-id"`
+	ChainName                 string                   `koanf:"chain-name"`
+	ChainInfoFiles            []string                 `koanf:"chain-info-files"`
+	DevWallet                 genericconf.WalletConfig `koanf:"dev-wallet"`
+	ChainInfoIpfsUrl          string                   `koanf:"chain-info-ipfs-url"`
+	ChainInfoIpfsDownloadPath string                   `koanf:"chain-info-ipfs-download-path"`
 }
 
 var L2ConfigDefault = L2Config{
-	ChainID:        0,
-	ChainName:      "",
-	ChainInfoFiles: []string{}, // Default file used is chaininfo/arbitrum_chain_info.json, stored in DefaultChainInfo in chain_info.go
-	DevWallet:      genericconf.WalletConfigDefault,
+	ChainID:                   0,
+	ChainName:                 "",
+	ChainInfoFiles:            []string{}, // Default file used is chaininfo/arbitrum_chain_info.json, stored in DefaultChainInfo in chain_info.go
+	DevWallet:                 genericconf.WalletConfigDefault,
+	ChainInfoIpfsUrl:          "",
+	ChainInfoIpfsDownloadPath: "/tmp/",
 }
 
 func L2ConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -54,6 +58,9 @@ func L2ConfigAddOptions(prefix string, f *flag.FlagSet) {
 
 	// Dev wallet does not exist unless specified
 	genericconf.WalletConfigAddOptions(prefix+".dev-wallet", f, "")
+	f.String(prefix+".chain-info-ipfs-url", L2ConfigDefault.ChainInfoIpfsUrl, "url to download chain info file")
+	f.String(prefix+".chain-info-ipfs-download-path", L2ConfigDefault.ChainInfoIpfsDownloadPath, "path to save temp downloaded file")
+
 }
 
 func (c *L2Config) ResolveDirectoryNames(chain string) {

--- a/cmd/conf/chain.go
+++ b/cmd/conf/chain.go
@@ -35,18 +35,21 @@ func (c *L1Config) ResolveDirectoryNames(chain string) {
 
 type L2Config struct {
 	ChainID        uint64                   `koanf:"chain-id"`
+	ChainName      string                   `koanf:"chain-name"`
 	ChainInfoFiles []string                 `koanf:"chain-info-files"`
 	DevWallet      genericconf.WalletConfig `koanf:"dev-wallet"`
 }
 
 var L2ConfigDefault = L2Config{
 	ChainID:        0,
+	ChainName:      "",
 	ChainInfoFiles: []string{}, // Default file used is chaininfo/arbitrum_chain_info.json, stored in DefaultChainInfo in chain_info.go
 	DevWallet:      genericconf.WalletConfigDefault,
 }
 
 func L2ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Uint64(prefix+".chain-id", L2ConfigDefault.ChainID, "L2 chain ID (determines Arbitrum network)")
+	f.String(prefix+".chain-name", L2ConfigDefault.ChainName, "L2 chain name (determines Arbitrum network)")
 	f.StringSlice(prefix+".chain-info-files", L2ConfigDefault.ChainInfoFiles, "L2 chain info json files")
 
 	// Dev wallet does not exist unless specified

--- a/cmd/conf/chain.go
+++ b/cmd/conf/chain.go
@@ -37,6 +37,7 @@ type L2Config struct {
 	ChainID                   uint64                   `koanf:"chain-id"`
 	ChainName                 string                   `koanf:"chain-name"`
 	ChainInfoFiles            []string                 `koanf:"chain-info-files"`
+	ChainInfoJson             string                   `koanf:"chain-info-json"`
 	DevWallet                 genericconf.WalletConfig `koanf:"dev-wallet"`
 	ChainInfoIpfsUrl          string                   `koanf:"chain-info-ipfs-url"`
 	ChainInfoIpfsDownloadPath string                   `koanf:"chain-info-ipfs-download-path"`
@@ -46,6 +47,7 @@ var L2ConfigDefault = L2Config{
 	ChainID:                   0,
 	ChainName:                 "",
 	ChainInfoFiles:            []string{}, // Default file used is chaininfo/arbitrum_chain_info.json, stored in DefaultChainInfo in chain_info.go
+	ChainInfoJson:             "",
 	DevWallet:                 genericconf.WalletConfigDefault,
 	ChainInfoIpfsUrl:          "",
 	ChainInfoIpfsDownloadPath: "/tmp/",
@@ -55,6 +57,7 @@ func L2ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Uint64(prefix+".chain-id", L2ConfigDefault.ChainID, "L2 chain ID (determines Arbitrum network)")
 	f.String(prefix+".chain-name", L2ConfigDefault.ChainName, "L2 chain name (determines Arbitrum network)")
 	f.StringSlice(prefix+".chain-info-files", L2ConfigDefault.ChainInfoFiles, "L2 chain info json files")
+	f.String(prefix+".chain-info-json", L2ConfigDefault.ChainInfoJson, "L2 chain info in json string format")
 
 	// Dev wallet does not exist unless specified
 	genericconf.WalletConfigAddOptions(prefix+".dev-wallet", f, "")

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -407,7 +407,7 @@ func pruneChainDb(ctx context.Context, chainDb ethdb.Database, stack *node.Node,
 	return pruner.Prune(root)
 }
 
-func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeConfig, chainId *big.Int, cacheConfig *core.CacheConfig, l1Client arbutil.L1Interface, rollupAddrs chaininfo.RollupAddresses) (ethdb.Database, *core.BlockChain, error) {
+func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeConfig, cacheConfig *core.CacheConfig, l1Client arbutil.L1Interface, rollupAddrs chaininfo.RollupAddresses) (ethdb.Database, *core.BlockChain, error) {
 	if !config.Init.Force {
 		if readOnlyDb, err := stack.OpenDatabaseWithFreezer("l2chaindata", 0, 0, "", "", true); err == nil {
 			if chainConfig := execution.TryReadStoredChainConfig(readOnlyDb); chainConfig != nil {
@@ -521,7 +521,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 		if err != nil {
 			return chainDb, nil, err
 		}
-		chainConfig, err = chaininfo.GetChainConfig(chainId, genesisBlockNr, config.L2.ChainInfoFiles)
+		chainConfig, err = chaininfo.GetChainConfig(new(big.Int).SetUint64(config.L2.ChainID), config.L2.ChainName, genesisBlockNr, config.L2.ChainInfoFiles)
 		if err != nil {
 			return chainDb, nil, err
 		}

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/offchainlabs/nitro/cmd/util"
 	"math/big"
 	"os"
 	"regexp"
@@ -521,7 +522,15 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 		if err != nil {
 			return chainDb, nil, err
 		}
-		chainConfig, err = chaininfo.GetChainConfig(ctx, new(big.Int).SetUint64(config.L2.ChainID), config.L2.ChainName, genesisBlockNr, config.L2.ChainInfoFiles, config.L2.ChainInfoIpfsUrl, config.L2.ChainInfoIpfsDownloadPath)
+		combinedL2ChainInfoFiles := config.L2.ChainInfoFiles
+		if config.L2.ChainInfoIpfsUrl != "" {
+			l2ChainInfoIpfsFile, err := util.GetL2ChainInfoIpfsFile(ctx, config.L2.ChainInfoIpfsUrl, config.L2.ChainInfoIpfsDownloadPath)
+			if err != nil {
+				log.Error("error getting l2 chain info file from ipfs", "err", err)
+			}
+			combinedL2ChainInfoFiles = append(combinedL2ChainInfoFiles, l2ChainInfoIpfsFile)
+		}
+		chainConfig, err = chaininfo.GetChainConfig(new(big.Int).SetUint64(config.L2.ChainID), config.L2.ChainName, genesisBlockNr, combinedL2ChainInfoFiles)
 		if err != nil {
 			return chainDb, nil, err
 		}

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -429,7 +429,7 @@ func pruneChainDb(ctx context.Context, chainDb ethdb.Database, stack *node.Node,
 	return pruner.Prune(root)
 }
 
-func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeConfig, cacheConfig *core.CacheConfig, l1Client arbutil.L1Interface, rollupAddrs chaininfo.RollupAddresses) (ethdb.Database, *core.BlockChain, error) {
+func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeConfig, chainId *big.Int, cacheConfig *core.CacheConfig, l1Client arbutil.L1Interface, rollupAddrs chaininfo.RollupAddresses) (ethdb.Database, *core.BlockChain, error) {
 	if !config.Init.Force {
 		if readOnlyDb, err := stack.OpenDatabaseWithFreezer("l2chaindata", 0, 0, "", "", true); err == nil {
 			if chainConfig := execution.TryReadStoredChainConfig(readOnlyDb); chainConfig != nil {

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -521,7 +521,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 		if err != nil {
 			return chainDb, nil, err
 		}
-		chainConfig, err = chaininfo.GetChainConfig(new(big.Int).SetUint64(config.L2.ChainID), config.L2.ChainName, genesisBlockNr, config.L2.ChainInfoFiles)
+		chainConfig, err = chaininfo.GetChainConfig(ctx, new(big.Int).SetUint64(config.L2.ChainID), config.L2.ChainName, genesisBlockNr, config.L2.ChainInfoFiles, config.L2.ChainInfoIpfsUrl, config.L2.ChainInfoIpfsDownloadPath)
 		if err != nil {
 			return chainDb, nil, err
 		}

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -530,7 +530,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 			}
 			combinedL2ChainInfoFiles = append(combinedL2ChainInfoFiles, l2ChainInfoIpfsFile)
 		}
-		chainConfig, err = chaininfo.GetChainConfig(new(big.Int).SetUint64(config.L2.ChainID), config.L2.ChainName, genesisBlockNr, combinedL2ChainInfoFiles)
+		chainConfig, err = chaininfo.GetChainConfig(new(big.Int).SetUint64(config.L2.ChainID), config.L2.ChainName, genesisBlockNr, combinedL2ChainInfoFiles, config.L2.ChainInfoJson)
 		if err != nil {
 			return chainDb, nil, err
 		}

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -335,7 +335,7 @@ func mainImpl() int {
 	if nodeConfig.Node.L1Reader.Enable {
 		log.Info("connected to l1 chain", "l1url", nodeConfig.L1.URL, "l1chainid", l1ChainId)
 
-		rollupAddrs, err = chaininfo.GetRollupAddressesConfig(nodeConfig.L2.ChainID, nodeConfig.L2.ChainName, combinedL2ChainInfoFile)
+		rollupAddrs, err = chaininfo.GetRollupAddressesConfig(nodeConfig.L2.ChainID, nodeConfig.L2.ChainName, combinedL2ChainInfoFile, nodeConfig.L2.ChainInfoJson)
 		if err != nil {
 			log.Crit("error getting rollup addresses config", "err", err)
 		}
@@ -372,7 +372,7 @@ func mainImpl() int {
 		}
 
 		// Just create validator smart wallet if needed then exit
-		deployInfo, err := chaininfo.GetRollupAddressesConfig(nodeConfig.L2.ChainID, nodeConfig.L2.ChainName, combinedL2ChainInfoFile)
+		deployInfo, err := chaininfo.GetRollupAddressesConfig(nodeConfig.L2.ChainID, nodeConfig.L2.ChainName, combinedL2ChainInfoFile, nodeConfig.L2.ChainInfoJson)
 		if err != nil {
 			log.Crit("error getting rollup addresses config", "err", err)
 		}
@@ -760,7 +760,8 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 		return nil, nil, nil, nil, nil, errors.New("must specify --l2.chain-id or --l2.chain-name to choose rollup")
 	}
 	l2ChainInfoFiles := k.Strings("l2.chain-info-files")
-	chainFound, err = applyChainParameters(ctx, k, uint64(l2ChainId), l2ChainName, l1ChainId.Uint64(), l2ChainInfoFiles, l2ChainInfoIpfsUrl, l2ChainInfoIpfsDownloadPath)
+	l2ChainInfoJson := k.String("l2.chain-info-json")
+	chainFound, err = applyChainParameters(ctx, k, uint64(l2ChainId), l2ChainName, l1ChainId.Uint64(), l2ChainInfoFiles, l2ChainInfoJson, l2ChainInfoIpfsUrl, l2ChainInfoIpfsDownloadPath)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
@@ -819,7 +820,7 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 	return &nodeConfig, &l1Wallet, &l2DevWallet, l1Client, l1ChainId, nil
 }
 
-func applyChainParameters(ctx context.Context, k *koanf.Koanf, chainId uint64, chainName string, l1ChainId uint64, l2ChainInfoFiles []string, l2ChainInfoIpfsUrl string, l2ChainInfoIpfsDownloadPath string) (bool, error) {
+func applyChainParameters(ctx context.Context, k *koanf.Koanf, chainId uint64, chainName string, l1ChainId uint64, l2ChainInfoFiles []string, l2ChainInfoJson string, l2ChainInfoIpfsUrl string, l2ChainInfoIpfsDownloadPath string) (bool, error) {
 	combinedL2ChainInfoFiles := l2ChainInfoFiles
 	if l2ChainInfoIpfsUrl != "" {
 		l2ChainInfoIpfsFile, err := util.GetL2ChainInfoIpfsFile(ctx, l2ChainInfoIpfsUrl, l2ChainInfoIpfsDownloadPath)
@@ -828,7 +829,7 @@ func applyChainParameters(ctx context.Context, k *koanf.Koanf, chainId uint64, c
 		}
 		combinedL2ChainInfoFiles = append(combinedL2ChainInfoFiles, l2ChainInfoIpfsFile)
 	}
-	chainInfo, err := chaininfo.ProcessChainInfo(chainId, chainName, combinedL2ChainInfoFiles)
+	chainInfo, err := chaininfo.ProcessChainInfo(chainId, chainName, combinedL2ChainInfoFiles, l2ChainInfoJson)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -327,7 +327,7 @@ func mainImpl() int {
 	if nodeConfig.Node.L1Reader.Enable {
 		log.Info("connected to l1 chain", "l1url", nodeConfig.L1.URL, "l1chainid", l1ChainId)
 
-		rollupAddrs, err = chaininfo.GetRollupAddressesConfig(ctx, nodeConfig.L2)
+		rollupAddrs, err = chaininfo.GetRollupAddressesConfig(ctx, nodeConfig.L2.ChainID, nodeConfig.L2.ChainName, nodeConfig.L2.ChainInfoFiles, nodeConfig.L2.ChainInfoIpfsUrl, nodeConfig.L2.ChainInfoIpfsDownloadPath)
 		if err != nil {
 			log.Crit("error getting rollup addresses config", "err", err)
 		}
@@ -364,7 +364,7 @@ func mainImpl() int {
 		}
 
 		// Just create validator smart wallet if needed then exit
-		deployInfo, err := chaininfo.GetRollupAddressesConfig(ctx, nodeConfig.L2)
+		deployInfo, err := chaininfo.GetRollupAddressesConfig(ctx, nodeConfig.L2.ChainID, nodeConfig.L2.ChainName, nodeConfig.L2.ChainInfoFiles, nodeConfig.L2.ChainInfoIpfsUrl, nodeConfig.L2.ChainInfoIpfsDownloadPath)
 		if err != nil {
 			log.Crit("error getting rollup addresses config", "err", err)
 		}

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -327,7 +327,7 @@ func mainImpl() int {
 	if nodeConfig.Node.L1Reader.Enable {
 		log.Info("connected to l1 chain", "l1url", nodeConfig.L1.URL, "l1chainid", l1ChainId)
 
-		rollupAddrs, err = chaininfo.GetRollupAddressesConfig(new(big.Int).SetUint64(nodeConfig.L2.ChainID), nodeConfig.L2.ChainInfoFiles)
+		rollupAddrs, err = chaininfo.GetRollupAddressesConfig(new(big.Int).SetUint64(nodeConfig.L2.ChainID), nodeConfig.L2.ChainName, nodeConfig.L2.ChainInfoFiles)
 		if err != nil {
 			log.Crit("error getting rollup addresses config", "err", err)
 		}
@@ -364,7 +364,7 @@ func mainImpl() int {
 		}
 
 		// Just create validator smart wallet if needed then exit
-		deployInfo, err := chaininfo.GetRollupAddressesConfig(new(big.Int).SetUint64(nodeConfig.L2.ChainID), nodeConfig.L2.ChainInfoFiles)
+		deployInfo, err := chaininfo.GetRollupAddressesConfig(new(big.Int).SetUint64(nodeConfig.L2.ChainID), nodeConfig.L2.ChainName, nodeConfig.L2.ChainInfoFiles)
 		if err != nil {
 			log.Crit("error getting rollup addresses config", "err", err)
 		}
@@ -397,7 +397,7 @@ func mainImpl() int {
 		}
 	}
 
-	chainDb, l2BlockChain, err := openInitializeChainDb(ctx, stack, nodeConfig, new(big.Int).SetUint64(nodeConfig.L2.ChainID), execution.DefaultCacheConfigFor(stack, &nodeConfig.Node.Caching), l1Client, rollupAddrs)
+	chainDb, l2BlockChain, err := openInitializeChainDb(ctx, stack, nodeConfig, execution.DefaultCacheConfigFor(stack, &nodeConfig.Node.Caching), l1Client, rollupAddrs)
 	defer closeDb(chainDb, "chainDb")
 	if l2BlockChain != nil {
 		// Calling Stop on the blockchain multiple times does nothing
@@ -745,11 +745,12 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 
 	chainFound := false
 	l2ChainId := k.Int64("l2.chain-id")
-	if l2ChainId == 0 {
-		return nil, nil, nil, nil, nil, errors.New("must specify --l2.chain-id to choose rollup")
+	l2ChainName := k.String("l2.chain-name")
+	if l2ChainId == 0 && l2ChainName == "" {
+		return nil, nil, nil, nil, nil, errors.New("must specify --l2.chain-id or --l2.chain-name to choose rollup")
 	}
 	l2ChainInfoFiles := k.Strings("l2.chain-info-files")
-	chainFound, err = applyChainParameters(k, uint64(l2ChainId), l1ChainId.Uint64(), l2ChainInfoFiles)
+	chainFound, err = applyChainParameters(k, uint64(l2ChainId), l2ChainName, l1ChainId.Uint64(), l2ChainInfoFiles)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
@@ -780,7 +781,11 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 	if nodeConfig.Persistent.Chain == "" {
 		if !chainFound {
 			// If persistent-chain not defined, user not creating custom chain
-			return nil, nil, nil, nil, nil, fmt.Errorf("Unknown chain with L1: %d, L2: %d, L2ChainInfoFiles: %s.  Change L1, update L2 chain id, modify --l2.chain-info-files or provide --persistent.chain\n", l1ChainId.Uint64(), l2ChainId, l2ChainInfoFiles)
+			if l2ChainId != 0 {
+				return nil, nil, nil, nil, nil, fmt.Errorf("Unknown chain with L1: %d, L2: %d, L2ChainInfoFiles: %s.  Change L1, update L2 chain id, modify --l2.chain-info-files or provide --persistent.chain\n", l1ChainId.Uint64(), l2ChainId, l2ChainInfoFiles)
+			} else {
+				return nil, nil, nil, nil, nil, fmt.Errorf("Unknown chain with L1: %d, L2 Name: %s, L2ChainInfoFiles: %s.  Change L1, update L2 chain name, modify --l2.chain-info-files or provide --persistent.chain\n", l1ChainId.Uint64(), l2ChainName, l2ChainInfoFiles)
+			}
 		}
 		return nil, nil, nil, nil, nil, errors.New("--persistent.chain not specified")
 	}
@@ -804,14 +809,18 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 	return &nodeConfig, &l1Wallet, &l2DevWallet, l1Client, l1ChainId, nil
 }
 
-func applyChainParameters(k *koanf.Koanf, chainId uint64, l1ChainId uint64, l2ChainInfoFiles []string) (bool, error) {
-	chainInfo, err := chaininfo.ProcessChainInfo(chainId, l2ChainInfoFiles)
+func applyChainParameters(k *koanf.Koanf, chainId uint64, chainName string, l1ChainId uint64, l2ChainInfoFiles []string) (bool, error) {
+	chainInfo, err := chaininfo.ProcessChainInfo(chainId, chainName, l2ChainInfoFiles)
 	if err != nil {
 		return false, err
 	}
 	if chainInfo.ChainParameters != nil {
 		if chainInfo.ParentChainId != l1ChainId {
-			return false, fmt.Errorf("ParentId: %d provided in %s for chainId: %d is not equal to l1ChainId: %d provided in commandline", chainInfo.ParentChainId, l2ChainInfoFiles, chainId, l1ChainId)
+			if chainId != 0 {
+				return false, fmt.Errorf("ParentId: %d provided in %s for chainId: %d is not equal to l1ChainId: %d provided in commandline", chainInfo.ParentChainId, l2ChainInfoFiles, chainId, l1ChainId)
+			} else {
+				return false, fmt.Errorf("ParentId: %d provided in %s for chainName: %s is not equal to l1ChainId: %d provided in commandline", chainInfo.ParentChainId, l2ChainInfoFiles, chainName, l1ChainId)
+			}
 		}
 		err = k.Load(rawbytes.Provider(*chainInfo.ChainParameters), json.Parser())
 		if err != nil {
@@ -819,7 +828,11 @@ func applyChainParameters(k *koanf.Koanf, chainId uint64, l1ChainId uint64, l2Ch
 		}
 		return true, nil
 	}
-	return false, fmt.Errorf("missing chain parameters for L2 chain ID %v", chainId)
+	if chainId != 0 {
+		return false, fmt.Errorf("missing chain parameters for L2 chain ID %v", chainId)
+	} else {
+		return false, fmt.Errorf("missing chain parameters for L2 chain name %v", chainName)
+	}
 }
 
 type OnReloadHook func(old *NodeConfig, new *NodeConfig) error

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -428,7 +428,7 @@ func mainImpl() int {
 		}
 	}
 
-	chainDb, l2BlockChain, err := openInitializeChainDb(ctx, stack, nodeConfig, execution.DefaultCacheConfigFor(stack, &nodeConfig.Node.Caching), l1Client, rollupAddrs)
+	chainDb, l2BlockChain, err := openInitializeChainDb(ctx, stack, nodeConfig, new(big.Int).SetUint64(nodeConfig.L2.ChainID), execution.DefaultCacheConfigFor(stack, &nodeConfig.Node.Caching), l1Client, rollupAddrs)
 	defer closeDb(chainDb, "chainDb")
 	if l2BlockChain != nil {
 		// Calling Stop on the blockchain multiple times does nothing

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -202,7 +202,7 @@ func main() {
 		if err != nil {
 			panic(fmt.Sprintf("Error getting chain ID from initial ArbOS state: %v", err.Error()))
 		}
-		chainConfig, err := chaininfo.GetChainConfig(chainId, "", genesisBlockNum, []string{})
+		chainConfig, err := chaininfo.GetChainConfig(context.Background(), chainId, "", genesisBlockNum, []string{}, "", "")
 		if err != nil {
 			panic(err)
 		}
@@ -227,7 +227,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		chainConfig, err := chaininfo.GetChainConfig(chainId, "", 0, []string{})
+		chainConfig, err := chaininfo.GetChainConfig(context.Background(), chainId, "", 0, []string{}, "", "")
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -202,7 +202,7 @@ func main() {
 		if err != nil {
 			panic(fmt.Sprintf("Error getting chain ID from initial ArbOS state: %v", err.Error()))
 		}
-		chainConfig, err := chaininfo.GetChainConfig(context.Background(), chainId, "", genesisBlockNum, []string{}, "", "")
+		chainConfig, err := chaininfo.GetChainConfig(chainId, "", genesisBlockNum, []string{})
 		if err != nil {
 			panic(err)
 		}
@@ -227,7 +227,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		chainConfig, err := chaininfo.GetChainConfig(context.Background(), chainId, "", 0, []string{}, "", "")
+		chainConfig, err := chaininfo.GetChainConfig(chainId, "", 0, []string{})
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -202,7 +202,7 @@ func main() {
 		if err != nil {
 			panic(fmt.Sprintf("Error getting chain ID from initial ArbOS state: %v", err.Error()))
 		}
-		chainConfig, err := chaininfo.GetChainConfig(chainId, genesisBlockNum, []string{})
+		chainConfig, err := chaininfo.GetChainConfig(chainId, "", genesisBlockNum, []string{})
 		if err != nil {
 			panic(err)
 		}
@@ -227,7 +227,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		chainConfig, err := chaininfo.GetChainConfig(chainId, 0, []string{})
+		chainConfig, err := chaininfo.GetChainConfig(chainId, "", 0, []string{})
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -202,7 +202,7 @@ func main() {
 		if err != nil {
 			panic(fmt.Sprintf("Error getting chain ID from initial ArbOS state: %v", err.Error()))
 		}
-		chainConfig, err := chaininfo.GetChainConfig(chainId, "", genesisBlockNum, []string{})
+		chainConfig, err := chaininfo.GetChainConfig(chainId, "", genesisBlockNum, []string{}, "")
 		if err != nil {
 			panic(err)
 		}
@@ -227,7 +227,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		chainConfig, err := chaininfo.GetChainConfig(chainId, "", 0, []string{})
+		chainConfig, err := chaininfo.GetChainConfig(chainId, "", 0, []string{}, "")
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/util/chaininfoutil.go
+++ b/cmd/util/chaininfoutil.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/offchainlabs/nitro/cmd/ipfshelper"
+)
+
+func GetL2ChainInfoIpfsFile(ctx context.Context, l2ChainInfoIpfsUrl string, l2ChainInfoIpfsDownloadPath string) (string, error) {
+	ipfsNode, err := ipfshelper.CreateIpfsHelper(ctx, l2ChainInfoIpfsDownloadPath, false, []string{}, ipfshelper.DefaultIpfsProfiles)
+	if err != nil {
+		return "", err
+	}
+	log.Info("Downloading l2 info file via IPFS", "url", l2ChainInfoIpfsDownloadPath)
+	l2ChainInfoFile, downloadErr := ipfsNode.DownloadFile(ctx, l2ChainInfoIpfsUrl, l2ChainInfoIpfsDownloadPath)
+	closeErr := ipfsNode.Close()
+	if downloadErr != nil {
+		if closeErr != nil {
+			log.Error("Failed to close IPFS node after download error", "err", closeErr)
+		}
+		return "", fmt.Errorf("failed to download file from IPFS: %w", downloadErr)
+	}
+	if closeErr != nil {
+		return "", fmt.Errorf("failed to close IPFS node: %w", err)
+	}
+	return l2ChainInfoFile, nil
+}


### PR DESCRIPTION
Added supports for following thing

- Choosing a chain with --l2.chain-name instead of --l2.chain-id
- Allow chain info file retrieval from IPFS
- Allow inline json in config to load chain info