### PR TITLE
Implement thin wrapper on sync.map to support generic thread-safe map.

### DIFF
--- a/util/containers/map.go
+++ b/util/containers/map.go
@@ -1,0 +1,27 @@
+package containers
+
+import "sync"
+
+// Map implements thread-safe generic map.
+type Map[K comparable, V any] struct {
+	m sync.Map
+}
+
+// Delete deletes the key. If it doesn't exist it's a no-op.
+func (m *Map[K, V]) Delete(k K) {
+	m.m.Delete(k)
+}
+
+// Load retrieves the key from the map.
+func (m *Map[K, V]) Load(k K) (val V, found bool) {
+	v, ok := m.m.Load(k)
+	if !ok {
+		return val, false
+	}
+	return v.(V), true
+}
+
+// Store stores key/value in the map.
+func (m *Map[K, V]) Store(k K, v V) {
+	m.m.Store(k, v)
+}

--- a/util/containers/map_test.go
+++ b/util/containers/map_test.go
@@ -1,0 +1,49 @@
+package containers
+
+import (
+	"testing"
+)
+
+func TestMap(t *testing.T) {
+	var m Map[int, int]
+	m.Store(13, 31)
+	m.Store(11, 12)
+	m.Store(11, 11)
+	m.Store(42, 24)
+	m.Delete(1) // Deleting non-existing key should be a no-op.
+	m.Delete(42)
+
+	for _, tc := range []struct {
+		desc      string
+		k, want   int
+		wantFound bool
+	}{
+		{
+			desc:      "key added once",
+			k:         13,
+			want:      31,
+			wantFound: true,
+		},
+		{
+			desc:      "key overwritten with different value",
+			k:         11,
+			want:      11,
+			wantFound: true,
+		},
+		{
+			desc: "key doesn't exist",
+			k:    -1,
+		},
+		{
+			desc: "key that was deleted",
+			k:    42,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got, found := m.Load(tc.k); found != tc.wantFound || got != tc.want {
+				t.Errorf("Load(%v) = (%v %t) want (%v %t)", tc.k, got, found, tc.want, tc.wantFound)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
and replace uses of sync.Map with it.