### PR TITLE
Reduce complexity by reducing nesting

### DIFF
--- a/arbnode/dataposter/slice_storage.go
+++ b/arbnode/dataposter/slice_storage.go
@@ -32,7 +32,7 @@ func (s *SliceStorage[Item]) GetContents(ctx context.Context, startingIndex uint
 }
 
 func (s *SliceStorage[Item]) GetLast(ctx context.Context) (*Item, error) {
-	if len(s.queue) <= 0 {
+	if len(s.queue) == 0 {
 		return nil, nil
 	}
 	return s.queue[len(s.queue)-1], nil

--- a/arbnode/dataposter/slice_storage.go
+++ b/arbnode/dataposter/slice_storage.go
@@ -32,11 +32,10 @@ func (s *SliceStorage[Item]) GetContents(ctx context.Context, startingIndex uint
 }
 
 func (s *SliceStorage[Item]) GetLast(ctx context.Context) (*Item, error) {
-	if len(s.queue) > 0 {
-		return s.queue[len(s.queue)-1], nil
-	} else {
+	if len(s.queue) <= 0 {
 		return nil, nil
 	}
+	return s.queue[len(s.queue)-1], nil
 }
 
 func (s *SliceStorage[Item]) Prune(ctx context.Context, keepStartingAt uint64) error {

--- a/arbnode/delayed.go
+++ b/arbnode/delayed.go
@@ -271,13 +271,14 @@ func (b *DelayedBridge) parseMessage(ctx context.Context, ethLog types.Log) (*bi
 		}
 		b.messageProviders[ethLog.Address] = con
 	}
-	if ethLog.Topics[0] == inboxMessageDeliveredID {
+	switch {
+	case ethLog.Topics[0] == inboxMessageDeliveredID:
 		parsedLog, err := con.ParseInboxMessageDelivered(ethLog)
 		if err != nil {
 			return nil, nil, errors.WithStack(err)
 		}
 		return parsedLog.MessageNum, parsedLog.Data, nil
-	} else if ethLog.Topics[0] == inboxMessageFromOriginID {
+	case ethLog.Topics[0] == inboxMessageFromOriginID:
 		parsedLog, err := con.ParseInboxMessageDeliveredFromOrigin(ethLog)
 		if err != nil {
 			return nil, nil, errors.WithStack(err)
@@ -292,7 +293,7 @@ func (b *DelayedBridge) parseMessage(ctx context.Context, ethLog types.Log) (*bi
 			return nil, nil, errors.WithStack(err)
 		}
 		return parsedLog.MessageNum, args["messageData"].([]byte), nil
-	} else {
+	default:
 		return nil, nil, errors.New("unexpected log type")
 	}
 }

--- a/arbnode/execution/sequencer.go
+++ b/arbnode/execution/sequencer.go
@@ -184,9 +184,8 @@ func (c *nonceCache) matches(header *types.Header) bool {
 		// The header is updated as the block is built,
 		// so instead of checking its hash, we do a pointer comparison.
 		return c.dirty == header
-	} else {
-		return c.block == header.ParentHash
 	}
+	return c.block == header.ParentHash
 }
 
 func (c *nonceCache) Reset(block common.Hash) {
@@ -982,10 +981,9 @@ func (s *Sequencer) Start(ctxIn context.Context) error {
 		if madeBlock {
 			// Note: this may return a negative duration, but timers are fine with that (they treat negative durations as 0).
 			return time.Until(nextBlock)
-		} else {
-			// If we didn't make a block, try again immediately.
-			return 0
 		}
+		// If we didn't make a block, try again immediately.
+		return 0
 	})
 
 	return nil

--- a/arbnode/execution/tx_pre_checker.go
+++ b/arbnode/execution/tx_pre_checker.go
@@ -79,34 +79,33 @@ type NonceError struct {
 func (e NonceError) Error() string {
 	if e.txNonce < e.stateNonce {
 		return fmt.Sprintf("%v: address %v, tx: %d state: %d", core.ErrNonceTooLow, e.sender, e.txNonce, e.stateNonce)
-	} else if e.txNonce > e.stateNonce {
-		return fmt.Sprintf("%v: address %v, tx: %d state: %d", core.ErrNonceTooHigh, e.sender, e.txNonce, e.stateNonce)
-	} else {
-		// This should be unreachable
-		return fmt.Sprintf("invalid nonce error for address %v nonce %v", e.sender, e.txNonce)
 	}
+	if e.txNonce > e.stateNonce {
+		return fmt.Sprintf("%v: address %v, tx: %d state: %d", core.ErrNonceTooHigh, e.sender, e.txNonce, e.stateNonce)
+	}
+	// This should be unreachable
+	return fmt.Sprintf("invalid nonce error for address %v nonce %v", e.sender, e.txNonce)
 }
 
 func (e NonceError) Unwrap() error {
 	if e.txNonce < e.stateNonce {
 		return core.ErrNonceTooLow
-	} else if e.txNonce > e.stateNonce {
-		return core.ErrNonceTooHigh
-	} else {
-		// This should be unreachable
-		return nil
 	}
+	if e.txNonce > e.stateNonce {
+		return core.ErrNonceTooHigh
+	}
+	// This should be unreachable
+	return nil
 }
 
 func MakeNonceError(sender common.Address, txNonce uint64, stateNonce uint64) error {
-	if txNonce != stateNonce {
-		return NonceError{
-			sender:     sender,
-			txNonce:    txNonce,
-			stateNonce: stateNonce,
-		}
-	} else {
+	if txNonce == stateNonce {
 		return nil
+	}
+	return NonceError{
+		sender:     sender,
+		txNonce:    txNonce,
+		stateNonce: stateNonce,
 	}
 }
 

--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -398,9 +398,8 @@ func (r *InboxReader) run(ctx context.Context, hadError bool) error {
 					idx := int(batchNum - sequencerBatches[0].SequenceNumber)
 					if idx < len(sequencerBatches) {
 						return sequencerBatches[idx].Serialize(ctx, r.l1Reader.Client())
-					} else {
-						log.Warn("missing mentioned batch in L1 message lookup", "batch", batchNum)
 					}
+					log.Warn("missing mentioned batch in L1 message lookup", "batch", batchNum)
 				}
 				return r.GetSequencerMessageBytes(ctx, batchNum)
 			})

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -334,9 +334,8 @@ func (t *InboxTracker) AddDelayedMessages(messages []*DelayedInboxMessage, hardR
 		if err != nil {
 			if errors.Is(err, AccumulatorNotFoundErr) {
 				return errors.New("missing previous delayed message")
-			} else {
-				return err
 			}
+			return err
 		}
 	}
 
@@ -422,15 +421,13 @@ func (t *InboxTracker) setDelayedCountReorgAndWriteBatch(batch ethdb.Batch, newD
 	var reorgSeqBatchesToCount *uint64
 	for seqBatchIter.Next() {
 		var batchSeqNum uint64
-		err := rlp.DecodeBytes(seqBatchIter.Value(), &batchSeqNum)
-		if err != nil {
+		if err := rlp.DecodeBytes(seqBatchIter.Value(), &batchSeqNum); err != nil {
 			return err
 		}
 		if !canReorgBatches {
 			return fmt.Errorf("reorging of sequencer batch number %v via delayed messages reorg to count %v disabled in this instance", batchSeqNum, newDelayedCount)
 		}
-		err = batch.Delete(seqBatchIter.Key())
-		if err != nil {
+		if err := batch.Delete(seqBatchIter.Key()); err != nil {
 			return err
 		}
 		if reorgSeqBatchesToCount == nil {
@@ -440,47 +437,44 @@ func (t *InboxTracker) setDelayedCountReorgAndWriteBatch(batch ethdb.Batch, newD
 			reorgSeqBatchesToCount = &batchSeqNum
 		}
 	}
-	err = seqBatchIter.Error()
-	if err != nil {
+	if err := seqBatchIter.Error(); err != nil {
 		return err
 	}
 	// Release the iterator early.
 	// It's fine to call Release multiple times,
 	// which we'll do because of the defer.
 	seqBatchIter.Release()
-	if reorgSeqBatchesToCount != nil {
-		// Clear the batchMeta cache after writing the reorg to disk
-		defer t.clearBatchMetaCache()
-
-		count := *reorgSeqBatchesToCount
-		if t.validator != nil {
-			t.validator.ReorgToBatchCount(count)
-		}
-		countData, err := rlp.EncodeToBytes(count)
-		if err != nil {
-			return err
-		}
-		err = batch.Put(sequencerBatchCountKey, countData)
-		if err != nil {
-			return err
-		}
-		log.Warn("InboxTracker delayed message reorg is causing a sequencer batch reorg", "sequencerBatchCount", count, "delayedCount", newDelayedCount)
-		err = deleteStartingAt(t.db, batch, sequencerBatchMetaPrefix, uint64ToKey(count))
-		if err != nil {
-			return err
-		}
-		var prevMesssageCount arbutil.MessageIndex
-		if count > 0 {
-			prevMesssageCount, err = t.GetBatchMessageCount(count - 1)
-			if err != nil {
-				return err
-			}
-		}
-		// Writes batch
-		return t.txStreamer.ReorgToAndEndBatch(batch, prevMesssageCount)
-	} else {
+	if reorgSeqBatchesToCount == nil {
 		return batch.Write()
 	}
+	// Clear the batchMeta cache after writing the reorg to disk
+	defer t.clearBatchMetaCache()
+
+	count := *reorgSeqBatchesToCount
+	if t.validator != nil {
+		t.validator.ReorgToBatchCount(count)
+	}
+	countData, err = rlp.EncodeToBytes(count)
+	if err != nil {
+		return err
+	}
+	if err := batch.Put(sequencerBatchCountKey, countData); err != nil {
+		return err
+	}
+	log.Warn("InboxTracker delayed message reorg is causing a sequencer batch reorg", "sequencerBatchCount", count, "delayedCount", newDelayedCount)
+
+	if err := deleteStartingAt(t.db, batch, sequencerBatchMetaPrefix, uint64ToKey(count)); err != nil {
+		return err
+	}
+	var prevMesssageCount arbutil.MessageIndex
+	if count > 0 {
+		prevMesssageCount, err = t.GetBatchMessageCount(count - 1)
+		if err != nil {
+			return err
+		}
+	}
+	// Writes batch
+	return t.txStreamer.ReorgToAndEndBatch(batch, prevMesssageCount)
 }
 
 type multiplexerBackend struct {
@@ -569,9 +563,11 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L
 			if errors.Is(err, AccumulatorNotFoundErr) {
 				// We somehow missed a referenced delayed message; go back and look for it
 				return delayedMessagesMismatch
-			} else if err != nil {
+			}
+			if err != nil {
 				return err
-			} else if haveDelayedAcc != batch.AfterDelayedAcc {
+			}
+			if haveDelayedAcc != batch.AfterDelayedAcc {
 				// We somehow missed a delayed message reorg; go back and look for it
 				return delayedMessagesMismatch
 			}
@@ -705,7 +701,8 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client arbutil.L
 		prevprevbatchmeta, err := t.GetBatchMetadata(pos - 2)
 		if errors.Is(err, AccumulatorNotFoundErr) {
 			return errors.New("missing previous previous sequencer batch")
-		} else if err != nil {
+		}
+		if err != nil {
 			return err
 		}
 		if prevprevbatchmeta.MessageCount > 0 {
@@ -727,7 +724,8 @@ func (t *InboxTracker) ReorgDelayedTo(count uint64, canReorgBatches bool) error 
 	}
 	if currentCount == count {
 		return nil
-	} else if currentCount < count {
+	}
+	if currentCount < count {
 		return errors.New("attempted to reorg to future delayed count")
 	}
 
@@ -744,7 +742,8 @@ func (t *InboxTracker) ReorgBatchesTo(count uint64) error {
 		prevBatchMeta, err = t.GetBatchMetadata(count - 1)
 		if errors.Is(err, AccumulatorNotFoundErr) {
 			return errors.New("attempted to reorg to future batch count")
-		} else if err != nil {
+		}
+		if err != nil {
 			return err
 		}
 	}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -784,9 +784,8 @@ func createNodeImpl(
 	if err != nil {
 		if config.ValidatorRequired() || config.Staker.Enable {
 			return nil, fmt.Errorf("%w: failed to init block validator", err)
-		} else {
-			log.Warn("validation not supported", "err", err)
 		}
+		log.Warn("validation not supported", "err", err)
 		statelessBlockValidator = nil
 	}
 
@@ -1051,9 +1050,8 @@ func (n *Node) Start(ctx context.Context) error {
 		if err != nil {
 			if n.configFetcher.Get().ValidatorRequired() {
 				return fmt.Errorf("error initializing stateless block validator: %w", err)
-			} else {
-				log.Info("validation not set up", "err", err)
 			}
+			log.Info("validation not set up", "err", err)
 			n.StatelessBlockValidator = nil
 			n.BlockValidator = nil
 		}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -556,45 +556,43 @@ func (s *TransactionStreamer) countDuplicateMessages(
 		if !bytes.Equal(haveMessage, wantMessage) {
 			// Current message does not exactly match message in database
 			var dbMessageParsed arbostypes.MessageWithMetadata
-			err := rlp.DecodeBytes(haveMessage, &dbMessageParsed)
-			if err != nil {
+
+			if err := rlp.DecodeBytes(haveMessage, &dbMessageParsed); err != nil {
 				log.Warn("TransactionStreamer: Reorg detected! (failed parsing db message)",
 					"pos", pos,
 					"err", err,
 				)
 				return curMsg, true, nil, nil
-			} else {
-				var duplicateMessage bool
-				if nextMessage.Message != nil {
-					if dbMessageParsed.Message.BatchGasCost == nil || nextMessage.Message.BatchGasCost == nil {
-						// Remove both of the batch gas costs and see if the messages still differ
-						nextMessageCopy := nextMessage
-						nextMessageCopy.Message = new(arbostypes.L1IncomingMessage)
-						*nextMessageCopy.Message = *nextMessage.Message
-						batchGasCostBkup := dbMessageParsed.Message.BatchGasCost
-						dbMessageParsed.Message.BatchGasCost = nil
-						nextMessageCopy.Message.BatchGasCost = nil
-						if reflect.DeepEqual(dbMessageParsed, nextMessageCopy) {
-							// Actually this isn't a reorg; only the batch gas costs differed
-							duplicateMessage = true
-							// If possible - update the message in the database to add the gas cost cache.
-							if batch != nil && nextMessage.Message.BatchGasCost != nil {
-								if *batch == nil {
-									*batch = s.db.NewBatch()
-								}
-								err = s.writeMessage(pos, nextMessage, *batch)
-								if err != nil {
-									return 0, false, nil, err
-								}
+			}
+			var duplicateMessage bool
+			if nextMessage.Message != nil {
+				if dbMessageParsed.Message.BatchGasCost == nil || nextMessage.Message.BatchGasCost == nil {
+					// Remove both of the batch gas costs and see if the messages still differ
+					nextMessageCopy := nextMessage
+					nextMessageCopy.Message = new(arbostypes.L1IncomingMessage)
+					*nextMessageCopy.Message = *nextMessage.Message
+					batchGasCostBkup := dbMessageParsed.Message.BatchGasCost
+					dbMessageParsed.Message.BatchGasCost = nil
+					nextMessageCopy.Message.BatchGasCost = nil
+					if reflect.DeepEqual(dbMessageParsed, nextMessageCopy) {
+						// Actually this isn't a reorg; only the batch gas costs differed
+						duplicateMessage = true
+						// If possible - update the message in the database to add the gas cost cache.
+						if batch != nil && nextMessage.Message.BatchGasCost != nil {
+							if *batch == nil {
+								*batch = s.db.NewBatch()
+							}
+							if err := s.writeMessage(pos, nextMessage, *batch); err != nil {
+								return 0, false, nil, err
 							}
 						}
-						dbMessageParsed.Message.BatchGasCost = batchGasCostBkup
 					}
+					dbMessageParsed.Message.BatchGasCost = batchGasCostBkup
 				}
+			}
 
-				if !duplicateMessage {
-					return curMsg, true, &dbMessageParsed, nil
-				}
+			if !duplicateMessage {
+				return curMsg, true, &dbMessageParsed, nil
 			}
 		}
 

--- a/arbos/addressTable/addressTable.go
+++ b/arbos/addressTable/addressTable.go
@@ -20,7 +20,7 @@ type AddressTable struct {
 }
 
 func Initialize(sto *storage.Storage) {
-	// no initialization needed
+	// No initialization needed.
 }
 
 func Open(sto *storage.Storage) *AddressTable {
@@ -34,24 +34,22 @@ func (atab *AddressTable) Register(addr common.Address) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if rev == (common.Hash{}) {
-		// addr isn't in the table, so add it
-		newNumItems, err := atab.numItems.Increment()
-		if err != nil {
-			return 0, err
-		}
-		err = atab.backingStorage.SetByUint64(newNumItems, addrAsHash)
-		if err != nil {
-			return 0, err
-		}
-		err = atab.byAddress.Set(addrAsHash, util.UintToHash(newNumItems))
-		if err != nil {
-			return 0, err
-		}
-		return newNumItems - 1, nil
-	} else {
+
+	if rev != (common.Hash{}) {
 		return rev.Big().Uint64() - 1, nil
 	}
+	// Addr isn't in the table, so add it.
+	newNumItems, err := atab.numItems.Increment()
+	if err != nil {
+		return 0, err
+	}
+	if err := atab.backingStorage.SetByUint64(newNumItems, addrAsHash); err != nil {
+		return 0, err
+	}
+	if err := atab.byAddress.Set(addrAsHash, util.UintToHash(newNumItems)); err != nil {
+		return 0, err
+	}
+	return newNumItems - 1, nil
 }
 
 func (atab *AddressTable) Lookup(addr common.Address) (uint64, bool, error) {

--- a/arbos/arbostypes/incomingmessage.go
+++ b/arbos/arbostypes/incomingmessage.go
@@ -244,7 +244,8 @@ func (msg *L1IncomingMessage) ParseInitMessage() (*big.Int, *params.ChainConfig,
 	if len(msg.L2msg) == 32 {
 		chainId = new(big.Int).SetBytes(msg.L2msg[:32])
 		return chainId, nil, nil, nil
-	} else if len(msg.L2msg) > 32 {
+	}
+	if len(msg.L2msg) > 32 {
 		chainId = new(big.Int).SetBytes(msg.L2msg[:32])
 		version := msg.L2msg[32]
 		if version == 0 && len(msg.L2msg) > 33 {

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -443,10 +443,9 @@ func ProduceBlockAdvanced(
 		// Fail if funds have been minted or debug mode is enabled (i.e. this is a test)
 		if balanceDelta.Cmp(expectedBalanceDelta) > 0 || chainConfig.DebugMode() {
 			return nil, nil, fmt.Errorf("unexpected total balance delta %v (expected %v)", balanceDelta, expectedBalanceDelta)
-		} else {
-			// This is a real chain and funds were burnt, not minted, so only log an error and don't panic
-			log.Error("Unexpected total balance delta", "delta", balanceDelta, "expected", expectedBalanceDelta)
 		}
+		// This is a real chain and funds were burnt, not minted, so only log an error and don't panic
+		log.Error("Unexpected total balance delta", "delta", balanceDelta, "expected", expectedBalanceDelta)
 	}
 
 	return block, receipts, nil

--- a/arbos/merkleAccumulator/merkleAccumulator.go
+++ b/arbos/merkleAccumulator/merkleAccumulator.go
@@ -67,17 +67,15 @@ func (acc *MerkleAccumulator) NonPersistentClone() (*MerkleAccumulator, error) {
 func (acc *MerkleAccumulator) Keccak(data ...[]byte) ([]byte, error) {
 	if acc.backingStorage != nil {
 		return acc.backingStorage.Keccak(data...)
-	} else {
-		return crypto.Keccak256(data...), nil
 	}
+	return crypto.Keccak256(data...), nil
 }
 
 func (acc *MerkleAccumulator) KeccakHash(data ...[]byte) (common.Hash, error) {
 	if acc.backingStorage != nil {
 		return acc.backingStorage.KeccakHash(data...)
-	} else {
-		return crypto.Keccak256Hash(data...), nil
 	}
+	return crypto.Keccak256Hash(data...), nil
 }
 
 func (acc *MerkleAccumulator) getPartial(level uint64) (*common.Hash, error) {
@@ -87,10 +85,9 @@ func (acc *MerkleAccumulator) getPartial(level uint64) (*common.Hash, error) {
 			acc.partials[level] = &h
 		}
 		return acc.partials[level], nil
-	} else {
-		ret, err := acc.backingStorage.GetByUint64(2 + level)
-		return &ret, err
 	}
+	ret, err := acc.backingStorage.GetByUint64(2 + level)
+	return &ret, err
 }
 
 func (acc *MerkleAccumulator) GetPartials() ([]*common.Hash, error) {

--- a/arbos/storage/storage.go
+++ b/arbos/storage/storage.go
@@ -461,7 +461,8 @@ func (sbbu *StorageBackedBigUint) Get() (*big.Int, error) {
 func (sbbu *StorageBackedBigUint) SetChecked(val *big.Int) error {
 	if val.Sign() < 0 {
 		return sbbu.burner.HandleError(fmt.Errorf("underflow in StorageBackedBigUint.Set setting value %v", val))
-	} else if val.BitLen() > 256 {
+	}
+	if val.BitLen() > 256 {
 		return sbbu.burner.HandleError(fmt.Errorf("overflow in StorageBackedBigUint.Set setting value %v", val))
 	}
 	return sbbu.StorageSlot.Set(common.BytesToHash(val.Bytes()))
@@ -579,9 +580,8 @@ func (sba *StorageBackedAddressOrNil) Get() (*common.Address, error) {
 func (sba *StorageBackedAddressOrNil) Set(val *common.Address) error {
 	if val == nil {
 		return sba.StorageSlot.Set(NilAddressRepresentation)
-	} else {
-		return sba.StorageSlot.Set(common.BytesToHash(val.Bytes()))
 	}
+	return sba.StorageSlot.Set(common.BytesToHash(val.Bytes()))
 }
 
 type StorageBackedBytes struct {

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -90,10 +90,9 @@ func takeFunds(pool *big.Int, take *big.Int) *big.Int {
 		oldPool := new(big.Int).Set(pool)
 		pool.Set(common.Big0)
 		return oldPool
-	} else {
-		pool.Sub(pool, take)
-		return new(big.Int).Set(take)
 	}
+	pool.Sub(pool, take)
+	return new(big.Int).Set(take)
 }
 
 func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, returnData []byte) {

--- a/arbutil/correspondingl1blocknumber.go
+++ b/arbutil/correspondingl1blocknumber.go
@@ -19,7 +19,6 @@ func CorrespondingL1BlockNumber(ctx context.Context, client L1Interface, blockNu
 	headerInfo := types.DeserializeHeaderExtraInformation(header)
 	if headerInfo.L1BlockNumber != 0 {
 		return headerInfo.L1BlockNumber, nil
-	} else {
-		return blockNumber, nil
 	}
+	return blockNumber, nil
 }

--- a/blsSignatures/blsSignatures.go
+++ b/blsSignatures/blsSignatures.go
@@ -194,14 +194,13 @@ func PublicKeyToBytes(pub PublicKey) []byte {
 	g2 := bls12381.NewG2()
 	if pub.validityProof == nil {
 		return append([]byte{0}, g2.ToBytes(pub.key)...)
-	} else {
-		keyBytes := g2.ToBytes(pub.key)
-		sigBytes := SignatureToBytes(pub.validityProof)
-		if len(sigBytes) > 255 {
-			panic("validity proof too large to serialize")
-		}
-		return append(append([]byte{byte(len(sigBytes))}, sigBytes...), keyBytes...)
 	}
+	keyBytes := g2.ToBytes(pub.key)
+	sigBytes := SignatureToBytes(pub.validityProof)
+	if len(sigBytes) > 255 {
+		panic("validity proof too large to serialize")
+	}
+	return append(append([]byte{byte(len(sigBytes))}, sigBytes...), keyBytes...)
 }
 
 func PublicKeyFromBytes(in []byte, trustedSource bool) (PublicKey, error) {

--- a/cmd/chaininfo/chain_info.go
+++ b/cmd/chaininfo/chain_info.go
@@ -41,9 +41,8 @@ func GetChainConfig(chainId *big.Int, chainName string, genesisBlockNum uint64, 
 	}
 	if chainId.Uint64() != 0 {
 		return nil, fmt.Errorf("missing chain config for L2 chain ID %v", chainId)
-	} else {
-		return nil, fmt.Errorf("missing chain config for L2 chain name %v", chainName)
 	}
+	return nil, fmt.Errorf("missing chain config for L2 chain name %v", chainName)
 }
 
 func GetRollupAddressesConfig(chainId uint64, chainName string, l2ChainInfoFiles []string, l2ChainInfoJson string) (RollupAddresses, error) {
@@ -56,9 +55,8 @@ func GetRollupAddressesConfig(chainId uint64, chainName string, l2ChainInfoFiles
 	}
 	if chainId != 0 {
 		return RollupAddresses{}, fmt.Errorf("missing rollup addresses for L2 chain ID %v", chainId)
-	} else {
-		return RollupAddresses{}, fmt.Errorf("missing rollup addresses for L2 chain name %v", chainName)
 	}
+	return RollupAddresses{}, fmt.Errorf("missing rollup addresses for L2 chain name %v", chainName)
 }
 
 func ProcessChainInfo(chainId uint64, chainName string, l2ChainInfoFiles []string, l2ChainInfoJson string) (*ChainInfo, error) {
@@ -85,9 +83,8 @@ func ProcessChainInfo(chainId uint64, chainName string, l2ChainInfoFiles []strin
 	}
 	if chainId != 0 {
 		return nil, fmt.Errorf("unsupported chain ID %v", chainId)
-	} else {
-		return nil, fmt.Errorf("unsupported chain name %v", chainName)
 	}
+	return nil, fmt.Errorf("unsupported chain name %v", chainName)
 }
 
 func findChainInfo(chainId uint64, chainName string, chainsInfoBytes []byte) (*ChainInfo, error) {

--- a/cmd/genericconf/jwt.go
+++ b/cmd/genericconf/jwt.go
@@ -21,7 +21,8 @@ func TryCreatingJWTSecret(filename string) error {
 	if errors.Is(err, fs.ErrExist) {
 		log.Info("using existing jwt file", "filename", filename)
 		return nil
-	} else if err != nil {
+	}
+	if err != nil {
 		return fmt.Errorf("couldn't create file: %w", err)
 	}
 	defer func() {

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/offchainlabs/nitro/cmd/util"
 	"math/big"
 	"os"
 	"regexp"
@@ -16,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/offchainlabs/nitro/cmd/util"
 
 	"github.com/cavaliergopher/grab/v3"
 	extract "github.com/codeclysm/extract/v3"
@@ -244,12 +245,11 @@ func (r *importantRoots) addHeader(header *types.Header, overwrite bool) error {
 	}
 	height := header.Number.Uint64()
 	for len(r.heights) > 0 && r.heights[len(r.heights)-1] > height {
-		if overwrite {
-			r.roots = r.roots[:len(r.roots)-1]
-			r.heights = r.heights[:len(r.heights)-1]
-		} else {
+		if !overwrite {
 			return nil
 		}
+		r.roots = r.roots[:len(r.roots)-1]
+		r.heights = r.heights[:len(r.heights)-1]
 	}
 	if len(r.heights) > 0 && r.heights[len(r.heights)-1]+minRootDistance > height {
 		return nil

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -652,9 +652,8 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 			// If persistent-chain not defined, user not creating custom chain
 			if l2ChainId != 0 {
 				return nil, nil, nil, fmt.Errorf("Unknown chain id: %d, L2ChainInfoFiles: %v.  update chain id, modify --chain.info-files or provide --persistent.chain\n", l2ChainId, l2ChainInfoFiles)
-			} else {
-				return nil, nil, nil, fmt.Errorf("Unknown chain name: %s, L2ChainInfoFiles: %v.  update chain name, modify --chain.info-files or provide --persistent.chain\n", l2ChainName, l2ChainInfoFiles)
 			}
+			return nil, nil, nil, fmt.Errorf("Unknown chain name: %s, L2ChainInfoFiles: %v.  update chain name, modify --chain.info-files or provide --persistent.chain\n", l2ChainName, l2ChainInfoFiles)
 		}
 		return nil, nil, nil, errors.New("--persistent.chain not specified")
 	}

--- a/das/db_storage_service.go
+++ b/das/db_storage_service.go
@@ -138,9 +138,8 @@ func (dbs *DBStorageService) Close(ctx context.Context) error {
 func (dbs *DBStorageService) ExpirationPolicy(ctx context.Context) (arbstate.ExpirationPolicy, error) {
 	if dbs.discardAfterTimeout {
 		return arbstate.DiscardAfterDataTimeout, nil
-	} else {
-		return arbstate.KeepForever, nil
 	}
+	return arbstate.KeepForever, nil
 }
 
 func (dbs *DBStorageService) String() string {

--- a/das/s3_storage_service.go
+++ b/das/s3_storage_service.go
@@ -148,9 +148,8 @@ func (s3s *S3StorageService) Close(ctx context.Context) error {
 func (s3s *S3StorageService) ExpirationPolicy(ctx context.Context) (arbstate.ExpirationPolicy, error) {
 	if s3s.discardAfterTimeout {
 		return arbstate.DiscardAfterDataTimeout, nil
-	} else {
-		return arbstate.KeepForever, nil
 	}
+	return arbstate.KeepForever, nil
 }
 
 func (s3s *S3StorageService) String() string {

--- a/das/sign_after_store_das_writer.go
+++ b/das/sign_after_store_das_writer.go
@@ -162,9 +162,8 @@ func NewSignAfterStoreDASWriterWithSeqInboxCaller(
 		extraBpVerifier = func(message []byte, timeout uint64, sig []byte) bool {
 			if len(sig) >= 64 {
 				return crypto.VerifySignature(pubkey, dasStoreHash(message, timeout), sig[:64])
-			} else {
-				return false
 			}
+			return false
 		}
 	}
 

--- a/precompiles/ArbRetryableTx.go
+++ b/precompiles/ArbRetryableTx.go
@@ -41,9 +41,8 @@ var ErrSelfModifyingRetryable = errors.New("retryable cannot modify itself")
 func (con ArbRetryableTx) oldNotFoundError(c ctx) error {
 	if c.State.ArbOSVersion() >= 3 {
 		return con.NoTicketWithIDError()
-	} else {
-		return errors.New("ticketId not found")
 	}
+	return errors.New("ticketId not found")
 }
 
 // Redeem schedules an attempt to redeem the retryable, donating all of the call's gas to the redeem attempt
@@ -226,9 +225,8 @@ func (con ArbRetryableTx) Cancel(c ctx, evm mech, ticketId bytes32) error {
 func (con ArbRetryableTx) GetCurrentRedeemer(c ctx, evm mech) (common.Address, error) {
 	if c.txProcessor.CurrentRefundTo != nil {
 		return *c.txProcessor.CurrentRefundTo, nil
-	} else {
-		return common.Address{}, nil
 	}
+	return common.Address{}, nil
 }
 
 func (con ArbRetryableTx) SubmitRetryable(

--- a/precompiles/ArbSys.go
+++ b/precompiles/ArbSys.go
@@ -39,9 +39,8 @@ func (con *ArbSys) ArbBlockHash(c ctx, evm mech, arbBlockNumber *big.Int) (bytes
 	if !arbBlockNumber.IsUint64() {
 		if c.State.ArbOSVersion() >= 11 {
 			return bytes32{}, con.InvalidBlockNumberError(arbBlockNumber, evm.Context.BlockNumber)
-		} else {
-			return bytes32{}, errors.New("invalid block number")
 		}
+		return bytes32{}, errors.New("invalid block number")
 	}
 	requestedBlockNum := arbBlockNumber.Uint64()
 
@@ -49,9 +48,8 @@ func (con *ArbSys) ArbBlockHash(c ctx, evm mech, arbBlockNumber *big.Int) (bytes
 	if requestedBlockNum >= currentNumber || requestedBlockNum+256 < currentNumber {
 		if c.State.ArbOSVersion() >= 11 {
 			return common.Hash{}, con.InvalidBlockNumberError(arbBlockNumber, evm.Context.BlockNumber)
-		} else {
-			return common.Hash{}, errors.New("invalid block number for ArbBlockHAsh")
 		}
+		return common.Hash{}, errors.New("invalid block number for ArbBlockHAsh")
 	}
 
 	return evm.Context.GetHash(requestedBlockNum), nil

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -742,10 +742,9 @@ func (p *Precompile) Call(
 		// nolint:errorlint
 		if arbosVersion >= 11 || errRet == vm.ErrExecutionReverted {
 			return nil, callerCtx.gasLeft, vm.ErrExecutionReverted
-		} else {
-			// Preserve behavior with old versions which would zero out gas on this type of error
-			return nil, 0, errRet
 		}
+		// Preserve behavior with old versions which would zero out gas on this type of error
+		return nil, 0, errRet
 	}
 	result := make([]interface{}, resultCount)
 	for i := 0; i < resultCount; i++ {

--- a/precompiles/wrapper.go
+++ b/precompiles/wrapper.go
@@ -41,10 +41,9 @@ func (wrapper *DebugPrecompile) Call(
 	if debugMode {
 		con := wrapper.precompile
 		return con.Call(input, precompileAddress, actingAsAddress, caller, value, readOnly, gasSupplied, evm)
-	} else {
-		// take all gas
-		return nil, 0, errors.New("debug precompiles are disabled")
 	}
+	// Take all gas.
+	return nil, 0, errors.New("debug precompiles are disabled")
 }
 
 func (wrapper *DebugPrecompile) Precompile() *Precompile {

--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -290,10 +290,9 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 		if latestHeader.Number.Int64() < expectedBlockHeight {
 			log.Info("catching up to chain blocks", "localBlocks", latestHeader.Number, "target", expectedBlockHeight)
 			return nil, false, nil
-		} else {
-			log.Error("unknown start block hash", "hash", startState.GlobalState.BlockHash, "batch", startState.GlobalState.Batch, "pos", startState.GlobalState.PosInBatch)
-			return nil, false, errors.New("unknown start block hash")
 		}
+		log.Error("unknown start block hash", "hash", startState.GlobalState.BlockHash, "batch", startState.GlobalState.Batch, "pos", startState.GlobalState.PosInBatch)
+		return nil, false, errors.New("unknown start block hash")
 	}
 
 	var lastBlockValidated uint64

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -85,17 +85,18 @@ type L1ValidatorConfig struct {
 }
 
 func (c *L1ValidatorConfig) ParseStrategy() (StakerStrategy, error) {
-	if strings.ToLower(c.Strategy) == "watchtower" {
+	switch strings.ToLower(c.Strategy) {
+	case "watchtower":
 		return WatchtowerStrategy, nil
-	} else if strings.ToLower(c.Strategy) == "defensive" {
+	case "defensive":
 		return DefensiveStrategy, nil
-	} else if strings.ToLower(c.Strategy) == "stakelatest" {
+	case "stakelatest":
 		return StakeLatestStrategy, nil
-	} else if strings.ToLower(c.Strategy) == "resolvenodes" {
+	case "resolvenodes":
 		return ResolveNodesStrategy, nil
-	} else if strings.ToLower(c.Strategy) == "makenodes" {
+	case "makenodes":
 		return MakeNodesStrategy, nil
-	} else {
+	default:
 		return WatchtowerStrategy, fmt.Errorf("unknown staker strategy \"%v\"", c.Strategy)
 	}
 }
@@ -209,8 +210,8 @@ func NewStaker(
 	statelessBlockValidator *StatelessBlockValidator,
 	validatorUtilsAddress common.Address,
 ) (*Staker, error) {
-	err := config.Validate()
-	if err != nil {
+
+	if err := config.Validate(); err != nil {
 		return nil, err
 	}
 	client := l1Reader.Client()
@@ -377,9 +378,8 @@ func (s *Staker) shouldAct(ctx context.Context) bool {
 			"highGasBuffer", s.highGasBlocksBuffer,
 		)
 		return false
-	} else {
-		return true
 	}
+	return true
 }
 
 func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {

--- a/staker/validator_wallet.go
+++ b/staker/validator_wallet.go
@@ -334,7 +334,8 @@ func GetValidatorWalletContract(
 	}
 	if len(logs) > 1 {
 		return nil, errors.New("more than one validator wallet created for address")
-	} else if len(logs) == 1 {
+	}
+	if len(logs) == 1 {
 		rawLog := logs[0]
 		parsed, err := walletCreator.ParseWalletCreated(rawLog)
 		if err != nil {

--- a/system_tests/seqinbox_test.go
+++ b/system_tests/seqinbox_test.go
@@ -81,9 +81,8 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 	accountName := func(x int) string {
 		if x == 0 {
 			return "Owner"
-		} else {
-			return fmt.Sprintf("Account%v", x)
 		}
+		return fmt.Sprintf("Account%v", x)
 	}
 
 	accounts := []string{"ReorgPadding"}

--- a/wsbroadcastserver/utils.go
+++ b/wsbroadcastserver/utils.go
@@ -52,9 +52,8 @@ func (cr *chainedReader) Read(b []byte) (n int, err error) {
 					// If this isn't the last reader, return the data without the EOF since this
 					// may not be the end of all the readers.
 					return n, nil
-				} else {
-					return
 				}
+				return
 			}
 		}
 		break

--- a/zeroheavy/zeroheavy.go
+++ b/zeroheavy/zeroheavy.go
@@ -70,45 +70,43 @@ func (enc *ZeroheavyEncoder) readOneImpl() (byte, error) {
 		}
 		if !secondBit {
 			return 0, nil
-		} else {
-			ret := byte(1)
-			for i := 0; i < 6; i++ {
-				nextBit, err := enc.nextInputBit()
-				if err != nil {
-					return 0, err
-				}
-				ret <<= 1
-				if nextBit {
-					ret++
-				}
-			}
-			if ret == 64 {
-				return 1, nil
-			}
-			ret = (ret << 1) & 0x7f
+		}
+		ret := byte(1)
+		for i := 0; i < 6; i++ {
 			nextBit, err := enc.nextInputBit()
 			if err != nil {
 				return 0, err
 			}
+			ret <<= 1
 			if nextBit {
 				ret++
 			}
-			return ret, nil
 		}
-	} else {
-		ret := byte(1) // first bit is 1
-		for i := 0; i < 7; i++ {
-			ret <<= 1
-			nextBit, err := enc.nextInputBit()
-			if err != nil {
-				return 0, err
-			}
-			if nextBit {
-				ret += 1
-			}
+		if ret == 64 {
+			return 1, nil
+		}
+		ret = (ret << 1) & 0x7f
+		nextBit, err := enc.nextInputBit()
+		if err != nil {
+			return 0, err
+		}
+		if nextBit {
+			ret++
 		}
 		return ret, nil
 	}
+	ret := byte(1) // first bit is 1
+	for i := 0; i < 7; i++ {
+		ret <<= 1
+		nextBit, err := enc.nextInputBit()
+		if err != nil {
+			return 0, err
+		}
+		if nextBit {
+			ret += 1
+		}
+	}
+	return ret, nil
 }
 
 func (enc *ZeroheavyEncoder) Read(p []byte) (int, error) {


### PR DESCRIPTION
- Drop unnecessary "} else {" when previous statement is return.
- inline error assignment for narrowing down scope of variable and ease of readability.
- use switch instead of lengthy if/elses.

[0] https://google.github.io/styleguide/go/decisions#indent-error-flow
[1] https://testing.googleblog.com/2017/06/code-health-reduce-nesting-reduce.html