### PR TITLE
Fix an off-by-one when loading legacy validation info

### DIFF
--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -984,9 +984,12 @@ func (v *BlockValidator) checkLegacyValid() error {
 		log.Warn("legacy valid batch ahead of db", "current", batchCount, "required", requiredBatchCount)
 		return nil
 	}
-	msgCount, err := v.inboxTracker.GetBatchMessageCount(v.legacyValidInfo.AfterPosition.BatchNumber)
-	if err != nil {
-		return err
+	var msgCount arbutil.MessageIndex
+	if v.legacyValidInfo.AfterPosition.BatchNumber > 0 {
+		msgCount, err = v.inboxTracker.GetBatchMessageCount(v.legacyValidInfo.AfterPosition.BatchNumber - 1)
+		if err != nil {
+			return err
+		}
 	}
 	msgCount += arbutil.MessageIndex(v.legacyValidInfo.AfterPosition.PosInBatch)
 	processedCount, err := v.streamer.GetProcessedMessageCount()


### PR DESCRIPTION
`GetBatchMessageCount` returns the message count at the end of a batch, not at the beginning of the batch, so this code was querying the wrong batch's message count. Maybe we should rename it for clarity.