### PR TITLE
If the data poster fails to acquire the redis lock, retry quicker

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -476,7 +476,7 @@ func (p *DataPoster[Meta]) Start(ctxIn context.Context) {
 		p.mutex.Lock()
 		defer p.mutex.Unlock()
 		if !p.redisLock.AttemptLock(ctx) {
-			return p.replacementTimes[0]
+			return minWait
 		}
 		err := p.updateBalance(ctx)
 		if err != nil {


### PR DESCRIPTION
The current backoff of 5 minutes is excessive given how cheap attempting to acquire the redis lock is.