### PR TITLE
staticfetcher: copy config to avoid race

### DIFF
--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -345,16 +345,17 @@ type validated interface {
 	Validate() error
 }
 
-func StaticFetcherFrom[T any](t *testing.T, config T) func() T {
+func StaticFetcherFrom[T any](t *testing.T, config *T) func() *T {
 	t.Helper()
-	asEmptyIf := interface{}(config)
+	tCopy := *config
+	asEmptyIf := interface{}(&tCopy)
 	if asValidtedIf, ok := asEmptyIf.(validated); ok {
 		err := asValidtedIf.Validate()
 		if err != nil {
 			Fail(t, err)
 		}
 	}
-	return func() T { return config }
+	return func() *T { return &tCopy }
 }
 
 func configByValidationNode(t *testing.T, clientConfig *arbnode.Config, valStack *node.Node) {


### PR DESCRIPTION
have each static fetcher use it's own copy of config to avoid race on validate