### PR TITLE
Fix the config key of chain info

### DIFF
--- a/cmd/chaininfo/chain_info.go
+++ b/cmd/chaininfo/chain_info.go
@@ -84,9 +84,9 @@ func ProcessChainInfo(chainId uint64, chainName string, l2ChainInfoFiles []strin
 		return chainInfo, err
 	}
 	if chainId != 0 {
-		return nil, fmt.Errorf("unsupported L2 chain ID %v", chainId)
+		return nil, fmt.Errorf("unsupported chain ID %v", chainId)
 	} else {
-		return nil, fmt.Errorf("unsupported L2 chain chain %v", chainName)
+		return nil, fmt.Errorf("unsupported chain name %v", chainName)
 	}
 }
 

--- a/cmd/conf/chain.go
+++ b/cmd/conf/chain.go
@@ -51,11 +51,11 @@ func (c *L1Config) ResolveDirectoryNames(chain string) {
 type L2Config struct {
 	ChainID                   uint64                   `koanf:"id"`
 	ChainName                 string                   `koanf:"name"`
-	ChainInfoFiles            []string                 `koanf:"chain-info-files"`
-	ChainInfoJson             string                   `koanf:"chain-info-json"`
+	ChainInfoFiles            []string                 `koanf:"info-files"`
+	ChainInfoJson             string                   `koanf:"info-json"`
 	DevWallet                 genericconf.WalletConfig `koanf:"dev-wallet"`
-	ChainInfoIpfsUrl          string                   `koanf:"chain-info-ipfs-url"`
-	ChainInfoIpfsDownloadPath string                   `koanf:"chain-info-ipfs-download-path"`
+	ChainInfoIpfsUrl          string                   `koanf:"info-ipfs-url"`
+	ChainInfoIpfsDownloadPath string                   `koanf:"info-ipfs-download-path"`
 }
 
 var L2ConfigDefault = L2Config{
@@ -71,13 +71,13 @@ var L2ConfigDefault = L2Config{
 func L2ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Uint64(prefix+".id", L2ConfigDefault.ChainID, "L2 chain ID (determines Arbitrum network)")
 	f.String(prefix+".name", L2ConfigDefault.ChainName, "L2 chain name (determines Arbitrum network)")
-	f.StringSlice(prefix+".chain-info-files", L2ConfigDefault.ChainInfoFiles, "L2 chain info json files")
-	f.String(prefix+".chain-info-json", L2ConfigDefault.ChainInfoJson, "L2 chain info in json string format")
+	f.StringSlice(prefix+".info-files", L2ConfigDefault.ChainInfoFiles, "L2 chain info json files")
+	f.String(prefix+".info-json", L2ConfigDefault.ChainInfoJson, "L2 chain info in json string format")
 
 	// Dev wallet does not exist unless specified
 	genericconf.WalletConfigAddOptions(prefix+".dev-wallet", f, "")
-	f.String(prefix+".chain-info-ipfs-url", L2ConfigDefault.ChainInfoIpfsUrl, "url to download chain info file")
-	f.String(prefix+".chain-info-ipfs-download-path", L2ConfigDefault.ChainInfoIpfsDownloadPath, "path to save temp downloaded file")
+	f.String(prefix+".info-ipfs-url", L2ConfigDefault.ChainInfoIpfsUrl, "url to download chain info file")
+	f.String(prefix+".info-ipfs-download-path", L2ConfigDefault.ChainInfoIpfsDownloadPath, "path to save temp downloaded file")
 
 }
 

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -708,13 +708,13 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 
 	l2ChainId := k.Int64("chain.id")
 	l2ChainName := k.String("chain.name")
-	l2ChainInfoIpfsUrl := k.String("l2.chain-info-ipfs-url")
-	l2ChainInfoIpfsDownloadPath := k.String("l2.chain-info-ipfs-download-path")
+	l2ChainInfoIpfsUrl := k.String("chain.info-ipfs-url")
+	l2ChainInfoIpfsDownloadPath := k.String("chain.info-ipfs-download-path")
 	if l2ChainId == 0 && l2ChainName == "" {
 		return nil, nil, nil, errors.New("must specify --chain.id or --chain.name to choose rollup")
 	}
-	l2ChainInfoFiles := k.Strings("l2.chain-info-files")
-	l2ChainInfoJson := k.String("l2.chain-info-json")
+	l2ChainInfoFiles := k.Strings("chain.info-files")
+	l2ChainInfoJson := k.String("chain.info-json")
 	chainFound, err := applyChainParameters(ctx, k, uint64(l2ChainId), l2ChainName, l2ChainInfoFiles, l2ChainInfoJson, l2ChainInfoIpfsUrl, l2ChainInfoIpfsDownloadPath)
 	if err != nil {
 		return nil, nil, nil, err
@@ -747,9 +747,9 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 		if !chainFound {
 			// If persistent-chain not defined, user not creating custom chain
 			if l2ChainId != 0 {
-				return nil, nil, nil, fmt.Errorf("Unknown chain with L2: %d, L2ChainInfoFiles: %s.  update L2 chain id, modify --l2.chain-info-files or provide --persistent.chain\n", l2ChainId, l2ChainInfoFiles)
+				return nil, nil, nil, fmt.Errorf("Unknown chain id: %d, L2ChainInfoFiles: %v.  update chain id, modify --chain.info-files or provide --persistent.chain\n", l2ChainId, l2ChainInfoFiles)
 			} else {
-				return nil, nil, nil, fmt.Errorf("Unknown chain with L2 Name: %s, L2ChainInfoFiles: %s.  update L2 chain name, modify --l2.chain-info-files or provide --persistent.chain\n", l2ChainName, l2ChainInfoFiles)
+				return nil, nil, nil, fmt.Errorf("Unknown chain name: %s, L2ChainInfoFiles: %v.  update chain name, modify --chain.info-files or provide --persistent.chain\n", l2ChainName, l2ChainInfoFiles)
 			}
 		}
 		return nil, nil, nil, errors.New("--persistent.chain not specified")

--- a/testnode-scripts/config.ts
+++ b/testnode-scripts/config.ts
@@ -164,7 +164,7 @@ function writeConfigs(argv: any) {
             "dev-wallet" : {
                 "private-key": "e887f7d17d07cc7b8004053fb8826f6657084e88904bb61590e498ca04704cf2"
             },
-			"chain-info-files": [chainInfoFile],
+            "info-files": [chainInfoFile],
         },
         "node": {
             "archive": true,

--- a/util/rpcclient/rpcclient.go
+++ b/util/rpcclient/rpcclient.go
@@ -68,7 +68,9 @@ func NewRpcClient(config ClientConfigFetcher, stack *node.Node) *RpcClient {
 }
 
 func (c *RpcClient) Close() {
-	c.client.Close()
+	if c.client != nil {
+		c.client.Close()
+	}
 }
 
 func limitString(limit int, str string) string {


### PR DESCRIPTION
The key fix is in `nitro.go` where we still referred to the chain info keys by their old `l2.` prefix. I've confirmed with a grep that a similar bug doesn't exist elsewhere.