### PR TITLE
Run pprof (by default enabled) on a separate port than metrics

### DIFF
--- a/cmd/genericconf/pprof.go
+++ b/cmd/genericconf/pprof.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	// Blank import pprof registers its HTTP handlers.
 	_ "net/http/pprof" // #nosec G108
 
 	"github.com/ethereum/go-ethereum/log"

--- a/cmd/genericconf/server.go
+++ b/cmd/genericconf/server.go
@@ -189,23 +189,32 @@ func AuthRPCConfigAddOptions(prefix string, f *flag.FlagSet) {
 type MetricsServerConfig struct {
 	Addr           string        `koanf:"addr"`
 	Port           int           `koanf:"port"`
-	Pprof          bool          `koanf:"pprof"`
-	PprofPort      int           `koanf:"pprof-port"`
 	UpdateInterval time.Duration `koanf:"update-interval"`
 }
 
 var MetricsServerConfigDefault = MetricsServerConfig{
 	Addr:           "127.0.0.1",
 	Port:           6070,
-	Pprof:          true,
-	PprofPort:      6071,
 	UpdateInterval: 3 * time.Second,
+}
+
+type PProf struct {
+	Addr string `koanf:"addr"`
+	Port int    `koanf:"port"`
+}
+
+var PProfDefault = PProf{
+	Addr: "127.0.0.1",
+	Port: 6071,
 }
 
 func MetricsServerAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".addr", MetricsServerConfigDefault.Addr, "metrics server address")
 	f.Int(prefix+".port", MetricsServerConfigDefault.Port, "metrics server port")
-	f.Bool(prefix+".pprof", MetricsServerConfigDefault.Pprof, "enable profiling for Go")
-	f.Int(prefix+".pprof-port", MetricsServerConfigDefault.PprofPort, "pprof server port")
 	f.Duration(prefix+".update-interval", MetricsServerConfigDefault.UpdateInterval, "metrics server update interval")
+}
+
+func PProfAddOptions(prefix string, f *flag.FlagSet) {
+	f.String(prefix+".addr", PProfDefault.Addr, "pprof server address")
+	f.Int(prefix+".port", PProfDefault.Port, "pprof server port")
 }

--- a/cmd/genericconf/server.go
+++ b/cmd/genericconf/server.go
@@ -190,13 +190,15 @@ type MetricsServerConfig struct {
 	Addr           string        `koanf:"addr"`
 	Port           int           `koanf:"port"`
 	Pprof          bool          `koanf:"pprof"`
+	PprofPort      int           `koanf:"pprof-port"`
 	UpdateInterval time.Duration `koanf:"update-interval"`
 }
 
 var MetricsServerConfigDefault = MetricsServerConfig{
 	Addr:           "127.0.0.1",
 	Port:           6070,
-	Pprof:          false,
+	Pprof:          true,
+	PprofPort:      6071,
 	UpdateInterval: 3 * time.Second,
 }
 
@@ -204,5 +206,6 @@ func MetricsServerAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".addr", MetricsServerConfigDefault.Addr, "metrics server address")
 	f.Int(prefix+".port", MetricsServerConfigDefault.Port, "metrics server port")
 	f.Bool(prefix+".pprof", MetricsServerConfigDefault.Pprof, "enable profiling for Go")
+	f.Int(prefix+".pprof-port", MetricsServerConfigDefault.PprofPort, "pprof server port")
 	f.Duration(prefix+".update-interval", MetricsServerConfigDefault.UpdateInterval, "metrics server update interval")
 }

--- a/cmd/nitro-val/config.go
+++ b/cmd/nitro-val/config.go
@@ -30,6 +30,8 @@ type ValidationNodeConfig struct {
 	AuthRPC       genericconf.AuthRPCConfig       `koanf:"auth"`
 	Metrics       bool                            `koanf:"metrics"`
 	MetricsServer genericconf.MetricsServerConfig `koanf:"metrics-server"`
+	PProf         bool                            `koanf:"pprof"`
+	PprofCfg      genericconf.PProf               `koanf:"pprof-cfg"`
 	Workdir       string                          `koanf:"workdir" reload:"hot"`
 }
 
@@ -67,6 +69,8 @@ var ValidationNodeConfigDefault = ValidationNodeConfig{
 	AuthRPC:       genericconf.AuthRPCConfigDefault,
 	Metrics:       false,
 	MetricsServer: genericconf.MetricsServerConfigDefault,
+	PProf:         false,
+	PprofCfg:      genericconf.PProfDefault,
 	Workdir:       "",
 }
 
@@ -83,6 +87,8 @@ func ValidationNodeConfigAddOptions(f *flag.FlagSet) {
 	genericconf.AuthRPCConfigAddOptions("auth", f)
 	f.Bool("metrics", ValidationNodeConfigDefault.Metrics, "enable metrics")
 	genericconf.MetricsServerAddOptions("metrics-server", f)
+	f.Bool("pprof", ValidationNodeConfigDefault.PProf, "enable pprof")
+	genericconf.PProfAddOptions("pprof-cfg", f)
 	f.String("workdir", ValidationNodeConfigDefault.Workdir, "path used for purpose of resolving relative paths (ia. jwt secret file, log files), if empty then current working directory will be used.")
 }
 

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -37,6 +37,24 @@ func printSampleUsage(progname string) {
 	fmt.Printf("Sample usage:                  %s --node.feed.input.url=<L1 RPC> --chain.id=<L2 chain id> \n", progname)
 }
 
+// Checks metrics and PProf flag, runs them if enabled.
+// Note: they are separate so one can enable/disable them as they wish, the only
+// requirement is that they can't run on the same address and port.
+func mustRunMetrics(cfg *relay.Config) {
+	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
+	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
+	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
+		log.Crit("Metrics and pprof cannot be enabled on the same address:port", "addr", mAddr)
+	}
+	if cfg.Metrics {
+		go metrics.CollectProcessMetrics(cfg.MetricsServer.UpdateInterval)
+		exp.Setup(fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port))
+	}
+	if cfg.PProf {
+		genericconf.StartPprof(pAddr)
+	}
+}
+
 func startup() error {
 	ctx := context.Background()
 
@@ -68,16 +86,12 @@ func startup() error {
 	if err != nil {
 		return err
 	}
+
+	mustRunMetrics(relayConfig)
+
 	err = newRelay.Start(ctx)
 	if err != nil {
 		return err
-	}
-
-	if relayConfig.Metrics && relayConfig.MetricsServer.Addr != "" {
-		go metrics.CollectProcessMetrics(relayConfig.MetricsServer.UpdateInterval)
-
-		address := fmt.Sprintf("%v:%v", relayConfig.MetricsServer.Addr, relayConfig.MetricsServer.Port)
-		exp.Setup(address)
 	}
 
 	select {

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -146,6 +146,8 @@ type Config struct {
 	LogType       string                          `koanf:"log-type"`
 	Metrics       bool                            `koanf:"metrics"`
 	MetricsServer genericconf.MetricsServerConfig `koanf:"metrics-server"`
+	PProf         bool                            `koanf:"pprof"`
+	PprofCfg      genericconf.PProf               `koanf:"pprof-cfg"`
 	Node          NodeConfig                      `koanf:"node"`
 	Queue         int                             `koanf:"queue"`
 }
@@ -157,6 +159,8 @@ var ConfigDefault = Config{
 	LogType:       "plaintext",
 	Metrics:       false,
 	MetricsServer: genericconf.MetricsServerConfigDefault,
+	PProf:         false,
+	PprofCfg:      genericconf.PProfDefault,
 	Node:          NodeConfigDefault,
 	Queue:         1024,
 }
@@ -168,6 +172,8 @@ func ConfigAddOptions(f *flag.FlagSet) {
 	f.String("log-type", ConfigDefault.LogType, "log type")
 	f.Bool("metrics", ConfigDefault.Metrics, "enable metrics")
 	genericconf.MetricsServerAddOptions("metrics-server", f)
+	f.Bool("pprof", ConfigDefault.PProf, "enable pprof")
+	genericconf.PProfAddOptions("pprof-cfg", f)
 	NodeConfigAddOptions("node", f)
 	f.Int("queue", ConfigDefault.Queue, "size of relay queue")
 }


### PR DESCRIPTION
Introduce a flag for pprof port (default 6071), and enable pprof by default. 

Default handler for pprof will be: "http://127.0.0.1:6071/debug/pprof/" which exposes stacktrace as well at "http://127.0.0.1:6071/debug/pprof/goroutine".

Leaving pprof flag itself to have ability to disable it, at we may consider dropping that after a while.