### PR TITLE
Add support for consensus v10.2 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,7 @@ COPY ./scripts/download-machine.sh .
 #RUN ./download-machine.sh consensus-v9 0xd1842bfbe047322b3f3b3635b5fe62eb611557784d17ac1d2b1ce9c170af6544
 RUN ./download-machine.sh consensus-v10 0x6b94a7fc388fd8ef3def759297828dc311761e88d8179c7ee8d3887dc554f3c3
 RUN ./download-machine.sh consensus-v10.1 0xda4e3ad5e7feacb817c21c8d0220da7650fe9051ece68a3f0b1c5d38bbb27b21
+RUN ./download-machine.sh consensus-v10.2 0x0754e09320c381566cc0449904c377a52bd34a6b9404432e80afd573b67f7b17
 
 FROM golang:1.20-bullseye as node-builder
 WORKDIR /workspace


### PR DESCRIPTION
This PR adds support for [consensus v10.2](https://github.com/OffchainLabs/nitro/releases/tag/consensus-v10.2) to validators in docker