### PR TITLE
Rename CI workflows so that we can differentiate them on github

### DIFF
--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -1,4 +1,5 @@
-name: "Arbitrator CI"
+name: Arbitrator CI
+run-name: Arbitrator CI triggered from @${{ github.actor }} of ${{ github.head_ref }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: "Arbitrator CI"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/arbitrator-skip-ci.yml
+++ b/.github/workflows/arbitrator-skip-ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: "Arbitrator skip CI"
 
 on:
   pull_request:

--- a/.github/workflows/arbitrator-skip-ci.yml
+++ b/.github/workflows/arbitrator-skip-ci.yml
@@ -1,4 +1,5 @@
-name: "Arbitrator skip CI"
+name: Arbitrator skip CI
+run-name: Arbitrator skip CI triggered from @${{ github.actor }} of ${{ github.head_ref }}
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-name: "Go tests CI"
+name: Go tests CI
+run-name: Go tests CI triggered from @${{ github.actor }} of ${{ github.head_ref }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: "Go tests CI"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,5 @@
-name: "Docker build CI"
+name: Docker build CI
+run-name: Docker build CI triggered from @${{ github.actor }} of ${{ github.head_ref }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: CI
+name: "Docker build CI"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Currently it appears like this:
![image](https://github.com/OffchainLabs/nitro/assets/12731709/15137b54-3636-47a5-9143-49d0b9c4af5d)
