### PR TITLE
Allow reposting old batches with old nonces

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -160,10 +160,6 @@ func (p *DataPoster[Meta]) From() common.Address {
 	return p.auth.From
 }
 
-func (p *DataPoster[Meta]) IsQueuePersistent() bool {
-	return p.queue.IsPersistent()
-}
-
 func (p *DataPoster[Meta]) GetNextNonceAndMeta(ctx context.Context) (uint64, Meta, error) {
 	config := p.config()
 	var emptyMeta Meta

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -160,6 +160,10 @@ func (p *DataPoster[Meta]) From() common.Address {
 	return p.auth.From
 }
 
+func (p *DataPoster[Meta]) IsQueuePersistent() bool {
+	return p.queue.IsPersistent()
+}
+
 func (p *DataPoster[Meta]) GetNextNonceAndMeta(ctx context.Context) (uint64, Meta, error) {
 	config := p.config()
 	var emptyMeta Meta


### PR DESCRIPTION
This amends https://github.com/OffchainLabs/nitro/pull/1685 to allow reposting an old batch with an old nonce. That's how the batch poster will behave on startup if the redis storage isn't enabled, and the batch poster is restarted shortly after a batch is posted (before it's finalized).