### PR TITLE
Check geth metrics are enabled properly

### DIFF
--- a/cmd/daserver/daserver.go
+++ b/cmd/daserver/daserver.go
@@ -148,6 +148,9 @@ func (c *L1ReaderCloser) String() string {
 func startMetrics(cfg *DAServerConfig) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
+	if cfg.Metrics && !metrics.Enabled {
+		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)
 	}

--- a/cmd/nitro-val/nitro_val.go
+++ b/cmd/nitro-val/nitro_val.go
@@ -38,6 +38,9 @@ func main() {
 func startMetrics(cfg *ValidationNodeConfig) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
+	if cfg.Metrics && !metrics.Enabled {
+		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)
 	}

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -129,6 +129,9 @@ func main() {
 func startMetrics(cfg *NodeConfig) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
+	if cfg.Metrics && !metrics.Enabled {
+		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)
 	}

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -43,6 +43,9 @@ func printSampleUsage(progname string) {
 func startMetrics(cfg *relay.Config) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
+	if cfg.Metrics && !metrics.Enabled {
+		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)
 	}


### PR DESCRIPTION
We use geth's metrics module for several executables in the nitro repository. It checks for the --metrics flag on module startup to determine whether to start or not, bypassing our configuration system. So for this one flag, we need to check that it was set by command line.

# Testing done 
Make a config file with `"metrics": true`
```
$ cat metrics.conf
{
  "metrics": true,
  "metrics-server": {
    "addr": "0.0.0.0",
    "port": 6070
  }
}
```

Try to start a relay with that config file, without setting `--metrics; it fails with an error message.
```
$ ./target/bin/relay --node.feed.input.url ws://127.0.0.1:9642/feed --chain.id 421613 --node.feed.outp
ut.connection-limits.enable --node.feed.output.connection-limits.per-ip-limit 2 --log-level 5 --node.f
eed.output.log-connect --node.feed.output.connection-limits.reconnect-cooldown-period 15s --node.feed.
output.port 10000 --conf.file metrics.conf                                                            
INFO [08-10|17:34:45.340] Running Arbitrum nitro relay             revision=9018996-modified vcs.time=
2023-08-10T20:43:25Z                                                                                  
INFO [08-10|17:34:45.341] Cleanly shutting down relay                                                 
ERROR[08-10|17:34:45.341] Error running relay                      err="metrics must be enabled via co
mmand line by adding --metrics, json config has no effect"                                            
```

Try to start a relay with that config file, setting `--metrics`; it starts up properly.
```
tristan@ramona ~/offchain/nitro 0                                                                     
Thu Aug 10 17:34:45                                                                                   
$ ./target/bin/relay --node.feed.input.url ws://127.0.0.1:9642/feed --chain.id 421613 --node.feed.outp
ut.connection-limits.enable --node.feed.output.connection-limits.per-ip-limit 2 --log-level 5 --node.f
eed.output.log-connect --node.feed.output.connection-limits.reconnect-cooldown-period 15s --node.feed.
output.port 10000 --conf.file metrics.conf --metrics                                                  
INFO [08-10|17:34:51.310] Running Arbitrum nitro relay             revision=9018996-modified vcs.time=
2023-08-10T20:43:25Z                                                                                  
INFO [08-10|17:34:51.311] Starting metrics server                  addr=http://0.0.0.0:6070/debug/metr
ics                                                                                                   
INFO [08-10|17:34:51.311] arbitrum websocket broadcast server is listening address=[::]:10000         
INFO [08-10|17:34:51.311] connecting to arbitrum inbox message broadcaster url=ws://127.0.0.1:9642/fee
d                                                                                                     
WARN [08-10|17:34:51.311] failed connect to sequencer broadcast, waiting and retrying url=ws://127.0.0
.1:9642/feed err="broadcast client unable to connect: dial tcp 127.0.0.1:9642: connect: connection ref
used"
^CINFO [08-10|17:34:51.989] shutting down because of sigint 
DEBUG[08-10|17:34:51.989] closing broadcaster client connection 
INFO [08-10|17:34:51.990] Cleanly shutting down relay 
```