### PR TITLE
fix: failing test on macOS  

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Set environment variables
         run: |
           mkdir -p target/tmp
-          echo "TMPDIR=$(pwd)/target/tmp" >> "$GITHUB_ENV"
+          echo "TMPDIR=$(pwd)/target/tmp/deadbeefdeadbeefdeadbeefdeadbeefdead" >> "$GITHUB_ENV"
           echo "GOMEMLIMIT=6GiB" >> "$GITHUB_ENV"
           echo "GOGC=80" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,8 @@ jobs:
 
       - name: Set environment variables
         run: |
-          mkdir -p target/tmp
-          echo "TMPDIR=$(pwd)/target/tmp/deadbeefdeadbeefdeadbeefdeadbeefdead" >> "$GITHUB_ENV"
+          mkdir -p target/tmp/deadbeefbee
+          echo "TMPDIR=$(pwd)/target/tmp/deadbeefbee" >> "$GITHUB_ENV"
           echo "GOMEMLIMIT=6GiB" >> "$GITHUB_ENV"
           echo "GOGC=80" >> "$GITHUB_ENV"
 

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -157,7 +158,14 @@ func createSequencer(
 
 // tmpPath returns file path with specified filename from temporary directory of the test.
 func tmpPath(t *testing.T, filename string) string {
-	return filepath.Join(t.TempDir(), filename)
+	// create a unique, maximum 10 characters-long temporary directory {name} with path as $TMPDIR/{name}
+	tmpDir, _ := os.MkdirTemp("", "")
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Errorf("tmpPath RemoveAll cleanup: %v", err)
+		}
+	})
+	return filepath.Join(tmpDir, filename)
 }
 
 // testNodes creates specified number of paths for ipc from temporary directory of the test.
@@ -295,8 +303,7 @@ func TestRedisForwarder(t *testing.T) {
 	}
 }
 
-// TestRFFallbackNoRedis is shortened from "TestRedisForwarderFallbackNoRedis" name for ipc url path to be less than "max_socket_path_size"
-func TestRFFallbackNoRedis(t *testing.T) {
+func TestRedisForwarderFallbackNoRedis(t *testing.T) {
 	ctx := context.Background()
 
 	fallbackIpcPath := tmpPath(t, "fallback.ipc")

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -295,7 +295,8 @@ func TestRedisForwarder(t *testing.T) {
 	}
 }
 
-func TestRedisForwarderFallbackNoRedis(t *testing.T) {
+// TestRFFallbackNoRedis is shortened from "TestRedisForwarderFallbackNoRedis" name for ipc url path to be less than "max_socket_path_size"
+func TestRFFallbackNoRedis(t *testing.T) {
 	ctx := context.Background()
 
 	fallbackIpcPath := tmpPath(t, "fallback.ipc")

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -158,11 +158,15 @@ func createSequencer(
 
 // tmpPath returns file path with specified filename from temporary directory of the test.
 func tmpPath(t *testing.T, filename string) string {
+	t.Helper()
 	// create a unique, maximum 10 characters-long temporary directory {name} with path as $TMPDIR/{name}
-	tmpDir, _ := os.MkdirTemp("", "")
+	tmpDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
 	t.Cleanup(func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Errorf("tmpPath RemoveAll cleanup: %v", err)
+		if err = os.RemoveAll(tmpDir); err != nil {
+			t.Errorf("Failed to cleanup temp dir: %v", err)
 		}
 	})
 	return filepath.Join(tmpDir, filename)


### PR DESCRIPTION
This PR fixes failing test on macOS systems because of large ipc url path being generated due to `$TMPDIR` being long. Padded `$TMPDIR` in CI to check against similar issues in future. 