### PR TITLE
Fix data poster nonce query

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -408,7 +408,7 @@ func (p *DataPoster[Meta]) updateNonce(ctx context.Context) error {
 	if p.lastBlock != nil && arbmath.BigEquals(p.lastBlock, header.Number) {
 		return nil
 	}
-	nonce, err := p.client.NonceAt(ctx, p.auth.From, p.lastBlock)
+	nonce, err := p.client.NonceAt(ctx, p.auth.From, header.Number)
 	if err != nil {
 		if p.lastBlock != nil {
 			log.Warn("failed to get current nonce", "lastBlock", p.lastBlock, "newBlock", header.Number, "err", err)
@@ -417,7 +417,7 @@ func (p *DataPoster[Meta]) updateNonce(ctx context.Context) error {
 		return err
 	}
 	if nonce > p.nonce {
-		log.Info("data poster transactions confirmed", "previousNonce", p.nonce, "newNonce", nonce, "l1Block", p.lastBlock)
+		log.Info("data poster transactions confirmed", "previousNonce", p.nonce, "newNonce", nonce, "previousL1Block", p.lastBlock, "newL1Block", header.Number)
 		if len(p.errorCount) > 0 {
 			for x := p.nonce; x < nonce; x++ {
 				delete(p.errorCount, x)

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -423,7 +423,8 @@ func (p *DataPoster[Meta]) updateNonce(ctx context.Context) error {
 				delete(p.errorCount, x)
 			}
 		}
-		err := p.queue.Prune(ctx, nonce)
+		// nonce > 0 is implied by nonce > p.nonce, so this won't underflow
+		err := p.queue.Prune(ctx, nonce-1)
 		if err != nil {
 			return err
 		}

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -423,7 +423,9 @@ func (p *DataPoster[Meta]) updateNonce(ctx context.Context) error {
 				delete(p.errorCount, x)
 			}
 		}
-		// nonce > 0 is implied by nonce > p.nonce, so this won't underflow
+		// We don't prune the most recent transaction in order to ensure that the data poster
+		// always has a reference point in its queue of the latest transaction nonce and metadata.
+		// nonce > 0 is implied by nonce > p.nonce, so this won't underflow.
 		err := p.queue.Prune(ctx, nonce-1)
 		if err != nil {
 			return err


### PR DESCRIPTION
The `NonceAt` query was originally written assuming that `p.lastBlock` had already been updated: https://github.com/OffchainLabs/nitro/blob/v2.0.14/arbnode/dataposter/data_poster.go#L382

Now though, it's only updated at the end of the function, so we should use `header.Number` instead.

This PR also makes a change to not prune the most recent transaction from redis, which means that the data poster should always be able to figure out its current state from redis and not have to rely on the L1.