### PR TITLE
[Config Changes] The great config rename

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -83,7 +83,7 @@ type BatchPosterConfig struct {
 	RedisUrl                           string                      `koanf:"redis-url"`
 	RedisLock                          SimpleRedisLockConfig       `koanf:"redis-lock" reload:"hot"`
 	ExtraBatchGas                      uint64                      `koanf:"extra-batch-gas" reload:"hot"`
-	L1Wallet                           genericconf.WalletConfig    `koanf:"l1-wallet"`
+	L1Wallet                           genericconf.WalletConfig    `koanf:"parent-chain-wallet"`
 
 	gasRefunder common.Address
 }
@@ -116,7 +116,7 @@ func BatchPosterConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".redis-url", DefaultBatchPosterConfig.RedisUrl, "if non-empty, the Redis URL to store queued transactions in")
 	RedisLockConfigAddOptions(prefix+".redis-lock", f)
 	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f)
-	genericconf.WalletConfigAddOptions(prefix+".l1-wallet", f, DefaultBatchPosterConfig.L1Wallet.Pathname)
+	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultBatchPosterConfig.L1Wallet.Pathname)
 }
 
 var DefaultBatchPosterConfig = BatchPosterConfig{

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -315,7 +315,7 @@ func DeployOnL1(ctx context.Context, l1client arbutil.L1Interface, deployAuth *b
 type Config struct {
 	RPC                  arbitrum.Config              `koanf:"rpc"`
 	Sequencer            execution.SequencerConfig    `koanf:"sequencer" reload:"hot"`
-	L1Reader             headerreader.Config          `koanf:"l1-reader" reload:"hot"`
+	L1Reader             headerreader.Config          `koanf:"parent-chain-reader" reload:"hot"`
 	InboxReader          InboxReaderConfig            `koanf:"inbox-reader" reload:"hot"`
 	DelayedSequencer     DelayedSequencerConfig       `koanf:"delayed-sequencer" reload:"hot"`
 	BatchPoster          BatchPosterConfig            `koanf:"batch-poster" reload:"hot"`
@@ -385,7 +385,7 @@ func (c *Config) ValidatorRequired() bool {
 func ConfigAddOptions(prefix string, f *flag.FlagSet, feedInputEnable bool, feedOutputEnable bool) {
 	arbitrum.ConfigAddOptions(prefix+".rpc", f)
 	execution.SequencerConfigAddOptions(prefix+".sequencer", f)
-	headerreader.AddOptions(prefix+".l1-reader", f)
+	headerreader.AddOptions(prefix+".parent-chain-reader", f)
 	InboxReaderConfigAddOptions(prefix+".inbox-reader", f)
 	DelayedSequencerConfigAddOptions(prefix+".delayed-sequencer", f)
 	BatchPosterConfigAddOptions(prefix+".batch-poster", f)

--- a/cmd/conf/chain.go
+++ b/cmd/conf/chain.go
@@ -12,7 +12,7 @@ import (
 )
 
 type L1Config struct {
-	ChainID    uint64                   `koanf:"chain-id"`
+	ChainID    uint64                   `koanf:"id"`
 	Connection rpcclient.ClientConfig   `koanf:"connection" reload:"hot"`
 	Wallet     genericconf.WalletConfig `koanf:"wallet"`
 }
@@ -39,7 +39,7 @@ var DefaultL1WalletConfig = genericconf.WalletConfig{
 }
 
 func L1ConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Uint64(prefix+".chain-id", L1ConfigDefault.ChainID, "if set other than 0, will be used to validate database and L1 connection")
+	f.Uint64(prefix+".id", L1ConfigDefault.ChainID, "if set other than 0, will be used to validate database and L1 connection")
 	rpcclient.RPCClientAddOptions(prefix+".connection", f, &L1ConfigDefault.Connection)
 	genericconf.WalletConfigAddOptions(prefix+".wallet", f, L1ConfigDefault.Wallet.Pathname)
 }
@@ -49,8 +49,8 @@ func (c *L1Config) ResolveDirectoryNames(chain string) {
 }
 
 type L2Config struct {
-	ChainID                   uint64                   `koanf:"chain-id"`
-	ChainName                 string                   `koanf:"chain-name"`
+	ChainID                   uint64                   `koanf:"id"`
+	ChainName                 string                   `koanf:"name"`
 	ChainInfoFiles            []string                 `koanf:"chain-info-files"`
 	ChainInfoJson             string                   `koanf:"chain-info-json"`
 	DevWallet                 genericconf.WalletConfig `koanf:"dev-wallet"`
@@ -69,8 +69,8 @@ var L2ConfigDefault = L2Config{
 }
 
 func L2ConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Uint64(prefix+".chain-id", L2ConfigDefault.ChainID, "L2 chain ID (determines Arbitrum network)")
-	f.String(prefix+".chain-name", L2ConfigDefault.ChainName, "L2 chain name (determines Arbitrum network)")
+	f.Uint64(prefix+".id", L2ConfigDefault.ChainID, "L2 chain ID (determines Arbitrum network)")
+	f.String(prefix+".name", L2ConfigDefault.ChainName, "L2 chain name (determines Arbitrum network)")
 	f.StringSlice(prefix+".chain-info-files", L2ConfigDefault.ChainInfoFiles, "L2 chain info json files")
 	f.String(prefix+".chain-info-json", L2ConfigDefault.ChainInfoJson, "L2 chain info in json string format")
 

--- a/cmd/nitro/config_test.go
+++ b/cmd/nitro/config_test.go
@@ -19,25 +19,25 @@ import (
 )
 
 func TestSeqConfig(t *testing.T) {
-	args := strings.Split("--persistent.chain /tmp/data --init.dev-init --node.l1-reader.enable=false --l1.chain-id 5 --l2.chain-id 421613 --l1.wallet.pathname /l1keystore --l1.wallet.password passphrase --http.addr 0.0.0.0 --ws.addr 0.0.0.0 --node.sequencer.enable --node.feed.output.enable --node.feed.output.port 9642", " ")
+	args := strings.Split("--persistent.chain /tmp/data --init.dev-init --node.parent-chain-reader.enable=false --parent-chain.id 5 --chain.id 421613 --parent-chain.wallet.pathname /l1keystore --parent-chain.wallet.password passphrase --http.addr 0.0.0.0 --ws.addr 0.0.0.0 --node.sequencer.enable --node.feed.output.enable --node.feed.output.port 9642", " ")
 	_, _, _, err := ParseNode(context.Background(), args)
 	Require(t, err)
 }
 
 func TestUnsafeStakerConfig(t *testing.T) {
-	args := strings.Split("--persistent.chain /tmp/data --init.dev-init --node.l1-reader.enable=false --l1.chain-id 5 --l2.chain-id 421613 --l1.wallet.pathname /l1keystore --l1.wallet.password passphrase --http.addr 0.0.0.0 --ws.addr 0.0.0.0 --node.staker.enable --node.staker.strategy MakeNodes --node.staker.staker-interval 10s --node.forwarding-target null --node.staker.dangerous.without-block-validator", " ")
+	args := strings.Split("--persistent.chain /tmp/data --init.dev-init --node.parent-chain-reader.enable=false --parent-chain.id 5 --chain.id 421613 --parent-chain.wallet.pathname /l1keystore --parent-chain.wallet.password passphrase --http.addr 0.0.0.0 --ws.addr 0.0.0.0 --node.staker.enable --node.staker.strategy MakeNodes --node.staker.staker-interval 10s --node.forwarding-target null --node.staker.dangerous.without-block-validator", " ")
 	_, _, _, err := ParseNode(context.Background(), args)
 	Require(t, err)
 }
 
 func TestValidatorConfig(t *testing.T) {
-	args := strings.Split("--persistent.chain /tmp/data --init.dev-init --node.l1-reader.enable=false --l1.chain-id 5 --l2.chain-id 421613 --l1.wallet.pathname /l1keystore --l1.wallet.password passphrase --http.addr 0.0.0.0 --ws.addr 0.0.0.0 --node.staker.enable --node.staker.strategy MakeNodes --node.staker.staker-interval 10s --node.forwarding-target null", " ")
+	args := strings.Split("--persistent.chain /tmp/data --init.dev-init --node.parent-chain-reader.enable=false --parent-chain.id 5 --chain.id 421613 --parent-chain.wallet.pathname /l1keystore --parent-chain.wallet.password passphrase --http.addr 0.0.0.0 --ws.addr 0.0.0.0 --node.staker.enable --node.staker.strategy MakeNodes --node.staker.staker-interval 10s --node.forwarding-target null", " ")
 	_, _, _, err := ParseNode(context.Background(), args)
 	Require(t, err)
 }
 
 func TestAggregatorConfig(t *testing.T) {
-	args := strings.Split("--persistent.chain /tmp/data --init.dev-init --node.l1-reader.enable=false --l1.chain-id 5 --l2.chain-id 421613 --l1.wallet.pathname /l1keystore --l1.wallet.password passphrase --http.addr 0.0.0.0 --ws.addr 0.0.0.0 --node.sequencer.enable --node.feed.output.enable --node.feed.output.port 9642 --node.data-availability.enable --node.data-availability.rpc-aggregator.backends {[\"url\":\"http://localhost:8547\",\"pubkey\":\"abc==\",\"signerMask\":0x1]}", " ")
+	args := strings.Split("--persistent.chain /tmp/data --init.dev-init --node.parent-chain-reader.enable=false --parent-chain.id 5 --chain.id 421613 --parent-chain.wallet.pathname /l1keystore --parent-chain.wallet.password passphrase --http.addr 0.0.0.0 --ws.addr 0.0.0.0 --node.sequencer.enable --node.feed.output.enable --node.feed.output.port 9642 --node.data-availability.enable --node.data-availability.rpc-aggregator.backends {[\"url\":\"http://localhost:8547\",\"pubkey\":\"abc==\",\"signerMask\":0x1]}", " ")
 	_, _, _, err := ParseNode(context.Background(), args)
 	Require(t, err)
 }
@@ -96,10 +96,10 @@ func TestLiveNodeConfig(t *testing.T) {
 
 	// create a config file
 	configFile := filepath.Join(t.TempDir(), "config.json")
-	jsonConfig := "{\"l2\":{\"chain-id\":421613}}"
+	jsonConfig := "{\"chain\":{\"id\":421613}}"
 	Require(t, WriteToConfigFile(configFile, jsonConfig))
 
-	args := strings.Split("--file-logging.enable=false --persistent.chain /tmp/data --init.dev-init --node.l1-reader.enable=false --l1.chain-id 5 --l1.wallet.pathname /l1keystore --l1.wallet.password passphrase --http.addr 0.0.0.0 --ws.addr 0.0.0.0 --node.sequencer.enable --node.feed.output.enable --node.feed.output.port 9642", " ")
+	args := strings.Split("--file-logging.enable=false --persistent.chain /tmp/data --init.dev-init --node.parent-chain-reader.enable=false --parent-chain.id 5 --parent-chain.wallet.pathname /l1keystore --parent-chain.wallet.password passphrase --http.addr 0.0.0.0 --ws.addr 0.0.0.0 --node.sequencer.enable --node.feed.output.enable --node.feed.output.port 9642", " ")
 	args = append(args, []string{"--conf.file", configFile}...)
 	config, _, _, err := ParseNode(context.Background(), args)
 	Require(t, err)
@@ -146,7 +146,7 @@ func TestLiveNodeConfig(t *testing.T) {
 	// change the config file
 	expected = config.ShallowClone()
 	expected.Node.Sequencer.MaxBlockSpeed += time.Millisecond
-	jsonConfig = fmt.Sprintf("{\"node\":{\"sequencer\":{\"max-block-speed\":\"%s\"}}, \"l2\":{\"chain-id\":421613}}", expected.Node.Sequencer.MaxBlockSpeed.String())
+	jsonConfig = fmt.Sprintf("{\"node\":{\"sequencer\":{\"max-block-speed\":\"%s\"}}, \"chain\":{\"id\":421613}}", expected.Node.Sequencer.MaxBlockSpeed.String())
 	Require(t, WriteToConfigFile(configFile, jsonConfig))
 
 	// trigger LiveConfig reload
@@ -156,8 +156,8 @@ func TestLiveNodeConfig(t *testing.T) {
 		Fail(t, "failed to update config", config.Node.Sequencer.MaxBlockSpeed, update.Node.Sequencer.MaxBlockSpeed)
 	}
 
-	// change l2.chain-id in the config file (currently non-reloadable)
-	jsonConfig = fmt.Sprintf("{\"node\":{\"sequencer\":{\"max-block-speed\":\"%s\"}}, \"l2\":{\"chain-id\":421703}}", expected.Node.Sequencer.MaxBlockSpeed.String())
+	// change chain.id in the config file (currently non-reloadable)
+	jsonConfig = fmt.Sprintf("{\"node\":{\"sequencer\":{\"max-block-speed\":\"%s\"}}, \"chain\":{\"id\":421703}}", expected.Node.Sequencer.MaxBlockSpeed.String())
 	Require(t, WriteToConfigFile(configFile, jsonConfig))
 
 	// trigger LiveConfig reload
@@ -177,7 +177,7 @@ func TestPeriodicReloadOfLiveNodeConfig(t *testing.T) {
 	jsonConfig := "{\"conf\":{\"reload-interval\":\"20ms\"}}"
 	Require(t, WriteToConfigFile(configFile, jsonConfig))
 
-	args := strings.Split("--persistent.chain /tmp/data --init.dev-init --node.l1-reader.enable=false --l1.chain-id 5 --l2.chain-id 421613 --l1.wallet.pathname /l1keystore --l1.wallet.password passphrase --http.addr 0.0.0.0 --ws.addr 0.0.0.0 --node.sequencer.enable --node.feed.output.enable --node.feed.output.port 9642", " ")
+	args := strings.Split("--persistent.chain /tmp/data --init.dev-init --node.parent-chain-reader.enable=false --parent-chain.id 5 --chain.id 421613 --parent-chain.wallet.pathname /l1keystore --parent-chain.wallet.password passphrase --http.addr 0.0.0.0 --ws.addr 0.0.0.0 --node.sequencer.enable --node.feed.output.enable --node.feed.output.port 9642", " ")
 	args = append(args, []string{"--conf.file", configFile}...)
 	config, _, _, err := ParseNode(context.Background(), args)
 	Require(t, err)

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -34,7 +34,7 @@ func main() {
 
 func printSampleUsage(progname string) {
 	fmt.Printf("\n")
-	fmt.Printf("Sample usage:                  %s --node.feed.input.url=<L1 RPC> --l2.chain-id=<L2 chain id> \n", progname)
+	fmt.Printf("Sample usage:                  %s --node.feed.input.url=<L1 RPC> --chain.id=<L2 chain id> \n", progname)
 }
 
 func startup() error {

--- a/das/das.go
+++ b/das/das.go
@@ -54,8 +54,8 @@ type DataAvailabilityConfig struct {
 	AggregatorConfig              AggregatorConfig              `koanf:"rpc-aggregator"`
 	RestfulClientAggregatorConfig RestfulClientAggregatorConfig `koanf:"rest-aggregator"`
 
-	L1NodeURL                       string `koanf:"l1-node-url"`
-	L1ConnectionAttempts            int    `koanf:"l1-connection-attempts"`
+	L1NodeURL                       string `koanf:"parent-chain-node-url"`
+	L1ConnectionAttempts            int    `koanf:"parent-chain-connection-attempts"`
 	SequencerInboxAddress           string `koanf:"sequencer-inbox-address"`
 	ExtraSignatureCheckingPublicKey string `koanf:"extra-signature-checking-public-key"`
 
@@ -132,8 +132,8 @@ func dataAvailabilityConfigAddOptions(prefix string, f *flag.FlagSet, r role) {
 	IpfsStorageServiceConfigAddOptions(prefix+".ipfs-storage", f)
 	RestfulClientAggregatorConfigAddOptions(prefix+".rest-aggregator", f)
 
-	f.String(prefix+".l1-node-url", DefaultDataAvailabilityConfig.L1NodeURL, "URL for L1 node, only used in standalone daserver; when running as part of a node that node's L1 configuration is used")
-	f.Int(prefix+".l1-connection-attempts", DefaultDataAvailabilityConfig.L1ConnectionAttempts, "layer 1 RPC connection attempts (spaced out at least 1 second per attempt, 0 to retry infinitely), only used in standalone daserver; when running as part of a node that node's L1 configuration is used")
+	f.String(prefix+".parent-chain-node-url", DefaultDataAvailabilityConfig.L1NodeURL, "URL for L1 node, only used in standalone daserver; when running as part of a node that node's L1 configuration is used")
+	f.Int(prefix+".parent-chain-connection-attempts", DefaultDataAvailabilityConfig.L1ConnectionAttempts, "layer 1 RPC connection attempts (spaced out at least 1 second per attempt, 0 to retry infinitely), only used in standalone daserver; when running as part of a node that node's L1 configuration is used")
 	f.String(prefix+".sequencer-inbox-address", DefaultDataAvailabilityConfig.SequencerInboxAddress, "L1 address of SequencerInbox contract")
 }
 

--- a/das/syncing_fallback_storage.go
+++ b/das/syncing_fallback_storage.go
@@ -63,7 +63,7 @@ type SyncToStorageConfig struct {
 	RetentionPeriod      time.Duration `koanf:"retention-period"`
 	DelayOnError         time.Duration `koanf:"delay-on-error"`
 	IgnoreWriteErrors    bool          `koanf:"ignore-write-errors"`
-	L1BlocksPerRead      uint64        `koanf:"l1-blocks-per-read"`
+	L1BlocksPerRead      uint64        `koanf:"parent-chain-blocks-per-read"`
 	StateDir             string        `koanf:"state-dir"`
 }
 
@@ -82,7 +82,7 @@ func SyncToStorageConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".check-already-exists", DefaultSyncToStorageConfig.CheckAlreadyExists, "check if the data already exists in this DAS's storage. Must be disabled for fast sync with an IPFS backend")
 	f.Bool(prefix+".eager", DefaultSyncToStorageConfig.Eager, "eagerly sync batch data to this DAS's storage from the rest endpoints, using L1 as the index of batch data hashes; otherwise only sync lazily")
 	f.Uint64(prefix+".eager-lower-bound-block", DefaultSyncToStorageConfig.EagerLowerBoundBlock, "when eagerly syncing, start indexing forward from this L1 block. Only used if there is no sync state")
-	f.Uint64(prefix+".l1-blocks-per-read", DefaultSyncToStorageConfig.L1BlocksPerRead, "when eagerly syncing, max l1 blocks to read per poll")
+	f.Uint64(prefix+".parent-chain-blocks-per-read", DefaultSyncToStorageConfig.L1BlocksPerRead, "when eagerly syncing, max l1 blocks to read per poll")
 	f.Duration(prefix+".retention-period", DefaultSyncToStorageConfig.RetentionPeriod, "period to retain synced data (defaults to forever)")
 	f.Duration(prefix+".delay-on-error", DefaultSyncToStorageConfig.DelayOnError, "time to wait if encountered an error before retrying")
 	f.Bool(prefix+".ignore-write-errors", DefaultSyncToStorageConfig.IgnoreWriteErrors, "log only on failures to write when syncing; otherwise treat it as an error")

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -163,7 +163,7 @@ var ConfigDefault = Config{
 
 func ConfigAddOptions(f *flag.FlagSet) {
 	genericconf.ConfConfigAddOptions("conf", f)
-	L2ConfigAddOptions("l2", f)
+	L2ConfigAddOptions("chain", f)
 	f.Int("log-level", ConfigDefault.LogLevel, "log level")
 	f.String("log-type", ConfigDefault.LogType, "log type")
 	f.Bool("metrics", ConfigDefault.Metrics, "enable metrics")
@@ -185,7 +185,7 @@ func NodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 }
 
 type L2Config struct {
-	ChainId uint64 `koanf:"chain-id"`
+	ChainId uint64 `koanf:"id"`
 }
 
 var L2ConfigDefault = L2Config{
@@ -193,7 +193,7 @@ var L2ConfigDefault = L2Config{
 }
 
 func L2ConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Uint64(prefix+".chain-id", L2ConfigDefault.ChainId, "L2 chain ID")
+	f.Uint64(prefix+".id", L2ConfigDefault.ChainId, "L2 chain ID")
 }
 
 func ParseRelay(_ context.Context, args []string) (*Config, error) {

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -141,7 +141,7 @@ func (r *Relay) StopAndWait() {
 
 type Config struct {
 	Conf          genericconf.ConfConfig          `koanf:"conf"`
-	L2            L2Config                        `koanf:"l2"`
+	L2            L2Config                        `koanf:"chain"`
 	LogLevel      int                             `koanf:"log-level"`
 	LogType       string                          `koanf:"log-type"`
 	Metrics       bool                            `koanf:"metrics"`

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -78,7 +78,7 @@ type L1ValidatorConfig struct {
 	ContractWalletAddress    string                   `koanf:"contract-wallet-address"`
 	GasRefunderAddress       string                   `koanf:"gas-refunder-address"`
 	Dangerous                DangerousConfig          `koanf:"dangerous"`
-	L1Wallet                 genericconf.WalletConfig `koanf:"l1-wallet"`
+	L1Wallet                 genericconf.WalletConfig `koanf:"parent-chain-wallet"`
 
 	strategy    StakerStrategy
 	gasRefunder common.Address
@@ -165,7 +165,7 @@ func L1ValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".contract-wallet-address", DefaultL1ValidatorConfig.ContractWalletAddress, "validator smart contract wallet public address")
 	f.String(prefix+".gas-refunder-address", DefaultL1ValidatorConfig.GasRefunderAddress, "The gas refunder contract address (optional)")
 	DangerousConfigAddOptions(prefix+".dangerous", f)
-	genericconf.WalletConfigAddOptions(prefix+".l1-wallet", f, DefaultL1ValidatorConfig.L1Wallet.Pathname)
+	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultL1ValidatorConfig.L1Wallet.Pathname)
 }
 
 type DangerousConfig struct {

--- a/testnode-scripts/config.ts
+++ b/testnode-scripts/config.ts
@@ -151,7 +151,7 @@ function writeGethGenesisConfig(argv: any) {
 function writeConfigs(argv: any) {
 	const chainInfoFile = path.join(consts.configpath, "l2_chain_info.json")
     const baseConfig = {
-        "l1": {
+        "parent-chain": {
             "url": argv.l1url,
             "wallet": {
                 "account": "",
@@ -159,8 +159,8 @@ function writeConfigs(argv: any) {
                 "pathname": consts.l1keystore,
             },
         },
-        "l2": {
-            "chain-id": 412346,
+        "chain": {
+            "id": 412346,
             "dev-wallet" : {
                 "private-key": "e887f7d17d07cc7b8004053fb8826f6657084e88904bb61590e498ca04704cf2"
             },
@@ -227,7 +227,7 @@ function writeConfigs(argv: any) {
     const baseConfJSON = JSON.stringify(baseConfig)
 
     let validatorConfig = JSON.parse(baseConfJSON)
-    validatorConfig.l1.wallet.account = namedAccount("validator").address
+    validatorConfig["parent-chain"].wallet.account = namedAccount("validator").address
     validatorConfig.node.staker.enable = true
     validatorConfig.node.staker["use-smart-contract-wallet"] = true
     let validconfJSON = JSON.stringify(validatorConfig)
@@ -244,7 +244,7 @@ function writeConfigs(argv: any) {
     fs.writeFileSync(path.join(consts.configpath, "sequencer_config.json"), JSON.stringify(sequencerConfig))
 
     let posterConfig = JSON.parse(baseConfJSON)
-    posterConfig.l1.wallet.account = namedAccount("sequencer").address
+    posterConfig["parent-chain"].wallet.account = namedAccount("sequencer").address
     posterConfig.node["seq-coordinator"].enable = true
     posterConfig.node["batch-poster"].enable = true
     fs.writeFileSync(path.join(consts.configpath, "poster_config.json"), JSON.stringify(posterConfig))


### PR DESCRIPTION
This renames `--l2.chain-id` to `--chain.id`, `--l2.chain-name` to `--chain.name`, all other `--l2.*` options to `--chain.*`, `--l1.chain-id` to `--parent-chain.id`, and all other `--l1.*` options to `--parent-chain.*`. It doesn't rename the variables in code yet to simplify review and avoid merge conflicts.