### PR TITLE
Fix a race of Validate being called on the rpcclient.TestClientConfig

### DIFF
--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -357,6 +357,10 @@ func StaticFetcherFrom[T any](t *testing.T, config T) func() T {
 	return func() T { return config }
 }
 
+func StaticPointerFetcherFrom[T any](t *testing.T, config T) func() *T {
+	return StaticFetcherFrom(t, &config)
+}
+
 func configByValidationNode(t *testing.T, clientConfig *arbnode.Config, valStack *node.Node) {
 	clientConfig.BlockValidator.ValidationServer.URL = valStack.WSEndpoint()
 	clientConfig.BlockValidator.ValidationServer.JWTSecret = ""

--- a/system_tests/validation_mock_test.go
+++ b/system_tests/validation_mock_test.go
@@ -179,7 +179,7 @@ func TestValidationServerAPI(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	validationDefault := createMockValidationNode(t, ctx, nil)
-	client := server_api.NewExecutionClient(StaticFetcherFrom(t, &rpcclient.TestClientConfig), validationDefault)
+	client := server_api.NewExecutionClient(StaticPointerFetcherFrom(t, rpcclient.TestClientConfig), validationDefault)
 	err := client.Start(ctx)
 	Require(t, err)
 
@@ -246,7 +246,7 @@ func TestExecutionKeepAlive(t *testing.T) {
 	shortTimeoutConfig := server_arb.DefaultArbitratorSpawnerConfig
 	shortTimeoutConfig.ExecRunTimeout = time.Second
 	validationShortTO := createMockValidationNode(t, ctx, &shortTimeoutConfig)
-	configFetcher := StaticFetcherFrom(t, &rpcclient.TestClientConfig)
+	configFetcher := StaticPointerFetcherFrom(t, rpcclient.TestClientConfig)
 
 	clientDefault := server_api.NewExecutionClient(configFetcher, validationDefault)
 	err := clientDefault.Start(ctx)


### PR DESCRIPTION
Example of this happening: https://github.com/OffchainLabs/nitro/actions/runs/5071506766/jobs/9107992557?pr=1665#step:21:1239

The new StaticPointerFetcherFrom function creates pointers to a copy of the TestClientConfig instead of pointers to the global itself