### PR TITLE
Add GetL1RewardRate and GetL1RewardRecipient methods to ArbGasInfo

### DIFF
--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -145,6 +145,10 @@ func (ps *L1PricingState) SetPayRewardsTo(addr common.Address) error {
 	return ps.payRewardsTo.Set(addr)
 }
 
+func (ps *L1PricingState) GetRewardsRecepient() (common.Address, error) {
+	return ps.payRewardsTo.Get()
+}
+
 func (ps *L1PricingState) EquilibrationUnits() (*big.Int, error) {
 	return ps.equilibrationUnits.Get()
 }
@@ -167,6 +171,10 @@ func (ps *L1PricingState) PerUnitReward() (uint64, error) {
 
 func (ps *L1PricingState) SetPerUnitReward(weiPerUnit uint64) error {
 	return ps.perUnitReward.Set(weiPerUnit)
+}
+
+func (ps *L1PricingState) GetRewardsRate() (uint64, error) {
+	return ps.perUnitReward.Get()
 }
 
 func (ps *L1PricingState) LastUpdateTime() (uint64, error) {

--- a/precompiles/ArbGasInfo.go
+++ b/precompiles/ArbGasInfo.go
@@ -162,6 +162,16 @@ func (con ArbGasInfo) GetL1BaseFeeEstimateInertia(c ctx, evm mech) (uint64, erro
 	return c.State.L1PricingState().Inertia()
 }
 
+// GetL1RewardRate gets the L1 pricer reward rate
+func (con ArbGasInfo) GetL1RewardRate(c ctx, evm mech) (uint64, error) {
+	return c.State.L1PricingState().GetRewardsRate()
+}
+
+// GetL1RewardRecipient gets the L1 pricer reward recipient
+func (con ArbGasInfo) GetL1RewardRecipient(c ctx, evm mech) (common.Address, error) {
+	return c.State.L1PricingState().GetRewardsRecepient()
+}
+
 // GetL1GasPriceEstimate gets the current estimate of the L1 basefee
 func (con ArbGasInfo) GetL1GasPriceEstimate(c ctx, evm mech) (huge, error) {
 	return con.GetL1BaseFeeEstimate(c, evm)

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -536,6 +536,8 @@ func Precompiles() map[addr]ArbosPrecompile {
 	insert(MakePrecompile(templates.ArbosTestMetaData, &ArbosTest{Address: hex("69")}))
 	ArbGasInfo := insert(MakePrecompile(templates.ArbGasInfoMetaData, &ArbGasInfo{Address: hex("6c")}))
 	ArbGasInfo.methodsByName["GetL1FeesAvailable"].arbosVersion = 10
+	ArbGasInfo.methodsByName["GetL1RewardRate"].arbosVersion = 11
+	ArbGasInfo.methodsByName["GetL1RewardRecipient"].arbosVersion = 11
 	insert(MakePrecompile(templates.ArbAggregatorMetaData, &ArbAggregator{Address: hex("6d")}))
 	insert(MakePrecompile(templates.ArbStatisticsMetaData, &ArbStatistics{Address: hex("6f")}))
 


### PR DESCRIPTION
This PR creates two new functions to get L1 pricer reward rate and reward recipient in ArbOS version 11

PR for changes to the ArbGasInfo interface file inside solidity contract -> https://github.com/OffchainLabs/nitro-contracts/pull/44