### PR TITLE
Optionally Ignore Rollup's Wasm Module Root When Staking

### DIFF
--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -319,7 +319,7 @@ func (v *L1Validator) generateNodeAction(
 					v.lastWasmModuleRoot, valInfo.WasmRoots,
 				)
 			}
-			log.Warn("wasmroot doesn't match rollup", v.lastWasmModuleRoot, valInfo.WasmRoots)
+			log.Warn("wasmroot doesn't match rollup", "rollup", v.lastWasmModuleRoot, "block_validator", valInfo.WasmRoots)
 		}
 	} else {
 		validatedCount, err = v.txStreamer.GetProcessedMessageCount()

--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -319,7 +319,7 @@ func (v *L1Validator) generateNodeAction(
 					v.lastWasmModuleRoot, valInfo.WasmRoots,
 				)
 			}
-			log.Warn("wasmroot doesn't match rollup", "rollup", v.lastWasmModuleRoot, "block_validator", valInfo.WasmRoots)
+			log.Warn("wasmroot doesn't match rollup", "rollup", v.lastWasmModuleRoot, "blockValidator", valInfo.WasmRoots)
 		}
 	} else {
 		validatedCount, err = v.txStreamer.GetProcessedMessageCount()

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -172,14 +172,17 @@ func L1ValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 }
 
 type DangerousConfig struct {
-	WithoutBlockValidator bool `koanf:"without-block-validator"`
+	IgnoreRollupWasmModuleRoot bool `koanf:"ignore-rollup-wasm-module-root"`
+	WithoutBlockValidator      bool `koanf:"without-block-validator"`
 }
 
 var DefaultDangerousConfig = DangerousConfig{
-	WithoutBlockValidator: false,
+	IgnoreRollupWasmModuleRoot: false,
+	WithoutBlockValidator:      false,
 }
 
 func DangerousConfigAddOptions(prefix string, f *flag.FlagSet) {
+	f.Bool(prefix+".ignore-rollup-wasm-module-root", DefaultL1ValidatorConfig.Dangerous.IgnoreRollupWasmModuleRoot, "DANGEROUS! make assertions even when the wasm module root is wrong")
 	f.Bool(prefix+".without-block-validator", DefaultL1ValidatorConfig.Dangerous.WithoutBlockValidator, "DANGEROUS! allows running an L1 validator without a block validator")
 }
 
@@ -693,7 +696,7 @@ func (s *Staker) handleConflict(ctx context.Context, info *StakerInfo) error {
 
 func (s *Staker) advanceStake(ctx context.Context, info *OurStakerInfo, effectiveStrategy StakerStrategy) error {
 	active := effectiveStrategy >= StakeLatestStrategy
-	action, wrongNodesExist, err := s.generateNodeAction(ctx, info, effectiveStrategy, s.config.MakeAssertionInterval)
+	action, wrongNodesExist, err := s.generateNodeAction(ctx, info, effectiveStrategy, &s.config)
 	if err != nil {
 		return fmt.Errorf("error generating node action: %w", err)
 	}


### PR DESCRIPTION
Adds a dangerous config option, `ignore-rollup-wasm-module-root`, which causes the L1 Validator to disregard any potential Wasm module root mismatch. End users should **not** enable this feature. A warning is still logged when the rollup's root does not match.

This is useful in rapid devnets that frequently upgrade.