### PR TITLE
Fix flaky RedisForwarder test

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1097,7 +1097,6 @@ func (n *Node) Start(ctx context.Context) error {
 }
 
 func (n *Node) StopAndWait() {
-	log.Info("anodar stopping node: ", n.Stack.Config().IPCPath)
 	if n.MaintenanceRunner != nil && n.MaintenanceRunner.Started() {
 		n.MaintenanceRunner.StopAndWait()
 	}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1097,6 +1097,7 @@ func (n *Node) Start(ctx context.Context) error {
 }
 
 func (n *Node) StopAndWait() {
+	log.Info("anodar stopping node: ", n.Stack.Config().IPCPath)
 	if n.MaintenanceRunner != nil && n.MaintenanceRunner.Started() {
 		n.MaintenanceRunner.StopAndWait()
 	}

--- a/system_tests/aliasing_test.go
+++ b/system_tests/aliasing_test.go
@@ -44,10 +44,10 @@ func TestAliasing(t *testing.T) {
 	alias, err := arbsys.MyCallersAddressWithoutAliasing(nil)
 	Require(t, err)
 	if !top {
-		Fail(t, "direct call is not top level")
+		Fatal(t, "direct call is not top level")
 	}
 	if was || alias != (common.Address{}) {
-		Fail(t, "direct call has an alias", was, alias)
+		Fatal(t, "direct call has an alias", was, alias)
 	}
 
 	testL2Signed := func(top, direct, static, delegate, callcode, call bool) {

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -125,7 +125,7 @@ func testBatchPosterParallel(t *testing.T, useRedis bool) {
 		}
 
 		if !foundMultipleInBlock {
-			Fail(t, "only found one batch per block")
+			Fatal(t, "only found one batch per block")
 		}
 	}
 
@@ -133,7 +133,7 @@ func testBatchPosterParallel(t *testing.T, useRedis bool) {
 	Require(t, err)
 
 	if l2balance.Sign() == 0 {
-		Fail(t, "Unexpected zero balance")
+		Fatal(t, "Unexpected zero balance")
 	}
 }
 
@@ -164,7 +164,7 @@ func TestBatchPosterLargeTx(t *testing.T) {
 	receiptB, err := EnsureTxSucceededWithTimeout(ctx, l2clientB, tx, time.Second*30)
 	Require(t, err)
 	if receiptA.BlockHash != receiptB.BlockHash {
-		Fail(t, "receipt A block hash", receiptA.BlockHash, "does not equal receipt B block hash", receiptB.BlockHash)
+		Fatal(t, "receipt A block hash", receiptA.BlockHash, "does not equal receipt B block hash", receiptB.BlockHash)
 	}
 }
 

--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -125,7 +125,7 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, workloadLoops 
 
 		expectedBalance := new(big.Int).Mul(perTransfer, big.NewInt(int64(workloadLoops+1)))
 		if l2balance.Cmp(expectedBalance) != 0 {
-			Fail(t, "Unexpected balance:", l2balance)
+			Fatal(t, "Unexpected balance:", l2balance)
 		}
 	}
 
@@ -148,7 +148,7 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, workloadLoops 
 	t.Log("waiting for block: ", lastBlock.NumberU64())
 	timeout := getDeadlineTimeout(t, time.Minute*10)
 	if !nodeB.BlockValidator.WaitForBlock(ctx, lastBlock.NumberU64(), timeout) {
-		Fail(t, "did not validate all blocks")
+		Fatal(t, "did not validate all blocks")
 	}
 	finalRefCount := nodeB.BlockValidator.RecordDBReferenceCount()
 	lastBlockNow, err := l2clientB.BlockByNumber(ctx, nil)
@@ -156,7 +156,7 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, workloadLoops 
 	// up to 3 extra references: awaiting validation, recently valid, lastValidatedHeader
 	largestRefCount := lastBlockNow.NumberU64() - lastBlock.NumberU64() + 3
 	if finalRefCount < 0 || finalRefCount > int64(largestRefCount) {
-		Fail(t, "unexpected refcount:", finalRefCount)
+		Fatal(t, "unexpected refcount:", finalRefCount)
 	}
 }
 

--- a/system_tests/bloom_test.go
+++ b/system_tests/bloom_test.go
@@ -84,7 +84,7 @@ func TestBloom(t *testing.T) {
 	for {
 		sectionSize, sectionNum := node.Execution.Backend.APIBackend().BloomStatus()
 		if sectionSize != 256 {
-			Fail(t, "unexpected section size: ", sectionSize)
+			Fatal(t, "unexpected section size: ", sectionSize)
 		}
 		t.Log("sections: ", sectionNum, "/", uint64(countsNum)/sectionSize)
 		if sectionSize*(sectionNum+1) > uint64(countsNum) && sectionNum > 1 {
@@ -102,7 +102,7 @@ func TestBloom(t *testing.T) {
 	logs, err := client.FilterLogs(ctx, nullEventQuery)
 	Require(t, err)
 	if len(logs) != len(nullEventCounts) {
-		Fail(t, "expected ", len(nullEventCounts), " logs, got ", len(logs))
+		Fatal(t, "expected ", len(nullEventCounts), " logs, got ", len(logs))
 	}
 	incrementEventQuery := ethereum.FilterQuery{
 		Topics: [][]common.Hash{{simpleABI.Events["CounterEvent"].ID}},
@@ -110,14 +110,14 @@ func TestBloom(t *testing.T) {
 	logs, err = client.FilterLogs(ctx, incrementEventQuery)
 	Require(t, err)
 	if len(logs) != len(eventCounts) {
-		Fail(t, "expected ", len(eventCounts), " logs, got ", len(logs))
+		Fatal(t, "expected ", len(eventCounts), " logs, got ", len(logs))
 	}
 	for _, log := range logs {
 		parsedLog, err := simple.ParseCounterEvent(log)
 		Require(t, err)
 		_, expected := eventCounts[parsedLog.Count-1]
 		if !expected {
-			Fail(t, "unxpected count in logs: ", parsedLog.Count)
+			Fatal(t, "unxpected count in logs: ", parsedLog.Count)
 		}
 	}
 }

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -281,7 +281,7 @@ func createTestL1BlockChain(t *testing.T, l1info info) (info, *ethclient.Client,
 	return createTestL1BlockChainWithConfig(t, l1info, nil)
 }
 
-func getTestStackConfig(t *testing.T) *node.Config {
+func testStackConfig(t *testing.T) *node.Config {
 	stackConfig := node.DefaultConfig
 	stackConfig.HTTPPort = 0
 	stackConfig.WSPort = 0
@@ -380,7 +380,7 @@ func createTestL1BlockChainWithConfig(t *testing.T, l1info info, stackConfig *no
 		l1info = NewL1TestInfo(t)
 	}
 	if stackConfig == nil {
-		stackConfig = getTestStackConfig(t)
+		stackConfig = testStackConfig(t)
 	}
 	l1info.GenerateAccount("Faucet")
 
@@ -697,7 +697,7 @@ func Create2ndNodeWithConfig(
 	l1client := ethclient.NewClient(l1rpcClient)
 
 	if stackConfig == nil {
-		stackConfig = getTestStackConfig(t)
+		stackConfig = testStackConfig(t)
 	}
 	l2stack, err := node.New(stackConfig)
 	Require(t, err)

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -105,7 +105,7 @@ func BridgeBalance(
 		l2acct := l2info.GetInfoWithPrivKey(account)
 		if l2acct.PrivateKey.X.Cmp(l1acct.PrivateKey.X) != 0 ||
 			l2acct.PrivateKey.Y.Cmp(l1acct.PrivateKey.Y) != 0 {
-			Fail(t, "l2 account already exists and not compatible to l1")
+			Fatal(t, "l2 account already exists and not compatible to l1")
 		}
 	}
 
@@ -137,7 +137,7 @@ func BridgeBalance(
 			}
 			TransferBalance(t, "Faucet", "User", big.NewInt(1), l1info, l1client, ctx)
 			if i > 20 {
-				Fail(t, "bridging failed")
+				Fatal(t, "bridging failed")
 			}
 			<-time.After(time.Millisecond * 100)
 		}
@@ -351,7 +351,7 @@ func StaticFetcherFrom[T any](t *testing.T, config T) func() T {
 	if asValidtedIf, ok := asEmptyIf.(validated); ok {
 		err := asValidtedIf.Validate()
 		if err != nil {
-			Fail(t, err)
+			Fatal(t, err)
 		}
 	}
 	return func() T { return config }
@@ -656,7 +656,7 @@ func Require(t *testing.T, err error, text ...interface{}) {
 	testhelpers.RequireImpl(t, err, text...)
 }
 
-func Fail(t *testing.T, printables ...interface{}) {
+func Fatal(t *testing.T, printables ...interface{}) {
 	t.Helper()
 	testhelpers.FailImpl(t, printables...)
 }
@@ -692,7 +692,7 @@ func Create2ndNodeWithConfig(
 	feedErrChan := make(chan error, 10)
 	l1rpcClient, err := l1stack.Attach()
 	if err != nil {
-		Fail(t, err)
+		Fatal(t, err)
 	}
 	l1client := ethclient.NewClient(l1rpcClient)
 
@@ -713,7 +713,7 @@ func Create2ndNodeWithConfig(
 	chainConfig := first.Execution.ArbInterface.BlockChain().Config()
 	serializedChainConfig, err := json.Marshal(chainConfig)
 	if err != nil {
-		Fail(t, err)
+		Fatal(t, err)
 	}
 	l2blockchain, err := execution.WriteOrTestBlockChain(l2chainDb, nil, initReader, chainConfig, serializedChainConfig, arbnode.ConfigDefaultL2Test().TxLookupLimit, 0)
 	Require(t, err)
@@ -790,7 +790,7 @@ func setupConfigWithDAS(
 	case "onchain":
 		enableDas = false
 	default:
-		Fail(t, "unknown storage type")
+		Fatal(t, "unknown storage type")
 	}
 	dbPath = t.TempDir()
 	dasSignerKey, _, err := das.GenerateAndStoreKeys(dbPath)

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -281,7 +281,7 @@ func createTestL1BlockChain(t *testing.T, l1info info) (info, *ethclient.Client,
 	return createTestL1BlockChainWithConfig(t, l1info, nil)
 }
 
-func testStackConfig(t *testing.T) *node.Config {
+func stackConfigForTest(t *testing.T) *node.Config {
 	stackConfig := node.DefaultConfig
 	stackConfig.HTTPPort = 0
 	stackConfig.WSPort = 0
@@ -380,7 +380,7 @@ func createTestL1BlockChainWithConfig(t *testing.T, l1info info, stackConfig *no
 		l1info = NewL1TestInfo(t)
 	}
 	if stackConfig == nil {
-		stackConfig = testStackConfig(t)
+		stackConfig = stackConfigForTest(t)
 	}
 	l1info.GenerateAccount("Faucet")
 
@@ -697,7 +697,7 @@ func Create2ndNodeWithConfig(
 	l1client := ethclient.NewClient(l1rpcClient)
 
 	if stackConfig == nil {
-		stackConfig = testStackConfig(t)
+		stackConfig = stackConfigForTest(t)
 	}
 	l2stack, err := node.New(stackConfig)
 	Require(t, err)

--- a/system_tests/conditionaltx_test.go
+++ b/system_tests/conditionaltx_test.go
@@ -53,7 +53,7 @@ func testConditionalTxThatShouldSucceed(t *testing.T, ctx context.Context, idx i
 	tx := l2info.PrepareTx("Owner", "User2", l2info.TransferGas, big.NewInt(1e12), nil)
 	err := arbitrum.SendConditionalTransactionRPC(ctx, rpcClient, tx, options)
 	if err != nil {
-		Fail(t, "SendConditionalTransactionRPC failed, idx:", idx, "err:", err)
+		Fatal(t, "SendConditionalTransactionRPC failed, idx:", idx, "err:", err)
 	}
 }
 
@@ -65,18 +65,18 @@ func testConditionalTxThatShouldFail(t *testing.T, ctx context.Context, idx int,
 	err := arbitrum.SendConditionalTransactionRPC(ctx, rpcClient, tx, options)
 	if err == nil {
 		if options == nil {
-			Fail(t, "SendConditionalTransactionRPC didn't fail as expected, idx:", idx, "options:", options)
+			Fatal(t, "SendConditionalTransactionRPC didn't fail as expected, idx:", idx, "options:", options)
 		} else {
-			Fail(t, "SendConditionalTransactionRPC didn't fail as expected, idx:", idx, "options:", *options)
+			Fatal(t, "SendConditionalTransactionRPC didn't fail as expected, idx:", idx, "options:", *options)
 		}
 	} else {
 		var rErr rpc.Error
 		if errors.As(err, &rErr) {
 			if rErr.ErrorCode() != expectedErrorCode {
-				Fail(t, "unexpected error code, have:", rErr.ErrorCode(), "want:", expectedErrorCode)
+				Fatal(t, "unexpected error code, have:", rErr.ErrorCode(), "want:", expectedErrorCode)
 			}
 		} else {
-			Fail(t, "unexpected error type, err:", err)
+			Fatal(t, "unexpected error type, err:", err)
 		}
 	}
 	accountInfo.Nonce = nonce // revert nonce as the tx failed
@@ -264,14 +264,14 @@ func TestSendRawTransactionConditionalBasic(t *testing.T) {
 	previousStorageRootHash1 := currentRootHash1
 	currentRootHash1 = getStorageRootHash(t, node, contractAddress1)
 	if bytes.Equal(previousStorageRootHash1.Bytes(), currentRootHash1.Bytes()) {
-		Fail(t, "storage root hash didn't change as expected")
+		Fatal(t, "storage root hash didn't change as expected")
 	}
 	currentSlotValueMap1 = getStorageSlotValue(t, node, contractAddress1)
 
 	previousStorageRootHash2 := currentRootHash2
 	currentRootHash2 = getStorageRootHash(t, node, contractAddress2)
 	if bytes.Equal(previousStorageRootHash2.Bytes(), currentRootHash2.Bytes()) {
-		Fail(t, "storage root hash didn't change as expected")
+		Fatal(t, "storage root hash didn't change as expected")
 	}
 	currentSlotValueMap2 = getStorageSlotValue(t, node, contractAddress2)
 
@@ -362,7 +362,7 @@ func TestSendRawTransactionConditionalMultiRoutine(t *testing.T) {
 		select {
 		case <-success:
 		case <-ctxWithTimeout.Done():
-			Fail(t, "test timeouted")
+			Fatal(t, "test timeouted")
 		}
 	}
 	cancelCtxWithTimeout()
@@ -375,7 +375,7 @@ func TestSendRawTransactionConditionalMultiRoutine(t *testing.T) {
 	for i := genesis + 1; header != nil; i++ {
 		blockReceipts := bc.GetReceiptsByHash(header.Hash())
 		if blockReceipts == nil {
-			Fail(t, "Failed to get block receipts, block number:", header.Number)
+			Fatal(t, "Failed to get block receipts, block number:", header.Number)
 		}
 		receipts = append(receipts, blockReceipts...)
 		header = bc.GetHeaderByNumber(i)
@@ -387,14 +387,14 @@ func TestSendRawTransactionConditionalMultiRoutine(t *testing.T) {
 			parsed, err := simple.ParseLogAndIncrementCalled(*receipt.Logs[0])
 			Require(t, err)
 			if parsed.Expected.Int64() != parsed.Have.Int64() {
-				Fail(t, "Got invalid log, log.Expected:", parsed.Expected, "log.Have:", parsed.Have)
+				Fatal(t, "Got invalid log, log.Expected:", parsed.Expected, "log.Have:", parsed.Have)
 			} else {
 				succeeded++
 			}
 		}
 	}
 	if succeeded != expectedSuccesses {
-		Fail(t, "Unexpected number of successful txes, want:", numTxes, "have:", succeeded)
+		Fatal(t, "Unexpected number of successful txes, want:", numTxes, "have:", succeeded)
 	}
 }
 

--- a/system_tests/contract_tx_test.go
+++ b/system_tests/contract_tx_test.go
@@ -94,12 +94,12 @@ func TestContractTxDeploy(t *testing.T) {
 		receipt, err := WaitForTx(ctx, client, txHash, time.Second*10)
 		Require(t, err)
 		if receipt.Status != types.ReceiptStatusSuccessful {
-			Fail(t, "Receipt has non-successful status", receipt.Status)
+			Fatal(t, "Receipt has non-successful status", receipt.Status)
 		}
 
 		expectedAddr := crypto.CreateAddress(from, stateNonce)
 		if receipt.ContractAddress != expectedAddr {
-			Fail(t, "expected address", from, "nonce", stateNonce, "to deploy to", expectedAddr, "but got", receipt.ContractAddress)
+			Fatal(t, "expected address", from, "nonce", stateNonce, "to deploy to", expectedAddr, "but got", receipt.ContractAddress)
 		}
 		t.Log("deployed contract", receipt.ContractAddress, "from address", from, "with nonce", stateNonce)
 		stateNonce++
@@ -107,7 +107,7 @@ func TestContractTxDeploy(t *testing.T) {
 		code, err := client.CodeAt(ctx, receipt.ContractAddress, nil)
 		Require(t, err)
 		if !bytes.Equal(code, []byte{0xFE}) {
-			Fail(t, "expected contract", receipt.ContractAddress, "code of 0xFE but got", hex.EncodeToString(code))
+			Fatal(t, "expected contract", receipt.ContractAddress, "code of 0xFE but got", hex.EncodeToString(code))
 		}
 	}
 }

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -218,7 +218,7 @@ func checkBatchPosting(t *testing.T, ctx context.Context, l1client, l2clientA *e
 		Require(t, err)
 
 		if l2balance.Cmp(expectedBalance) != 0 {
-			Fail(t, "Unexpected balance:", l2balance)
+			Fatal(t, "Unexpected balance:", l2balance)
 		}
 
 	}

--- a/system_tests/delayedinbox_test.go
+++ b/system_tests/delayedinbox_test.go
@@ -50,6 +50,6 @@ func TestDelayInboxSimple(t *testing.T) {
 	l2balance, err := l2client.BalanceAt(ctx, l2info.GetAddress("User2"), nil)
 	Require(t, err)
 	if l2balance.Cmp(big.NewInt(1e6)) != 0 {
-		Fail(t, "Unexpected balance:", l2balance)
+		Fatal(t, "Unexpected balance:", l2balance)
 	}
 }

--- a/system_tests/delayedinboxlong_test.go
+++ b/system_tests/delayedinboxlong_test.go
@@ -63,7 +63,7 @@ func TestDelayInboxLong(t *testing.T) {
 
 	t.Log("Done sending", delayedMessages, "delayedMessages")
 	if delayedMessages == 0 {
-		Fail(t, "No delayed messages sent!")
+		Fatal(t, "No delayed messages sent!")
 	}
 
 	// sending l1 messages creates l1 blocks.. make enough to get that delayed inbox message in
@@ -78,6 +78,6 @@ func TestDelayInboxLong(t *testing.T) {
 	l2balance, err := l2client.BalanceAt(ctx, l2info.GetAddress("User2"), nil)
 	Require(t, err)
 	if l2balance.Cmp(big.NewInt(fundsPerDelayed*delayedMessages)) != 0 {
-		Fail(t, "Unexpected balance:", "balance", l2balance, "expected", fundsPerDelayed*delayedMessages)
+		Fatal(t, "Unexpected balance:", "balance", l2balance, "expected", fundsPerDelayed*delayedMessages)
 	}
 }

--- a/system_tests/estimation_test.go
+++ b/system_tests/estimation_test.go
@@ -43,7 +43,7 @@ func TestDeploy(t *testing.T) {
 	Require(t, err, "failed to get counter")
 
 	if counter != 1 {
-		Fail(t, "Unexpected counter value", counter)
+		Fatal(t, "Unexpected counter value", counter)
 	}
 }
 
@@ -88,7 +88,7 @@ func TestEstimate(t *testing.T) {
 		numTriesLeft--
 	}
 	if !equilibrated {
-		Fail(t, "L2 gas price did not converge", gasPrice)
+		Fatal(t, "L2 gas price did not converge", gasPrice)
 	}
 
 	initialBalance, err := client.BalanceAt(ctx, auth.From, nil)
@@ -103,7 +103,7 @@ func TestEstimate(t *testing.T) {
 	header, err := client.HeaderByNumber(ctx, receipt.BlockNumber)
 	Require(t, err, "could not get header")
 	if header.BaseFee.Cmp(gasPrice) != 0 {
-		Fail(t, "Header has wrong basefee", header.BaseFee, gasPrice)
+		Fatal(t, "Header has wrong basefee", header.BaseFee, gasPrice)
 	}
 
 	balance, err := client.BalanceAt(ctx, auth.From, nil)
@@ -111,7 +111,7 @@ func TestEstimate(t *testing.T) {
 	expectedCost := receipt.GasUsed * gasPrice.Uint64()
 	observedCost := initialBalance.Uint64() - balance.Uint64()
 	if expectedCost != observedCost {
-		Fail(t, "Expected deployment to cost", expectedCost, "instead of", observedCost)
+		Fatal(t, "Expected deployment to cost", expectedCost, "instead of", observedCost)
 	}
 
 	tx, err = simple.Increment(&auth)
@@ -123,7 +123,7 @@ func TestEstimate(t *testing.T) {
 	Require(t, err, "failed to get counter")
 
 	if counter != 1 {
-		Fail(t, "Unexpected counter value", counter)
+		Fatal(t, "Unexpected counter value", counter)
 	}
 }
 
@@ -177,7 +177,7 @@ func TestComponentEstimate(t *testing.T) {
 	outputs, err := nodeMethod.Outputs.Unpack(returnData)
 	Require(t, err)
 	if len(outputs) != 4 {
-		Fail(t, "expected 4 outputs from gasEstimateComponents, got", len(outputs))
+		Fatal(t, "expected 4 outputs from gasEstimateComponents, got", len(outputs))
 	}
 
 	gasEstimate, _ := outputs[0].(uint64)
@@ -201,10 +201,10 @@ func TestComponentEstimate(t *testing.T) {
 	colors.PrintBlue("Est. ", gasEstimate, " - ", gasEstimateForL1, " = ", l2Estimate)
 
 	if !arbmath.BigEquals(l1BaseFeeEstimate, l1BaseFee) {
-		Fail(t, l1BaseFeeEstimate, l1BaseFee)
+		Fatal(t, l1BaseFeeEstimate, l1BaseFee)
 	}
 	if !arbmath.BigEquals(baseFee, l2BaseFee) {
-		Fail(t, baseFee, l2BaseFee.Uint64())
+		Fatal(t, baseFee, l2BaseFee.Uint64())
 	}
 
 	Require(t, client.SendTransaction(ctx, tx))
@@ -215,6 +215,6 @@ func TestComponentEstimate(t *testing.T) {
 	colors.PrintMint("True ", receipt.GasUsed, " - ", receipt.GasUsedForL1, " = ", l2Used)
 
 	if l2Estimate != l2Used {
-		Fail(t, l2Estimate, l2Used)
+		Fatal(t, l2Estimate, l2Used)
 	}
 }

--- a/system_tests/fees_test.go
+++ b/system_tests/fees_test.go
@@ -82,10 +82,10 @@ func TestSequencerFeePaid(t *testing.T) {
 		tipPaidToNet := arbmath.BigMulByUint(tipCap, receipt.GasUsedForL1)
 		gotTip := arbmath.BigEquals(networkRevenue, arbmath.BigAdd(feePaidForL2, tipPaidToNet))
 		if !gotTip && version == 9 {
-			Fail(t, "network didn't receive expected payment", networkRevenue, feePaidForL2, tipPaidToNet)
+			Fatal(t, "network didn't receive expected payment", networkRevenue, feePaidForL2, tipPaidToNet)
 		}
 		if gotTip && version != 9 {
-			Fail(t, "tips are somehow enabled")
+			Fatal(t, "tips are somehow enabled")
 		}
 
 		txSize := compressedTxSize(t, tx)
@@ -95,7 +95,7 @@ func TestSequencerFeePaid(t *testing.T) {
 		colors.PrintBlue("bytes ", l1GasBought/params.TxDataNonZeroGasEIP2028, txSize)
 
 		if l1GasBought != l1GasActual {
-			Fail(t, "the sequencer's future revenue does not match its costs", l1GasBought, l1GasActual)
+			Fatal(t, "the sequencer's future revenue does not match its costs", l1GasBought, l1GasActual)
 		}
 		return networkRevenue, tipPaidToNet
 	}
@@ -109,10 +109,10 @@ func TestSequencerFeePaid(t *testing.T) {
 	net2, tip2 := testFees(2)
 
 	if tip0.Sign() != 0 {
-		Fail(t, "nonzero tip")
+		Fatal(t, "nonzero tip")
 	}
 	if arbmath.BigEquals(arbmath.BigSub(net2, tip2), net0) {
-		Fail(t, "a tip of 2 should yield a total of 3")
+		Fatal(t, "a tip of 2 should yield a total of 3")
 	}
 }
 
@@ -211,7 +211,7 @@ func testSequencerPriceAdjustsFrom(t *testing.T, initialEstimate uint64) {
 				if numRetrogradeMoves > 1 {
 					colors.PrintRed(timesPriceAdjusted, newDiff, oldDiff, lastEstimate, surplus)
 					colors.PrintRed(estimatedL1FeePerUnit, l1Header.BaseFee, actualL1FeePerUnit)
-					Fail(t, "L1 gas price estimate should tend toward the basefee")
+					Fatal(t, "L1 gas price estimate should tend toward the basefee")
 				}
 			} else {
 				numRetrogradeMoves = 0
@@ -219,10 +219,10 @@ func testSequencerPriceAdjustsFrom(t *testing.T, initialEstimate uint64) {
 			diff := arbmath.BigAbs(arbmath.BigSub(actualL1FeePerUnit, estimatedL1FeePerUnit))
 			maxDiffToAllow := arbmath.BigDivByUint(actualL1FeePerUnit, 100)
 			if arbmath.BigLessThan(maxDiffToAllow, diff) { // verify that estimates is within 1% of actual
-				Fail(t, "New L1 estimate differs too much from receipt")
+				Fatal(t, "New L1 estimate differs too much from receipt")
 			}
 			if arbmath.BigEquals(actualL1FeePerUnit, common.Big0) {
-				Fail(t, "Estimate is zero", i)
+				Fatal(t, "Estimate is zero", i)
 			}
 			lastEstimate = actualL1FeePerUnit
 			timesPriceAdjusted++
@@ -240,7 +240,7 @@ func testSequencerPriceAdjustsFrom(t *testing.T, initialEstimate uint64) {
 					break
 				}
 				if j == 1 {
-					Fail(t, "batch count didn't update in time")
+					Fatal(t, "batch count didn't update in time")
 				}
 				time.Sleep(time.Millisecond * 100)
 			}
@@ -252,10 +252,10 @@ func testSequencerPriceAdjustsFrom(t *testing.T, initialEstimate uint64) {
 	colors.PrintMint("price changes     ", timesPriceAdjusted)
 
 	if timesPriceAdjusted == 0 {
-		Fail(t, "L1 gas price estimate never adjusted")
+		Fatal(t, "L1 gas price estimate never adjusted")
 	}
 	if !arbmath.BigGreaterThan(rewardRecipientBalanceAfter, rewardRecipientBalanceBefore) {
-		Fail(t, "reward recipient didn't get paid")
+		Fatal(t, "reward recipient didn't get paid")
 	}
 
 	arbAggregator, err := precompilesgen.NewArbAggregator(common.HexToAddress("0x6d"), l2client)
@@ -269,12 +269,12 @@ func testSequencerPriceAdjustsFrom(t *testing.T, initialEstimate uint64) {
 			bal, err := l1client.BalanceAt(ctx, bpAddr, nil)
 			Require(t, err)
 			if bal.Sign() == 0 {
-				Fail(t, "Batch poster balance is zero for", bpAddr)
+				Fatal(t, "Batch poster balance is zero for", bpAddr)
 			}
 		}
 	}
 	if numReimbursed != 1 {
-		Fail(t, "Wrong number of batch posters were reimbursed", numReimbursed)
+		Fatal(t, "Wrong number of batch posters were reimbursed", numReimbursed)
 	}
 }
 

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -57,13 +57,13 @@ func TestStaticForwarder(t *testing.T) {
 	l2info.GenerateAccount("User2")
 	tx := l2info.PrepareTx("Owner", "User2", l2info.TransferGas, transferAmount, nil)
 	err := clientB.SendTransaction(ctx, tx)
-	testhelpers.RequireImpl(t, err)
+	Require(t, err)
 
 	_, err = EnsureTxSucceeded(ctx, clientA, tx)
-	testhelpers.RequireImpl(t, err)
+	Require(t, err)
 
 	l2balance, err := clientA.BalanceAt(ctx, l2info.GetAddress("User2"), nil)
-	testhelpers.RequireImpl(t, err)
+	Require(t, err)
 
 	if l2balance.Cmp(transferAmount) != 0 {
 		testhelpers.FailImpl(t, "Unexpected balance:", l2balance)
@@ -74,16 +74,16 @@ func initRedis(ctx context.Context, t *testing.T, nodeNames []string) (*miniredi
 	t.Helper()
 
 	redisServer, err := miniredis.Run()
-	testhelpers.RequireImpl(t, err)
+	Require(t, err)
 
 	redisUrl := fmt.Sprintf("redis://%s/0", redisServer.Addr())
 	redisClient, err := redisutil.RedisClientFromURL(redisUrl)
-	testhelpers.RequireImpl(t, err)
+	Require(t, err)
 	defer redisClient.Close()
 
 	priorities := strings.Join(nodeNames, ",")
 
-	testhelpers.RequireImpl(t, redisClient.Set(ctx, redisutil.PRIORITIES_KEY, priorities, time.Duration(0)).Err())
+	Require(t, redisClient.Set(ctx, redisutil.PRIORITIES_KEY, priorities, time.Duration(0)).Err())
 	return redisServer, redisUrl
 }
 
@@ -262,9 +262,9 @@ func TestRedisForwarder(t *testing.T) {
 		l2info.GenerateAccount(userA)
 		tx := l2info.PrepareTx("Owner", userA, l2info.TransferGas, big.NewInt(1e12+int64(l2info.TransferGas)*l2info.GasPrice.Int64()), nil)
 		err := fallbackClient.SendTransaction(ctx, tx)
-		testhelpers.RequireImpl(t, err)
+		Require(t, err)
 		_, err = EnsureTxSucceeded(ctx, fallbackClient, tx)
-		testhelpers.RequireImpl(t, err)
+		Require(t, err)
 	}
 
 	for i := range seqClients {
@@ -281,10 +281,10 @@ func TestRedisForwarder(t *testing.T) {
 			t.Fatalf("Client: %v, error sending transaction: %v", i, err)
 		}
 		_, err := EnsureTxSucceeded(ctx, seqClients[i], tx)
-		testhelpers.RequireImpl(t, err)
+		Require(t, err)
 
 		l2balance, err := seqClients[i].BalanceAt(ctx, l2info.GetAddress(userB), nil)
-		testhelpers.RequireImpl(t, err)
+		Require(t, err)
 
 		if l2balance.Cmp(transferAmount) != 0 {
 			testhelpers.FailImpl(t, "Unexpected balance:", l2balance)
@@ -321,13 +321,13 @@ func TestRedisForwarderFallbackNoRedis(t *testing.T) {
 	tx := l2info.PrepareTx("Owner", "User2", l2info.TransferGas, transferAmount, nil)
 	sendFunc := func() error { return forwardingClient.SendTransaction(ctx, tx) }
 	err := tryWithTimeout(ctx, sendFunc, execution.DefaultTestForwarderConfig.UpdateInterval*10)
-	testhelpers.RequireImpl(t, err)
+	Require(t, err)
 
 	_, err = EnsureTxSucceeded(ctx, fallbackClient, tx)
-	testhelpers.RequireImpl(t, err)
+	Require(t, err)
 
 	l2balance, err := fallbackClient.BalanceAt(ctx, l2info.GetAddress(user), nil)
-	testhelpers.RequireImpl(t, err)
+	Require(t, err)
 
 	if l2balance.Cmp(transferAmount) != 0 {
 		t.Errorf("Got balance: %v, want: %v", l2balance, transferAmount)

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,14 +16,18 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbnode/execution"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/statetransfer"
 	"github.com/offchainlabs/nitro/util/redisutil"
-	"github.com/offchainlabs/nitro/util/testhelpers"
 )
+
+var transferAmount = big.NewInt(1e12) // amount of ether to use for transactions in tests
+
+const nodesCount = 5 // number of testnodes to create in tests
 
 func TestStaticForwarder(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -30,7 +35,7 @@ func TestStaticForwarder(t *testing.T) {
 	ipcPath := filepath.Join(t.TempDir(), "test.ipc")
 	ipcConfig := genericconf.IPCConfigDefault
 	ipcConfig.Path = ipcPath
-	stackConfig := getTestStackConfig(t)
+	stackConfig := testStackConfig(t)
 	ipcConfig.Apply(stackConfig)
 	nodeConfigA := arbnode.ConfigDefaultL1Test()
 	nodeConfigA.BatchPoster.Enable = false
@@ -50,54 +55,62 @@ func TestStaticForwarder(t *testing.T) {
 	defer nodeB.StopAndWait()
 
 	l2info.GenerateAccount("User2")
-	tx := l2info.PrepareTx("Owner", "User2", l2info.TransferGas, big.NewInt(1e12), nil)
-	err := clientB.SendTransaction(ctx, tx)
-	testhelpers.RequireImpl(t, err)
-
-	_, err = EnsureTxSucceeded(ctx, clientA, tx)
-	testhelpers.RequireImpl(t, err)
+	tx := l2info.PrepareTx("Owner", "User2", l2info.TransferGas, transferAmount, nil)
+	if err := clientB.SendTransaction(ctx, tx); err != nil {
+		t.Fatalf("Error sending transaction: %v", err)
+	}
+	if _, err := EnsureTxSucceeded(ctx, clientA, tx); err != nil {
+		t.Fatalf("Error ensuring transaction succeeded: %v", err)
+	}
 	l2balance, err := clientA.BalanceAt(ctx, l2info.GetAddress("User2"), nil)
-	testhelpers.RequireImpl(t, err)
-	if l2balance.Cmp(big.NewInt(1e12)) != 0 {
-		testhelpers.FailImpl(t, "Unexpected balance:", l2balance)
+	if err != nil {
+		t.Fatalf("Error checking a balance: %v", err)
+	}
+	if l2balance.Cmp(transferAmount) != 0 {
+		t.Errorf("Got balance: %v, want: %v", l2balance, transferAmount)
 	}
 }
 
-func initMiniRedisForTest(t *testing.T, ctx context.Context, nodeNames []string) (*miniredis.Miniredis, string) {
-	var priorities string
+func initRedis(ctx context.Context, t *testing.T, nodeNames []string) (*miniredis.Miniredis, string) {
+	t.Helper()
+
 	redisServer, err := miniredis.Run()
-	testhelpers.RequireImpl(t, err)
+	if err != nil {
+		t.Fatalf("Error running miniredis: %v", err)
+	}
 
 	redisUrl := fmt.Sprintf("redis://%s/0", redisServer.Addr())
 	redisClient, err := redisutil.RedisClientFromURL(redisUrl)
-	testhelpers.RequireImpl(t, err)
+	if err != nil {
+		t.Fatalf("Error getting redis client from url: %v", err)
+	}
 	defer redisClient.Close()
 
-	for _, name := range nodeNames {
-		priorities = priorities + name + ","
+	priorities := strings.Join(nodeNames, ",")
+
+	if err := redisClient.Set(ctx, redisutil.PRIORITIES_KEY, priorities, time.Duration(0)).Err(); err != nil {
+		t.Fatalf("Error setting priorities in redis: %v", err)
 	}
-	priorities = priorities[:len(priorities)-1] // remove last ","
-	testhelpers.RequireImpl(t, redisClient.Set(ctx, redisutil.PRIORITIES_KEY, priorities, time.Duration(0)).Err())
 	return redisServer, redisUrl
 }
 
 func createFallbackSequencer(
-	t *testing.T, ctx context.Context, ipcPath string, redisUrl string,
+	ctx context.Context, t *testing.T, ipcPath string, redisUrl string,
 ) (l2info info, currentNode *arbnode.Node, l2client *ethclient.Client,
 	l1info info, l1backend *eth.Ethereum, l1client *ethclient.Client, l1stack *node.Node) {
-	stackConfig := getTestStackConfig(t)
+	stackConfig := testStackConfig(t)
 	ipcConfig := genericconf.IPCConfigDefault
 	ipcConfig.Path = ipcPath
 	ipcConfig.Apply(stackConfig)
 	nodeConfig := arbnode.ConfigDefaultL1Test()
-	nodeConfig.SeqCoordinator.Enable = false
+	nodeConfig.SeqCoordinator.Enable = true
 	nodeConfig.SeqCoordinator.RedisUrl = redisUrl
 	nodeConfig.SeqCoordinator.MyUrlImpl = ipcPath
 	return createTestNodeOnL1WithConfig(t, ctx, true, nodeConfig, nil, stackConfig)
 }
 
 func createForwardingNode(
-	t *testing.T, ctx context.Context,
+	ctx context.Context, t *testing.T,
 	first *arbnode.Node,
 	l1stack *node.Node,
 	l1info *BlockchainTestInfo,
@@ -106,7 +119,7 @@ func createForwardingNode(
 	redisUrl string,
 	fallbackPath string,
 ) (*ethclient.Client, *arbnode.Node) {
-	stackConfig := getTestStackConfig(t)
+	stackConfig := testStackConfig(t)
 	if ipcPath != "" {
 		ipcConfig := genericconf.IPCConfigDefault
 		ipcConfig.Path = ipcPath
@@ -123,7 +136,7 @@ func createForwardingNode(
 }
 
 func createSequencer(
-	t *testing.T, ctx context.Context,
+	ctx context.Context, t *testing.T,
 	first *arbnode.Node,
 	l1stack *node.Node,
 	l1info *BlockchainTestInfo,
@@ -131,7 +144,7 @@ func createSequencer(
 	ipcPath string,
 	redisUrl string,
 ) (*ethclient.Client, *arbnode.Node) {
-	stackConfig := getTestStackConfig(t)
+	stackConfig := testStackConfig(t)
 	ipcConfig := genericconf.IPCConfigDefault
 	ipcConfig.Path = ipcPath
 	ipcConfig.Apply(stackConfig)
@@ -144,126 +157,179 @@ func createSequencer(
 	return Create2ndNodeWithConfig(t, ctx, first, l1stack, l1info, l2InitData, nodeConfig, stackConfig)
 }
 
-func TestRedisForwarder(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+// tmpPath returns file path with specified filename from temporary directory of the test.
+func tmpPath(t *testing.T, filename string) string {
+	return filepath.Join(t.TempDir(), filename)
+}
 
-	fallbackIpcPath := filepath.Join(t.TempDir(), "fallback.ipc")
-	nodePaths := []string{}
-	for i := 0; i < 5; i++ {
-		nodePaths = append(nodePaths, filepath.Join(t.TempDir(), fmt.Sprintf("%d.ipc", i)))
+// testNodes creates specified number of paths for ipc from temporary directory of the test.
+// e.g. /tmp/TestRedisForwarder689063006/003/0.ipc, /tmp/TestRedisForwarder689063006/003/1.ipc and so on.
+func testNodes(t *testing.T, n int) []string {
+	var paths []string
+	for i := 0; i < n; i++ {
+		paths = append(paths, tmpPath(t, fmt.Sprintf("%d.ipc", i)))
 	}
-	redisServer, redisUrl := initMiniRedisForTest(t, ctx, nodePaths)
+	return paths
+}
+
+// waitForSequencerLockout blocks and waits until there is some sequencer chosen for specified duration.
+// Errors out after timeout.
+func waitForSequencerLockout(ctx context.Context, node *arbnode.Node, duration time.Duration) error {
+	if node == nil {
+		return fmt.Errorf("node is nil")
+	}
+	if node.SeqCoordinator == nil {
+		return fmt.Errorf("sequence coordinator in the node is nil")
+	}
+	// TODO: implement exponential backoff retry mechanism and use it instead.
+	for {
+		select {
+		case <-time.After(duration):
+			return fmt.Errorf("no sequencer was chosen")
+		default:
+			if c, err := node.SeqCoordinator.CurrentChosenSequencer(ctx); err == nil && c != "" {
+				log.Error("anodar currently chosen sequencer:", c)
+				return nil
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+// stopNodes blocks and waits until all nodes are stopped.
+func stopNodes(nodes []*arbnode.Node) {
+	var wg sync.WaitGroup
+	for _, node := range nodes {
+		if node != nil {
+			wg.Add(1)
+			n := node
+			go func() {
+				n.StopAndWait()
+				wg.Done()
+			}()
+		}
+	}
+	wg.Wait()
+}
+
+func user(suffix string, idx int) string {
+	return fmt.Sprintf("User%s_%d", suffix, idx)
+}
+
+// tryWithTimeout calls function f() repeatedly foruntil it succeeds.
+// Returns an error if
+func tryWithTimeout(ctx context.Context, f func() error, duration time.Duration) error {
+	for {
+		select {
+		case <-time.After(duration):
+			return fmt.Errorf("timeout expired")
+		default:
+			if err := f(); err == nil {
+				return nil
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+func TestRedisForwarder(t *testing.T) {
+	ctx := context.Background()
+
+	nodePaths := testNodes(t, nodesCount)
+	fbNodePath := tmpPath(t, "fallback.ipc") // fallback node path
+	redisServer, redisUrl := initRedis(ctx, t, append(nodePaths, fbNodePath))
 	defer redisServer.Close()
 
-	l2info, fallbackNode, fallbackClient, l1info, _, _, l1stack := createFallbackSequencer(t, ctx, fallbackIpcPath, redisUrl)
+	l2info, fallbackNode, fallbackClient, l1info, _, _, l1stack := createFallbackSequencer(ctx, t, fbNodePath, redisUrl)
 	defer requireClose(t, l1stack)
 	defer fallbackNode.StopAndWait()
 
-	forwardingClient, forwardingNode := createForwardingNode(t, ctx, fallbackNode, l1stack, l1info, &l2info.ArbInitData, "", redisUrl, fallbackIpcPath)
+	forwardingClient, forwardingNode := createForwardingNode(ctx, t, fallbackNode, l1stack, l1info, &l2info.ArbInitData, "", redisUrl, fbNodePath)
 	defer forwardingNode.StopAndWait()
 
-	var sequencers []*arbnode.Node
+	var seqNodes []*arbnode.Node
 	var seqClients []*ethclient.Client
 	for _, path := range nodePaths {
-		client, node := createSequencer(t, ctx, fallbackNode, l1stack, l1info, &l2info.ArbInitData, path, redisUrl)
-		sequencers = append(sequencers, node)
+		client, node := createSequencer(ctx, t, fallbackNode, l1stack, l1info, &l2info.ArbInitData, path, redisUrl)
+		seqNodes = append(seqNodes, node)
 		seqClients = append(seqClients, client)
 	}
-	clients := seqClients
-	clients = append(clients, fallbackClient)
-	nodes := sequencers
-	nodes = append(nodes, fallbackNode)
-	defer func() {
-		var wg sync.WaitGroup
-		for _, node := range nodes {
-			if node != nil && node != fallbackNode {
-				wg.Add(1)
-				n := node
-				go func() {
-					n.StopAndWait()
-					wg.Done()
-				}()
-			}
-		}
-		wg.Wait()
-	}()
+	defer stopNodes(seqNodes)
 
-	for i := range clients {
-		userA := fmt.Sprintf("UserA%d", i)
+	for i := range seqClients {
+		userA := user("A", i)
 		l2info.GenerateAccount(userA)
 		tx := l2info.PrepareTx("Owner", userA, l2info.TransferGas, big.NewInt(1e12+int64(l2info.TransferGas)*l2info.GasPrice.Int64()), nil)
-		err := fallbackClient.SendTransaction(ctx, tx)
-		testhelpers.RequireImpl(t, err)
-		_, err = EnsureTxSucceeded(ctx, fallbackClient, tx)
-		testhelpers.RequireImpl(t, err)
+		if err := fallbackClient.SendTransaction(ctx, tx); err != nil {
+			t.Errorf("Client: %v error sending transaction: %v", i, err)
+		}
+		if _, err := EnsureTxSucceeded(ctx, fallbackClient, tx); err != nil {
+			t.Errorf("Client: %v, error ensuring transaction succeeded: %v", i, err)
+		}
 	}
 
-	for i := range clients {
-		userA := fmt.Sprintf("UserA%d", i)
-		userB := fmt.Sprintf("UserB%d", i)
+	for i := range seqClients {
+		if err := waitForSequencerLockout(ctx, fallbackNode, 2*time.Second); err != nil {
+			t.Fatalf("Error waiting for lockout: %v", err)
+		}
+		userA := user("A", i)
+		userB := user("B", i)
 		l2info.GenerateAccount(userB)
-		tx := l2info.PrepareTx(userA, userB, l2info.TransferGas, big.NewInt(1e12), nil)
-		var err error
-		for j := 0; j < 20; j++ {
-			err = forwardingClient.SendTransaction(ctx, tx)
-			if err == nil {
-				break
-			}
-			time.Sleep(execution.DefaultTestForwarderConfig.UpdateInterval / 2)
+		tx := l2info.PrepareTx(userA, userB, l2info.TransferGas, transferAmount, nil)
+
+		sendFunc := func() error { return forwardingClient.SendTransaction(ctx, tx) }
+		if err := tryWithTimeout(ctx, sendFunc, execution.DefaultTestForwarderConfig.UpdateInterval*10); err != nil {
+			t.Fatalf("Client: %v, error sending transaction: %v", i, err)
 		}
-		testhelpers.RequireImpl(t, err)
-		_, err = EnsureTxSucceeded(ctx, clients[i], tx)
-		testhelpers.RequireImpl(t, err)
-		l2balance, err := clients[i].BalanceAt(ctx, l2info.GetAddress(userB), nil)
-		testhelpers.RequireImpl(t, err)
-		if l2balance.Cmp(big.NewInt(1e12)) != 0 {
-			testhelpers.FailImpl(t, "Unexpected balance:", l2balance)
+		if _, err := EnsureTxSucceeded(ctx, seqClients[i], tx); err != nil {
+			t.Fatalf("Couldn't send transaction through forwarding client: %d, error: %v", i, err)
 		}
-		if i < len(nodes)-1 {
-			time.Sleep(100 * time.Millisecond)
-			nodes[i].StopAndWait()
-			nodes[i] = nil
+
+		l2balance, err := seqClients[i].BalanceAt(ctx, l2info.GetAddress(userB), nil)
+		if err != nil {
+			t.Fatalf("Error checking balance of a client: %v, error: %v", i, err)
+		}
+		if l2balance.Cmp(transferAmount) != 0 {
+			t.Errorf("Got balance: %v, want: %v", l2balance, transferAmount)
+		}
+		if i < len(seqNodes) {
+			seqNodes[i].StopAndWait()
+			seqNodes[i] = nil
 		}
 	}
 }
 
 func TestRedisForwarderFallbackNoRedis(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := context.Background()
 
-	fallbackIpcPath := filepath.Join(t.TempDir(), "fallback.ipc")
-	nodePaths := []string{}
-	for i := 0; i < 10; i++ {
-		nodePaths = append(nodePaths, filepath.Join(t.TempDir(), fmt.Sprintf("%d.ipc", i)))
-	}
-	redisServer, redisUrl := initMiniRedisForTest(t, ctx, nodePaths)
+	fallbackIpcPath := tmpPath(t, "fallback.ipc")
+	nodePaths := testNodes(t, nodesCount)
+	redisServer, redisUrl := initRedis(ctx, t, nodePaths)
 	redisServer.Close()
 
-	l2info, fallbackNode, fallbackClient, l1info, _, _, l1stack := createFallbackSequencer(t, ctx, fallbackIpcPath, redisUrl)
+	l2info, fallbackNode, fallbackClient, l1info, _, _, l1stack := createFallbackSequencer(ctx, t, fallbackIpcPath, redisUrl)
 	defer requireClose(t, l1stack)
 	defer fallbackNode.StopAndWait()
 
-	forwardingClient, forwardingNode := createForwardingNode(t, ctx, fallbackNode, l1stack, l1info, &l2info.ArbInitData, "", redisUrl, fallbackIpcPath)
+	forwardingClient, forwardingNode := createForwardingNode(ctx, t, fallbackNode, l1stack, l1info, &l2info.ArbInitData, "", redisUrl, fallbackIpcPath)
 	defer forwardingNode.StopAndWait()
 
-	l2info.GenerateAccount("User2")
-	var err error
-	tx := l2info.PrepareTx("Owner", "User2", l2info.TransferGas, big.NewInt(1e12), nil)
-	for j := 0; j < 20; j++ {
-		err = forwardingClient.SendTransaction(ctx, tx)
-		if err == nil {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
+	user := "User2"
+	l2info.GenerateAccount(user)
+	tx := l2info.PrepareTx("Owner", "User2", l2info.TransferGas, transferAmount, nil)
+	sendFunc := func() error { return forwardingClient.SendTransaction(ctx, tx) }
+	if err := tryWithTimeout(ctx, sendFunc, execution.DefaultTestForwarderConfig.UpdateInterval*10); err != nil {
+		t.Fatalf("Error sending transaction: %v", err)
 	}
-	testhelpers.RequireImpl(t, err)
 
-	_, err = EnsureTxSucceeded(ctx, fallbackClient, tx)
-	testhelpers.RequireImpl(t, err)
-	l2balance, err := fallbackClient.BalanceAt(ctx, l2info.GetAddress("User2"), nil)
-	testhelpers.RequireImpl(t, err)
-	if l2balance.Cmp(big.NewInt(1e12)) != 0 {
-		t.Fatal("Unexpected balance:", l2balance)
+	if _, err := EnsureTxSucceeded(ctx, fallbackClient, tx); err != nil {
+		t.Fatalf("Transaction didn't succeed: %v", err)
+	}
+	l2balance, err := fallbackClient.BalanceAt(ctx, l2info.GetAddress(user), nil)
+	if err != nil {
+		t.Fatalf("Error checking balance for %s, error: %v", user, err)
+	}
+	if l2balance.Cmp(transferAmount) != 0 {
+		t.Errorf("Got balance: %v, want: %v", l2balance, transferAmount)
 	}
 }

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/statetransfer"
 	"github.com/offchainlabs/nitro/util/redisutil"
-	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 
 var transferAmount = big.NewInt(1e12) // amount of ether to use for transactions in tests
@@ -66,7 +65,7 @@ func TestStaticForwarder(t *testing.T) {
 	Require(t, err)
 
 	if l2balance.Cmp(transferAmount) != 0 {
-		testhelpers.FailImpl(t, "Unexpected balance:", l2balance)
+		Fatal(t, "Unexpected balance:", l2balance)
 	}
 }
 
@@ -287,7 +286,7 @@ func TestRedisForwarder(t *testing.T) {
 		Require(t, err)
 
 		if l2balance.Cmp(transferAmount) != 0 {
-			testhelpers.FailImpl(t, "Unexpected balance:", l2balance)
+			Fatal(t, "Unexpected balance:", l2balance)
 		}
 		if i < len(seqNodes) {
 			seqNodes[i].StopAndWait()

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -34,7 +34,7 @@ func TestStaticForwarder(t *testing.T) {
 	ipcPath := filepath.Join(t.TempDir(), "test.ipc")
 	ipcConfig := genericconf.IPCConfigDefault
 	ipcConfig.Path = ipcPath
-	stackConfig := testStackConfig(t)
+	stackConfig := stackConfigForTest(t)
 	ipcConfig.Apply(stackConfig)
 	nodeConfigA := arbnode.ConfigDefaultL1Test()
 	nodeConfigA.BatchPoster.Enable = false
@@ -96,7 +96,7 @@ func fallbackSequencer(
 	ctx context.Context, t *testing.T, opts *fallbackSequencerOpts,
 ) (l2info info, currentNode *arbnode.Node, l2client *ethclient.Client,
 	l1info info, l1backend *eth.Ethereum, l1client *ethclient.Client, l1stack *node.Node) {
-	stackConfig := testStackConfig(t)
+	stackConfig := stackConfigForTest(t)
 	ipcConfig := genericconf.IPCConfigDefault
 	ipcConfig.Path = opts.ipcPath
 	ipcConfig.Apply(stackConfig)
@@ -117,7 +117,7 @@ func createForwardingNode(
 	redisUrl string,
 	fallbackPath string,
 ) (*ethclient.Client, *arbnode.Node) {
-	stackConfig := testStackConfig(t)
+	stackConfig := stackConfigForTest(t)
 	if ipcPath != "" {
 		ipcConfig := genericconf.IPCConfigDefault
 		ipcConfig.Path = ipcPath
@@ -142,7 +142,7 @@ func createSequencer(
 	ipcPath string,
 	redisUrl string,
 ) (*ethclient.Client, *arbnode.Node) {
-	stackConfig := testStackConfig(t)
+	stackConfig := stackConfigForTest(t)
 	ipcConfig := genericconf.IPCConfigDefault
 	ipcConfig.Path = ipcPath
 	ipcConfig.Apply(stackConfig)
@@ -161,7 +161,7 @@ func tmpPath(t *testing.T, filename string) string {
 }
 
 // testNodes creates specified number of paths for ipc from temporary directory of the test.
-// e.g. /tmp/TestRedisForwarder689063006/003/0.ipc, /tmp/TestRedisForwarder689063006/003/1.ipc and so on.
+// e.g. /tmp/TestRedisForwarder689063006/003/0.ipc, /tmp/TestRedisForwarder689063006/007/1.ipc and so on.
 func testNodes(t *testing.T, n int) []string {
 	var paths []string
 	for i := 0; i < n; i++ {

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbnode/execution"
@@ -188,7 +187,6 @@ func waitForSequencerLockout(ctx context.Context, node *arbnode.Node, duration t
 			return fmt.Errorf("no sequencer was chosen")
 		default:
 			if c, err := node.SeqCoordinator.CurrentChosenSequencer(ctx); err == nil && c != "" {
-				log.Error("anodar currently chosen sequencer:", c)
 				return nil
 			}
 			time.Sleep(100 * time.Millisecond)

--- a/system_tests/infra_fee_test.go
+++ b/system_tests/infra_fee_test.go
@@ -67,9 +67,9 @@ func TestInfraFee(t *testing.T) {
 	Require(t, err)
 
 	if !arbmath.BigEquals(netFeeBalanceBefore, netFeeBalanceAfter) {
-		Fail(t, netFeeBalanceBefore, netFeeBalanceAfter)
+		Fatal(t, netFeeBalanceBefore, netFeeBalanceAfter)
 	}
 	if !arbmath.BigEquals(infraFeeBalanceAfter, expectedBalanceAfter) {
-		Fail(t, infraFeeBalanceBefore, expectedFunds, infraFeeBalanceAfter, expectedBalanceAfter)
+		Fatal(t, infraFeeBalanceBefore, expectedFunds, infraFeeBalanceAfter, expectedBalanceAfter)
 	}
 }

--- a/system_tests/ipc_test.go
+++ b/system_tests/ipc_test.go
@@ -18,7 +18,7 @@ func TestIpcRpc(t *testing.T) {
 	ipcConfig := genericconf.IPCConfigDefault
 	ipcConfig.Path = ipcPath
 
-	stackConf := testStackConfig(t)
+	stackConf := stackConfigForTest(t)
 	ipcConfig.Apply(stackConf)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/system_tests/ipc_test.go
+++ b/system_tests/ipc_test.go
@@ -18,7 +18,7 @@ func TestIpcRpc(t *testing.T) {
 	ipcConfig := genericconf.IPCConfigDefault
 	ipcConfig.Path = ipcPath
 
-	stackConf := getTestStackConfig(t)
+	stackConf := testStackConfig(t)
 	ipcConfig.Apply(stackConf)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/system_tests/log_subscription_test.go
+++ b/system_tests/log_subscription_test.go
@@ -37,7 +37,7 @@ func TestLogSubscription(t *testing.T) {
 	Require(t, err)
 
 	if len(receipt.Logs) != 1 {
-		Fail(t, "Unexpected number of logs", len(receipt.Logs))
+		Fatal(t, "Unexpected number of logs", len(receipt.Logs))
 	}
 
 	var receiptLog types.Log = *receipt.Logs[0]
@@ -46,11 +46,11 @@ func TestLogSubscription(t *testing.T) {
 	defer timer.Stop()
 	select {
 	case <-timer.C:
-		Fail(t, "Hit timeout waiting for log from subscription")
+		Fatal(t, "Hit timeout waiting for log from subscription")
 	case subscriptionLog = <-logChan:
 	}
 	if !reflect.DeepEqual(receiptLog, subscriptionLog) {
-		Fail(t, "Receipt log", receiptLog, "is different than subscription log", subscriptionLog)
+		Fatal(t, "Receipt log", receiptLog, "is different than subscription log", subscriptionLog)
 	}
 	_, err = client.BlockByHash(ctx, subscriptionLog.BlockHash)
 	Require(t, err)

--- a/system_tests/meaningless_reorg_test.go
+++ b/system_tests/meaningless_reorg_test.go
@@ -35,14 +35,14 @@ func TestMeaninglessBatchReorg(t *testing.T) {
 
 	for i := 0; ; i++ {
 		if i >= 500 {
-			Fail(t, "Failed to read batch from L1")
+			Fatal(t, "Failed to read batch from L1")
 		}
 		msgNum, err := arbNode.Execution.ExecEngine.HeadMessageNumber()
 		Require(t, err)
 		if msgNum == 1 {
 			break
 		} else if msgNum > 1 {
-			Fail(t, "More than two batches in test?")
+			Fatal(t, "More than two batches in test?")
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -50,7 +50,7 @@ func TestMeaninglessBatchReorg(t *testing.T) {
 	Require(t, err)
 	originalBatchBlock := batchReceipt.BlockNumber.Uint64()
 	if metadata.L1Block != originalBatchBlock {
-		Fail(t, "Posted batch in block", originalBatchBlock, "but metadata says L1 block was", metadata.L1Block)
+		Fatal(t, "Posted batch in block", originalBatchBlock, "but metadata says L1 block was", metadata.L1Block)
 	}
 
 	_, l2Receipt := TransferBalance(t, "Owner", "Owner", common.Big1, l2Info, l2Client, ctx)
@@ -77,21 +77,21 @@ func TestMeaninglessBatchReorg(t *testing.T) {
 
 	newBatchBlock := newBatchReceipt.BlockNumber.Uint64()
 	if newBatchBlock == originalBatchBlock {
-		Fail(t, "Attempted to change L1 block number in batch reorg, but it ended up in the same block", newBatchBlock)
+		Fatal(t, "Attempted to change L1 block number in batch reorg, but it ended up in the same block", newBatchBlock)
 	} else {
 		t.Log("Batch successfully moved in reorg from L1 block", originalBatchBlock, "to L1 block", newBatchBlock)
 	}
 
 	for i := 0; ; i++ {
 		if i >= 500 {
-			Fail(t, "Failed to read batch reorg from L1")
+			Fatal(t, "Failed to read batch reorg from L1")
 		}
 		metadata, err = arbNode.InboxTracker.GetBatchMetadata(1)
 		Require(t, err)
 		if metadata.L1Block == newBatchBlock {
 			break
 		} else if metadata.L1Block != originalBatchBlock {
-			Fail(t, "Batch L1 block changed from", originalBatchBlock, "to", metadata.L1Block, "instead of expected", metadata.L1Block)
+			Fatal(t, "Batch L1 block changed from", originalBatchBlock, "to", metadata.L1Block, "instead of expected", metadata.L1Block)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -103,6 +103,6 @@ func TestMeaninglessBatchReorg(t *testing.T) {
 	Require(t, err)
 
 	if l2Header.Hash() != l2Receipt.BlockHash {
-		Fail(t, "L2 block hash changed")
+		Fatal(t, "L2 block hash changed")
 	}
 }

--- a/system_tests/outbox_test.go
+++ b/system_tests/outbox_test.go
@@ -90,10 +90,10 @@ func TestOutboxProofs(t *testing.T) {
 		Require(t, err, "No receipt for txn")
 
 		if receipt.Status != types.ReceiptStatusSuccessful {
-			Fail(t, "Tx failed with status code:", receipt)
+			Fatal(t, "Tx failed with status code:", receipt)
 		}
 		if len(receipt.Logs) == 0 {
-			Fail(t, "Tx didn't emit any logs")
+			Fatal(t, "Tx didn't emit any logs")
 		}
 
 		for _, log := range receipt.Logs {
@@ -230,7 +230,7 @@ func TestOutboxProofs(t *testing.T) {
 
 				if zero, ok := partials[place]; ok {
 					if zero != (common.Hash{}) {
-						Fail(t, "Somehow got 2 partials for the same level\n\t1st:", zero, "\n\t2nd:", hash)
+						Fatal(t, "Somehow got 2 partials for the same level\n\t1st:", zero, "\n\t2nd:", hash)
 					}
 					partials[place] = hash
 					partialsByLevel[level] = hash
@@ -264,7 +264,7 @@ func TestOutboxProofs(t *testing.T) {
 
 					curr, ok := known[step]
 					if !ok {
-						Fail(t, "We should know the current node's value")
+						Fatal(t, "We should know the current node's value")
 					}
 
 					left := curr
@@ -276,7 +276,7 @@ func TestOutboxProofs(t *testing.T) {
 						step.Leaf -= 1 << step.Level
 						partial, ok := known[step]
 						if !ok {
-							Fail(t, "There should be a partial here")
+							Fatal(t, "There should be a partial here")
 						}
 						left = partial
 					} else {
@@ -309,7 +309,7 @@ func TestOutboxProofs(t *testing.T) {
 			for i, place := range nodes {
 				hash, ok := known[place]
 				if !ok {
-					Fail(t, "We're missing data for the node at position", place)
+					Fatal(t, "We're missing data for the node at position", place)
 				}
 				hashes[i] = hash
 				t.Log("node", place, hash)
@@ -323,7 +323,7 @@ func TestOutboxProofs(t *testing.T) {
 			}
 
 			if !proof.IsCorrect() {
-				Fail(t, "Proof is wrong")
+				Fatal(t, "Proof is wrong")
 			}
 
 			// Check NodeInterface.sol produces equivalent proofs
@@ -336,10 +336,10 @@ func TestOutboxProofs(t *testing.T) {
 			nodeSend := outboxProof.Send
 
 			if nodeRoot != rootHash {
-				Fail(t, "NodeInterface root differs\n", nodeRoot, "\n", rootHash)
+				Fatal(t, "NodeInterface root differs\n", nodeRoot, "\n", rootHash)
 			}
 			if len(hashes) != len(nodeProof) {
-				Fail(t, "NodeInterface proof is the wrong size", len(nodeProof), len(hashes))
+				Fatal(t, "NodeInterface proof is the wrong size", len(nodeProof), len(hashes))
 			}
 			for i, correct := range hashes {
 				if nodeProof[i] != correct {
@@ -347,7 +347,7 @@ func TestOutboxProofs(t *testing.T) {
 				}
 			}
 			if nodeSend != provable.hash {
-				Fail(t, "NodeInterface send differs\n", nodeSend, "\n", provable.hash)
+				Fatal(t, "NodeInterface send differs\n", nodeSend, "\n", provable.hash)
 			}
 		}
 	}

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -29,7 +29,7 @@ func TestPurePrecompileMethodCalls(t *testing.T) {
 	chainId, err := arbSys.ArbChainID(&bind.CallOpts{})
 	Require(t, err, "failed to get the ChainID")
 	if chainId.Uint64() != params.ArbitrumDevTestChainConfig().ChainID.Uint64() {
-		Fail(t, "Wrong ChainID", chainId.Uint64())
+		Fatal(t, "Wrong ChainID", chainId.Uint64())
 	}
 }
 
@@ -45,7 +45,7 @@ func TestViewLogReverts(t *testing.T) {
 
 	err = arbDebug.EventsView(nil)
 	if err == nil {
-		Fail(t, "unexpected success")
+		Fatal(t, "unexpected success")
 	}
 }
 
@@ -61,24 +61,24 @@ func TestCustomSolidityErrors(t *testing.T) {
 	Require(t, err, "could not bind ArbDebug contract")
 	customError := arbDebug.CustomRevert(callOpts, 1024)
 	if customError == nil {
-		Fail(t, "customRevert call should have errored")
+		Fatal(t, "customRevert call should have errored")
 	}
 	observedMessage := customError.Error()
 	expectedMessage := "execution reverted: error Custom(1024, This spider family wards off bugs: /\\oo/\\ //\\(oo)/\\ /\\oo/\\, true)"
 	if observedMessage != expectedMessage {
-		Fail(t, observedMessage)
+		Fatal(t, observedMessage)
 	}
 
 	arbSys, err := precompilesgen.NewArbSys(arbos.ArbSysAddress, client)
 	Require(t, err, "could not bind ArbSys contract")
 	_, customError = arbSys.ArbBlockHash(callOpts, big.NewInt(1e9))
 	if customError == nil {
-		Fail(t, "out of range ArbBlockHash call should have errored")
+		Fatal(t, "out of range ArbBlockHash call should have errored")
 	}
 	observedMessage = customError.Error()
 	expectedMessage = "execution reverted: error InvalidBlockNumber(1000000000, 1)"
 	if observedMessage != expectedMessage {
-		Fail(t, observedMessage)
+		Fatal(t, observedMessage)
 	}
 }
 
@@ -98,7 +98,7 @@ func TestPrecompileErrorGasLeft(t *testing.T) {
 		Require(t, err, "Failed to call CheckGasUsed to precompile", to)
 		maxGas := big.NewInt(100_000)
 		if arbmath.BigGreaterThan(gas, maxGas) {
-			Fail(t, "Precompile", to, "used", gas, "gas reverting, greater than max expected", maxGas)
+			Fatal(t, "Precompile", to, "used", gas, "gas reverting, greater than max expected", maxGas)
 		}
 	}
 

--- a/system_tests/reorg_resequencing_test.go
+++ b/system_tests/reorg_resequencing_test.go
@@ -42,7 +42,7 @@ func TestReorgResequencing(t *testing.T) {
 			balance, err := client.BalanceAt(ctx, l2info.GetAddress(account), nil)
 			Require(t, err)
 			if balance.Int64() != params.Ether {
-				Fail(t, "expected account", account, "to have a balance of 1 ether but instead it has", balance, "wei "+scenario)
+				Fatal(t, "expected account", account, "to have a balance of 1 ether but instead it has", balance, "wei "+scenario)
 			}
 		}
 	}

--- a/system_tests/seq_coordinator_test.go
+++ b/system_tests/seq_coordinator_test.go
@@ -125,7 +125,7 @@ func TestRedisSeqCoordinatorPriorities(t *testing.T) {
 					break
 				}
 				if attempts > 10 {
-					Fail(t, "timeout waiting for msg ", msgNum, " debug: ", currentNode.SeqCoordinator.DebugPrint())
+					Fatal(t, "timeout waiting for msg ", msgNum, " debug: ", currentNode.SeqCoordinator.DebugPrint())
 				}
 				<-time.After(nodeConfig.SeqCoordinator.UpdateInterval / 3)
 			}
@@ -198,7 +198,7 @@ func TestRedisSeqCoordinatorPriorities(t *testing.T) {
 		// sequencing suceeds only on the leder
 		for i := arbutil.MessageIndex(0); i < messagesPerRound; i++ {
 			if sequencer := trySequencingEverywhere(); sequencer != currentSequencer {
-				Fail(t, "unexpected sequencer. expected: ", currentSequencer, " got ", sequencer)
+				Fatal(t, "unexpected sequencer. expected: ", currentSequencer, " got ", sequencer)
 			}
 			sequencedMesssages++
 		}
@@ -223,7 +223,7 @@ func TestRedisSeqCoordinatorPriorities(t *testing.T) {
 		for attempts := 0; ; attempts++ {
 			sequencer := trySequencingEverywhere()
 			if sequencer == -1 && attempts > 15 {
-				Fail(t, "failed to sequence")
+				Fatal(t, "failed to sequence")
 			}
 			if sequencer != -1 {
 				sequencedMesssages++
@@ -236,7 +236,7 @@ func TestRedisSeqCoordinatorPriorities(t *testing.T) {
 			if sequencer == currentSequencer {
 				break
 			}
-			Fail(t, "unexpected sequencer", "expected", currentSequencer, "got", sequencer, "messages", sequencedMesssages)
+			Fatal(t, "unexpected sequencer", "expected", currentSequencer, "got", sequencer, "messages", sequencedMesssages)
 		}
 
 		// all nodes get messages
@@ -246,7 +246,7 @@ func TestRedisSeqCoordinatorPriorities(t *testing.T) {
 		for i := arbutil.MessageIndex(0); i < messagesPerRound; i++ {
 			sequencer := trySequencingEverywhere()
 			if sequencer != currentSequencer {
-				Fail(t, "unexpected sequencer", "expected", currentSequencer, "got", sequencer, "messages", sequencedMesssages)
+				Fatal(t, "unexpected sequencer", "expected", currentSequencer, "got", sequencer, "messages", sequencedMesssages)
 			}
 			sequencedMesssages++
 		}
@@ -329,7 +329,7 @@ func testCoordinatorMessageSync(t *testing.T, successCase bool) {
 	} else {
 		_, err = WaitForTx(ctx, clientB, tx.Hash(), time.Second)
 		if err == nil {
-			Fail(t, "tx received by node with different seq coordinator signing key")
+			Fatal(t, "tx received by node with different seq coordinator signing key")
 		}
 	}
 }

--- a/system_tests/seq_nonce_test.go
+++ b/system_tests/seq_nonce_test.go
@@ -53,7 +53,7 @@ func TestSequencerParallelNonces(t *testing.T) {
 	balance, err := client.BalanceAt(ctx, addr, nil)
 	Require(t, err)
 	if !arbmath.BigEquals(balance, big.NewInt(100)) {
-		Fail(t, "Unexpected user balance", balance)
+		Fatal(t, "Unexpected user balance", balance)
 	}
 }
 
@@ -72,14 +72,14 @@ func TestSequencerNonceTooHigh(t *testing.T) {
 	tx := l2info.PrepareTx("Owner", "Owner", l2info.TransferGas, common.Big0, nil)
 	err := client.SendTransaction(ctx, tx)
 	if err == nil {
-		Fail(t, "No error when nonce was too high")
+		Fatal(t, "No error when nonce was too high")
 	}
 	if !strings.Contains(err.Error(), core.ErrNonceTooHigh.Error()) {
-		Fail(t, "Unexpected transaction error", err)
+		Fatal(t, "Unexpected transaction error", err)
 	}
 	elapsed := time.Since(before)
 	if elapsed > 2*config.Sequencer.NonceFailureCacheExpiry {
-		Fail(t, "Sequencer took too long to respond with nonce too high")
+		Fatal(t, "Sequencer took too long to respond with nonce too high")
 	}
 }
 
@@ -102,7 +102,7 @@ func TestSequencerNonceTooHighQueueFull(t *testing.T) {
 		go func() {
 			err := client.SendTransaction(ctx, tx)
 			if err == nil {
-				Fail(t, "No error when nonce was too high")
+				Fatal(t, "No error when nonce was too high")
 			}
 			atomic.AddUint64(&completed, 1)
 		}()
@@ -115,7 +115,7 @@ func TestSequencerNonceTooHighQueueFull(t *testing.T) {
 			break
 		}
 		if wait == 0 || got > expected {
-			Fail(t, "Wrong number of transaction responses; got", got, "but expected", expected)
+			Fatal(t, "Wrong number of transaction responses; got", got, "but expected", expected)
 		}
 		time.Sleep(time.Millisecond * 100)
 	}

--- a/system_tests/seq_reject_test.go
+++ b/system_tests/seq_reject_test.go
@@ -108,11 +108,11 @@ func TestSequencerRejection(t *testing.T) {
 			break
 		}
 		if i == 0 {
-			Fail(t, "failed to reach block 200, only reached block", block)
+			Fatal(t, "failed to reach block 200, only reached block", block)
 		}
 		select {
 		case err := <-feedErrChan:
-			Fail(t, "error: ", err)
+			Fatal(t, "error: ", err)
 		case <-time.After(time.Millisecond * 100):
 		}
 	}
@@ -128,12 +128,12 @@ func TestSequencerRejection(t *testing.T) {
 		if err != nil {
 			select {
 			case err := <-feedErrChan:
-				Fail(t, "error: ", err)
+				Fatal(t, "error: ", err)
 			case <-time.After(time.Millisecond * 100):
 			}
 			if i == 0 {
 				client2Block, _ := client2.BlockNumber(ctx)
-				Fail(t, "client2 failed to reach client1 block ", header1.Number, ", only reached block", client2Block)
+				Fatal(t, "client2 failed to reach client1 block ", header1.Number, ", only reached block", client2Block)
 			}
 			continue
 		}
@@ -143,7 +143,7 @@ func TestSequencerRejection(t *testing.T) {
 		} else {
 			colors.PrintBlue("header 1:", header1)
 			colors.PrintBlue("header 2:", header2)
-			Fail(t, "header 1 and header 2 have different hashes")
+			Fatal(t, "header 1 and header 2 have different hashes")
 		}
 	}
 }

--- a/system_tests/seq_whitelist_test.go
+++ b/system_tests/seq_whitelist_test.go
@@ -35,6 +35,6 @@ func TestSequencerWhitelist(t *testing.T) {
 	tx := l2info.PrepareTx("User2", "User", l2info.TransferGas, big.NewInt(params.Ether/10), nil)
 	err := client.SendTransaction(ctx, tx)
 	if err == nil {
-		Fail(t, "transaction from user not on whitelist accepted")
+		Fatal(t, "transaction from user not on whitelist accepted")
 	}
 }

--- a/system_tests/seqcompensation_test.go
+++ b/system_tests/seqcompensation_test.go
@@ -50,12 +50,12 @@ func TestSequencerCompensation(t *testing.T) {
 	l2balance, err := l2clientB.BalanceAt(ctx, l2info.GetAddress("User2"), nil)
 	Require(t, err)
 	if l2balance.Cmp(big.NewInt(1e12)) != 0 {
-		Fail(t, "Unexpected balance:", l2balance)
+		Fatal(t, "Unexpected balance:", l2balance)
 	}
 
 	initialSeqBalance, err := l2clientB.BalanceAt(ctx, l1pricing.BatchPosterAddress, big.NewInt(0))
 	Require(t, err)
 	if initialSeqBalance.Sign() != 0 {
-		Fail(t, "Unexpected initial sequencer balance:", initialSeqBalance)
+		Fatal(t, "Unexpected initial sequencer balance:", initialSeqBalance)
 	}
 }

--- a/system_tests/seqinbox_test.go
+++ b/system_tests/seqinbox_test.go
@@ -123,7 +123,7 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 			currentHeader, err := l1Client.HeaderByNumber(ctx, nil)
 			Require(t, err)
 			if currentHeader.Number.Int64()-int64(reorgTargetNumber) < 65 {
-				Fail(t, "Less than 65 blocks of difference between current block", currentHeader.Number, "and target", reorgTargetNumber)
+				Fatal(t, "Less than 65 blocks of difference between current block", currentHeader.Number, "and target", reorgTargetNumber)
 			}
 			t.Logf("Reorganizing to L1 block %v", reorgTargetNumber)
 			reorgTarget := l1BlockChain.GetBlockByNumber(reorgTargetNumber)
@@ -244,12 +244,12 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 		for i := 0; ; i++ {
 			batchCount, err := seqInbox.BatchCount(&bind.CallOpts{})
 			if err != nil {
-				Fail(t, err)
+				Fatal(t, err)
 			}
 			if batchCount.Cmp(big.NewInt(int64(len(blockStates)))) == 0 {
 				break
 			} else if i >= 100 {
-				Fail(t, "timed out waiting for l1 batch count update; have", batchCount, "want", len(blockStates)-1)
+				Fatal(t, "timed out waiting for l1 batch count update; have", batchCount, "want", len(blockStates)-1)
 			}
 			time.Sleep(10 * time.Millisecond)
 		}
@@ -260,7 +260,7 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 			if blockNumber == expectedBlockNumber {
 				break
 			} else if i >= 1000 {
-				Fail(t, "timed out waiting for l2 block update; have", blockNumber, "want", expectedBlockNumber)
+				Fatal(t, "timed out waiting for l2 block update; have", blockNumber, "want", expectedBlockNumber)
 			}
 			time.Sleep(10 * time.Millisecond)
 		}
@@ -271,7 +271,7 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 				if lastValidated == expectedBlockNumber {
 					break
 				} else if i >= 1000 {
-					Fail(t, "timed out waiting for block validator; have", lastValidated, "want", expectedBlockNumber)
+					Fatal(t, "timed out waiting for block validator; have", lastValidated, "want", expectedBlockNumber)
 				}
 				time.Sleep(time.Second)
 			}
@@ -281,14 +281,14 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 			block, err := l2Backend.APIBackend().BlockByNumber(ctx, rpc.BlockNumber(state.l2BlockNumber))
 			Require(t, err)
 			if block == nil {
-				Fail(t, "missing state block", state.l2BlockNumber)
+				Fatal(t, "missing state block", state.l2BlockNumber)
 			}
 			stateDb, _, err := l2Backend.APIBackend().StateAndHeaderByNumber(ctx, rpc.BlockNumber(state.l2BlockNumber))
 			Require(t, err)
 			for acct, expectedBalance := range state.balances {
 				haveBalance := stateDb.GetBalance(acct)
 				if expectedBalance.Cmp(haveBalance) < 0 {
-					Fail(t, "unexpected balance for account", acct, "; expected", expectedBalance, "got", haveBalance)
+					Fatal(t, "unexpected balance for account", acct, "; expected", expectedBalance, "got", haveBalance)
 				}
 			}
 		}

--- a/system_tests/staker_test.go
+++ b/system_tests/staker_test.go
@@ -89,11 +89,11 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 	nodeBGenesis := l2nodeB.Execution.Backend.APIBackend().CurrentHeader().Hash()
 	if faultyStaker {
 		if nodeAGenesis == nodeBGenesis {
-			Fail(t, "node A L2 genesis hash", nodeAGenesis, "== node B L2 genesis hash", nodeBGenesis)
+			Fatal(t, "node A L2 genesis hash", nodeAGenesis, "== node B L2 genesis hash", nodeBGenesis)
 		}
 	} else {
 		if nodeAGenesis != nodeBGenesis {
-			Fail(t, "node A L2 genesis hash", nodeAGenesis, "!= node B L2 genesis hash", nodeBGenesis)
+			Fatal(t, "node A L2 genesis hash", nodeAGenesis, "!= node B L2 genesis hash", nodeBGenesis)
 		}
 	}
 
@@ -304,7 +304,7 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 					Require(t, err)
 					proxyAdminAddr := common.BytesToAddress(proxyAdminBytes)
 					if proxyAdminAddr == (common.Address{}) {
-						Fail(t, "failed to get challenge manager proxy admin")
+						Fatal(t, "failed to get challenge manager proxy admin")
 					}
 
 					proxyAdmin, err := mocksgen.NewProxyAdminForBinding(proxyAdminAddr, l1client)
@@ -348,14 +348,14 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 		isHonestZombie, err := rollup.IsZombie(&bind.CallOpts{}, valWalletAddrA)
 		Require(t, err)
 		if isHonestZombie {
-			Fail(t, "staker A became a zombie")
+			Fatal(t, "staker A became a zombie")
 		}
 		watchTx, err := stakerC.Act(ctx)
 		if err != nil && !strings.Contains(err.Error(), "catch up") {
 			Require(t, err, "watchtower staker failed to act")
 		}
 		if watchTx != nil {
-			Fail(t, "watchtower staker made a transaction")
+			Fatal(t, "watchtower staker made a transaction")
 		}
 		if !stakerAWasStaked {
 			stakerAWasStaked, err = rollup.IsStaked(&bind.CallOpts{}, valWalletAddrA)
@@ -371,7 +371,7 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 	}
 
 	if stakerATxs == 0 || stakerBTxs == 0 {
-		Fail(t, "staker didn't make txs: staker A made", stakerATxs, "staker B made", stakerBTxs)
+		Fatal(t, "staker didn't make txs: staker A made", stakerATxs, "staker B made", stakerBTxs)
 	}
 
 	latestConfirmedNode, err := rollup.LatestConfirmed(&bind.CallOpts{})
@@ -380,18 +380,18 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 	if latestConfirmedNode <= 1 && !honestStakerInactive {
 		latestCreatedNode, err := rollup.LatestNodeCreated(&bind.CallOpts{})
 		Require(t, err)
-		Fail(t, "latest confirmed node didn't advance:", latestConfirmedNode, latestCreatedNode)
+		Fatal(t, "latest confirmed node didn't advance:", latestConfirmedNode, latestCreatedNode)
 	}
 
 	if faultyStaker && !sawStakerZombie {
-		Fail(t, "staker B didn't become a zombie despite being faulty")
+		Fatal(t, "staker B didn't become a zombie despite being faulty")
 	}
 
 	if !stakerAWasStaked {
-		Fail(t, "staker A was never staked")
+		Fatal(t, "staker A was never staked")
 	}
 	if !stakerBWasStaked {
-		Fail(t, "staker B was never staked")
+		Fatal(t, "staker B was never staked")
 	}
 }
 

--- a/system_tests/transfer_test.go
+++ b/system_tests/transfer_test.go
@@ -32,6 +32,6 @@ func TestTransfer(t *testing.T) {
 	bal2, err := client.BalanceAt(ctx, l2info.GetAddress("User2"), nil)
 	Require(t, err)
 	if bal2.Cmp(big.NewInt(1e12)) != 0 {
-		Fail(t, "Unexpected recipient balance: ", bal2)
+		Fatal(t, "Unexpected recipient balance: ", bal2)
 	}
 }

--- a/system_tests/twonodes_test.go
+++ b/system_tests/twonodes_test.go
@@ -57,7 +57,7 @@ func testTwoNodesSimple(t *testing.T, dasModeStr string) {
 	Require(t, err)
 
 	if l2balance.Cmp(big.NewInt(1e12)) != 0 {
-		Fail(t, "Unexpected balance:", l2balance)
+		Fatal(t, "Unexpected balance:", l2balance)
 	}
 }
 

--- a/system_tests/twonodeslong_test.go
+++ b/system_tests/twonodeslong_test.go
@@ -75,7 +75,7 @@ func testTwoNodesLong(t *testing.T, dasModeStr string) {
 	t.Logf("DelayedFaucet has %v, per delayd: %v, baseprice: %v", delayedFaucetBalance, fundsPerDelayed, l2pricing.InitialBaseFeeWei)
 
 	if avgTotalL1MessagesPerLoop < avgDelayedMessagesPerLoop {
-		Fail(t, "bad params, avgTotalL1MessagesPerLoop should include avgDelayedMessagesPerLoop")
+		Fatal(t, "bad params, avgTotalL1MessagesPerLoop should include avgDelayedMessagesPerLoop")
 	}
 	for i := 0; i < largeLoops; i++ {
 		l1TxsThisTime := rand.Int() % (avgTotalL1MessagesPerLoop * 2)
@@ -97,7 +97,7 @@ func testTwoNodesLong(t *testing.T, dasModeStr string) {
 		errs := l1backend.TxPool().AddLocals(l1Txs)
 		for _, err := range errs {
 			if err != nil {
-				Fail(t, err)
+				Fatal(t, err)
 			}
 		}
 		l2TxsThisTime := rand.Int() % (avgL2MsgsPerLoop * 2)
@@ -110,7 +110,7 @@ func testTwoNodesLong(t *testing.T, dasModeStr string) {
 		if len(l1Txs) > 0 {
 			_, err := EnsureTxSucceeded(ctx, l1client, l1Txs[len(l1Txs)-1])
 			if err != nil {
-				Fail(t, err)
+				Fatal(t, err)
 			}
 		}
 		// create bad tx on delayed inbox
@@ -129,7 +129,7 @@ func testTwoNodesLong(t *testing.T, dasModeStr string) {
 
 	t.Log("Done sending", delayedTransfers, "delayed transfers", directTransfers, "direct transfers")
 	if (delayedTransfers + directTransfers) == 0 {
-		Fail(t, "No transfers sent!")
+		Fatal(t, "No transfers sent!")
 	}
 
 	// sending l1 messages creates l1 blocks.. make enough to get that delayed inbox message in
@@ -139,11 +139,11 @@ func testTwoNodesLong(t *testing.T, dasModeStr string) {
 			tx = l1info.PrepareTx("Faucet", "User", 30000, big.NewInt(1e12), nil)
 			err := l1client.SendTransaction(ctx, tx)
 			if err != nil {
-				Fail(t, err)
+				Fatal(t, err)
 			}
 			_, err = EnsureTxSucceeded(ctx, l1client, tx)
 			if err != nil {
-				Fail(t, err)
+				Fatal(t, err)
 			}
 		}
 	}
@@ -164,7 +164,7 @@ func testTwoNodesLong(t *testing.T, dasModeStr string) {
 		ownerBalance, _ := l2clientB.BalanceAt(ctx, l2info.GetAddress("Owner"), nil)
 		delayedFaucetBalance, _ := l2clientB.BalanceAt(ctx, l2info.GetAddress("DelayedFaucet"), nil)
 		t.Error("owner balance", ownerBalance, "delayed faucet", delayedFaucetBalance)
-		Fail(t, "Unexpected balance")
+		Fatal(t, "Unexpected balance")
 	}
 
 	nodeA.StopAndWait()
@@ -174,7 +174,7 @@ func testTwoNodesLong(t *testing.T, dasModeStr string) {
 		Require(t, err)
 		timeout := getDeadlineTimeout(t, time.Minute*30)
 		if !nodeB.BlockValidator.WaitForBlock(ctx, lastBlockHeader.Number.Uint64(), timeout) {
-			Fail(t, "did not validate all blocks")
+			Fatal(t, "did not validate all blocks")
 		}
 	}
 }


### PR DESCRIPTION
Also :

- get rid of using assert library [0] and assertion helpers[1].
- reorder testing.T and context.Context as context comes first [2] 
- drop "ForTest" suffix from method in _test file as it's already obvious it used (and is only possible to be used) for testing.
- move declaration of variables close to it's use.
- use strings.Join instead of joining it manually
- factor out test initialisation/cleanup in helper functions
- drop getter

[0] https://google.github.io/styleguide/go/decisions#assertion-libraries
[1] https://google.github.io/styleguide/go/best-practices#leave-testing-to-the-test-function
[2] https://google.github.io/styleguide/go/decisions#contexts