### PR TITLE
Fix build-brotli.sh target path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,8 +347,8 @@ contracts/test/prover/proofs/%.json: $(arbitrator_cases)/%.wasm $(arbitrator_pro
 	@touch $@
 
 .make/wasm-lib: $(DEP_PREDICATE) arbitrator/wasm-libraries/soft-float/SoftFloat/build/Wasm-Clang/softfloat.a  $(ORDER_ONLY_PREDICATE) .make
-	test -f arbitrator/wasm-libraries/soft-float/bindings32.o || ./scripts/build-brotli.sh -f -d -t .
-	test -f arbitrator/wasm-libraries/soft-float/bindings64.o || ./scripts/build-brotli.sh -f -d -t .
+	test -f arbitrator/wasm-libraries/soft-float/bindings32.o || ./scripts/build-brotli.sh -f -d -t ..
+	test -f arbitrator/wasm-libraries/soft-float/bindings64.o || ./scripts/build-brotli.sh -f -d -t ..
 	@touch $@
 
 .make:


### PR DESCRIPTION
In #1679 when build-brotli.sh was moved into the scripts directory, we missed that its target argument is relative to its own location, because it does a `cd "$(dirname "$0")"`. This fixes the invocation in the Makefile to output soft float libraries to the correct destination.