### PR TITLE
[Configuration Changes] Don't treat hitting batch L1 bounds as a backlog

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -56,21 +56,23 @@ type batchPosterPosition struct {
 
 type BatchPoster struct {
 	stopwaiter.StopWaiter
-	l1Reader        *headerreader.HeaderReader
-	inbox           *InboxTracker
-	streamer        *TransactionStreamer
-	config          BatchPosterConfigFetcher
-	seqInbox        *bridgegen.SequencerInbox
-	bridge          *bridgegen.Bridge
-	syncMonitor     *SyncMonitor
-	seqInboxABI     *abi.ABI
-	seqInboxAddr    common.Address
-	building        *buildingBatch
-	daWriter        das.DataAvailabilityServiceWriter
-	dataPoster      *dataposter.DataPoster
-	redisLock       *redislock.Simple
-	firstAccErr     time.Time // first time a continuous missing accumulator occurred
-	backlog         uint64    // An estimate of the number of unposted batches
+	l1Reader     *headerreader.HeaderReader
+	inbox        *InboxTracker
+	streamer     *TransactionStreamer
+	config       BatchPosterConfigFetcher
+	seqInbox     *bridgegen.SequencerInbox
+	bridge       *bridgegen.Bridge
+	syncMonitor  *SyncMonitor
+	seqInboxABI  *abi.ABI
+	seqInboxAddr common.Address
+	building     *buildingBatch
+	daWriter     das.DataAvailabilityServiceWriter
+	dataPoster   *dataposter.DataPoster
+	redisLock    *redislock.Simple
+	firstAccErr  time.Time // first time a continuous missing accumulator occurred
+	// An estimate of the number of batches we want to post but haven't yet.
+	// This doesn't include batches which we don't want to post yet due to the L1 bounds.
+	backlog         uint64
 	lastHitL1Bounds time.Time // The last time we wanted to post a message but hit the L1 bounds
 
 	batchReverted atomic.Bool // indicates whether data poster batch was reverted


### PR DESCRIPTION
When we hit the L1 bounds, we don't have a real backlog in that there aren't a bunch of messages we want to post but haven't yet. We don't need to try to speed up batch posting by lowering the compression level as the code does when it detects a backlog. Instead, these are just messages that we can't post yet because of the L1 bounds.

This PR also renames `--node.batch-poster.poll-delay` to `--node.batch-poster.poll-interval` and updates the config description. The thinking here is that this is separate from the batch posting delay, and it's more of a polling interval because we only wait that long after having not posted a batch (this wasn't always the behavior hence the old config description).