### PR TITLE
Update to build against geth merge-v1.11.4 branch

### DIFF
--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -529,22 +529,22 @@ var randS = crypto.Keccak256Hash([]byte("S")).Big()
 
 // The returned tx will be invalid, likely for a number of reasons such as an invalid signature.
 // It's only used to check how large it is after brotli level 0 compression.
-func makeFakeTxForMessage(message core.Message) *types.Transaction {
-	nonce := message.Nonce()
+func makeFakeTxForMessage(message *core.Message) *types.Transaction {
+	nonce := message.Nonce
 	if nonce == 0 {
 		nonce = randomNonce
 	}
-	gasTipCap := message.GasTipCap()
+	gasTipCap := message.GasTipCap
 	if gasTipCap.Sign() == 0 {
 		gasTipCap = randomGasTipCap
 	}
-	gasFeeCap := message.GasFeeCap()
+	gasFeeCap := message.GasFeeCap
 	if gasFeeCap.Sign() == 0 {
 		gasFeeCap = randomGasFeeCap
 	}
 	// During gas estimation, we don't want the gas limit variability to change the L1 cost.
-	gas := message.Gas()
-	if gas == 0 || message.RunMode() == types.MessageGasEstimationMode {
+	gas := message.GasLimit
+	if gas == 0 || message.TxRunMode == core.MessageGasEstimationMode {
 		gas = RandomGas
 	}
 	return types.NewTx(&types.DynamicFeeTx{
@@ -552,18 +552,18 @@ func makeFakeTxForMessage(message core.Message) *types.Transaction {
 		GasTipCap:  gasTipCap,
 		GasFeeCap:  gasFeeCap,
 		Gas:        gas,
-		To:         message.To(),
-		Value:      message.Value(),
-		Data:       message.Data(),
-		AccessList: message.AccessList(),
+		To:         message.To,
+		Value:      message.Value,
+		Data:       message.Data,
+		AccessList: message.AccessList,
 		V:          randV,
 		R:          randR,
 		S:          randS,
 	})
 }
 
-func (ps *L1PricingState) PosterDataCost(message core.Message, poster common.Address) (*big.Int, uint64) {
-	tx := message.UnderlyingTransaction()
+func (ps *L1PricingState) PosterDataCost(message *core.Message, poster common.Address) (*big.Int, uint64) {
+	tx := message.Tx
 	if tx != nil {
 		return ps.GetPosterInfo(tx, poster)
 	}

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -35,7 +35,7 @@ const GasEstimationL1PricePadding arbmath.Bips = 11000 // pad estimates by 10%
 // It tracks state for ArbOS, allowing it infuence in Geth's tx processing.
 // Public fields are accessible in precompiles.
 type TxProcessor struct {
-	msg              core.Message
+	msg              *core.Message
 	state            *arbosState.ArbosState
 	PosterFee        *big.Int // set once in GasChargingHook to track L1 calldata costs
 	posterGas        uint64
@@ -53,8 +53,8 @@ type TxProcessor struct {
 	cachedL1BlockHashes map[uint64]common.Hash
 }
 
-func NewTxProcessor(evm *vm.EVM, msg core.Message) *TxProcessor {
-	tracingInfo := util.NewTracingInfo(evm, msg.From(), arbosAddress, util.TracingBeforeEVM)
+func NewTxProcessor(evm *vm.EVM, msg *core.Message) *TxProcessor {
+	tracingInfo := util.NewTracingInfo(evm, msg.From, arbosAddress, util.TracingBeforeEVM)
 	arbosState := arbosState.OpenSystemArbosStateOrPanic(evm.StateDB, tracingInfo, false)
 	return &TxProcessor{
 		msg:                 msg,
@@ -100,7 +100,7 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 	// This hook is called before gas charging and will end the state transition if endTxNow is set to true
 	// Hence, we must charge for any l2 resources if endTxNow is returned true
 
-	underlyingTx := p.msg.UnderlyingTransaction()
+	underlyingTx := p.msg.Tx
 	if underlyingTx == nil {
 		return false, 0, nil, nil
 	}
@@ -116,26 +116,26 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 		}
 		evm.IncrementDepth() // fake a call
 		tracer := evm.Config.Tracer
-		from := p.msg.From()
-		tracer.CaptureStart(evm, from, *p.msg.To(), false, p.msg.Data(), p.msg.Gas(), p.msg.Value())
+		from := p.msg.From
+		tracer.CaptureStart(evm, from, *p.msg.To, false, p.msg.Data, p.msg.GasLimit, p.msg.Value)
 
-		tracingInfo = util.NewTracingInfo(evm, from, *p.msg.To(), util.TracingDuringEVM)
+		tracingInfo = util.NewTracingInfo(evm, from, *p.msg.To, util.TracingDuringEVM)
 		p.state = arbosState.OpenSystemArbosStateOrPanic(evm.StateDB, tracingInfo, false)
 
 		return func() {
 			tracer.CaptureEnd(nil, p.state.Burner.Burned(), nil)
 			evm.DecrementDepth() // fake the return to the first faked call
 
-			tracingInfo = util.NewTracingInfo(evm, from, *p.msg.To(), util.TracingAfterEVM)
+			tracingInfo = util.NewTracingInfo(evm, from, *p.msg.To, util.TracingAfterEVM)
 			p.state = arbosState.OpenSystemArbosStateOrPanic(evm.StateDB, tracingInfo, false)
 		}
 	}
 
 	switch tx := underlyingTx.GetInner().(type) {
 	case *types.ArbitrumDepositTx:
-		from := p.msg.From()
-		to := p.msg.To()
-		value := p.msg.Value()
+		from := p.msg.From
+		to := p.msg.To
+		value := p.msg.Value
 		if to == nil {
 			return true, 0, errors.New("eth deposit has no To address"), nil
 		}
@@ -148,7 +148,7 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 		return true, 0, nil, nil
 	case *types.ArbitrumInternalTx:
 		defer (startTracer())()
-		if p.msg.From() != arbosAddress {
+		if p.msg.From != arbosAddress {
 			return false, 0, errors.New("internal tx not from arbAddress"), nil
 		}
 		err = ApplyInternalTxUpdate(tx, p.state, evm)
@@ -247,11 +247,11 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 
 		balance := statedb.GetBalance(tx.From)
 		basefee := evm.Context.BaseFee
-		usergas := p.msg.Gas()
+		usergas := p.msg.GasLimit
 
 		maxGasCost := arbmath.BigMulByUint(tx.GasFeeCap, usergas)
 		maxFeePerGasTooLow := arbmath.BigLessThan(tx.GasFeeCap, basefee)
-		if p.msg.RunMode() == types.MessageGasEstimationMode && tx.GasFeeCap.BitLen() == 0 {
+		if p.msg.TxRunMode == core.MessageGasEstimationMode && tx.GasFeeCap.BitLen() == 0 {
 			// In gas estimation mode, we permit a zero gas fee cap.
 			// This matches behavior with normal tx gas estimation.
 			maxFeePerGasTooLow = false
@@ -349,8 +349,8 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 	return false, 0, nil, nil
 }
 
-func GetPosterGas(state *arbosState.ArbosState, baseFee *big.Int, runMode types.MessageRunMode, posterCost *big.Int) uint64 {
-	if runMode == types.MessageGasEstimationMode {
+func GetPosterGas(state *arbosState.ArbosState, baseFee *big.Int, runMode core.MessageRunMode, posterCost *big.Int) uint64 {
+	if runMode == core.MessageGasEstimationMode {
 		// Suggest the amount of gas needed for a given amount of ETH is higher in case of congestion.
 		// This will help the user pad the total they'll pay in case the price rises a bit.
 		// Note, reducing the poster cost will increase share the network fee gets, not reduce the total.
@@ -380,7 +380,7 @@ func (p *TxProcessor) GasChargingHook(gasRemaining *uint64) (common.Address, err
 	basefee := p.evm.Context.BaseFee
 
 	var poster common.Address
-	if p.msg.RunMode() != types.MessageCommitMode {
+	if p.msg.TxRunMode != core.MessageCommitMode {
 		poster = l1pricing.BatchPosterAddress
 	} else {
 		poster = p.evm.Context.Coinbase
@@ -394,7 +394,7 @@ func (p *TxProcessor) GasChargingHook(gasRemaining *uint64) (common.Address, err
 		if calldataUnits > 0 {
 			p.state.Restrict(p.state.L1PricingState().AddToUnitsSinceUpdate(calldataUnits))
 		}
-		p.posterGas = GetPosterGas(p.state, basefee, p.msg.RunMode(), posterCost)
+		p.posterGas = GetPosterGas(p.state, basefee, p.msg.TxRunMode, posterCost)
 		p.PosterFee = arbmath.BigMulByUint(basefee, p.posterGas) // round down
 		gasNeededToStartEVM = p.posterGas
 	}
@@ -405,7 +405,7 @@ func (p *TxProcessor) GasChargingHook(gasRemaining *uint64) (common.Address, err
 	}
 	*gasRemaining -= gasNeededToStartEVM
 
-	if p.msg.RunMode() != types.MessageEthcallMode {
+	if p.msg.TxRunMode != core.MessageEthcallMode {
 		// If this is a real tx, limit the amount of computed based on the gas pool.
 		// We do this by charging extra gas, and then refunding it later.
 		gasAvailable, _ := p.state.L2PricingState().PerBlockGasLimit()
@@ -430,15 +430,15 @@ func (p *TxProcessor) ForceRefundGas() uint64 {
 
 func (p *TxProcessor) EndTxHook(gasLeft uint64, success bool) {
 
-	underlyingTx := p.msg.UnderlyingTransaction()
+	underlyingTx := p.msg.Tx
 	networkFeeAccount, _ := p.state.NetworkFeeAccount()
 	basefee := p.evm.Context.BaseFee
 	scenario := util.TracingAfterEVM
 
-	if gasLeft > p.msg.Gas() {
+	if gasLeft > p.msg.GasLimit {
 		panic("Tx somehow refunds gas after computation")
 	}
-	gasUsed := p.msg.Gas() - gasLeft
+	gasUsed := p.msg.GasLimit - gasLeft
 
 	if underlyingTx != nil && underlyingTx.Type() == types.ArbitrumRetryTxType {
 		inner, _ := underlyingTx.GetInner().(*types.ArbitrumRetryTx)
@@ -485,7 +485,7 @@ func (p *TxProcessor) EndTxHook(gasLeft uint64, success bool) {
 
 		if success {
 			// we don't want to charge for this
-			tracingInfo := util.NewTracingInfo(p.evm, arbosAddress, p.msg.From(), scenario)
+			tracingInfo := util.NewTracingInfo(p.evm, arbosAddress, p.msg.From, scenario)
 			state := arbosState.OpenSystemArbosStateOrPanic(p.evm.StateDB, tracingInfo, false)
 			_, _ = state.RetryableState().DeleteRetryable(inner.TicketId, p.evm, scenario)
 		} else {
@@ -544,7 +544,7 @@ func (p *TxProcessor) EndTxHook(gasLeft uint64, success bool) {
 		}
 	}
 
-	if p.msg.GasPrice().Sign() > 0 { // in tests, gas price could be 0
+	if p.msg.GasPrice.Sign() > 0 { // in tests, gas price could be 0
 		// ArbOS's gas pool is meant to enforce the computational speed-limit.
 		// We don't want to remove from the pool the poster's L1 costs (as expressed in L2 gas in this func)
 		// Hence, we deduct the previously saved poster L2-gas-equivalent to reveal the compute-only gas
@@ -603,7 +603,7 @@ func (p *TxProcessor) L1BlockNumber(blockCtx vm.BlockContext) (uint64, error) {
 	if p.cachedL1BlockNumber != nil {
 		return *p.cachedL1BlockNumber, nil
 	}
-	tracingInfo := util.NewTracingInfo(p.evm, p.msg.From(), arbosAddress, util.TracingDuringEVM)
+	tracingInfo := util.NewTracingInfo(p.evm, p.msg.From, arbosAddress, util.TracingDuringEVM)
 	state, err := arbosState.OpenSystemArbosState(p.evm.StateDB, tracingInfo, false)
 	if err != nil {
 		return 0, err
@@ -621,7 +621,7 @@ func (p *TxProcessor) L1BlockHash(blockCtx vm.BlockContext, l1BlockNumber uint64
 	if cached {
 		return hash, nil
 	}
-	tracingInfo := util.NewTracingInfo(p.evm, p.msg.From(), arbosAddress, util.TracingDuringEVM)
+	tracingInfo := util.NewTracingInfo(p.evm, p.msg.From, arbosAddress, util.TracingDuringEVM)
 	state, err := arbosState.OpenSystemArbosState(p.evm.StateDB, tracingInfo, false)
 	if err != nil {
 		return common.Hash{}, err
@@ -644,7 +644,7 @@ func (p *TxProcessor) GetPaidGasPrice() *big.Int {
 	version := p.state.ArbOSVersion()
 	if version != 9 {
 		gasPrice = p.evm.Context.BaseFee
-		if p.msg.RunMode() != types.MessageCommitMode && p.msg.GasFeeCap().Sign() == 0 {
+		if p.msg.TxRunMode != core.MessageCommitMode && p.msg.GasFeeCap.Sign() == 0 {
 			gasPrice.SetInt64(0) // gasprice zero behavior
 		}
 	}

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -665,6 +665,6 @@ func (p *TxProcessor) MsgIsNonMutating() bool {
 	if p.msg == nil {
 		return false
 	}
-	mode := p.msg.RunMode()
-	return mode == types.MessageGasEstimationMode || mode == types.MessageEthcallMode
+	mode := p.msg.TxRunMode
+	return mode == core.MessageGasEstimationMode || mode == core.MessageEthcallMode
 }

--- a/gethhook/geth-hook.go
+++ b/gethhook/geth-hook.go
@@ -44,7 +44,7 @@ func (p ArbosPrecompileWrapper) RunAdvanced(
 }
 
 func init() {
-	core.ReadyEVMForL2 = func(evm *vm.EVM, msg core.Message) {
+	core.ReadyEVMForL2 = func(evm *vm.EVM, msg *core.Message) {
 		if evm.ChainConfig().IsArbitrum() {
 			evm.ProcessingHook = arbos.NewTxProcessor(evm, msg)
 		}

--- a/nodeInterface/NodeInterface.go
+++ b/nodeInterface/NodeInterface.go
@@ -39,9 +39,9 @@ type NodeInterface struct {
 	backend       core.NodeInterfaceBackendAPI
 	context       context.Context
 	header        *types.Header
-	sourceMessage types.Message
+	sourceMessage *core.Message
 	returnMessage struct {
-		message *types.Message
+		message *core.Message
 		changed *bool
 	}
 }
@@ -143,8 +143,8 @@ func (n NodeInterface) EstimateRetryableTicket(
 		From:             util.RemapL1Address(sender),
 		L1BaseFee:        l1BaseFee,
 		DepositValue:     deposit,
-		GasFeeCap:        n.sourceMessage.GasPrice(),
-		Gas:              n.sourceMessage.Gas(),
+		GasFeeCap:        n.sourceMessage.GasPrice,
+		Gas:              n.sourceMessage.GasLimit,
 		RetryTo:          pRetryTo,
 		RetryValue:       l2CallValue,
 		Beneficiary:      callValueRefundAddress,
@@ -154,13 +154,13 @@ func (n NodeInterface) EstimateRetryableTicket(
 	}
 
 	// ArbitrumSubmitRetryableTx is unsigned so the following won't panic
-	msg, err := types.NewTx(submitTx).AsMessage(types.NewArbitrumSigner(nil), nil)
+	msg, err := core.TransactionToMessage(types.NewTx(submitTx), types.NewArbitrumSigner(nil), nil)
 	if err != nil {
 		return err
 	}
 
-	msg.TxRunMode = types.MessageGasEstimationMode
-	*n.returnMessage.message = msg
+	msg.TxRunMode = core.MessageGasEstimationMode
+	*n.returnMessage.message = *msg
 	*n.returnMessage.changed = true
 	return nil
 }
@@ -425,11 +425,11 @@ func (n NodeInterface) messageArgs(
 	evm mech, value huge, to addr, contractCreation bool, data []byte,
 ) arbitrum.TransactionArgs {
 	msg := n.sourceMessage
-	from := msg.From()
-	gas := msg.Gas()
-	nonce := msg.Nonce()
-	maxFeePerGas := msg.GasFeeCap()
-	maxPriorityFeePerGas := msg.GasTipCap()
+	from := msg.From
+	gas := msg.GasLimit
+	nonce := msg.Nonce
+	maxFeePerGas := msg.GasFeeCap
+	maxPriorityFeePerGas := msg.GasTipCap
 	chainid := evm.ChainConfig().ChainID
 
 	args := arbitrum.TransactionArgs{
@@ -458,7 +458,7 @@ func (n NodeInterface) GasEstimateL1Component(
 	args.Gas = (*hexutil.Uint64)(&randomGas)
 
 	// We set the run mode to eth_call mode here because we want an exact estimate, not a padded estimate
-	msg, err := args.ToMessage(randomGas, n.header, evm.StateDB.(*state.StateDB), types.MessageEthcallMode)
+	msg, err := args.ToMessage(randomGas, n.header, evm.StateDB.(*state.StateDB), core.MessageEthcallMode)
 	if err != nil {
 		return 0, nil, nil, err
 	}
@@ -510,7 +510,7 @@ func (n NodeInterface) GasEstimateComponents(
 	// Setting the gas currently doesn't affect the PosterDataCost,
 	// but we do it anyways for accuracy with potential future changes.
 	args.Gas = &totalRaw
-	msg, err := args.ToMessage(gasCap, n.header, evm.StateDB.(*state.StateDB), types.MessageGasEstimationMode)
+	msg, err := args.ToMessage(gasCap, n.header, evm.StateDB.(*state.StateDB), core.MessageGasEstimationMode)
 	if err != nil {
 		return 0, 0, nil, nil, err
 	}
@@ -526,7 +526,7 @@ func (n NodeInterface) GasEstimateComponents(
 	}
 
 	// Compute the fee paid for L1 in L2 terms
-	gasForL1 := arbos.GetPosterGas(c.State, baseFee, types.MessageGasEstimationMode, feeForL1)
+	gasForL1 := arbos.GetPosterGas(c.State, baseFee, core.MessageGasEstimationMode, feeForL1)
 
 	return total, gasForL1, baseFee, l1BaseFeeEstimate, nil
 }

--- a/nodeInterface/NodeInterfaceDebug.go
+++ b/nodeInterface/NodeInterfaceDebug.go
@@ -18,9 +18,9 @@ type NodeInterfaceDebug struct {
 	backend       core.NodeInterfaceBackendAPI
 	context       context.Context
 	header        *types.Header
-	sourceMessage types.Message
+	sourceMessage *core.Message
 	returnMessage struct {
-		message *types.Message
+		message *core.Message
 		changed *bool
 	}
 }

--- a/nodeInterface/virtual-contracts.go
+++ b/nodeInterface/virtual-contracts.go
@@ -33,7 +33,6 @@ type hash = common.Hash
 type bytes32 = [32]byte
 type ctx = *precompiles.Context
 
-type Message = types.Message
 type BackendAPI = core.NodeInterfaceBackendAPI
 type ExecutionResult = core.ExecutionResult
 
@@ -49,18 +48,18 @@ func init() {
 	_, nodeInterfaceDebug := precompiles.MakePrecompile(nodeInterfaceDebugMeta, nodeInterfaceDebugImpl)
 
 	core.InterceptRPCMessage = func(
-		msg Message,
+		msg *core.Message,
 		ctx context.Context,
 		statedb *state.StateDB,
 		header *types.Header,
 		backend core.NodeInterfaceBackendAPI,
-	) (Message, *ExecutionResult, error) {
-		to := msg.To()
+	) (*core.Message, *ExecutionResult, error) {
+		to := msg.To
 		arbosVersion := arbosState.ArbOSVersion(statedb) // check ArbOS has been installed
 		if to != nil && arbosVersion != 0 {
 			var precompile precompiles.ArbosPrecompile
 			var swapMessages bool
-			returnMessage := &Message{}
+			returnMessage := &core.Message{}
 			var address addr
 
 			switch *to {
@@ -99,16 +98,16 @@ func init() {
 			core.ReadyEVMForL2(evm, msg)
 
 			output, gasLeft, err := precompile.Call(
-				msg.Data(), address, address, msg.From(), msg.Value(), false, msg.Gas(), evm,
+				msg.Data, address, address, msg.From, msg.Value, false, msg.GasLimit, evm,
 			)
 			if err != nil {
 				return msg, nil, err
 			}
 			if swapMessages {
-				return *returnMessage, nil, nil
+				return returnMessage, nil, nil
 			}
 			res := &ExecutionResult{
-				UsedGas:       msg.Gas() - gasLeft,
+				UsedGas:       msg.GasLimit - gasLeft,
 				Err:           nil,
 				ReturnData:    output,
 				ScheduledTxes: nil,
@@ -118,7 +117,7 @@ func init() {
 		return msg, nil, nil
 	}
 
-	core.InterceptRPCGasCap = func(gascap *uint64, msg Message, header *types.Header, statedb *state.StateDB) {
+	core.InterceptRPCGasCap = func(gascap *uint64, msg *core.Message, header *types.Header, statedb *state.StateDB) {
 		if *gascap == 0 {
 			// It's already unlimited
 			return
@@ -139,7 +138,7 @@ func init() {
 		}
 
 		posterCost, _ := state.L1PricingState().PosterDataCost(msg, l1pricing.BatchPosterAddress)
-		posterCostInL2Gas := arbos.GetPosterGas(state, header.BaseFee, msg.RunMode(), posterCost)
+		posterCostInL2Gas := arbos.GetPosterGas(state, header.BaseFee, msg.TxRunMode, posterCost)
 		*gascap = arbmath.SaturatingUAdd(*gascap, posterCostInL2Gas)
 	}
 

--- a/precompiles/ArbAddressTable_test.go
+++ b/precompiles/ArbAddressTable_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
@@ -154,9 +154,9 @@ func newMockEVMForTesting() *vm.EVM {
 	return newMockEVMForTestingWithVersion(nil)
 }
 
-func newMockEVMForTestingWithVersionAndRunMode(version *uint64, runMode types.MessageRunMode) *vm.EVM {
+func newMockEVMForTestingWithVersionAndRunMode(version *uint64, runMode core.MessageRunMode) *vm.EVM {
 	evm := newMockEVMForTestingWithVersion(version)
-	evm.ProcessingHook = arbos.NewTxProcessor(evm, types.Message{TxRunMode: runMode})
+	evm.ProcessingHook = arbos.NewTxProcessor(evm, &core.Message{TxRunMode: runMode})
 	return evm
 }
 

--- a/precompiles/ArbOwner_test.go
+++ b/precompiles/ArbOwner_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos/l1pricing"
 
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbos/arbosState"
@@ -155,7 +156,7 @@ func TestArbOwner(t *testing.T) {
 }
 
 func TestArbOwnerSetChainConfig(t *testing.T) {
-	evm := newMockEVMForTestingWithVersionAndRunMode(nil, types.MessageGasEstimationMode)
+	evm := newMockEVMForTestingWithVersionAndRunMode(nil, core.MessageGasEstimationMode)
 	caller := common.BytesToAddress(crypto.Keccak256([]byte{})[:20])
 	tracer := util.NewTracingInfo(evm, testhelpers.RandomAddress(), types.ArbosAddress, util.TracingDuringEVM)
 	state, err := arbosState.OpenArbosState(evm.StateDB, burn.NewSystemBurner(tracer, false))

--- a/system_tests/precompile_fuzz_test.go
+++ b/system_tests/precompile_fuzz_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
@@ -71,19 +70,18 @@ func FuzzPrecompiles(f *testing.F) {
 		}
 
 		// Create and apply a message
-		msg := types.NewMessage(
-			common.Address{},
-			&addr,
-			0,
-			new(big.Int),
-			fuzzGas,
-			new(big.Int),
-			new(big.Int),
-			new(big.Int),
-			input,
-			nil,
-			true,
-		)
+		msg := &core.Message{
+			From:       common.Address{},
+			To:         &addr,
+			Nonce:      0,
+			Value:      new(big.Int),
+			GasLimit:   fuzzGas,
+			GasPrice:   new(big.Int),
+			GasFeeCap:  new(big.Int),
+			GasTipCap:  new(big.Int),
+			Data:       input,
+			AccessList: nil,
+		}
 		_, _ = core.ApplyMessage(evm, msg, &gp)
 	})
 }


### PR DESCRIPTION
Most of the changes were related to upstream's `core.Message` change. `core.Message` has been changed from interface to struct and `types.Message` has been removed. We used the `core.Message` interface in a number of places and it needed to be changed to a pointer to the `core.Message` struct to maintain the same semantics.

This depends on https://github.com/OffchainLabs/go-ethereum/pull/221

# Testing done
make push passes

## Start node 
Node is able to be started from a genesis snapshot and starts syncing
```
./target/bin/nitro  --l1.url <L1 url>  --l2.chain-id=42161 --node.rpc.classic-redirect=https://arb1.arbitrum.io/rpc   --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*  --persistent.global-config /home/tristan/offchain/geth-upgrade/nitro-genesis/
```
