### PR TITLE
Use the latest nonce, instead of the pending nonce, in the staker

### DIFF
--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -169,7 +169,11 @@ func (v *L1Validator) resolveNextNode(ctx context.Context, info *StakerInfo, lat
 			return false, nil
 		}
 		log.Warn("rejecting node", "node", unresolvedNodeIndex)
-		_, err = v.rollup.RejectNextNode(v.builder.Auth(ctx), *addr)
+		auth, err := v.builder.Auth(ctx)
+		if err != nil {
+			return false, err
+		}
+		_, err = v.rollup.RejectNextNode(auth, *addr)
 		return true, err
 	case CONFIRM_TYPE_VALID:
 		nodeInfo, err := v.rollup.LookupNode(ctx, unresolvedNodeIndex)
@@ -178,7 +182,11 @@ func (v *L1Validator) resolveNextNode(ctx context.Context, info *StakerInfo, lat
 		}
 		afterGs := nodeInfo.AfterState().GlobalState
 		log.Info("confirming node", "node", unresolvedNodeIndex)
-		_, err = v.rollup.ConfirmNextNode(v.builder.Auth(ctx), afterGs.BlockHash, afterGs.SendRoot)
+		auth, err := v.builder.Auth(ctx)
+		if err != nil {
+			return false, err
+		}
+		_, err = v.rollup.ConfirmNextNode(auth, afterGs.BlockHash, afterGs.SendRoot)
 		if err != nil {
 			return false, err
 		}

--- a/staker/validator_wallet.go
+++ b/staker/validator_wallet.go
@@ -266,6 +266,9 @@ func (v *ContractValidatorWallet) ExecuteTransactions(ctx context.Context, build
 	}
 
 	callValue := new(big.Int).Sub(totalAmount, balanceInContract)
+	if callValue.Sign() < 0 {
+		callValue.SetInt64(0)
+	}
 	auth, err := v.getAuth(ctx, callValue)
 	if err != nil {
 		return nil, err

--- a/staker/validator_wallet.go
+++ b/staker/validator_wallet.go
@@ -152,12 +152,25 @@ func (v *ContractValidatorWallet) From() common.Address {
 	return v.auth.From
 }
 
-func (v *ContractValidatorWallet) executeTransaction(ctx context.Context, tx *types.Transaction, gasRefunder common.Address) (*types.Transaction, error) {
-	oldAuthValue := v.auth.Value
-	v.auth.Value = tx.Value()
-	defer (func() { v.auth.Value = oldAuthValue })()
+// nil value == 0 value
+func (v *ContractValidatorWallet) getAuth(ctx context.Context, value *big.Int) (*bind.TransactOpts, error) {
+	newAuth := *v.auth
+	newAuth.Context = ctx
+	newAuth.Value = value
+	nonce, err := v.L1Client().NonceAt(ctx, v.auth.From, nil)
+	if err != nil {
+		return nil, err
+	}
+	newAuth.Nonce = new(big.Int).SetUint64(nonce)
+	return &newAuth, nil
+}
 
-	return v.con.ExecuteTransactionWithGasRefunder(v.auth, gasRefunder, tx.Data(), *tx.To(), tx.Value())
+func (v *ContractValidatorWallet) executeTransaction(ctx context.Context, tx *types.Transaction, gasRefunder common.Address) (*types.Transaction, error) {
+	auth, err := v.getAuth(ctx, tx.Value())
+	if err != nil {
+		return nil, err
+	}
+	return v.con.ExecuteTransactionWithGasRefunder(auth, gasRefunder, tx.Data(), *tx.To(), tx.Value())
 }
 
 func (v *ContractValidatorWallet) populateWallet(ctx context.Context, createIfMissing bool) error {
@@ -171,7 +184,11 @@ func (v *ContractValidatorWallet) populateWallet(ctx context.Context, createIfMi
 		return nil
 	}
 	if v.address == nil {
-		addr, err := GetValidatorWalletContract(ctx, v.walletFactoryAddr, v.rollupFromBlock, v.auth, v.l1Reader, createIfMissing)
+		auth, err := v.getAuth(ctx, nil)
+		if err != nil {
+			return err
+		}
+		addr, err := GetValidatorWalletContract(ctx, v.walletFactoryAddr, v.rollupFromBlock, auth, v.l1Reader, createIfMissing)
 		if err != nil {
 			return err
 		}
@@ -248,14 +265,12 @@ func (v *ContractValidatorWallet) ExecuteTransactions(ctx context.Context, build
 		return nil, err
 	}
 
-	oldAuthValue := v.auth.Value
-	v.auth.Value = new(big.Int).Sub(totalAmount, balanceInContract)
-	if v.auth.Value.Sign() < 0 {
-		v.auth.Value.SetInt64(0)
+	callValue := new(big.Int).Sub(totalAmount, balanceInContract)
+	auth, err := v.getAuth(ctx, callValue)
+	if err != nil {
+		return nil, err
 	}
-	defer (func() { v.auth.Value = oldAuthValue })()
-
-	arbTx, err := v.con.ExecuteTransactionsWithGasRefunder(v.auth, gasRefunder, data, dest, amount)
+	arbTx, err := v.con.ExecuteTransactionsWithGasRefunder(auth, gasRefunder, data, dest, amount)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +279,11 @@ func (v *ContractValidatorWallet) ExecuteTransactions(ctx context.Context, build
 }
 
 func (v *ContractValidatorWallet) TimeoutChallenges(ctx context.Context, challenges []uint64) (*types.Transaction, error) {
-	return v.con.TimeoutChallenges(v.auth, v.challengeManagerAddress, challenges)
+	auth, err := v.getAuth(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return v.con.TimeoutChallenges(auth, v.challengeManagerAddress, challenges)
 }
 
 func (v *ContractValidatorWallet) L1Client() arbutil.L1Interface {


### PR DESCRIPTION
The staker's transactions are all made according to what needs done at the latest state, so it makes sense to also use the latest nonce. This improves reliability, as the latest state is more consistent than the pending state.