### PR TITLE
Default to using "safe" instead of "finalized" for delayed sequencing

### DIFF
--- a/arbnode/delayed_sequencer.go
+++ b/arbnode/delayed_sequencer.go
@@ -52,14 +52,14 @@ func DelayedSequencerConfigAddOptions(prefix string, f *flag.FlagSet) {
 var DefaultDelayedSequencerConfig = DelayedSequencerConfig{
 	Enable:              false,
 	FinalizeDistance:    20,
-	RequireFullFinality: true,
+	RequireFullFinality: false,
 	UseMergeFinality:    true,
 }
 
 var TestDelayedSequencerConfig = DelayedSequencerConfig{
 	Enable:              true,
 	FinalizeDistance:    20,
-	RequireFullFinality: true,
+	RequireFullFinality: false,
 	UseMergeFinality:    true,
 }
 


### PR DESCRIPTION
We've already set this for the sequencers we run but this is a better default to have for new chains.