### PR TITLE
Fix clippy lint about useless drop

### DIFF
--- a/arbitrator/jit/src/runtime.rs
+++ b/arbitrator/jit/src/runtime.rs
@@ -39,20 +39,20 @@ pub fn wasm_write(mut env: WasmEnvMut, sp: u32) {
 }
 
 pub fn nanotime1(mut env: WasmEnvMut, sp: u32) {
-    let (sp, mut env) = GoStack::new(sp, &mut env);
+    let (sp, env) = GoStack::new(sp, &mut env);
     env.go_state.time += env.go_state.time_interval;
     sp.write_u64(0, env.go_state.time);
 }
 
 pub fn walltime(mut env: WasmEnvMut, sp: u32) {
-    let (sp, mut env) = GoStack::new(sp, &mut env);
+    let (sp, env) = GoStack::new(sp, &mut env);
     env.go_state.time += env.go_state.time_interval;
     sp.write_u64(0, env.go_state.time / 1_000_000_000);
     sp.write_u32(1, (env.go_state.time % 1_000_000_000) as u32);
 }
 
 pub fn walltime1(mut env: WasmEnvMut, sp: u32) {
-    let (sp, mut env) = GoStack::new(sp, &mut env);
+    let (sp, env) = GoStack::new(sp, &mut env);
     env.go_state.time += env.go_state.time_interval;
     sp.write_u64(0, env.go_state.time / 1_000_000_000);
     sp.write_u64(1, env.go_state.time % 1_000_000_000);

--- a/arbitrator/wasm-libraries/go-stub/src/lib.rs
+++ b/arbitrator/wasm-libraries/go-stub/src/lib.rs
@@ -587,7 +587,10 @@ pub unsafe extern "C" fn wavm__go_after_run() {
     while let Some(info) = state.times.pop() {
         while state.pending_ids.contains(&info.id) {
             TIME = std::cmp::max(TIME, info.time);
-            drop(state);
+            // Important: the current reference to state shouldn't be used after this resume call,
+            // as it might during the resume call the reference might be invalidated.
+            // That's why immediately after this resume call, we replace the reference
+            // with a new reference to TIMEOUT_STATE.
             wavm_guest_call__resume();
             state = TIMEOUT_STATE.get_or_insert_with(Default::default);
         }


### PR DESCRIPTION
The drop was not there to actually do anything but just to indicate that the current state reference shouldn't be used after resume. I've replaced it with a comment explaining that.