### PR TITLE
Make the staker NodeInfo BlockProposed an L1 block

### DIFF
--- a/staker/assertion.go
+++ b/staker/assertion.go
@@ -64,7 +64,7 @@ type Assertion struct {
 
 type NodeInfo struct {
 	NodeNum            uint64
-	BlockProposed      uint64
+	L1BlockProposed    uint64
 	Assertion          *Assertion
 	InboxMaxCount      *big.Int
 	AfterInboxBatchAcc common.Hash

--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -340,7 +340,7 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 		return nil, false, fmt.Errorf("error getting latest L1 block number: %w", err)
 	}
 
-	parentChainBlockNumber, err := arbutil.CorrespondingL1BlockNumber(ctx, v.client, currentL1BlockNum)
+	l1BlockNumber, err := arbutil.CorrespondingL1BlockNumber(ctx, v.client, currentL1BlockNum)
 	if err != nil {
 		return nil, false, err
 	}
@@ -350,7 +350,7 @@ func (v *L1Validator) generateNodeAction(ctx context.Context, stakerInfo *OurSta
 		return nil, false, fmt.Errorf("error getting rollup minimum assertion period: %w", err)
 	}
 
-	timeSinceProposed := big.NewInt(int64(parentChainBlockNumber) - int64(startStateProposed))
+	timeSinceProposed := big.NewInt(int64(l1BlockNumber) - int64(startStateProposed))
 	if timeSinceProposed.Cmp(minAssertionPeriod) < 0 {
 		// Too soon to assert
 		return nil, false, nil
@@ -595,7 +595,7 @@ func (v *L1Validator) createNewNodeAction(
 }
 
 // Returns (execution state, inbox max count, L1 block proposed, error)
-func lookupNodeStartState(ctx context.Context, rollup *RollupWatcher, nodeNum uint64, nodeHash [32]byte) (*validator.ExecutionState, *big.Int, uint64, error) {
+func lookupNodeStartState(ctx context.Context, rollup *RollupWatcher, nodeNum uint64, nodeHash common.Hash) (*validator.ExecutionState, *big.Int, uint64, error) {
 	if nodeNum == 0 {
 		creationEvent, err := rollup.LookupCreation(ctx)
 		if err != nil {
@@ -617,5 +617,5 @@ func lookupNodeStartState(ctx context.Context, rollup *RollupWatcher, nodeNum ui
 	if node.NodeHash != nodeHash {
 		return nil, nil, 0, errors.New("looked up starting node but found wrong hash")
 	}
-	return node.AfterState(), node.InboxMaxCount, node.BlockProposed, nil
+	return node.AfterState(), node.InboxMaxCount, node.L1BlockProposed, nil
 }

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -790,7 +790,7 @@ func (s *Staker) createConflict(ctx context.Context, info *StakerInfo) error {
 			node1Info.GlobalStates(),
 			node1Info.Assertion.NumBlocks,
 			node2Info.Assertion.ExecutionHash(),
-			[2]*big.Int{new(big.Int).SetUint64(node1Info.BlockProposed), new(big.Int).SetUint64(node2Info.BlockProposed)},
+			[2]*big.Int{new(big.Int).SetUint64(node1Info.L1BlockProposed), new(big.Int).SetUint64(node2Info.L1BlockProposed)},
 			[2][32]byte{node1Info.WasmModuleRoot, node2Info.WasmModuleRoot},
 		)
 		if err != nil {


### PR DESCRIPTION
Both usages of BlockProposed (previously incorrectly) assumed it was an L1 block number (as opposed to a parent chain block number), so this PR renames the field to L1BlockProposed and makes it the L1 block number