### PR TITLE
Sequence txs with the L1 (not parent chain) block number

### DIFF
--- a/arbnode/execution/sequencer.go
+++ b/arbnode/execution/sequencer.go
@@ -929,9 +929,13 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 func (s *Sequencer) updateLatestL1Block(header *types.Header) {
 	s.L1BlockAndTimeMutex.Lock()
 	defer s.L1BlockAndTimeMutex.Unlock()
-	if s.l1BlockNumber < header.Number.Uint64() {
-		s.l1BlockNumber = header.Number.Uint64()
+	if s.l1Timestamp < header.Time {
 		s.l1Timestamp = header.Time
+
+		arbosInfo := types.DeserializeHeaderExtraInformation(header)
+		if arbosInfo.ArbOSFormatVersion > 0 {
+			s.l1BlockNumber = arbosInfo.L1BlockNumber
+		}
 	}
 }
 

--- a/arbnode/execution/sequencer.go
+++ b/arbnode/execution/sequencer.go
@@ -935,6 +935,8 @@ func (s *Sequencer) updateLatestL1Block(header *types.Header) {
 		arbosInfo := types.DeserializeHeaderExtraInformation(header)
 		if arbosInfo.ArbOSFormatVersion > 0 {
 			s.l1BlockNumber = arbosInfo.L1BlockNumber
+		} else {
+			s.l1BlockNumber = header.Number.Uint64()
 		}
 	}
 }

--- a/arbnode/execution/sequencer.go
+++ b/arbnode/execution/sequencer.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/containers"
 	"github.com/offchainlabs/nitro/util/headerreader"
@@ -929,15 +930,11 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 func (s *Sequencer) updateLatestL1Block(header *types.Header) {
 	s.L1BlockAndTimeMutex.Lock()
 	defer s.L1BlockAndTimeMutex.Unlock()
-	if s.l1Timestamp < header.Time {
-		s.l1Timestamp = header.Time
 
-		arbosInfo := types.DeserializeHeaderExtraInformation(header)
-		if arbosInfo.ArbOSFormatVersion > 0 {
-			s.l1BlockNumber = arbosInfo.L1BlockNumber
-		} else {
-			s.l1BlockNumber = header.Number.Uint64()
-		}
+	l1BlockNumber := arbutil.HeaderL1BlockNumber(header)
+	if header.Time > s.l1Timestamp || (header.Time == s.l1Timestamp && l1BlockNumber > s.l1BlockNumber) {
+		s.l1Timestamp = header.Time
+		s.l1BlockNumber = l1BlockNumber
 	}
 }
 

--- a/arbnode/execution/sequencer.go
+++ b/arbnode/execution/sequencer.go
@@ -927,11 +927,11 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 	return madeBlock
 }
 
-func (s *Sequencer) updateLatestL1Block(header *types.Header) {
+func (s *Sequencer) updateLatestParentChainBlock(header *types.Header) {
 	s.L1BlockAndTimeMutex.Lock()
 	defer s.L1BlockAndTimeMutex.Unlock()
 
-	l1BlockNumber := arbutil.HeaderL1BlockNumber(header)
+	l1BlockNumber := arbutil.ParentHeaderToL1BlockNumber(header)
 	if header.Time > s.l1Timestamp || (header.Time == s.l1Timestamp && l1BlockNumber > s.l1BlockNumber) {
 		s.l1Timestamp = header.Time
 		s.l1BlockNumber = l1BlockNumber
@@ -947,7 +947,7 @@ func (s *Sequencer) Initialize(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	s.updateLatestL1Block(header)
+	s.updateLatestParentChainBlock(header)
 	return nil
 }
 
@@ -969,7 +969,7 @@ func (s *Sequencer) Start(ctxIn context.Context) error {
 					if !ok {
 						return
 					}
-					s.updateLatestL1Block(header)
+					s.updateLatestParentChainBlock(header)
 				case <-ctx.Done():
 					return
 				}

--- a/arbutil/correspondingl1blocknumber.go
+++ b/arbutil/correspondingl1blocknumber.go
@@ -17,7 +17,7 @@ func CorrespondingL1BlockNumber(ctx context.Context, client L1Interface, blockNu
 		return 0, fmt.Errorf("error getting L1 block number %d header : %w", blockNumber, err)
 	}
 	headerInfo := types.DeserializeHeaderExtraInformation(header)
-	if headerInfo.L1BlockNumber != 0 {
+	if headerInfo.ArbOSFormatVersion > 0 {
 		return headerInfo.L1BlockNumber, nil
 	}
 	return blockNumber, nil

--- a/arbutil/correspondingl1blocknumber.go
+++ b/arbutil/correspondingl1blocknumber.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-func HeaderL1BlockNumber(header *types.Header) uint64 {
+func ParentHeaderToL1BlockNumber(header *types.Header) uint64 {
 	headerInfo := types.DeserializeHeaderExtraInformation(header)
 	if headerInfo.ArbOSFormatVersion > 0 {
 		return headerInfo.L1BlockNumber
@@ -19,10 +19,10 @@ func HeaderL1BlockNumber(header *types.Header) uint64 {
 	return header.Number.Uint64()
 }
 
-func CorrespondingL1BlockNumber(ctx context.Context, client L1Interface, blockNumber uint64) (uint64, error) {
-	header, err := client.HeaderByNumber(ctx, big.NewInt(int64(blockNumber)))
+func CorrespondingL1BlockNumber(ctx context.Context, client L1Interface, parentBlockNumber uint64) (uint64, error) {
+	header, err := client.HeaderByNumber(ctx, big.NewInt(int64(parentBlockNumber)))
 	if err != nil {
-		return 0, fmt.Errorf("error getting L1 block number %d header : %w", blockNumber, err)
+		return 0, fmt.Errorf("error getting L1 block number %d header : %w", parentBlockNumber, err)
 	}
-	return HeaderL1BlockNumber(header), nil
+	return ParentHeaderToL1BlockNumber(header), nil
 }

--- a/arbutil/correspondingl1blocknumber.go
+++ b/arbutil/correspondingl1blocknumber.go
@@ -11,14 +11,18 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
+func HeaderL1BlockNumber(header *types.Header) uint64 {
+	headerInfo := types.DeserializeHeaderExtraInformation(header)
+	if headerInfo.ArbOSFormatVersion > 0 {
+		return headerInfo.L1BlockNumber
+	}
+	return header.Number.Uint64()
+}
+
 func CorrespondingL1BlockNumber(ctx context.Context, client L1Interface, blockNumber uint64) (uint64, error) {
 	header, err := client.HeaderByNumber(ctx, big.NewInt(int64(blockNumber)))
 	if err != nil {
 		return 0, fmt.Errorf("error getting L1 block number %d header : %w", blockNumber, err)
 	}
-	headerInfo := types.DeserializeHeaderExtraInformation(header)
-	if headerInfo.ArbOSFormatVersion > 0 {
-		return headerInfo.L1BlockNumber, nil
-	}
-	return blockNumber, nil
+	return HeaderL1BlockNumber(header), nil
 }

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -291,9 +291,10 @@ func (s *Staker) Start(ctxIn context.Context) {
 		arbTx, err := s.Act(ctx)
 		if err == nil && arbTx != nil {
 			_, err = s.l1Reader.WaitForTxApproval(ctx, arbTx)
-			err = fmt.Errorf("error waiting for tx receipt: %w", err)
 			if err == nil {
 				log.Info("successfully executed staker transaction", "hash", arbTx.Hash())
+			} else {
+				err = fmt.Errorf("error waiting for tx receipt: %w", err)
 			}
 		}
 		if err == nil {


### PR DESCRIPTION
For L3s, transactions were incorrectly being sequenced with the parent chain block number instead of the L1 block number. This PR fixes that.