### PR TITLE
Cache the start key for message pruning and use latest confirmed

### DIFF
--- a/arbnode/message_pruner.go
+++ b/arbnode/message_pruner.go
@@ -64,7 +64,7 @@ func (m *MessagePruner) Start(ctxIn context.Context) {
 	m.StopWaiter.Start(ctxIn, m)
 }
 
-func (m *MessagePruner) UpdateLatestStaked(count arbutil.MessageIndex, globalState validator.GoGlobalState) {
+func (m *MessagePruner) UpdateLatestConfirmed(count arbutil.MessageIndex, globalState validator.GoGlobalState) {
 	locked := m.pruningLock.TryLock()
 	if !locked {
 		return

--- a/arbnode/message_pruner.go
+++ b/arbnode/message_pruner.go
@@ -23,11 +23,13 @@ import (
 
 type MessagePruner struct {
 	stopwaiter.StopWaiter
-	transactionStreamer *TransactionStreamer
-	inboxTracker        *InboxTracker
-	config              MessagePrunerConfigFetcher
-	pruningLock         sync.Mutex
-	lastPruneDone       time.Time
+	transactionStreamer         *TransactionStreamer
+	inboxTracker                *InboxTracker
+	config                      MessagePrunerConfigFetcher
+	pruningLock                 sync.Mutex
+	lastPruneDone               time.Time
+	cachedPrunedMessages        uint64
+	cachedPrunedDelayedMessages uint64
 }
 
 type MessagePrunerConfig struct {
@@ -108,11 +110,11 @@ func (m *MessagePruner) prune(ctx context.Context, count arbutil.MessageIndex, g
 	msgCount := endBatchMetadata.MessageCount
 	delayedCount := endBatchMetadata.DelayedMessageCount
 
-	return deleteOldMessageFromDB(ctx, msgCount, delayedCount, m.inboxTracker.db, m.transactionStreamer.db)
+	return m.deleteOldMessagesFromDB(ctx, msgCount, delayedCount)
 }
 
-func deleteOldMessageFromDB(ctx context.Context, messageCount arbutil.MessageIndex, delayedMessageCount uint64, inboxTrackerDb ethdb.Database, transactionStreamerDb ethdb.Database) error {
-	prunedKeysRange, err := deleteFromLastPrunedUptoEndKey(ctx, transactionStreamerDb, messagePrefix, uint64(messageCount))
+func (m *MessagePruner) deleteOldMessagesFromDB(ctx context.Context, messageCount arbutil.MessageIndex, delayedMessageCount uint64) error {
+	prunedKeysRange, err := deleteFromLastPrunedUptoEndKey(ctx, m.transactionStreamer.db, messagePrefix, &m.cachedPrunedMessages, uint64(messageCount))
 	if err != nil {
 		return fmt.Errorf("error deleting last batch messages: %w", err)
 	}
@@ -120,7 +122,7 @@ func deleteOldMessageFromDB(ctx context.Context, messageCount arbutil.MessageInd
 		log.Info("Pruned last batch messages:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
 	}
 
-	prunedKeysRange, err = deleteFromLastPrunedUptoEndKey(ctx, inboxTrackerDb, rlpDelayedMessagePrefix, delayedMessageCount)
+	prunedKeysRange, err = deleteFromLastPrunedUptoEndKey(ctx, m.inboxTracker.db, rlpDelayedMessagePrefix, &m.cachedPrunedDelayedMessages, delayedMessageCount)
 	if err != nil {
 		return fmt.Errorf("error deleting last batch delayed messages: %w", err)
 	}
@@ -130,15 +132,25 @@ func deleteOldMessageFromDB(ctx context.Context, messageCount arbutil.MessageInd
 	return nil
 }
 
-func deleteFromLastPrunedUptoEndKey(ctx context.Context, db ethdb.Database, prefix []byte, endMinKey uint64) ([]uint64, error) {
-	startIter := db.NewIterator(prefix, uint64ToKey(1))
-	if !startIter.Next() {
+// deleteFromLastPrunedUptoEndKey is similar to deleteFromRange but automatically populates the start key
+// cachedStartMinKey must not be nil. It's set to the new start key at the end of this function if successful.
+func deleteFromLastPrunedUptoEndKey(ctx context.Context, db ethdb.Database, prefix []byte, cachedStartMinKey *uint64, endMinKey uint64) ([]uint64, error) {
+	startMinKey := *cachedStartMinKey
+	if startMinKey == 0 {
+		startIter := db.NewIterator(prefix, uint64ToKey(1))
+		if !startIter.Next() {
+			return nil, nil
+		}
+		startMinKey = binary.BigEndian.Uint64(bytes.TrimPrefix(startIter.Key(), prefix))
+		startIter.Release()
+	}
+	if endMinKey <= startMinKey {
+		*cachedStartMinKey = startMinKey
 		return nil, nil
 	}
-	startMinKey := binary.BigEndian.Uint64(bytes.TrimPrefix(startIter.Key(), prefix))
-	startIter.Release()
-	if endMinKey > startMinKey {
-		return deleteFromRange(ctx, db, prefix, startMinKey, endMinKey-1)
+	keys, err := deleteFromRange(ctx, db, prefix, startMinKey, endMinKey-1)
+	if err == nil {
+		*cachedStartMinKey = endMinKey - 1
 	}
-	return nil, nil
+	return keys, err
 }

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -825,13 +825,13 @@ func createNodeImpl(
 			}
 		}
 
-		notifiers := make([]staker.LatestStakedNotifier, 0)
+		var confirmedNotifiers []staker.LatestConfirmedNotifier
 		if config.MessagePruner.Enable && !config.Caching.Archive {
 			messagePruner = NewMessagePruner(txStreamer, inboxTracker, func() *MessagePrunerConfig { return &configFetcher.Get().MessagePruner })
-			notifiers = append(notifiers, messagePruner)
+			confirmedNotifiers = append(confirmedNotifiers, messagePruner)
 		}
 
-		stakerObj, err = staker.NewStaker(l1Reader, wallet, bind.CallOpts{}, config.Staker, blockValidator, statelessBlockValidator, notifiers, deployInfo.ValidatorUtils, fatalErrChan)
+		stakerObj, err = staker.NewStaker(l1Reader, wallet, bind.CallOpts{}, config.Staker, blockValidator, statelessBlockValidator, nil, confirmedNotifiers, deployInfo.ValidatorUtils, fatalErrChan)
 		if err != nil {
 			return nil, err
 		}

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -84,6 +84,7 @@ type L1ReaderInterface interface {
 	Client() arbutil.L1Interface
 	Subscribe(bool) (<-chan *types.Header, func())
 	WaitForTxApproval(ctx context.Context, tx *types.Transaction) (*types.Receipt, error)
+	UseFinalityData() bool
 }
 
 type GlobalStatePosition struct {

--- a/system_tests/staker_test.go
+++ b/system_tests/staker_test.go
@@ -166,6 +166,7 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 		nil,
 		statelessA,
 		nil,
+		nil,
 		l2nodeA.DeployInfo.ValidatorUtils,
 		nil,
 	)
@@ -201,6 +202,7 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 		nil,
 		statelessB,
 		nil,
+		nil,
 		l2nodeB.DeployInfo.ValidatorUtils,
 		nil,
 	)
@@ -222,6 +224,7 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 		valConfig,
 		nil,
 		statelessA,
+		nil,
 		nil,
 		l2nodeA.DeployInfo.ValidatorUtils,
 		nil,

--- a/util/headerreader/header_reader.go
+++ b/util/headerreader/header_reader.go
@@ -434,6 +434,10 @@ func (s *HeaderReader) Client() arbutil.L1Interface {
 	return s.client
 }
 
+func (s *HeaderReader) UseFinalityData() bool {
+	return s.config().UseFinalityData
+}
+
 func (s *HeaderReader) Start(ctxIn context.Context) {
 	s.StopWaiter.Start(ctxIn, s)
 	s.LaunchThread(s.broadcastLoop)


### PR DESCRIPTION
While shutting down my node, I noticed it would often be taking a while in the message pruner:
```
github.com/syndtr/goleveldb/leveldb.(*dbIter).Next(0xc07fdd3200)
        /home/lee/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7/leveldb/db_iter.go:254 +0xc9
github.com/offchainlabs/nitro/arbnode.deleteFromLastPrunedUptoEndKey({0x49e8ba8, 0xc011722f50}, {0x4a18aa0?, 0xc00e07fd40?}, {0x64c8f4a, 0x1, 0x1}, 0x5222c9c)
        /home/lee/programming/go/nitro/arbnode/message_pruner.go:135 +0xe9
github.com/offchainlabs/nitro/arbnode.deleteOldMessageFromDB({0x49e8ba8, 0xc011722f50}, 0x2319edf3f9f2778d?, 0x50b852464f739f16?, {0x4a18aa0, 0xc00e07fd40}, {0x4a18aa0?, 0xc00e07fd40?})
        /home/lee/programming/go/nitro/arbnode/message_pruner.go:115 +0x8a
github.com/offchainlabs/nitro/arbnode.(*MessagePruner).prune(0xc000e9e140, {0x49e8ba8, 0xc011722f50}, 0x0?, {{0xb2, 0x8f, 0x52, 0x9, 0x8b, 0xcd, ...}, ...})
        /home/lee/programming/go/nitro/arbnode/message_pruner.go:111 +0x196
```
It would appear leveldb iteration isn't as efficient as I thought it would be. Perhaps the fact that we'd just deleted a lot of keys in the db that we'd otherwise be iterating over is slowing it down. Regardless, I've added in this PR an in-memory cache of where we should start pruning to avoid paying this cost repeatedly. This shouldn't pose an issue where we miss a key that was re-inserted, because we're only pruning confirmed messages which are at least a week old and can't be reorg'd.

I added a second commit to this PR (I'd recommend reviewing them individually) that switches (back?) to using the latest confirmed instead of latest staked rollup node for message pruning. We can't prune what we're staked on, because we might get a challenge about something before that, but we can't get a challenge about something already confirmed so we're safe to prune there.