### PR TITLE
Fix lost txQueueItems in sequencer

### DIFF
--- a/arbnode/execution/sequencer.go
+++ b/arbnode/execution/sequencer.go
@@ -375,11 +375,11 @@ func (s *Sequencer) onNonceFailureEvict(_ addressAndNonce, failure *nonceFailure
 var ErrRetrySequencer = errors.New("please retry transaction")
 
 // ctxWithTimeout is like context.WithTimeout except a timeout of 0 means unlimited instead of instantly expired.
-func ctxWithTimeout(inctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+func ctxWithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if timeout == time.Duration(0) {
-		return context.WithCancel(inctx)
+		return context.WithCancel(ctx)
 	}
-	return context.WithTimeout(inctx, timeout)
+	return context.WithTimeout(ctx, timeout)
 }
 
 func (s *Sequencer) PublishTransaction(parentCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions) error {
@@ -442,7 +442,7 @@ func (s *Sequencer) PublishTransaction(parentCtx context.Context, tx *types.Tran
 		// We want to give the background queue as much time as possible to make a response.
 		if time.Now().After(abortDeadline) {
 			// If we've hit the abort deadline (as opposed to parentCtx being canceled), something went wrong.
-			log.Warn("transaction sequencing hit abort deadline", "submissionStart", submissionStart, "queueTimeout", queueTimeout, "txHash", tx.Hash())
+			log.Warn("Transaction sequencing hit abort deadline", "submissionStart", submissionStart, "queueTimeout", queueTimeout, "txHash", tx.Hash())
 		}
 		return abortCtx.Err()
 	}
@@ -1009,7 +1009,7 @@ func (s *Sequencer) StopAndWait() {
 		return
 	}
 	// this usually means that coordinator's safe-shutdown-delay is too low
-	log.Warn("sequencer has queued items while shutting down", "txQueue", len(s.txQueue), "retryQueue", s.txRetryQueue.Len(), "nonceFailures", s.nonceFailures.Len())
+	log.Warn("Sequencer has queued items while shutting down", "txQueue", len(s.txQueue), "retryQueue", s.txRetryQueue.Len(), "nonceFailures", s.nonceFailures.Len())
 	_, forwarder := s.GetPauseAndForwarder()
 	if forwarder != nil {
 		var wg sync.WaitGroup

--- a/arbnode/execution/sequencer.go
+++ b/arbnode/execution/sequencer.go
@@ -1004,7 +1004,7 @@ func (s *Sequencer) StopAndWait() {
 		return
 	}
 	// this usually means that coordinator's safe-shutdown-delay is too low
-	log.Warn("sequencer has queued items while shutting down", "txQueue", len(s.txQueue), "retryQueue", s.txRetryQueue.Len())
+	log.Warn("sequencer has queued items while shutting down", "txQueue", len(s.txQueue), "retryQueue", s.txRetryQueue.Len(), "nonceFailures", s.nonceFailures.Len())
 	_, forwarder := s.GetPauseAndForwarder()
 	if forwarder != nil {
 		var wg sync.WaitGroup


### PR DESCRIPTION
The core issue here was that when s.nonceFailures.Add was called here https://github.com/OffchainLabs/nitro/blob/02455204d11d34553edd0e697cbd217a6d9ee039/arbnode/execution/sequencer.go#L922 , if that nonceError was already in the nonceFailures map, it would silently drop the queueItem it was trying to add. We already had a check for this at the other callsite of s.nonceFailures.Add, but I refactored it in this PR so that the Add function takes care of the check and is thus a lot safer.

To replicate this issue, you can run a node with:
```
go run ./cmd/nitro --init.dev-init --init.dev-init-address 0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E --node.dangerous.no-l1-listener --node.parent-chain-reader.enable=false --parent-chain.id=1337 --chain.id=412346 --persistent.chain /tmp/nitro-dev-test --node.sequencer.enable --node.sequencer.dangerous.no-coordinator --node.staker.enable=false --init.empty=false --http.port 10000 --http.addr 127.0.0.1 --http.corsdomain '*' --metrics --metrics-server.port 6080 --node.sequencer.max-block-speed 2s
```

and then (the private key is from test-node.sh, obviously don't use this public private key for real funds):

```sh
cast send --rpc-url 'http://localhost:10000' --private-key b6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659 0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E --gas-limit 1000000 & sleep 0.2; cast send --rpc-url 'http://localhost:10000' --private-key b6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659 0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E --gas-limit 100 --nonce 1 & cast send --rpc-url 'http://localhost:10000' --private-key b6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659 0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E --nonce 2 --gas-limit 100 & cast send --rpc-url 'http://localhost:10000' --private-key b6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659 0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E --nonce 2 --gas-limit 101
```

Notice how there's one "intrinsic gas too low" and a "nonce too high" error, but then there's an unexpected "context canceled" when `cast` hits its default 30 second request timeout. With this PR applied, you'll still get one "intrinsic gas too low" but two "nonce too high" errors instead of one of them being "context canceled". That means that the sequencer is properly processing all transactions and issuing correct errors for them instead of just timing out because the queue item got lost.

This PR also fixes a couple other issues I noticed while investigating:
- Adds a hard timeout of 2x the queue timeout to sequencer tx submission, just in case a queue item somehow gets lost again
- Improves the forwarding of nonce failures on sequencer shutdown