### PR TITLE
Implement support of duplicated members in redis sorted set

### DIFF
--- a/arbnode/dataposter/storage_test.go
+++ b/arbnode/dataposter/storage_test.go
@@ -163,7 +163,7 @@ func TestGetLast(t *testing.T) {
 			ctx := context.Background()
 			for i := 0; i < cnt-1; i++ {
 				prev := strconv.Itoa(i)
-				newVal := strconv.Itoa(cnt + i)
+				newVal := strconv.Itoa(i * 2)
 				if err := s.Put(ctx, uint64(i), &prev, &newVal); err != nil {
 					t.Fatalf("Error putting a key/value: %v, prev: %v, new: %v", err, prev, newVal)
 				}


### PR DESCRIPTION
Redis doesn't support this natively.

https://redis.io/docs/data-types/sorted-sets/: "A Redis sorted set is a collection of unique strings (members) ordered by an associated score."

https://redis.io/commands/zadd/: "If a specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering."