### PR TITLE
Fix koanf lint errors by matching koanf tags with field names

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -88,23 +88,28 @@ const (
 )
 
 type BatchPosterConfig struct {
-	Enable                             bool                        `koanf:"enable"`
-	DisableDasFallbackStoreDataOnChain bool                        `koanf:"disable-das-fallback-store-data-on-chain" reload:"hot"`
-	MaxBatchSize                       int                         `koanf:"max-size" reload:"hot"`
-	MaxBatchPostDelay                  time.Duration               `koanf:"max-delay" reload:"hot"`
-	WaitForMaxBatchPostDelay           bool                        `koanf:"wait-for-max-delay" reload:"hot"`
-	BatchPollDelay                     time.Duration               `koanf:"poll-delay" reload:"hot"`
-	PostingErrorDelay                  time.Duration               `koanf:"error-delay" reload:"hot"`
-	CompressionLevel                   int                         `koanf:"compression-level" reload:"hot"`
-	DASRetentionPeriod                 time.Duration               `koanf:"das-retention-period" reload:"hot"`
-	GasRefunderAddress                 string                      `koanf:"gas-refunder-address" reload:"hot"`
-	DataPoster                         dataposter.DataPosterConfig `koanf:"data-poster" reload:"hot"`
-	RedisUrl                           string                      `koanf:"redis-url"`
-	RedisLock                          redislock.SimpleCfg         `koanf:"redis-lock" reload:"hot"`
-	ExtraBatchGas                      uint64                      `koanf:"extra-batch-gas" reload:"hot"`
-	L1Wallet                           genericconf.WalletConfig    `koanf:"parent-chain-wallet"`
-	L1BlockBound                       string                      `koanf:"l1-block-bound" reload:"hot"`
-	L1BlockBoundBypass                 time.Duration               `koanf:"l1-block-bound-bypass" reload:"hot"`
+	Enable                             bool `koanf:"enable"`
+	DisableDasFallbackStoreDataOnChain bool `koanf:"disable-das-fallback-store-data-on-chain" reload:"hot"`
+	// Max batch size.
+	MaxSize int `koanf:"max-size" reload:"hot"`
+	// Max batch post delay.
+	MaxDelay time.Duration `koanf:"max-delay" reload:"hot"`
+	// Wait for max BatchPost delay.
+	WaitForMaxDelay bool `koanf:"wait-for-max-delay" reload:"hot"`
+	// Batch post polling delay.
+	PollDelay time.Duration `koanf:"poll-delay" reload:"hot"`
+	// Batch posting error delay.
+	ErrorDelay         time.Duration               `koanf:"error-delay" reload:"hot"`
+	CompressionLevel   int                         `koanf:"compression-level" reload:"hot"`
+	DASRetentionPeriod time.Duration               `koanf:"das-retention-period" reload:"hot"`
+	GasRefunderAddress string                      `koanf:"gas-refunder-address" reload:"hot"`
+	DataPoster         dataposter.DataPosterConfig `koanf:"data-poster" reload:"hot"`
+	RedisUrl           string                      `koanf:"redis-url"`
+	RedisLock          redislock.SimpleCfg         `koanf:"redis-lock" reload:"hot"`
+	ExtraBatchGas      uint64                      `koanf:"extra-batch-gas" reload:"hot"`
+	ParentChainWallet  genericconf.WalletConfig    `koanf:"parent-chain-wallet"`
+	L1BlockBound       string                      `koanf:"l1-block-bound" reload:"hot"`
+	L1BlockBoundBypass time.Duration               `koanf:"l1-block-bound-bypass" reload:"hot"`
 
 	gasRefunder  common.Address
 	l1BlockBound l1BlockBound
@@ -115,7 +120,7 @@ func (c *BatchPosterConfig) Validate() error {
 		return fmt.Errorf("invalid gas refunder address \"%v\"", c.GasRefunderAddress)
 	}
 	c.gasRefunder = common.HexToAddress(c.GasRefunderAddress)
-	if c.MaxBatchSize <= 40 {
+	if c.MaxSize <= 40 {
 		return errors.New("MaxBatchSize too small")
 	}
 	if c.L1BlockBound == "" {
@@ -139,11 +144,11 @@ type BatchPosterConfigFetcher func() *BatchPosterConfig
 func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultBatchPosterConfig.Enable, "enable posting batches to l1")
 	f.Bool(prefix+".disable-das-fallback-store-data-on-chain", DefaultBatchPosterConfig.DisableDasFallbackStoreDataOnChain, "If unable to batch to DAS, disable fallback storing data on chain")
-	f.Int(prefix+".max-size", DefaultBatchPosterConfig.MaxBatchSize, "maximum batch size")
-	f.Duration(prefix+".max-delay", DefaultBatchPosterConfig.MaxBatchPostDelay, "maximum batch posting delay")
-	f.Bool(prefix+".wait-for-max-delay", DefaultBatchPosterConfig.WaitForMaxBatchPostDelay, "wait for the max batch delay, even if the batch is full")
-	f.Duration(prefix+".poll-delay", DefaultBatchPosterConfig.BatchPollDelay, "how long to delay after successfully posting batch")
-	f.Duration(prefix+".error-delay", DefaultBatchPosterConfig.PostingErrorDelay, "how long to delay after error posting batch")
+	f.Int(prefix+".max-size", DefaultBatchPosterConfig.MaxSize, "maximum batch size")
+	f.Duration(prefix+".max-delay", DefaultBatchPosterConfig.MaxDelay, "maximum batch posting delay")
+	f.Bool(prefix+".wait-for-max-delay", DefaultBatchPosterConfig.WaitForMaxDelay, "wait for the max batch delay, even if the batch is full")
+	f.Duration(prefix+".poll-delay", DefaultBatchPosterConfig.PollDelay, "how long to delay after successfully posting batch")
+	f.Duration(prefix+".error-delay", DefaultBatchPosterConfig.ErrorDelay, "how long to delay after error posting batch")
 	f.Int(prefix+".compression-level", DefaultBatchPosterConfig.CompressionLevel, "batch compression level")
 	f.Duration(prefix+".das-retention-period", DefaultBatchPosterConfig.DASRetentionPeriod, "In AnyTrust mode, the period which DASes are requested to retain the stored batches.")
 	f.String(prefix+".gas-refunder-address", DefaultBatchPosterConfig.GasRefunderAddress, "The gas refunder contract address (optional)")
@@ -153,50 +158,50 @@ func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Duration(prefix+".l1-block-bound-bypass", DefaultBatchPosterConfig.L1BlockBoundBypass, "post batches even if not within the layer 1 future bounds if we're within this margin of the max delay")
 	redislock.AddConfigOptions(prefix+".redis-lock", f)
 	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f)
-	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultBatchPosterConfig.L1Wallet.Pathname)
+	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultBatchPosterConfig.ParentChainWallet.Pathname)
 }
 
 var DefaultBatchPosterConfig = BatchPosterConfig{
 	Enable:                             false,
 	DisableDasFallbackStoreDataOnChain: false,
-	MaxBatchSize:                       100000,
-	BatchPollDelay:                     time.Second * 10,
-	PostingErrorDelay:                  time.Second * 10,
-	MaxBatchPostDelay:                  time.Hour,
-	WaitForMaxBatchPostDelay:           false,
+	MaxSize:                            100000,
+	PollDelay:                          time.Second * 10,
+	ErrorDelay:                         time.Second * 10,
+	MaxDelay:                           time.Hour,
+	WaitForMaxDelay:                    false,
 	CompressionLevel:                   brotli.BestCompression,
 	DASRetentionPeriod:                 time.Hour * 24 * 15,
 	GasRefunderAddress:                 "",
 	ExtraBatchGas:                      50_000,
 	DataPoster:                         dataposter.DefaultDataPosterConfig,
-	L1Wallet:                           DefaultBatchPosterL1WalletConfig,
+	ParentChainWallet:                  DefaultBatchPosterL1WalletConfig,
 	L1BlockBound:                       "",
 	L1BlockBoundBypass:                 time.Hour,
 }
 
 var DefaultBatchPosterL1WalletConfig = genericconf.WalletConfig{
 	Pathname:      "batch-poster-wallet",
-	PasswordImpl:  genericconf.WalletConfigDefault.PasswordImpl,
+	Password:      genericconf.WalletConfigDefault.Password,
 	PrivateKey:    genericconf.WalletConfigDefault.PrivateKey,
 	Account:       genericconf.WalletConfigDefault.Account,
 	OnlyCreateKey: genericconf.WalletConfigDefault.OnlyCreateKey,
 }
 
 var TestBatchPosterConfig = BatchPosterConfig{
-	Enable:                   true,
-	MaxBatchSize:             100000,
-	BatchPollDelay:           time.Millisecond * 10,
-	PostingErrorDelay:        time.Millisecond * 10,
-	MaxBatchPostDelay:        0,
-	WaitForMaxBatchPostDelay: false,
-	CompressionLevel:         2,
-	DASRetentionPeriod:       time.Hour * 24 * 15,
-	GasRefunderAddress:       "",
-	ExtraBatchGas:            10_000,
-	DataPoster:               dataposter.TestDataPosterConfig,
-	L1Wallet:                 DefaultBatchPosterL1WalletConfig,
-	L1BlockBound:             "",
-	L1BlockBoundBypass:       time.Hour,
+	Enable:             true,
+	MaxSize:            100000,
+	PollDelay:          time.Millisecond * 10,
+	ErrorDelay:         time.Millisecond * 10,
+	MaxDelay:           0,
+	WaitForMaxDelay:    false,
+	CompressionLevel:   2,
+	DASRetentionPeriod: time.Hour * 24 * 15,
+	GasRefunderAddress: "",
+	ExtraBatchGas:      10_000,
+	DataPoster:         dataposter.TestDataPosterConfig,
+	ParentChainWallet:  DefaultBatchPosterL1WalletConfig,
+	L1BlockBound:       "",
+	L1BlockBoundBypass: time.Hour,
 }
 
 func NewBatchPoster(dataPosterDB ethdb.Database, l1Reader *headerreader.HeaderReader, inbox *InboxTracker, streamer *TransactionStreamer, syncMonitor *SyncMonitor, config BatchPosterConfigFetcher, deployInfo *chaininfo.RollupAddresses, transactOpts *bind.TransactOpts, daWriter das.DataAvailabilityServiceWriter) (*BatchPoster, error) {
@@ -374,8 +379,8 @@ type buildingBatch struct {
 }
 
 func newBatchSegments(firstDelayed uint64, config *BatchPosterConfig, backlog uint64) *batchSegments {
-	compressedBuffer := bytes.NewBuffer(make([]byte, 0, config.MaxBatchSize*2))
-	if config.MaxBatchSize <= 40 {
+	compressedBuffer := bytes.NewBuffer(make([]byte, 0, config.MaxSize*2))
+	if config.MaxSize <= 40 {
 		panic("MaxBatchSize too small")
 	}
 	compressionLevel := config.CompressionLevel
@@ -401,7 +406,7 @@ func newBatchSegments(firstDelayed uint64, config *BatchPosterConfig, backlog ui
 	return &batchSegments{
 		compressedBuffer:   compressedBuffer,
 		compressedWriter:   brotli.NewWriterLevel(compressedBuffer, compressionLevel),
-		sizeLimit:          config.MaxBatchSize - 40, // TODO
+		sizeLimit:          config.MaxSize - 40, // TODO
 		recompressionLevel: recompressionLevel,
 		rawSegments:        make([][]byte, 0, 128),
 		delayedMsg:         firstDelayed,
@@ -717,7 +722,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 	firstMsgTime := time.Unix(int64(firstMsg.Message.Header.Timestamp), 0)
 
 	config := b.config()
-	forcePostBatch := time.Since(firstMsgTime) >= config.MaxBatchPostDelay
+	forcePostBatch := time.Since(firstMsgTime) >= config.MaxDelay
 
 	var l1BoundMaxBlockNumber uint64 = math.MaxUint64
 	var l1BoundMaxTimestamp uint64 = math.MaxUint64
@@ -815,7 +820,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		}
 		if !success {
 			// this batch is full
-			if !config.WaitForMaxBatchPostDelay {
+			if !config.WaitForMaxDelay {
 				forcePostBatch = true
 			}
 			b.building.haveUsefulMessage = true
@@ -930,7 +935,7 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 		}
 		if !b.redisLock.AttemptLock(ctx) {
 			b.building = nil
-			return b.config().BatchPollDelay
+			return b.config().PollDelay
 		}
 		posted, err := b.maybePostSequencerBatch(ctx)
 		if err != nil {
@@ -949,11 +954,11 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 				b.firstAccErr = time.Time{}
 			}
 			logLevel("error posting batch", "err", err)
-			return b.config().PostingErrorDelay
+			return b.config().ErrorDelay
 		} else if posted {
 			return 0
 		} else {
-			return b.config().BatchPollDelay
+			return b.config().PollDelay
 		}
 	})
 }

--- a/arbnode/execution/blockchain.go
+++ b/arbnode/execution/blockchain.go
@@ -26,15 +26,15 @@ import (
 )
 
 type CachingConfig struct {
-	Archive               bool          `koanf:"archive"`
-	BlockCount            uint64        `koanf:"block-count"`
-	BlockAge              time.Duration `koanf:"block-age"`
-	TrieTimeLimit         time.Duration `koanf:"trie-time-limit"`
-	TrieDirtyCache        int           `koanf:"trie-dirty-cache"`
-	TrieCleanCache        int           `koanf:"trie-clean-cache"`
-	SnapshotCache         int           `koanf:"snapshot-cache"`
-	DatabaseCache         int           `koanf:"database-cache"`
-	SnapshotRestoreMaxGas uint64        `koanf:"snapshot-restore-gas-limit"`
+	Archive                 bool          `koanf:"archive"`
+	BlockCount              uint64        `koanf:"block-count"`
+	BlockAge                time.Duration `koanf:"block-age"`
+	TrieTimeLimit           time.Duration `koanf:"trie-time-limit"`
+	TrieDirtyCache          int           `koanf:"trie-dirty-cache"`
+	TrieCleanCache          int           `koanf:"trie-clean-cache"`
+	SnapshotCache           int           `koanf:"snapshot-cache"`
+	DatabaseCache           int           `koanf:"database-cache"`
+	SnapshotRestoreGasLimit uint64        `koanf:"snapshot-restore-gas-limit"`
 }
 
 func CachingConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -46,19 +46,19 @@ func CachingConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Int(prefix+".trie-clean-cache", DefaultCachingConfig.TrieCleanCache, "amount of memory in megabytes to cache unchanged state trie nodes with")
 	f.Int(prefix+".snapshot-cache", DefaultCachingConfig.SnapshotCache, "amount of memory in megabytes to cache state snapshots with")
 	f.Int(prefix+".database-cache", DefaultCachingConfig.DatabaseCache, "amount of memory in megabytes to cache database contents with")
-	f.Uint64(prefix+".snapshot-restore-gas-limit", DefaultCachingConfig.SnapshotRestoreMaxGas, "maximum gas rolled back to recover snapshot")
+	f.Uint64(prefix+".snapshot-restore-gas-limit", DefaultCachingConfig.SnapshotRestoreGasLimit, "maximum gas rolled back to recover snapshot")
 }
 
 var DefaultCachingConfig = CachingConfig{
-	Archive:               false,
-	BlockCount:            128,
-	BlockAge:              30 * time.Minute,
-	TrieTimeLimit:         time.Hour,
-	TrieDirtyCache:        1024,
-	TrieCleanCache:        600,
-	SnapshotCache:         400,
-	DatabaseCache:         2048,
-	SnapshotRestoreMaxGas: 300_000_000_000,
+	Archive:                 false,
+	BlockCount:              128,
+	BlockAge:                30 * time.Minute,
+	TrieTimeLimit:           time.Hour,
+	TrieDirtyCache:          1024,
+	TrieCleanCache:          600,
+	SnapshotCache:           400,
+	DatabaseCache:           2048,
+	SnapshotRestoreGasLimit: 300_000_000_000,
 }
 
 func DefaultCacheConfigFor(stack *node.Node, cachingConfig *CachingConfig) *core.CacheConfig {
@@ -79,7 +79,7 @@ func DefaultCacheConfigFor(stack *node.Node, cachingConfig *CachingConfig) *core
 		TrieRetention:         cachingConfig.BlockAge,
 		SnapshotLimit:         cachingConfig.SnapshotCache,
 		Preimages:             baseConf.Preimages,
-		SnapshotRestoreMaxGas: cachingConfig.SnapshotRestoreMaxGas,
+		SnapshotRestoreMaxGas: cachingConfig.SnapshotRestoreGasLimit,
 	}
 }
 

--- a/arbnode/message_pruner.go
+++ b/arbnode/message_pruner.go
@@ -33,22 +33,23 @@ type MessagePruner struct {
 }
 
 type MessagePrunerConfig struct {
-	Enable               bool          `koanf:"enable"`
-	MessagePruneInterval time.Duration `koanf:"prune-interval" reload:"hot"`
-	MinBatchesLeft       uint64        `koanf:"min-batches-left" reload:"hot"`
+	Enable bool `koanf:"enable"`
+	// Message pruning interval.
+	PruneInterval  time.Duration `koanf:"prune-interval" reload:"hot"`
+	MinBatchesLeft uint64        `koanf:"min-batches-left" reload:"hot"`
 }
 
 type MessagePrunerConfigFetcher func() *MessagePrunerConfig
 
 var DefaultMessagePrunerConfig = MessagePrunerConfig{
-	Enable:               true,
-	MessagePruneInterval: time.Minute,
-	MinBatchesLeft:       2,
+	Enable:         true,
+	PruneInterval:  time.Minute,
+	MinBatchesLeft: 2,
 }
 
 func MessagePrunerConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultMessagePrunerConfig.Enable, "enable message pruning")
-	f.Duration(prefix+".prune-interval", DefaultMessagePrunerConfig.MessagePruneInterval, "interval for running message pruner")
+	f.Duration(prefix+".prune-interval", DefaultMessagePrunerConfig.PruneInterval, "interval for running message pruner")
 	f.Uint64(prefix+".min-batches-left", DefaultMessagePrunerConfig.MinBatchesLeft, "min number of batches not pruned")
 }
 
@@ -70,7 +71,7 @@ func (m *MessagePruner) UpdateLatestConfirmed(count arbutil.MessageIndex, global
 		return
 	}
 
-	if m.lastPruneDone.Add(m.config().MessagePruneInterval).After(time.Now()) {
+	if m.lastPruneDone.Add(m.config().PruneInterval).After(time.Now()) {
 		m.pruningLock.Unlock()
 		return
 	}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -297,7 +297,7 @@ type Config struct {
 	Forwarder           execution.ForwarderConfig        `koanf:"forwarder"`
 	TxPreChecker        execution.TxPreCheckerConfig     `koanf:"tx-pre-checker" reload:"hot"`
 	BlockValidator      staker.BlockValidatorConfig      `koanf:"block-validator" reload:"hot"`
-	RecordingDB         arbitrum.RecordingDatabaseConfig `koanf:"recording-db"`
+	RecordingDatabase   arbitrum.RecordingDatabaseConfig `koanf:"recording-database"`
 	Feed                broadcastclient.FeedConfig       `koanf:"feed" reload:"hot"`
 	Staker              staker.L1ValidatorConfig         `koanf:"staker"`
 	SeqCoordinator      SeqCoordinatorConfig             `koanf:"seq-coordinator"`
@@ -309,7 +309,7 @@ type Config struct {
 	TxLookupLimit       uint64                           `koanf:"tx-lookup-limit"`
 	TransactionStreamer TransactionStreamerConfig        `koanf:"transaction-streamer" reload:"hot"`
 	Maintenance         MaintenanceConfig                `koanf:"maintenance" reload:"hot"`
-	ResourceManagement  resourcemanager.Config           `koanf:"resource-management" reload:"hot"`
+	ResourceMgmt        resourcemanager.Config           `koanf:"resource-mgmt" reload:"hot"`
 }
 
 func (c *Config) Validate() error {
@@ -373,7 +373,7 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet, feedInputEnable bool, feed
 	execution.AddOptionsForNodeForwarderConfig(prefix+".forwarder", f)
 	execution.TxPreCheckerConfigAddOptions(prefix+".tx-pre-checker", f)
 	staker.BlockValidatorConfigAddOptions(prefix+".block-validator", f)
-	arbitrum.RecordingDatabaseConfigAddOptions(prefix+".recording-db", f)
+	arbitrum.RecordingDatabaseConfigAddOptions(prefix+".recording-database", f)
 	broadcastclient.FeedConfigAddOptions(prefix+".feed", f, feedInputEnable, feedOutputEnable)
 	staker.L1ValidatorConfigAddOptions(prefix+".staker", f)
 	SeqCoordinatorConfigAddOptions(prefix+".seq-coordinator", f)
@@ -384,7 +384,7 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet, feedInputEnable bool, feed
 	f.Uint64(prefix+".tx-lookup-limit", ConfigDefault.TxLookupLimit, "retain the ability to lookup transactions by hash for the past N blocks (0 = all blocks)")
 	TransactionStreamerConfigAddOptions(prefix+".transaction-streamer", f)
 	MaintenanceConfigAddOptions(prefix+".maintenance", f)
-	resourcemanager.ConfigAddOptions(prefix+".resource-management", f)
+	resourcemanager.ConfigAddOptions(prefix+".resource-mgmt", f)
 
 	archiveMsg := fmt.Sprintf("retain past block state (deprecated, please use %v.caching.archive)", prefix)
 	f.Bool(prefix+".archive", ConfigDefault.Archive, archiveMsg)
@@ -401,7 +401,7 @@ var ConfigDefault = Config{
 	ForwardingTarget:    "",
 	TxPreChecker:        execution.DefaultTxPreCheckerConfig,
 	BlockValidator:      staker.DefaultBlockValidatorConfig,
-	RecordingDB:         arbitrum.DefaultRecordingDatabaseConfig,
+	RecordingDatabase:   arbitrum.DefaultRecordingDatabaseConfig,
 	Feed:                broadcastclient.FeedConfigDefault,
 	Staker:              staker.DefaultL1ValidatorConfig,
 	SeqCoordinator:      DefaultSeqCoordinatorConfig,
@@ -412,7 +412,7 @@ var ConfigDefault = Config{
 	TxLookupLimit:       126_230_400, // 1 year at 4 blocks per second
 	Caching:             execution.DefaultCachingConfig,
 	TransactionStreamer: DefaultTransactionStreamerConfig,
-	ResourceManagement:  resourcemanager.DefaultConfig,
+	ResourceMgmt:        resourcemanager.DefaultConfig,
 }
 
 func ConfigDefaultL1Test() *Config {
@@ -447,7 +447,7 @@ func ConfigDefaultL2Test() *Config {
 	config.Sequencer = execution.TestSequencerConfig
 	config.ParentChainReader.Enable = false
 	config.SeqCoordinator = TestSeqCoordinatorConfig
-	config.Feed.Input.Verifier.Dangerous.AcceptMissing = true
+	config.Feed.Input.Verify.Dangerous.AcceptMissing = true
 	config.Feed.Output.Signed = false
 	config.SeqCoordinator.Signer.ECDSA.AcceptSequencer = false
 	config.SeqCoordinator.Signer.ECDSA.Dangerous.AcceptMissing = true
@@ -613,7 +613,7 @@ func createNodeImpl(
 	sequencerConfigFetcher := func() *execution.SequencerConfig { return &configFetcher.Get().Sequencer }
 	txprecheckConfigFetcher := func() *execution.TxPreCheckerConfig { return &configFetcher.Get().TxPreChecker }
 	exec, err := execution.CreateExecutionNode(stack, chainDb, l2BlockChain, l1Reader, syncMonitor,
-		config.ForwardingTargetF(), &config.Forwarder, config.RPC, &config.RecordingDB,
+		config.ForwardingTargetF(), &config.Forwarder, config.RPC, &config.RecordingDatabase,
 		sequencerConfigFetcher, txprecheckConfigFetcher)
 	if err != nil {
 		return nil, err

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -286,34 +286,34 @@ func DeployOnL1(ctx context.Context, l1client arbutil.L1Interface, deployAuth *b
 }
 
 type Config struct {
-	RPC                  arbitrum.Config                  `koanf:"rpc"`
-	Sequencer            execution.SequencerConfig        `koanf:"sequencer" reload:"hot"`
-	L1Reader             headerreader.Config              `koanf:"parent-chain-reader" reload:"hot"`
-	InboxReader          InboxReaderConfig                `koanf:"inbox-reader" reload:"hot"`
-	DelayedSequencer     DelayedSequencerConfig           `koanf:"delayed-sequencer" reload:"hot"`
-	BatchPoster          BatchPosterConfig                `koanf:"batch-poster" reload:"hot"`
-	MessagePruner        MessagePrunerConfig              `koanf:"message-pruner" reload:"hot"`
-	ForwardingTargetImpl string                           `koanf:"forwarding-target"`
-	Forwarder            execution.ForwarderConfig        `koanf:"forwarder"`
-	TxPreChecker         execution.TxPreCheckerConfig     `koanf:"tx-pre-checker" reload:"hot"`
-	BlockValidator       staker.BlockValidatorConfig      `koanf:"block-validator" reload:"hot"`
-	RecordingDB          arbitrum.RecordingDatabaseConfig `koanf:"recording-database"`
-	Feed                 broadcastclient.FeedConfig       `koanf:"feed" reload:"hot"`
-	Staker               staker.L1ValidatorConfig         `koanf:"staker"`
-	SeqCoordinator       SeqCoordinatorConfig             `koanf:"seq-coordinator"`
-	DataAvailability     das.DataAvailabilityConfig       `koanf:"data-availability"`
-	SyncMonitor          SyncMonitorConfig                `koanf:"sync-monitor"`
-	Dangerous            DangerousConfig                  `koanf:"dangerous"`
-	Caching              execution.CachingConfig          `koanf:"caching"`
-	Archive              bool                             `koanf:"archive"`
-	TxLookupLimit        uint64                           `koanf:"tx-lookup-limit"`
-	TransactionStreamer  TransactionStreamerConfig        `koanf:"transaction-streamer" reload:"hot"`
-	Maintenance          MaintenanceConfig                `koanf:"maintenance" reload:"hot"`
-	ResourceManagement   resourcemanager.Config           `koanf:"resource-mgmt" reload:"hot"`
+	RPC                 arbitrum.Config                  `koanf:"rpc"`
+	Sequencer           execution.SequencerConfig        `koanf:"sequencer" reload:"hot"`
+	ParentChainReader   headerreader.Config              `koanf:"parent-chain-reader" reload:"hot"`
+	InboxReader         InboxReaderConfig                `koanf:"inbox-reader" reload:"hot"`
+	DelayedSequencer    DelayedSequencerConfig           `koanf:"delayed-sequencer" reload:"hot"`
+	BatchPoster         BatchPosterConfig                `koanf:"batch-poster" reload:"hot"`
+	MessagePruner       MessagePrunerConfig              `koanf:"message-pruner" reload:"hot"`
+	ForwardingTarget    string                           `koanf:"forwarding-target"`
+	Forwarder           execution.ForwarderConfig        `koanf:"forwarder"`
+	TxPreChecker        execution.TxPreCheckerConfig     `koanf:"tx-pre-checker" reload:"hot"`
+	BlockValidator      staker.BlockValidatorConfig      `koanf:"block-validator" reload:"hot"`
+	RecordingDB         arbitrum.RecordingDatabaseConfig `koanf:"recording-db"`
+	Feed                broadcastclient.FeedConfig       `koanf:"feed" reload:"hot"`
+	Staker              staker.L1ValidatorConfig         `koanf:"staker"`
+	SeqCoordinator      SeqCoordinatorConfig             `koanf:"seq-coordinator"`
+	DataAvailability    das.DataAvailabilityConfig       `koanf:"data-availability"`
+	SyncMonitor         SyncMonitorConfig                `koanf:"sync-monitor"`
+	Dangerous           DangerousConfig                  `koanf:"dangerous"`
+	Caching             execution.CachingConfig          `koanf:"caching"`
+	Archive             bool                             `koanf:"archive"`
+	TxLookupLimit       uint64                           `koanf:"tx-lookup-limit"`
+	TransactionStreamer TransactionStreamerConfig        `koanf:"transaction-streamer" reload:"hot"`
+	Maintenance         MaintenanceConfig                `koanf:"maintenance" reload:"hot"`
+	ResourceManagement  resourcemanager.Config           `koanf:"resource-management" reload:"hot"`
 }
 
 func (c *Config) Validate() error {
-	if c.L1Reader.Enable && c.Sequencer.Enable && !c.DelayedSequencer.Enable {
+	if c.ParentChainReader.Enable && c.Sequencer.Enable && !c.DelayedSequencer.Enable {
 		log.Warn("delayed sequencer is not enabled, despite sequencer and l1 reader being enabled")
 	}
 	if c.DelayedSequencer.Enable && !c.Sequencer.Enable {
@@ -343,12 +343,12 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func (c *Config) ForwardingTarget() string {
-	if c.ForwardingTargetImpl == "null" {
+func (c *Config) ForwardingTargetF() string {
+	if c.ForwardingTarget == "null" {
 		return ""
 	}
 
-	return c.ForwardingTargetImpl
+	return c.ForwardingTarget
 }
 
 func (c *Config) ValidatorRequired() bool {
@@ -369,11 +369,11 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet, feedInputEnable bool, feed
 	DelayedSequencerConfigAddOptions(prefix+".delayed-sequencer", f)
 	BatchPosterConfigAddOptions(prefix+".batch-poster", f)
 	MessagePrunerConfigAddOptions(prefix+".message-pruner", f)
-	f.String(prefix+".forwarding-target", ConfigDefault.ForwardingTargetImpl, "transaction forwarding target URL, or \"null\" to disable forwarding (iff not sequencer)")
+	f.String(prefix+".forwarding-target", ConfigDefault.ForwardingTarget, "transaction forwarding target URL, or \"null\" to disable forwarding (iff not sequencer)")
 	execution.AddOptionsForNodeForwarderConfig(prefix+".forwarder", f)
 	execution.TxPreCheckerConfigAddOptions(prefix+".tx-pre-checker", f)
 	staker.BlockValidatorConfigAddOptions(prefix+".block-validator", f)
-	arbitrum.RecordingDatabaseConfigAddOptions(prefix+".recording-database", f)
+	arbitrum.RecordingDatabaseConfigAddOptions(prefix+".recording-db", f)
 	broadcastclient.FeedConfigAddOptions(prefix+".feed", f, feedInputEnable, feedOutputEnable)
 	staker.L1ValidatorConfigAddOptions(prefix+".staker", f)
 	SeqCoordinatorConfigAddOptions(prefix+".seq-coordinator", f)
@@ -384,35 +384,35 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet, feedInputEnable bool, feed
 	f.Uint64(prefix+".tx-lookup-limit", ConfigDefault.TxLookupLimit, "retain the ability to lookup transactions by hash for the past N blocks (0 = all blocks)")
 	TransactionStreamerConfigAddOptions(prefix+".transaction-streamer", f)
 	MaintenanceConfigAddOptions(prefix+".maintenance", f)
-	resourcemanager.ConfigAddOptions(prefix+".resource-mgmt", f)
+	resourcemanager.ConfigAddOptions(prefix+".resource-management", f)
 
 	archiveMsg := fmt.Sprintf("retain past block state (deprecated, please use %v.caching.archive)", prefix)
 	f.Bool(prefix+".archive", ConfigDefault.Archive, archiveMsg)
 }
 
 var ConfigDefault = Config{
-	RPC:                  arbitrum.DefaultConfig,
-	Sequencer:            execution.DefaultSequencerConfig,
-	L1Reader:             headerreader.DefaultConfig,
-	InboxReader:          DefaultInboxReaderConfig,
-	DelayedSequencer:     DefaultDelayedSequencerConfig,
-	BatchPoster:          DefaultBatchPosterConfig,
-	MessagePruner:        DefaultMessagePrunerConfig,
-	ForwardingTargetImpl: "",
-	TxPreChecker:         execution.DefaultTxPreCheckerConfig,
-	BlockValidator:       staker.DefaultBlockValidatorConfig,
-	RecordingDB:          arbitrum.DefaultRecordingDatabaseConfig,
-	Feed:                 broadcastclient.FeedConfigDefault,
-	Staker:               staker.DefaultL1ValidatorConfig,
-	SeqCoordinator:       DefaultSeqCoordinatorConfig,
-	DataAvailability:     das.DefaultDataAvailabilityConfig,
-	SyncMonitor:          DefaultSyncMonitorConfig,
-	Dangerous:            DefaultDangerousConfig,
-	Archive:              false,
-	TxLookupLimit:        126_230_400, // 1 year at 4 blocks per second
-	Caching:              execution.DefaultCachingConfig,
-	TransactionStreamer:  DefaultTransactionStreamerConfig,
-	ResourceManagement:   resourcemanager.DefaultConfig,
+	RPC:                 arbitrum.DefaultConfig,
+	Sequencer:           execution.DefaultSequencerConfig,
+	ParentChainReader:   headerreader.DefaultConfig,
+	InboxReader:         DefaultInboxReaderConfig,
+	DelayedSequencer:    DefaultDelayedSequencerConfig,
+	BatchPoster:         DefaultBatchPosterConfig,
+	MessagePruner:       DefaultMessagePrunerConfig,
+	ForwardingTarget:    "",
+	TxPreChecker:        execution.DefaultTxPreCheckerConfig,
+	BlockValidator:      staker.DefaultBlockValidatorConfig,
+	RecordingDB:         arbitrum.DefaultRecordingDatabaseConfig,
+	Feed:                broadcastclient.FeedConfigDefault,
+	Staker:              staker.DefaultL1ValidatorConfig,
+	SeqCoordinator:      DefaultSeqCoordinatorConfig,
+	DataAvailability:    das.DefaultDataAvailabilityConfig,
+	SyncMonitor:         DefaultSyncMonitorConfig,
+	Dangerous:           DefaultDangerousConfig,
+	Archive:             false,
+	TxLookupLimit:       126_230_400, // 1 year at 4 blocks per second
+	Caching:             execution.DefaultCachingConfig,
+	TransactionStreamer: DefaultTransactionStreamerConfig,
+	ResourceManagement:  resourcemanager.DefaultConfig,
 }
 
 func ConfigDefaultL1Test() *Config {
@@ -427,7 +427,7 @@ func ConfigDefaultL1Test() *Config {
 
 func ConfigDefaultL1NonSequencerTest() *Config {
 	config := ConfigDefault
-	config.L1Reader = headerreader.TestConfig
+	config.ParentChainReader = headerreader.TestConfig
 	config.InboxReader = TestInboxReaderConfig
 	config.Sequencer.Enable = false
 	config.DelayedSequencer.Enable = false
@@ -445,12 +445,12 @@ func ConfigDefaultL1NonSequencerTest() *Config {
 func ConfigDefaultL2Test() *Config {
 	config := ConfigDefault
 	config.Sequencer = execution.TestSequencerConfig
-	config.L1Reader.Enable = false
+	config.ParentChainReader.Enable = false
 	config.SeqCoordinator = TestSeqCoordinatorConfig
 	config.Feed.Input.Verifier.Dangerous.AcceptMissing = true
 	config.Feed.Output.Signed = false
-	config.SeqCoordinator.Signing.ECDSA.AcceptSequencer = false
-	config.SeqCoordinator.Signing.ECDSA.Dangerous.AcceptMissing = true
+	config.SeqCoordinator.Signer.ECDSA.AcceptSequencer = false
+	config.SeqCoordinator.Signer.ECDSA.Dangerous.AcceptMissing = true
 	config.Staker.Enable = false
 	config.BlockValidator.ValidationServer.URL = ""
 	config.TransactionStreamer = DefaultTransactionStreamerConfig
@@ -603,8 +603,8 @@ func createNodeImpl(
 	}
 
 	var l1Reader *headerreader.HeaderReader
-	if config.L1Reader.Enable {
-		l1Reader, err = headerreader.New(ctx, l1client, func() *headerreader.Config { return &configFetcher.Get().L1Reader })
+	if config.ParentChainReader.Enable {
+		l1Reader, err = headerreader.New(ctx, l1client, func() *headerreader.Config { return &configFetcher.Get().ParentChainReader })
 		if err != nil {
 			return nil, err
 		}
@@ -613,7 +613,7 @@ func createNodeImpl(
 	sequencerConfigFetcher := func() *execution.SequencerConfig { return &configFetcher.Get().Sequencer }
 	txprecheckConfigFetcher := func() *execution.TxPreCheckerConfig { return &configFetcher.Get().TxPreChecker }
 	exec, err := execution.CreateExecutionNode(stack, chainDb, l2BlockChain, l1Reader, syncMonitor,
-		config.ForwardingTarget(), &config.Forwarder, config.RPC, &config.RecordingDB,
+		config.ForwardingTargetF(), &config.Forwarder, config.RPC, &config.RecordingDB,
 		sequencerConfigFetcher, txprecheckConfigFetcher)
 	if err != nil {
 		return nil, err
@@ -683,7 +683,7 @@ func createNodeImpl(
 		}
 	}
 
-	if !config.L1Reader.Enable {
+	if !config.ParentChainReader.Enable {
 		return &Node{
 			ArbDB:                   arbDb,
 			Stack:                   stack,

--- a/arbnode/resourcemanager/resource_management.go
+++ b/arbnode/resourcemanager/resource_management.go
@@ -31,7 +31,7 @@ var (
 //
 // Must be run before the go-ethereum stack is set up (ethereum/go-ethereum/node.New).
 func Init(conf *Config) {
-	if conf.MemoryLimitPercent > 0 {
+	if conf.MemLimitPercent > 0 {
 		node.WrapHTTPHandler = func(srv http.Handler) (http.Handler, error) {
 			return newHttpServer(srv, newLimitChecker(conf)), nil
 		}
@@ -42,18 +42,18 @@ func Init(conf *Config) {
 // Currently only a memory limit is supported, other limits may be added
 // in the future.
 type Config struct {
-	MemoryLimitPercent int `koanf:"mem-limit-percent" reload:"hot"`
+	MemLimitPercent int `koanf:"mem-limit-percent" reload:"hot"`
 }
 
 // DefaultConfig has the defaul resourcemanager configuration,
 // all limits are disabled.
 var DefaultConfig = Config{
-	MemoryLimitPercent: 0,
+	MemLimitPercent: 0,
 }
 
 // ConfigAddOptions adds the configuration options for resourcemanager.
 func ConfigAddOptions(prefix string, f *pflag.FlagSet) {
-	f.Int(prefix+".mem-limit-percent", DefaultConfig.MemoryLimitPercent, "RPC calls are throttled if system memory utilization exceeds this percent value, zero (default) is disabled")
+	f.Int(prefix+".mem-limit-percent", DefaultConfig.MemLimitPercent, "RPC calls are throttled if system memory utilization exceeds this percent value, zero (default) is disabled")
 }
 
 // httpServer implements http.Handler and wraps calls to inner with a resource
@@ -96,7 +96,7 @@ type limitChecker interface {
 // mechanism is discovered, it logs an error and fails open, ie
 // it creates a trivialLimitChecker that does no checks.
 func newLimitChecker(conf *Config) limitChecker {
-	c := newCgroupsV1MemoryLimitChecker(DefaultCgroupsV1MemoryDirectory, conf.MemoryLimitPercent)
+	c := newCgroupsV1MemoryLimitChecker(DefaultCgroupsV1MemoryDirectory, conf.MemLimitPercent)
 	if isSupported(c) {
 		log.Info("Cgroups v1 detected, enabling memory limit RPC throttling")
 		return c

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -58,28 +58,28 @@ type SeqCoordinator struct {
 }
 
 type SeqCoordinatorConfig struct {
-	Enable                bool                       `koanf:"enable"`
-	ChosenHealthcheckAddr string                     `koanf:"chosen-healthcheck-addr"`
-	RedisUrl              string                     `koanf:"redis-url"`
-	LockoutDuration       time.Duration              `koanf:"lockout-duration"`
-	LockoutSpare          time.Duration              `koanf:"lockout-spare"`
-	SeqNumDuration        time.Duration              `koanf:"seq-num-duration"`
-	UpdateInterval        time.Duration              `koanf:"update-interval"`
-	RetryInterval         time.Duration              `koanf:"retry-interval"`
-	HandoffTimeout        time.Duration              `koanf:"handoff-timeout"`
-	SafeShutdownDelay     time.Duration              `koanf:"safe-shutdown-delay"`
-	ReleaseRetries        int                        `koanf:"release-retries"`
-	MaxMsgPerPoll         arbutil.MessageIndex       `koanf:"msg-per-poll"`
-	MyUrlImpl             string                     `koanf:"my-url"`
-	Signing               signature.SignVerifyConfig `koanf:"signer"`
+	Enable                bool          `koanf:"enable"`
+	ChosenHealthcheckAddr string        `koanf:"chosen-healthcheck-addr"`
+	RedisUrl              string        `koanf:"redis-url"`
+	LockoutDuration       time.Duration `koanf:"lockout-duration"`
+	LockoutSpare          time.Duration `koanf:"lockout-spare"`
+	SeqNumDuration        time.Duration `koanf:"seq-num-duration"`
+	UpdateInterval        time.Duration `koanf:"update-interval"`
+	RetryInterval         time.Duration `koanf:"retry-interval"`
+	HandoffTimeout        time.Duration `koanf:"handoff-timeout"`
+	SafeShutdownDelay     time.Duration `koanf:"safe-shutdown-delay"`
+	ReleaseRetries        int           `koanf:"release-retries"`
+	// Max message per poll.
+	MsgPerPoll arbutil.MessageIndex       `koanf:"msg-per-poll"`
+	MyUrl      string                     `koanf:"my-url"`
+	Signer     signature.SignVerifyConfig `koanf:"signer"`
 }
 
-func (c *SeqCoordinatorConfig) MyUrl() string {
-	if c.MyUrlImpl == "" {
+func (c *SeqCoordinatorConfig) Url() string {
+	if c.MyUrl == "" {
 		return redisutil.INVALID_URL
 	}
-
-	return c.MyUrlImpl
+	return c.MyUrl
 }
 
 func SeqCoordinatorConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -94,8 +94,8 @@ func SeqCoordinatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Duration(prefix+".handoff-timeout", DefaultSeqCoordinatorConfig.HandoffTimeout, "the maximum amount of time to spend waiting for another sequencer to accept the lockout when handing it off on shutdown or db compaction")
 	f.Duration(prefix+".safe-shutdown-delay", DefaultSeqCoordinatorConfig.SafeShutdownDelay, "if non-zero will add delay after transferring control")
 	f.Int(prefix+".release-retries", DefaultSeqCoordinatorConfig.ReleaseRetries, "the number of times to retry releasing the wants lockout and chosen one status on shutdown")
-	f.Uint64(prefix+".msg-per-poll", uint64(DefaultSeqCoordinatorConfig.MaxMsgPerPoll), "will only be marked as wanting the lockout if not too far behind")
-	f.String(prefix+".my-url", DefaultSeqCoordinatorConfig.MyUrlImpl, "url for this sequencer if it is the chosen")
+	f.Uint64(prefix+".msg-per-poll", uint64(DefaultSeqCoordinatorConfig.MsgPerPoll), "will only be marked as wanting the lockout if not too far behind")
+	f.String(prefix+".my-url", DefaultSeqCoordinatorConfig.MyUrl, "url for this sequencer if it is the chosen")
 	signature.SignVerifyConfigAddOptions(prefix+".signer", f)
 }
 
@@ -111,9 +111,9 @@ var DefaultSeqCoordinatorConfig = SeqCoordinatorConfig{
 	SafeShutdownDelay:     5 * time.Second,
 	ReleaseRetries:        4,
 	RetryInterval:         50 * time.Millisecond,
-	MaxMsgPerPoll:         2000,
-	MyUrlImpl:             redisutil.INVALID_URL,
-	Signing:               signature.DefaultSignVerifyConfig,
+	MsgPerPoll:            2000,
+	MyUrl:                 redisutil.INVALID_URL,
+	Signer:                signature.DefaultSignVerifyConfig,
 }
 
 var TestSeqCoordinatorConfig = SeqCoordinatorConfig{
@@ -127,9 +127,9 @@ var TestSeqCoordinatorConfig = SeqCoordinatorConfig{
 	SafeShutdownDelay: time.Millisecond * 100,
 	ReleaseRetries:    4,
 	RetryInterval:     time.Millisecond * 3,
-	MaxMsgPerPoll:     20,
-	MyUrlImpl:         redisutil.INVALID_URL,
-	Signing:           signature.DefaultSignVerifyConfig,
+	MsgPerPoll:        20,
+	MyUrl:             redisutil.INVALID_URL,
+	Signer:            signature.DefaultSignVerifyConfig,
 }
 
 func NewSeqCoordinator(dataSigner signature.DataSignerFunc, bpvalidator *contracts.BatchPosterVerifier, streamer *TransactionStreamer, sequencer *execution.Sequencer, sync *SyncMonitor, config SeqCoordinatorConfig) (*SeqCoordinator, error) {
@@ -137,7 +137,7 @@ func NewSeqCoordinator(dataSigner signature.DataSignerFunc, bpvalidator *contrac
 	if err != nil {
 		return nil, err
 	}
-	signer, err := signature.NewSignVerify(&config.Signing, dataSigner, bpvalidator)
+	signer, err := signature.NewSignVerify(&config.Signer, dataSigner, bpvalidator)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (c *SeqCoordinator) acquireLockoutAndWriteMessage(ctx context.Context, msgC
 		if err != nil {
 			return err
 		}
-		if c.config.Signing.SymmetricSign {
+		if c.config.Signer.SymmetricSign {
 			messageString := string(append(msgSig, msgBytes...))
 			messageData = &messageString
 		} else {
@@ -278,7 +278,7 @@ func (c *SeqCoordinator) acquireLockoutAndWriteMessage(ctx context.Context, msgC
 		if err != nil {
 			return err
 		}
-		if !wasEmpty && (current != c.config.MyUrl()) {
+		if !wasEmpty && (current != c.config.Url()) {
 			return fmt.Errorf("%w: failed to catch lock. redis shows chosen: %s", execution.ErrRetrySequencer, current)
 		}
 		remoteMsgCount, err := c.getRemoteMsgCountImpl(ctx, tx)
@@ -300,7 +300,7 @@ func (c *SeqCoordinator) acquireLockoutAndWriteMessage(ctx context.Context, msgC
 			initialDuration = 2 * time.Second
 		}
 		if wasEmpty {
-			pipe.Set(ctx, redisutil.CHOSENSEQ_KEY, c.config.MyUrl(), initialDuration)
+			pipe.Set(ctx, redisutil.CHOSENSEQ_KEY, c.config.Url(), initialDuration)
 		}
 		pipe.Set(ctx, redisutil.MSG_COUNT_KEY, msgCountMsg, c.config.SeqNumDuration)
 		if messageData != nil {
@@ -311,7 +311,7 @@ func (c *SeqCoordinator) acquireLockoutAndWriteMessage(ctx context.Context, msgC
 		}
 		pipe.PExpireAt(ctx, redisutil.CHOSENSEQ_KEY, lockoutUntil)
 		if setWantsLockout {
-			myWantsLockoutKey := redisutil.WantsLockoutKeyFor(c.config.MyUrl())
+			myWantsLockoutKey := redisutil.WantsLockoutKeyFor(c.config.Url())
 			pipe.Set(ctx, myWantsLockoutKey, redisutil.WANTS_LOCKOUT_VAL, initialDuration)
 			pipe.PExpireAt(ctx, myWantsLockoutKey, lockoutUntil)
 		}
@@ -362,7 +362,7 @@ func (c *SeqCoordinator) wantsLockoutUpdateWithMutex(ctx context.Context) error 
 	if c.avoidLockout > 0 {
 		return nil
 	}
-	myWantsLockoutKey := redisutil.WantsLockoutKeyFor(c.config.MyUrl())
+	myWantsLockoutKey := redisutil.WantsLockoutKeyFor(c.config.Url())
 	wantsLockoutUntil := time.Now().Add(c.config.LockoutDuration)
 	pipe := c.Client.TxPipeline()
 	initialDuration := c.config.LockoutDuration
@@ -390,7 +390,7 @@ func (c *SeqCoordinator) chosenOneRelease(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if current != c.config.MyUrl() {
+		if current != c.config.Url() {
 			return nil
 		}
 		pipe := tx.TxPipeline()
@@ -409,7 +409,7 @@ func (c *SeqCoordinator) chosenOneRelease(ctx context.Context) error {
 	if errors.Is(readErr, redis.Nil) {
 		return nil
 	}
-	if current != c.config.MyUrl() {
+	if current != c.config.Url() {
 		return nil
 	}
 	return releaseErr
@@ -421,7 +421,7 @@ func (c *SeqCoordinator) wantsLockoutRelease(ctx context.Context) error {
 	if !c.reportedWantsLockout {
 		return nil
 	}
-	myWantsLockoutKey := redisutil.WantsLockoutKeyFor(c.config.MyUrl())
+	myWantsLockoutKey := redisutil.WantsLockoutKeyFor(c.config.Url())
 	releaseErr := c.Client.Del(ctx, myWantsLockoutKey).Err()
 	if releaseErr != nil {
 		// got error - was it still deleted?
@@ -450,7 +450,7 @@ func (c *SeqCoordinator) noRedisError() time.Duration {
 
 // update for the prev known-chosen sequencer (no need to load new messages)
 func (c *SeqCoordinator) updateWithLockout(ctx context.Context, nextChosen string) time.Duration {
-	if nextChosen != "" && nextChosen != c.config.MyUrl() {
+	if nextChosen != "" && nextChosen != c.config.Url() {
 		// was the active sequencer, but no longer
 		// we maintain chosen status if we had it and nobody in the priorities wants the lockout
 		setPrevChosenTo := nextChosen
@@ -467,7 +467,7 @@ func (c *SeqCoordinator) updateWithLockout(ctx context.Context, nextChosen strin
 			return c.retryAfterRedisError()
 		}
 		c.prevChosenSequencer = setPrevChosenTo
-		log.Info("released chosen-coordinator lock", "myUrl", c.config.MyUrl(), "nextChosen", nextChosen)
+		log.Info("released chosen-coordinator lock", "myUrl", c.config.Url(), "nextChosen", nextChosen)
 		return c.noRedisError()
 	}
 	// Was, and still is, the active sequencer
@@ -496,10 +496,10 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 		log.Warn("coordinator failed finding sequencer wanting lockout", "err", err)
 		return c.retryAfterRedisError()
 	}
-	if c.prevChosenSequencer == c.config.MyUrl() {
+	if c.prevChosenSequencer == c.config.Url() {
 		return c.updateWithLockout(ctx, chosenSeq)
 	}
-	if chosenSeq != c.config.MyUrl() && chosenSeq != c.prevChosenSequencer {
+	if chosenSeq != c.config.Url() && chosenSeq != c.prevChosenSequencer {
 		var err error
 		if c.sequencer != nil {
 			err = c.sequencer.ForwardTo(chosenSeq)
@@ -526,8 +526,8 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 		return c.retryAfterRedisError()
 	}
 	readUntil := remoteMsgCount
-	if readUntil > localMsgCount+c.config.MaxMsgPerPoll {
-		readUntil = localMsgCount + c.config.MaxMsgPerPoll
+	if readUntil > localMsgCount+c.config.MsgPerPoll {
+		readUntil = localMsgCount + c.config.MsgPerPoll
 	}
 	var messages []arbostypes.MessageWithMetadata
 	msgToRead := localMsgCount
@@ -599,7 +599,7 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 		}
 	}
 
-	if c.config.MyUrl() == redisutil.INVALID_URL {
+	if c.config.Url() == redisutil.INVALID_URL {
 		return c.noRedisError()
 	}
 
@@ -614,7 +614,7 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 	}
 
 	// can take over as main sequencer?
-	if synced && localMsgCount >= remoteMsgCount && chosenSeq == c.config.MyUrl() {
+	if synced && localMsgCount >= remoteMsgCount && chosenSeq == c.config.Url() {
 		if c.sequencer == nil {
 			log.Error("myurl main sequencer, but no sequencer exists")
 			return c.noRedisError()
@@ -639,7 +639,7 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 				c.prevChosenSequencer = ""
 				return c.retryAfterRedisError()
 			}
-			log.Info("caught chosen-coordinator lock", "myUrl", c.config.MyUrl())
+			log.Info("caught chosen-coordinator lock", "myUrl", c.config.Url())
 			if c.delayedSequencer != nil {
 				err = c.delayedSequencer.ForceSequenceDelayed(ctx)
 				if err != nil {
@@ -651,7 +651,7 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 				log.Warn("failed to populate the feed backlog on lockout acquisition", "err", err)
 			}
 			c.sequencer.Activate()
-			c.prevChosenSequencer = c.config.MyUrl()
+			c.prevChosenSequencer = c.config.Url()
 			return c.noRedisError()
 		}
 	}
@@ -684,7 +684,7 @@ func (c *SeqCoordinator) AvoidingLockout() bool {
 func (c *SeqCoordinator) DebugPrint() string {
 	c.wantsLockoutMutex.Lock()
 	defer c.wantsLockoutMutex.Unlock()
-	return fmt.Sprint("Url:", c.config.MyUrl(),
+	return fmt.Sprint("Url:", c.config.Url(),
 		" prevChosenSequencer:", c.prevChosenSequencer,
 		" reportedWantsLockout:", c.reportedWantsLockout,
 		" lockoutUntil:", c.lockoutUntil,
@@ -760,7 +760,7 @@ func (c *SeqCoordinator) StopAndWait() {
 	// We've just stopped our normal context so we need to use our parent's context.
 	parentCtx := c.StopWaiter.GetParentContext()
 	for i := 0; i <= c.config.ReleaseRetries || c.config.ReleaseRetries < 0; i++ {
-		log.Info("releasing wants lockout key", "myUrl", c.config.MyUrl(), "attempt", i)
+		log.Info("releasing wants lockout key", "myUrl", c.config.Url(), "attempt", i)
 		err := c.wantsLockoutRelease(parentCtx)
 		if err == nil {
 			c.noRedisError()
@@ -771,7 +771,7 @@ func (c *SeqCoordinator) StopAndWait() {
 		}
 	}
 	for i := 0; i < c.config.ReleaseRetries || c.config.ReleaseRetries < 0; i++ {
-		log.Info("releasing chosen one", "myUrl", c.config.MyUrl(), "attempt", i)
+		log.Info("releasing chosen one", "myUrl", c.config.Url(), "attempt", i)
 		err := c.chosenOneRelease(parentCtx)
 		if err == nil {
 			c.noRedisError()
@@ -804,7 +804,7 @@ func (c *SeqCoordinator) AvoidLockout(ctx context.Context) bool {
 	c.wantsLockoutMutex.Lock()
 	c.avoidLockout++
 	c.wantsLockoutMutex.Unlock()
-	log.Info("avoiding lockout", "myUrl", c.config.MyUrl())
+	log.Info("avoiding lockout", "myUrl", c.config.Url())
 	err := c.wantsLockoutRelease(ctx)
 	if err != nil {
 		log.Error("failed to release wanting the lockout in redis", "err", err)
@@ -818,7 +818,7 @@ func (c *SeqCoordinator) TryToHandoffChosenOne(ctx context.Context) bool {
 	ctx, cancel := context.WithTimeout(ctx, c.config.HandoffTimeout)
 	defer cancel()
 	if c.CurrentlyChosen() {
-		log.Info("waiting for another sequencer to become chosen...", "timeout", c.config.HandoffTimeout, "myUrl", c.config.MyUrl())
+		log.Info("waiting for another sequencer to become chosen...", "timeout", c.config.HandoffTimeout, "myUrl", c.config.Url())
 		success := c.waitFor(ctx, func() bool {
 			return !c.CurrentlyChosen()
 		})
@@ -842,7 +842,7 @@ func (c *SeqCoordinator) SeekLockout(ctx context.Context) {
 	c.wantsLockoutMutex.Lock()
 	defer c.wantsLockoutMutex.Unlock()
 	c.avoidLockout--
-	log.Info("seeking lockout", "myUrl", c.config.MyUrl())
+	log.Info("seeking lockout", "myUrl", c.config.Url())
 	if c.sync.Synced() {
 		// Even if this errors we still internally marked ourselves as wanting the lockout
 		err := c.wantsLockoutUpdateWithMutex(ctx)

--- a/arbnode/seq_coordinator_atomic_test.go
+++ b/arbnode/seq_coordinator_atomic_test.go
@@ -69,7 +69,7 @@ func coordinatorTestThread(ctx context.Context, coord *SeqCoordinator, data *Coo
 			timeLaunching := time.Now()
 			// didn't sequence.. should we have succeeded?
 			if timeLaunching.Before(holdingLockout) {
-				execError = fmt.Errorf("failed while holding lock %s err %w", coord.config.MyUrl(), err)
+				execError = fmt.Errorf("failed while holding lock %s err %w", coord.config.Url(), err)
 				break
 			}
 		}
@@ -79,9 +79,9 @@ func coordinatorTestThread(ctx context.Context, coord *SeqCoordinator, data *Coo
 				continue
 			}
 			if data.sequencer[i] != "" {
-				execError = fmt.Errorf("two sequencers for same msg: submsg %d, success for %s, %s", i, data.sequencer[i], coord.config.MyUrl())
+				execError = fmt.Errorf("two sequencers for same msg: submsg %d, success for %s, %s", i, data.sequencer[i], coord.config.Url())
 			}
-			data.sequencer[i] = coord.config.MyUrl()
+			data.sequencer[i] = coord.config.Url()
 		}
 		if execError != nil {
 			data.err = execError
@@ -99,16 +99,16 @@ func TestRedisSeqCoordinatorAtomic(t *testing.T) {
 	coordConfig := TestSeqCoordinatorConfig
 	coordConfig.LockoutDuration = time.Millisecond * 100
 	coordConfig.LockoutSpare = time.Millisecond * 10
-	coordConfig.Signing.ECDSA.AcceptSequencer = false
-	coordConfig.Signing.SymmetricFallback = true
-	coordConfig.Signing.SymmetricSign = true
-	coordConfig.Signing.Symmetric.Dangerous.DisableSignatureVerification = true
-	coordConfig.Signing.Symmetric.SigningKey = ""
+	coordConfig.Signer.ECDSA.AcceptSequencer = false
+	coordConfig.Signer.SymmetricFallback = true
+	coordConfig.Signer.SymmetricSign = true
+	coordConfig.Signer.Symmetric.Dangerous.DisableSignatureVerification = true
+	coordConfig.Signer.Symmetric.SigningKey = ""
 	testData := CoordinatorTestData{
 		testStartRound: -1,
 		sequencer:      make([]string, messagesPerRound),
 	}
-	nullSigner, err := signature.NewSignVerify(&coordConfig.Signing, nil, nil)
+	nullSigner, err := signature.NewSignVerify(&coordConfig.Signer, nil, nil)
 	Require(t, err)
 
 	redisUrl := redisutil.CreateTestRedis(ctx, t)
@@ -121,7 +121,7 @@ func TestRedisSeqCoordinatorAtomic(t *testing.T) {
 
 	for i := 0; i < NumOfThreads; i++ {
 		config := coordConfig
-		config.MyUrlImpl = fmt.Sprint(i)
+		config.MyUrl = fmt.Sprint(i)
 		redisCoordinator, err := redisutil.NewRedisCoordinator(config.RedisUrl)
 		Require(t, err)
 		coordinator := &SeqCoordinator{

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -69,7 +69,7 @@ type TransactionStreamer struct {
 }
 
 type TransactionStreamerConfig struct {
-	MaxBroadcastQueueSize   int           `koanf:"max-broadcaster-queue-size"`
+	MaxBroadcasterQueueSize int           `koanf:"max-broadcaster-queue-size"`
 	MaxReorgResequenceDepth int64         `koanf:"max-reorg-resequence-depth" reload:"hot"`
 	ExecuteMessageLoopDelay time.Duration `koanf:"execute-message-loop-delay" reload:"hot"`
 }
@@ -77,19 +77,19 @@ type TransactionStreamerConfig struct {
 type TransactionStreamerConfigFetcher func() *TransactionStreamerConfig
 
 var DefaultTransactionStreamerConfig = TransactionStreamerConfig{
-	MaxBroadcastQueueSize:   1024,
+	MaxBroadcasterQueueSize: 1024,
 	MaxReorgResequenceDepth: 1024,
 	ExecuteMessageLoopDelay: time.Millisecond * 100,
 }
 
 var TestTransactionStreamerConfig = TransactionStreamerConfig{
-	MaxBroadcastQueueSize:   10_000,
+	MaxBroadcasterQueueSize: 10_000,
 	MaxReorgResequenceDepth: 128 * 1024,
 	ExecuteMessageLoopDelay: time.Millisecond,
 }
 
 func TransactionStreamerConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Int(prefix+".max-broadcaster-queue-size", DefaultTransactionStreamerConfig.MaxBroadcastQueueSize, "maximum cache of pending broadcaster messages")
+	f.Int(prefix+".max-broadcaster-queue-size", DefaultTransactionStreamerConfig.MaxBroadcasterQueueSize, "maximum cache of pending broadcaster messages")
 	f.Int64(prefix+".max-reorg-resequence-depth", DefaultTransactionStreamerConfig.MaxReorgResequenceDepth, "maximum number of messages to attempt to resequence on reorg (0 = never resequence, -1 = always resequence)")
 	f.Duration(prefix+".execute-message-loop-delay", DefaultTransactionStreamerConfig.ExecuteMessageLoopDelay, "delay when polling calls to execute messages")
 }
@@ -479,7 +479,7 @@ func (s *TransactionStreamer) AddBroadcastMessages(feedMessages []*broadcaster.B
 			s.broadcasterQueuedMessagesActiveReorg = feedReorg
 		} else if broadcasterQueuedMessagesPos+arbutil.MessageIndex(len(s.broadcasterQueuedMessages)) == broadcastStartPos {
 			// Feed messages can be added directly to end of cache
-			maxQueueSize := s.config().MaxBroadcastQueueSize
+			maxQueueSize := s.config().MaxBroadcasterQueueSize
 			if maxQueueSize == 0 || len(s.broadcasterQueuedMessages) <= maxQueueSize {
 				s.broadcasterQueuedMessages = append(s.broadcasterQueuedMessages, messages...)
 			}

--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -68,13 +68,13 @@ type Config struct {
 	RequireChainId          bool                     `koanf:"require-chain-id" reload:"hot"`
 	RequireFeedVersion      bool                     `koanf:"require-feed-version" reload:"hot"`
 	Timeout                 time.Duration            `koanf:"timeout" reload:"hot"`
-	URLs                    []string                 `koanf:"urls"`
-	Verifier                signature.VerifierConfig `koanf:"verifier"`
+	URL                     []string                 `koanf:"url"`
+	Verify                  signature.VerifierConfig `koanf:"verify"`
 	EnableCompression       bool                     `koanf:"enable-compression" reload:"hot"`
 }
 
 func (c *Config) Enable() bool {
-	return len(c.URLs) > 0 && c.URLs[0] != ""
+	return len(c.URL) > 0 && c.URL[0] != ""
 }
 
 type ConfigFetcher func() *Config
@@ -85,8 +85,8 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".require-chain-id", DefaultConfig.RequireChainId, "require chain id to be present on connect")
 	f.Bool(prefix+".require-feed-version", DefaultConfig.RequireFeedVersion, "require feed version to be present on connect")
 	f.Duration(prefix+".timeout", DefaultConfig.Timeout, "duration to wait before timing out connection to sequencer feed")
-	f.StringSlice(prefix+".urls", DefaultConfig.URLs, "URL of sequencer feed source")
-	signature.FeedVerifierConfigAddOptions(prefix+".verifier", f)
+	f.StringSlice(prefix+".url", DefaultConfig.URL, "URL of sequencer feed source")
+	signature.FeedVerifierConfigAddOptions(prefix+".verify", f)
 	f.Bool(prefix+".enable-compression", DefaultConfig.EnableCompression, "enable per message deflate compression support")
 }
 
@@ -95,8 +95,8 @@ var DefaultConfig = Config{
 	ReconnectMaximumBackoff: time.Second * 64,
 	RequireChainId:          false,
 	RequireFeedVersion:      false,
-	Verifier:                signature.DefultFeedVerifierConfig,
-	URLs:                    []string{""},
+	Verify:                  signature.DefultFeedVerifierConfig,
+	URL:                     []string{""},
 	Timeout:                 20 * time.Second,
 	EnableCompression:       true,
 }
@@ -106,8 +106,8 @@ var DefaultTestConfig = Config{
 	ReconnectMaximumBackoff: 0,
 	RequireChainId:          false,
 	RequireFeedVersion:      false,
-	Verifier:                signature.DefultFeedVerifierConfig,
-	URLs:                    []string{""},
+	Verify:                  signature.DefultFeedVerifierConfig,
+	URL:                     []string{""},
 	Timeout:                 200 * time.Millisecond,
 	EnableCompression:       true,
 }
@@ -156,7 +156,7 @@ func NewBroadcastClient(
 	bpVerifier contracts.BatchPosterVerifierInterface,
 	adjustCount func(int32),
 ) (*BroadcastClient, error) {
-	sigVerifier, err := signature.NewVerifier(&config().Verifier, bpVerifier)
+	sigVerifier, err := signature.NewVerifier(&config().Verify, bpVerifier)
 	if err != nil {
 		return nil, err
 	}
@@ -480,7 +480,7 @@ func (bc *BroadcastClient) StopAndWait() {
 }
 
 func (bc *BroadcastClient) isValidSignature(ctx context.Context, message *broadcaster.BroadcastFeedMessage) error {
-	if bc.config().Verifier.Dangerous.AcceptMissing && bc.sigVerifier == nil {
+	if bc.config().Verify.Dangerous.AcceptMissing && bc.sigVerifier == nil {
 		// Verifier disabled
 		return nil
 	}

--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -68,8 +68,8 @@ type Config struct {
 	RequireChainId          bool                     `koanf:"require-chain-id" reload:"hot"`
 	RequireFeedVersion      bool                     `koanf:"require-feed-version" reload:"hot"`
 	Timeout                 time.Duration            `koanf:"timeout" reload:"hot"`
-	URLs                    []string                 `koanf:"url"`
-	Verifier                signature.VerifierConfig `koanf:"verify"`
+	URLs                    []string                 `koanf:"urls"`
+	Verifier                signature.VerifierConfig `koanf:"verifier"`
 	EnableCompression       bool                     `koanf:"enable-compression" reload:"hot"`
 }
 
@@ -85,8 +85,8 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".require-chain-id", DefaultConfig.RequireChainId, "require chain id to be present on connect")
 	f.Bool(prefix+".require-feed-version", DefaultConfig.RequireFeedVersion, "require feed version to be present on connect")
 	f.Duration(prefix+".timeout", DefaultConfig.Timeout, "duration to wait before timing out connection to sequencer feed")
-	f.StringSlice(prefix+".url", DefaultConfig.URLs, "URL of sequencer feed source")
-	signature.FeedVerifierConfigAddOptions(prefix+".verify", f)
+	f.StringSlice(prefix+".urls", DefaultConfig.URLs, "URL of sequencer feed source")
+	signature.FeedVerifierConfigAddOptions(prefix+".verifier", f)
 	f.Bool(prefix+".enable-compression", DefaultConfig.EnableCompression, "enable per message deflate compression support")
 }
 

--- a/broadcastclient/broadcastclient_test.go
+++ b/broadcastclient/broadcastclient_test.go
@@ -202,10 +202,10 @@ func newTestBroadcastClient(config Config, listenerAddress net.Addr, chainId uin
 	port := listenerAddress.(*net.TCPAddr).Port
 	var bpv contracts.BatchPosterVerifierInterface
 	if validAddr != nil {
-		config.Verifier.AcceptSequencer = true
+		config.Verify.AcceptSequencer = true
 		bpv = contracts.NewMockBatchPosterVerifier(*validAddr)
 	} else {
-		config.Verifier.AcceptSequencer = false
+		config.Verify.AcceptSequencer = false
 	}
 	return NewBroadcastClient(func() *Config { return &config }, fmt.Sprintf("ws://127.0.0.1:%d/", port), chainId, currentMessageCount, txStreamer, confirmedSequenceNumberListener, feedErrChan, bpv, func(_ int32) {})
 }

--- a/broadcastclients/broadcastclients.go
+++ b/broadcastclients/broadcastclients.go
@@ -31,7 +31,7 @@ func NewBroadcastClients(
 	bpVerifier contracts.BatchPosterVerifierInterface,
 ) (*BroadcastClients, error) {
 	config := configFetcher()
-	urlCount := len(config.URLs)
+	urlCount := len(config.URL)
 	if urlCount <= 0 {
 		return nil, nil
 	}
@@ -39,7 +39,7 @@ func NewBroadcastClients(
 	clients := BroadcastClients{}
 	clients.clients = make([]*broadcastclient.BroadcastClient, 0, urlCount)
 	var lastClientErr error
-	for _, address := range config.URLs {
+	for _, address := range config.URL {
 		client, err := broadcastclient.NewBroadcastClient(
 			configFetcher,
 			address,

--- a/cmd/conf/chain.go
+++ b/cmd/conf/chain.go
@@ -12,7 +12,7 @@ import (
 )
 
 type L1Config struct {
-	ChainID    uint64                   `koanf:"chain-id"`
+	ID         uint64                   `koanf:"id"`
 	Connection rpcclient.ClientConfig   `koanf:"connection" reload:"hot"`
 	Wallet     genericconf.WalletConfig `koanf:"wallet"`
 }
@@ -25,7 +25,7 @@ var L1ConnectionConfigDefault = rpcclient.ClientConfig{
 }
 
 var L1ConfigDefault = L1Config{
-	ChainID:    0,
+	ID:         0,
 	Connection: L1ConnectionConfigDefault,
 	Wallet:     DefaultL1WalletConfig,
 }
@@ -39,7 +39,7 @@ var DefaultL1WalletConfig = genericconf.WalletConfig{
 }
 
 func L1ConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Uint64(prefix+".id", L1ConfigDefault.ChainID, "if set other than 0, will be used to validate database and L1 connection")
+	f.Uint64(prefix+".id", L1ConfigDefault.ID, "if set other than 0, will be used to validate database and L1 connection")
 	rpcclient.RPCClientAddOptions(prefix+".connection", f, &L1ConfigDefault.Connection)
 	genericconf.WalletConfigAddOptions(prefix+".wallet", f, L1ConfigDefault.Wallet.Pathname)
 }

--- a/cmd/conf/chain.go
+++ b/cmd/conf/chain.go
@@ -12,7 +12,7 @@ import (
 )
 
 type L1Config struct {
-	ChainID    uint64                   `koanf:"id"`
+	ChainID    uint64                   `koanf:"chain-id"`
 	Connection rpcclient.ClientConfig   `koanf:"connection" reload:"hot"`
 	Wallet     genericconf.WalletConfig `koanf:"wallet"`
 }
@@ -32,7 +32,7 @@ var L1ConfigDefault = L1Config{
 
 var DefaultL1WalletConfig = genericconf.WalletConfig{
 	Pathname:      "wallet",
-	PasswordImpl:  genericconf.WalletConfigDefault.PasswordImpl,
+	Password:      genericconf.WalletConfigDefault.Password,
 	PrivateKey:    genericconf.WalletConfigDefault.PrivateKey,
 	Account:       genericconf.WalletConfigDefault.Account,
 	OnlyCreateKey: genericconf.WalletConfigDefault.OnlyCreateKey,
@@ -53,35 +53,35 @@ func (c *L1Config) Validate() error {
 }
 
 type L2Config struct {
-	ChainID                   uint64                   `koanf:"id"`
-	ChainName                 string                   `koanf:"name"`
-	ChainInfoFiles            []string                 `koanf:"info-files"`
-	ChainInfoJson             string                   `koanf:"info-json"`
-	DevWallet                 genericconf.WalletConfig `koanf:"dev-wallet"`
-	ChainInfoIpfsUrl          string                   `koanf:"info-ipfs-url"`
-	ChainInfoIpfsDownloadPath string                   `koanf:"info-ipfs-download-path"`
+	ID                   uint64                   `koanf:"id"`
+	Name                 string                   `koanf:"name"`
+	InfoFiles            []string                 `koanf:"info-files"`
+	InfoJson             string                   `koanf:"info-json"`
+	DevWallet            genericconf.WalletConfig `koanf:"dev-wallet"`
+	InfoIpfsUrl          string                   `koanf:"info-ipfs-url"`
+	InfoIpfsDownloadPath string                   `koanf:"info-ipfs-download-path"`
 }
 
 var L2ConfigDefault = L2Config{
-	ChainID:                   0,
-	ChainName:                 "",
-	ChainInfoFiles:            []string{}, // Default file used is chaininfo/arbitrum_chain_info.json, stored in DefaultChainInfo in chain_info.go
-	ChainInfoJson:             "",
-	DevWallet:                 genericconf.WalletConfigDefault,
-	ChainInfoIpfsUrl:          "",
-	ChainInfoIpfsDownloadPath: "/tmp/",
+	ID:                   0,
+	Name:                 "",
+	InfoFiles:            []string{}, // Default file used is chaininfo/arbitrum_chain_info.json, stored in DefaultChainInfo in chain_info.go
+	InfoJson:             "",
+	DevWallet:            genericconf.WalletConfigDefault,
+	InfoIpfsUrl:          "",
+	InfoIpfsDownloadPath: "/tmp/",
 }
 
 func L2ConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Uint64(prefix+".id", L2ConfigDefault.ChainID, "L2 chain ID (determines Arbitrum network)")
-	f.String(prefix+".name", L2ConfigDefault.ChainName, "L2 chain name (determines Arbitrum network)")
-	f.StringSlice(prefix+".info-files", L2ConfigDefault.ChainInfoFiles, "L2 chain info json files")
-	f.String(prefix+".info-json", L2ConfigDefault.ChainInfoJson, "L2 chain info in json string format")
+	f.Uint64(prefix+".id", L2ConfigDefault.ID, "L2 chain ID (determines Arbitrum network)")
+	f.String(prefix+".name", L2ConfigDefault.Name, "L2 chain name (determines Arbitrum network)")
+	f.StringSlice(prefix+".info-files", L2ConfigDefault.InfoFiles, "L2 chain info json files")
+	f.String(prefix+".info-json", L2ConfigDefault.InfoJson, "L2 chain info in json string format")
 
 	// Dev wallet does not exist unless specified
 	genericconf.WalletConfigAddOptions(prefix+".dev-wallet", f, "")
-	f.String(prefix+".info-ipfs-url", L2ConfigDefault.ChainInfoIpfsUrl, "url to download chain info file")
-	f.String(prefix+".info-ipfs-download-path", L2ConfigDefault.ChainInfoIpfsDownloadPath, "path to save temp downloaded file")
+	f.String(prefix+".info-ipfs-url", L2ConfigDefault.InfoIpfsUrl, "url to download chain info file")
+	f.String(prefix+".info-ipfs-download-path", L2ConfigDefault.InfoIpfsDownloadPath, "path to save temp downloaded file")
 
 }
 

--- a/cmd/daserver/daserver.go
+++ b/cmd/daserver/daserver.go
@@ -38,10 +38,10 @@ type DAServerConfig struct {
 	RESTPort           uint64                              `koanf:"rest-port"`
 	RESTServerTimeouts genericconf.HTTPServerTimeoutConfig `koanf:"rest-server-timeouts"`
 
-	DAConf das.DataAvailabilityConfig `koanf:"data-availability"`
+	DataAvailability das.DataAvailabilityConfig `koanf:"data-availability"`
 
-	ConfConfig genericconf.ConfConfig `koanf:"conf"`
-	LogLevel   int                    `koanf:"log-level"`
+	Conf     genericconf.ConfConfig `koanf:"conf"`
+	LogLevel int                    `koanf:"log-level"`
 
 	Metrics       bool                            `koanf:"metrics"`
 	MetricsServer genericconf.MetricsServerConfig `koanf:"metrics-server"`
@@ -58,8 +58,8 @@ var DefaultDAServerConfig = DAServerConfig{
 	RESTAddr:           "localhost",
 	RESTPort:           9877,
 	RESTServerTimeouts: genericconf.HTTPServerTimeoutConfigDefault,
-	DAConf:             das.DefaultDataAvailabilityConfig,
-	ConfConfig:         genericconf.ConfConfigDefault,
+	DataAvailability:   das.DefaultDataAvailabilityConfig,
+	Conf:               genericconf.ConfConfigDefault,
 	Metrics:            false,
 	MetricsServer:      genericconf.MetricsServerConfigDefault,
 	PProf:              false,
@@ -109,7 +109,7 @@ func parseDAServer(args []string) (*DAServerConfig, error) {
 	if err := confighelpers.EndCommonParse(k, &serverConfig); err != nil {
 		return nil, err
 	}
-	if serverConfig.ConfConfig.Dump {
+	if serverConfig.Conf.Dump {
 		err = confighelpers.DumpConfig(k, map[string]interface{}{
 			"data-availability.key.priv-key": "",
 		})
@@ -191,8 +191,8 @@ func startup() error {
 	defer cancel()
 
 	var l1Reader *headerreader.HeaderReader
-	if serverConfig.DAConf.L1NodeURL != "" && serverConfig.DAConf.L1NodeURL != "none" {
-		l1Client, err := das.GetL1Client(ctx, serverConfig.DAConf.L1ConnectionAttempts, serverConfig.DAConf.L1NodeURL)
+	if serverConfig.DataAvailability.ParentChainNodeURL != "" && serverConfig.DataAvailability.ParentChainNodeURL != "none" {
+		l1Client, err := das.GetL1Client(ctx, serverConfig.DataAvailability.ParentChainConnectionAttempts, serverConfig.DataAvailability.ParentChainNodeURL)
 		if err != nil {
 			return err
 		}
@@ -203,10 +203,10 @@ func startup() error {
 	}
 
 	var seqInboxAddress *common.Address
-	if serverConfig.DAConf.SequencerInboxAddress == "none" {
+	if serverConfig.DataAvailability.SequencerInboxAddress == "none" {
 		seqInboxAddress = nil
-	} else if len(serverConfig.DAConf.SequencerInboxAddress) > 0 {
-		seqInboxAddress, err = das.OptionalAddressFromString(serverConfig.DAConf.SequencerInboxAddress)
+	} else if len(serverConfig.DataAvailability.SequencerInboxAddress) > 0 {
+		seqInboxAddress, err = das.OptionalAddressFromString(serverConfig.DataAvailability.SequencerInboxAddress)
 		if err != nil {
 			return err
 		}
@@ -217,7 +217,7 @@ func startup() error {
 		return errors.New("sequencer-inbox-address must be set to a valid L1 URL and contract address, or 'none'")
 	}
 
-	daReader, daWriter, daHealthChecker, dasLifecycleManager, err := das.CreateDAComponentsForDaserver(ctx, &serverConfig.DAConf, l1Reader, seqInboxAddress)
+	daReader, daWriter, daHealthChecker, dasLifecycleManager, err := das.CreateDAComponentsForDaserver(ctx, &serverConfig.DataAvailability, l1Reader, seqInboxAddress)
 	if err != nil {
 		return err
 	}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -64,10 +64,10 @@ func main() {
 	}
 
 	wallet := genericconf.WalletConfig{
-		Pathname:     *l1keystore,
-		Account:      *deployAccount,
-		PasswordImpl: *l1passphrase,
-		PrivateKey:   *l1privatekey,
+		Pathname:   *l1keystore,
+		Account:    *deployAccount,
+		Password:   *l1passphrase,
+		PrivateKey: *l1privatekey,
 	}
 	l1TransactionOpts, _, err := util.OpenWallet("l1", &wallet, l1ChainId)
 	if err != nil {

--- a/cmd/genericconf/wallet.go
+++ b/cmd/genericconf/wallet.go
@@ -14,22 +14,22 @@ const PASSWORD_NOT_SET = "PASSWORD_NOT_SET"
 
 type WalletConfig struct {
 	Pathname      string `koanf:"pathname"`
-	PasswordImpl  string `koanf:"password"`
+	Password      string `koanf:"password"`
 	PrivateKey    string `koanf:"private-key"`
 	Account       string `koanf:"account"`
 	OnlyCreateKey bool   `koanf:"only-create-key"`
 }
 
-func (w *WalletConfig) Password() *string {
-	if w.PasswordImpl == PASSWORD_NOT_SET {
+func (w *WalletConfig) Pwd() *string {
+	if w.Password == PASSWORD_NOT_SET {
 		return nil
 	}
-	return &w.PasswordImpl
+	return &w.Password
 }
 
 var WalletConfigDefault = WalletConfig{
 	Pathname:      "",
-	PasswordImpl:  PASSWORD_NOT_SET,
+	Password:      PASSWORD_NOT_SET,
 	PrivateKey:    "",
 	Account:       "",
 	OnlyCreateKey: false,
@@ -37,7 +37,7 @@ var WalletConfigDefault = WalletConfig{
 
 func WalletConfigAddOptions(prefix string, f *flag.FlagSet, defaultPathname string) {
 	f.String(prefix+".pathname", defaultPathname, "pathname for wallet")
-	f.String(prefix+".password", WalletConfigDefault.PasswordImpl, "wallet passphrase")
+	f.String(prefix+".password", WalletConfigDefault.Password, "wallet passphrase")
 	f.String(prefix+".private-key", WalletConfigDefault.PrivateKey, "private key for wallet")
 	f.String(prefix+".account", WalletConfigDefault.Account, "account to use (default is first account in keystore)")
 	f.Bool(prefix+".only-create-key", WalletConfigDefault.OnlyCreateKey, "if true, creates new key then exits")

--- a/cmd/nitro-val/config.go
+++ b/cmd/nitro-val/config.go
@@ -27,7 +27,7 @@ type ValidationNodeConfig struct {
 	HTTP          genericconf.HTTPConfig          `koanf:"http"`
 	WS            genericconf.WSConfig            `koanf:"ws"`
 	IPC           genericconf.IPCConfig           `koanf:"ipc"`
-	AuthRPC       genericconf.AuthRPCConfig       `koanf:"auth"`
+	Auth          genericconf.AuthRPCConfig       `koanf:"auth"`
 	Metrics       bool                            `koanf:"metrics"`
 	MetricsServer genericconf.MetricsServerConfig `koanf:"metrics-server"`
 	PProf         bool                            `koanf:"pprof"`
@@ -66,7 +66,7 @@ var ValidationNodeConfigDefault = ValidationNodeConfig{
 	HTTP:          HTTPConfigDefault,
 	WS:            WSConfigDefault,
 	IPC:           IPCConfigDefault,
-	AuthRPC:       genericconf.AuthRPCConfigDefault,
+	Auth:          genericconf.AuthRPCConfigDefault,
 	Metrics:       false,
 	MetricsServer: genericconf.MetricsServerConfigDefault,
 	PProf:         false,

--- a/cmd/nitro-val/nitro_val.go
+++ b/cmd/nitro-val/nitro_val.go
@@ -68,7 +68,7 @@ func mainImpl() int {
 	stackConf.DataDir = "" // ephemeral
 	nodeConfig.HTTP.Apply(&stackConf)
 	nodeConfig.WS.Apply(&stackConf)
-	nodeConfig.AuthRPC.Apply(&stackConf)
+	nodeConfig.Auth.Apply(&stackConf)
 	nodeConfig.IPC.Apply(&stackConf)
 	stackConf.P2P.ListenAddr = ""
 	stackConf.P2P.NoDial = true

--- a/cmd/nitro/config_test.go
+++ b/cmd/nitro/config_test.go
@@ -85,7 +85,7 @@ func TestReloads(t *testing.T) {
 	// check that non-reloadable fields fail assignment
 	update.Metrics = !update.Metrics
 	testUnsafe()
-	update.L2.ChainID++
+	update.Chain.ID++
 	testUnsafe()
 	update.Node.Sequencer.Forwarder.ConnectionTimeout++
 	testUnsafe()
@@ -122,7 +122,7 @@ func TestLiveNodeConfig(t *testing.T) {
 
 	// check that an invalid reload gets rejected
 	update = config.ShallowClone()
-	update.L2.ChainID++
+	update.Chain.ID++
 	if liveConfig.Set(update) == nil {
 		Fail(t, "failed to reject invalid update")
 	}

--- a/cmd/nitro/config_test.go
+++ b/cmd/nitro/config_test.go
@@ -85,7 +85,7 @@ func TestReloads(t *testing.T) {
 	// check that non-reloadable fields fail assignment
 	update.Metrics = !update.Metrics
 	testUnsafe()
-	update.Chain.ID++
+	update.ParentChain.ID++
 	testUnsafe()
 	update.Node.Sequencer.Forwarder.ConnectionTimeout++
 	testUnsafe()
@@ -122,7 +122,7 @@ func TestLiveNodeConfig(t *testing.T) {
 
 	// check that an invalid reload gets rejected
 	update = config.ShallowClone()
-	update.Chain.ID++
+	update.ParentChain.ID++
 	if liveConfig.Set(update) == nil {
 		Fail(t, "failed to reject invalid update")
 	}

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -51,7 +51,7 @@ type InitConfig struct {
 	DownloadPath    string        `koanf:"download-path"`
 	DownloadPoll    time.Duration `koanf:"download-poll"`
 	DevInit         bool          `koanf:"dev-init"`
-	DevInitAddr     string        `koanf:"dev-init-address"`
+	DevInitAddress  string        `koanf:"dev-init-address"`
 	DevInitBlockNum uint64        `koanf:"dev-init-blocknum"`
 	Empty           bool          `koanf:"empty"`
 	AccountsPerSync uint          `koanf:"accounts-per-sync"`
@@ -59,7 +59,7 @@ type InitConfig struct {
 	ThenQuit        bool          `koanf:"then-quit"`
 	Prune           string        `koanf:"prune"`
 	PruneBloomSize  uint64        `koanf:"prune-bloom-size"`
-	ResetToMsg      int64         `koanf:"reset-to-message"`
+	ResetToMessage  int64         `koanf:"reset-to-message"`
 }
 
 var InitConfigDefault = InitConfig{
@@ -68,14 +68,14 @@ var InitConfigDefault = InitConfig{
 	DownloadPath:    "/tmp/",
 	DownloadPoll:    time.Minute,
 	DevInit:         false,
-	DevInitAddr:     "",
+	DevInitAddress:  "",
 	DevInitBlockNum: 0,
 	ImportFile:      "",
 	AccountsPerSync: 100000,
 	ThenQuit:        false,
 	Prune:           "",
 	PruneBloomSize:  2048,
-	ResetToMsg:      -1,
+	ResetToMessage:  -1,
 }
 
 func InitConfigAddOptions(prefix string, f *pflag.FlagSet) {
@@ -84,7 +84,7 @@ func InitConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.String(prefix+".download-path", InitConfigDefault.DownloadPath, "path to save temp downloaded file")
 	f.Duration(prefix+".download-poll", InitConfigDefault.DownloadPoll, "how long to wait between polling attempts")
 	f.Bool(prefix+".dev-init", InitConfigDefault.DevInit, "init with dev data (1 account with balance) instead of file import")
-	f.String(prefix+".dev-init-address", InitConfigDefault.DevInitAddr, "Address of dev-account. Leave empty to use the dev-wallet.")
+	f.String(prefix+".dev-init-address", InitConfigDefault.DevInitAddress, "Address of dev-account. Leave empty to use the dev-wallet.")
 	f.Uint64(prefix+".dev-init-blocknum", InitConfigDefault.DevInitBlockNum, "Number of preinit blocks. Must exist in ancient database.")
 	f.Bool(prefix+".empty", InitConfigDefault.DevInit, "init with empty state")
 	f.Bool(prefix+".then-quit", InitConfigDefault.ThenQuit, "quit after init is done")
@@ -92,7 +92,7 @@ func InitConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Uint(prefix+".accounts-per-sync", InitConfigDefault.AccountsPerSync, "during init - sync database every X accounts. Lower value for low-memory systems. 0 disables.")
 	f.String(prefix+".prune", InitConfigDefault.Prune, "pruning for a given use: \"full\" for full nodes serving RPC requests, or \"validator\" for validators")
 	f.Uint64(prefix+".prune-bloom-size", InitConfigDefault.PruneBloomSize, "the amount of memory in megabytes to use for the pruning bloom filter (higher values prune better)")
-	f.Int64(prefix+".reset-to-message", InitConfigDefault.ResetToMsg, "forces a reset to an old message height. Also set max-reorg-resequence-depth=0 to force re-reading messages")
+	f.Int64(prefix+".reset-to-message", InitConfigDefault.ResetToMessage, "forces a reset to an old message height. Also set max-reorg-resequence-depth=0 to force re-reading messages")
 }
 
 func downloadInit(ctx context.Context, initConfig *InitConfig) (string, error) {
@@ -515,7 +515,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 			NextBlockNumber: config.Init.DevInitBlockNum,
 			Accounts: []statetransfer.AccountInitializationInfo{
 				{
-					Addr:       common.HexToAddress(config.Init.DevInitAddr),
+					Addr:       common.HexToAddress(config.Init.DevInitAddress),
 					EthBalance: new(big.Int).Mul(big.NewInt(params.Ether), big.NewInt(1000)),
 					Nonce:      0,
 				},
@@ -551,15 +551,15 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 		if err != nil {
 			return chainDb, nil, err
 		}
-		combinedL2ChainInfoFiles := config.L2.ChainInfoFiles
-		if config.L2.ChainInfoIpfsUrl != "" {
-			l2ChainInfoIpfsFile, err := util.GetL2ChainInfoIpfsFile(ctx, config.L2.ChainInfoIpfsUrl, config.L2.ChainInfoIpfsDownloadPath)
+		combinedL2ChainInfoFiles := config.Chain.InfoFiles
+		if config.Chain.InfoIpfsUrl != "" {
+			l2ChainInfoIpfsFile, err := util.GetL2ChainInfoIpfsFile(ctx, config.Chain.InfoIpfsUrl, config.Chain.InfoIpfsDownloadPath)
 			if err != nil {
 				log.Error("error getting l2 chain info file from ipfs", "err", err)
 			}
 			combinedL2ChainInfoFiles = append(combinedL2ChainInfoFiles, l2ChainInfoIpfsFile)
 		}
-		chainConfig, err = chaininfo.GetChainConfig(new(big.Int).SetUint64(config.L2.ChainID), config.L2.ChainName, genesisBlockNr, combinedL2ChainInfoFiles, config.L2.ChainInfoJson)
+		chainConfig, err = chaininfo.GetChainConfig(new(big.Int).SetUint64(config.Chain.ID), config.Chain.Name, genesisBlockNr, combinedL2ChainInfoFiles, config.Chain.InfoJson)
 		if err != nil {
 			return chainDb, nil, err
 		}
@@ -584,7 +584,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 			cacheConfig.SnapshotWait = true
 		}
 		var parsedInitMessage *arbostypes.ParsedInitMessage
-		if config.Node.L1Reader.Enable {
+		if config.Node.ParentChainReader.Enable {
 			delayedBridge, err := arbnode.NewDelayedBridge(l1Client, rollupAddrs.Bridge, rollupAddrs.DeployedAt)
 			if err != nil {
 				return chainDb, nil, fmt.Errorf("failed creating delayed bridge while attempting to get serialized chain config from init message: %w", err)

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -249,7 +249,7 @@ func mainImpl() int {
 
 	if nodeConfig.Node.Staker.ParentChainWallet == defaultValidatorL1WalletConfig && nodeConfig.Node.BatchPoster.ParentChainWallet == defaultBatchPosterL1WalletConfig {
 		if sequencerNeedsKey || validatorNeedsKey || l1Wallet.OnlyCreateKey {
-			l1TransactionOpts, dataSigner, err = util.OpenWallet("l1", l1Wallet, new(big.Int).SetUint64(nodeConfig.ParentChain.ChainID))
+			l1TransactionOpts, dataSigner, err = util.OpenWallet("l1", l1Wallet, new(big.Int).SetUint64(nodeConfig.ParentChain.ID))
 			if err != nil {
 				flag.Usage()
 				log.Crit("error opening parent chain wallet", "path", l1Wallet.Pathname, "account", l1Wallet.Account, "err", err)
@@ -265,7 +265,7 @@ func mainImpl() int {
 			log.Crit("--parent-chain.wallet cannot be set if either --node.staker.l1-wallet or --node.batch-poster.l1-wallet are set")
 		}
 		if sequencerNeedsKey || nodeConfig.Node.BatchPoster.ParentChainWallet.OnlyCreateKey {
-			l1TransactionOptsBatchPoster, dataSigner, err = util.OpenWallet("l1-batch-poster", &nodeConfig.Node.BatchPoster.ParentChainWallet, new(big.Int).SetUint64(nodeConfig.ParentChain.ChainID))
+			l1TransactionOptsBatchPoster, dataSigner, err = util.OpenWallet("l1-batch-poster", &nodeConfig.Node.BatchPoster.ParentChainWallet, new(big.Int).SetUint64(nodeConfig.ParentChain.ID))
 			if err != nil {
 				flag.Usage()
 				log.Crit("error opening Batch poster parent chain wallet", "path", nodeConfig.Node.BatchPoster.ParentChainWallet.Pathname, "account", nodeConfig.Node.BatchPoster.ParentChainWallet.Account, "err", err)
@@ -275,7 +275,7 @@ func mainImpl() int {
 			}
 		}
 		if validatorNeedsKey || nodeConfig.Node.Staker.ParentChainWallet.OnlyCreateKey {
-			l1TransactionOptsValidator, _, err = util.OpenWallet("l1-validator", &nodeConfig.Node.Staker.ParentChainWallet, new(big.Int).SetUint64(nodeConfig.ParentChain.ChainID))
+			l1TransactionOptsValidator, _, err = util.OpenWallet("l1-validator", &nodeConfig.Node.Staker.ParentChainWallet, new(big.Int).SetUint64(nodeConfig.ParentChain.ID))
 			if err != nil {
 				flag.Usage()
 				log.Crit("error opening Validator parent chain wallet", "path", nodeConfig.Node.Staker.ParentChainWallet.Pathname, "account", nodeConfig.Node.Staker.ParentChainWallet.Account, "err", err)
@@ -328,11 +328,11 @@ func mainImpl() int {
 		if err != nil {
 			log.Crit("couldn't read L1 chainid", "err", err)
 		}
-		if l1ChainId.Uint64() != nodeConfig.ParentChain.ChainID {
-			log.Crit("L1 chainID doesn't fit config", "found", l1ChainId.Uint64(), "expected", nodeConfig.ParentChain.ChainID)
+		if l1ChainId.Uint64() != nodeConfig.ParentChain.ID {
+			log.Crit("L1 chainID doesn't fit config", "found", l1ChainId.Uint64(), "expected", nodeConfig.ParentChain.ID)
 		}
 
-		log.Info("connected to l1 chain", "l1url", nodeConfig.ParentChain.Connection.URL, "l1chainid", nodeConfig.ParentChain.ChainID)
+		log.Info("connected to l1 chain", "l1url", nodeConfig.ParentChain.Connection.URL, "l1chainid", nodeConfig.ParentChain.ID)
 
 		rollupAddrs, err = chaininfo.GetRollupAddressesConfig(nodeConfig.Chain.ID, nodeConfig.Chain.Name, combinedL2ChainInfoFile, nodeConfig.Chain.InfoJson)
 		if err != nil {
@@ -768,7 +768,7 @@ func applyChainParameters(ctx context.Context, k *koanf.Koanf, chainId uint64, c
 		chainDefaults["node.forwarding-target"] = chainInfo.SequencerUrl
 	}
 	if chainInfo.FeedUrl != "" {
-		chainDefaults["node.feed.input.url"] = chainInfo.FeedUrl
+		chainDefaults["node.feed.input.urls"] = chainInfo.FeedUrl
 	}
 	if chainInfo.DasIndexUrl != "" {
 		chainDefaults["node.data-availability.enable"] = true

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -369,7 +369,7 @@ func mainImpl() int {
 		nodeConfig.Node.TxLookupLimit = 0
 	}
 
-	resourcemanager.Init(&nodeConfig.Node.ResourceManagement)
+	resourcemanager.Init(&nodeConfig.Node.ResourceMgmt)
 
 	var sameProcessValidationNodeEnabled bool
 	if nodeConfig.Node.BlockValidator.Enable && (nodeConfig.Node.BlockValidator.ValidationServer.URL == "self" || nodeConfig.Node.BlockValidator.ValidationServer.URL == "self-auth") {
@@ -768,7 +768,7 @@ func applyChainParameters(ctx context.Context, k *koanf.Koanf, chainId uint64, c
 		chainDefaults["node.forwarding-target"] = chainInfo.SequencerUrl
 	}
 	if chainInfo.FeedUrl != "" {
-		chainDefaults["node.feed.input.urls"] = chainInfo.FeedUrl
+		chainDefaults["node.feed.input.url"] = chainInfo.FeedUrl
 	}
 	if chainInfo.DasIndexUrl != "" {
 		chainDefaults["node.data-availability.enable"] = true

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -87,21 +87,21 @@ func addUnlockWallet(accountManager *accounts.Manager, walletConf *genericconf.W
 			account.Address = common.HexToAddress(walletConf.Account)
 			account, err = myKeystore.Find(account)
 		} else {
-			if walletConf.Password() == nil {
+			if walletConf.Pwd() == nil {
 				return common.Address{}, errors.New("l2 password not set")
 			}
 			if devPrivKey == nil {
 				return common.Address{}, errors.New("l2 private key not set")
 			}
-			account, err = myKeystore.ImportECDSA(devPrivKey, *walletConf.Password())
+			account, err = myKeystore.ImportECDSA(devPrivKey, *walletConf.Pwd())
 		}
 		if err != nil {
 			return common.Address{}, err
 		}
-		if walletConf.Password() == nil {
+		if walletConf.Pwd() == nil {
 			return common.Address{}, errors.New("l2 password not set")
 		}
-		err = myKeystore.Unlock(account, *walletConf.Password())
+		err = myKeystore.Unlock(account, *walletConf.Pwd())
 		if err != nil {
 			return common.Address{}, err
 		}
@@ -159,7 +159,7 @@ func mainImpl() int {
 	stackConf.DataDir = nodeConfig.Persistent.Chain
 	nodeConfig.HTTP.Apply(&stackConf)
 	nodeConfig.WS.Apply(&stackConf)
-	nodeConfig.AuthRPC.Apply(&stackConf)
+	nodeConfig.Auth.Apply(&stackConf)
 	nodeConfig.IPC.Apply(&stackConf)
 	nodeConfig.GraphQL.Apply(&stackConf)
 	if nodeConfig.WS.ExposeAll {
@@ -207,23 +207,23 @@ func mainImpl() int {
 	log.Info("Running Arbitrum nitro node", "revision", vcsRevision, "vcs.time", vcsTime)
 
 	if nodeConfig.Node.Dangerous.NoL1Listener {
-		nodeConfig.Node.L1Reader.Enable = false
+		nodeConfig.Node.ParentChainReader.Enable = false
 		nodeConfig.Node.BatchPoster.Enable = false
 		nodeConfig.Node.DelayedSequencer.Enable = false
 	} else {
-		nodeConfig.Node.L1Reader.Enable = true
+		nodeConfig.Node.ParentChainReader.Enable = true
 	}
 
 	if nodeConfig.Node.Sequencer.Enable {
-		if nodeConfig.Node.ForwardingTarget() != "" {
+		if nodeConfig.Node.ForwardingTargetF() != "" {
 			flag.Usage()
 			log.Crit("forwarding-target cannot be set when sequencer is enabled")
 		}
-		if nodeConfig.Node.L1Reader.Enable && nodeConfig.Node.InboxReader.HardReorg {
+		if nodeConfig.Node.ParentChainReader.Enable && nodeConfig.Node.InboxReader.HardReorg {
 			flag.Usage()
 			log.Crit("hard reorgs cannot safely be enabled with sequencer mode enabled")
 		}
-	} else if nodeConfig.Node.ForwardingTargetImpl == "" {
+	} else if nodeConfig.Node.ForwardingTarget == "" {
 		flag.Usage()
 		log.Crit("forwarding-target unset, and not sequencer (can set to \"null\" to disable forwarding)")
 	}
@@ -239,17 +239,17 @@ func mainImpl() int {
 	defaultL1WalletConfig := conf.DefaultL1WalletConfig
 	defaultL1WalletConfig.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
 
-	nodeConfig.Node.Staker.L1Wallet.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
+	nodeConfig.Node.Staker.ParentChainWallet.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
 	defaultValidatorL1WalletConfig := staker.DefaultValidatorL1WalletConfig
 	defaultValidatorL1WalletConfig.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
 
-	nodeConfig.Node.BatchPoster.L1Wallet.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
+	nodeConfig.Node.BatchPoster.ParentChainWallet.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
 	defaultBatchPosterL1WalletConfig := arbnode.DefaultBatchPosterL1WalletConfig
 	defaultBatchPosterL1WalletConfig.ResolveDirectoryNames(nodeConfig.Persistent.Chain)
 
-	if nodeConfig.Node.Staker.L1Wallet == defaultValidatorL1WalletConfig && nodeConfig.Node.BatchPoster.L1Wallet == defaultBatchPosterL1WalletConfig {
+	if nodeConfig.Node.Staker.ParentChainWallet == defaultValidatorL1WalletConfig && nodeConfig.Node.BatchPoster.ParentChainWallet == defaultBatchPosterL1WalletConfig {
 		if sequencerNeedsKey || validatorNeedsKey || l1Wallet.OnlyCreateKey {
-			l1TransactionOpts, dataSigner, err = util.OpenWallet("l1", l1Wallet, new(big.Int).SetUint64(nodeConfig.L1.ChainID))
+			l1TransactionOpts, dataSigner, err = util.OpenWallet("l1", l1Wallet, new(big.Int).SetUint64(nodeConfig.ParentChain.ChainID))
 			if err != nil {
 				flag.Usage()
 				log.Crit("error opening parent chain wallet", "path", l1Wallet.Pathname, "account", l1Wallet.Account, "err", err)
@@ -264,31 +264,31 @@ func mainImpl() int {
 		if *l1Wallet != defaultL1WalletConfig {
 			log.Crit("--parent-chain.wallet cannot be set if either --node.staker.l1-wallet or --node.batch-poster.l1-wallet are set")
 		}
-		if sequencerNeedsKey || nodeConfig.Node.BatchPoster.L1Wallet.OnlyCreateKey {
-			l1TransactionOptsBatchPoster, dataSigner, err = util.OpenWallet("l1-batch-poster", &nodeConfig.Node.BatchPoster.L1Wallet, new(big.Int).SetUint64(nodeConfig.L1.ChainID))
+		if sequencerNeedsKey || nodeConfig.Node.BatchPoster.ParentChainWallet.OnlyCreateKey {
+			l1TransactionOptsBatchPoster, dataSigner, err = util.OpenWallet("l1-batch-poster", &nodeConfig.Node.BatchPoster.ParentChainWallet, new(big.Int).SetUint64(nodeConfig.ParentChain.ChainID))
 			if err != nil {
 				flag.Usage()
-				log.Crit("error opening Batch poster parent chain wallet", "path", nodeConfig.Node.BatchPoster.L1Wallet.Pathname, "account", nodeConfig.Node.BatchPoster.L1Wallet.Account, "err", err)
+				log.Crit("error opening Batch poster parent chain wallet", "path", nodeConfig.Node.BatchPoster.ParentChainWallet.Pathname, "account", nodeConfig.Node.BatchPoster.ParentChainWallet.Account, "err", err)
 			}
-			if nodeConfig.Node.BatchPoster.L1Wallet.OnlyCreateKey {
+			if nodeConfig.Node.BatchPoster.ParentChainWallet.OnlyCreateKey {
 				return 0
 			}
 		}
-		if validatorNeedsKey || nodeConfig.Node.Staker.L1Wallet.OnlyCreateKey {
-			l1TransactionOptsValidator, _, err = util.OpenWallet("l1-validator", &nodeConfig.Node.Staker.L1Wallet, new(big.Int).SetUint64(nodeConfig.L1.ChainID))
+		if validatorNeedsKey || nodeConfig.Node.Staker.ParentChainWallet.OnlyCreateKey {
+			l1TransactionOptsValidator, _, err = util.OpenWallet("l1-validator", &nodeConfig.Node.Staker.ParentChainWallet, new(big.Int).SetUint64(nodeConfig.ParentChain.ChainID))
 			if err != nil {
 				flag.Usage()
-				log.Crit("error opening Validator parent chain wallet", "path", nodeConfig.Node.Staker.L1Wallet.Pathname, "account", nodeConfig.Node.Staker.L1Wallet.Account, "err", err)
+				log.Crit("error opening Validator parent chain wallet", "path", nodeConfig.Node.Staker.ParentChainWallet.Pathname, "account", nodeConfig.Node.Staker.ParentChainWallet.Account, "err", err)
 			}
-			if nodeConfig.Node.Staker.L1Wallet.OnlyCreateKey {
+			if nodeConfig.Node.Staker.ParentChainWallet.OnlyCreateKey {
 				return 0
 			}
 		}
 	}
 
-	combinedL2ChainInfoFile := nodeConfig.L2.ChainInfoFiles
-	if nodeConfig.L2.ChainInfoIpfsUrl != "" {
-		l2ChainInfoIpfsFile, err := util.GetL2ChainInfoIpfsFile(ctx, nodeConfig.L2.ChainInfoIpfsUrl, nodeConfig.L2.ChainInfoIpfsDownloadPath)
+	combinedL2ChainInfoFile := nodeConfig.Chain.InfoFiles
+	if nodeConfig.Chain.InfoIpfsUrl != "" {
+		l2ChainInfoIpfsFile, err := util.GetL2ChainInfoIpfsFile(ctx, nodeConfig.Chain.InfoIpfsUrl, nodeConfig.Chain.InfoIpfsDownloadPath)
 		if err != nil {
 			log.Error("error getting chain info file from ipfs", "err", err)
 		}
@@ -296,7 +296,7 @@ func mainImpl() int {
 	}
 
 	if nodeConfig.Node.Staker.Enable {
-		if !nodeConfig.Node.L1Reader.Enable {
+		if !nodeConfig.Node.ParentChainReader.Enable {
 			flag.Usage()
 			log.Crit("validator must have the parent chain reader enabled")
 		}
@@ -316,8 +316,8 @@ func mainImpl() int {
 
 	var rollupAddrs chaininfo.RollupAddresses
 	var l1Client *ethclient.Client
-	if nodeConfig.Node.L1Reader.Enable {
-		confFetcher := func() *rpcclient.ClientConfig { return &liveNodeConfig.Get().L1.Connection }
+	if nodeConfig.Node.ParentChainReader.Enable {
+		confFetcher := func() *rpcclient.ClientConfig { return &liveNodeConfig.Get().ParentChain.Connection }
 		rpcClient := rpcclient.NewRpcClient(confFetcher, nil)
 		err := rpcClient.Start(ctx)
 		if err != nil {
@@ -328,13 +328,13 @@ func mainImpl() int {
 		if err != nil {
 			log.Crit("couldn't read L1 chainid", "err", err)
 		}
-		if l1ChainId.Uint64() != nodeConfig.L1.ChainID {
-			log.Crit("L1 chainID doesn't fit config", "found", l1ChainId.Uint64(), "expected", nodeConfig.L1.ChainID)
+		if l1ChainId.Uint64() != nodeConfig.ParentChain.ChainID {
+			log.Crit("L1 chainID doesn't fit config", "found", l1ChainId.Uint64(), "expected", nodeConfig.ParentChain.ChainID)
 		}
 
-		log.Info("connected to l1 chain", "l1url", nodeConfig.L1.Connection.URL, "l1chainid", nodeConfig.L1.ChainID)
+		log.Info("connected to l1 chain", "l1url", nodeConfig.ParentChain.Connection.URL, "l1chainid", nodeConfig.ParentChain.ChainID)
 
-		rollupAddrs, err = chaininfo.GetRollupAddressesConfig(nodeConfig.L2.ChainID, nodeConfig.L2.ChainName, combinedL2ChainInfoFile, nodeConfig.L2.ChainInfoJson)
+		rollupAddrs, err = chaininfo.GetRollupAddressesConfig(nodeConfig.Chain.ID, nodeConfig.Chain.Name, combinedL2ChainInfoFile, nodeConfig.Chain.InfoJson)
 		if err != nil {
 			log.Crit("error getting rollup addresses", "err", err)
 		}
@@ -345,14 +345,14 @@ func mainImpl() int {
 			flag.Usage()
 			log.Crit("--node.validator.only-create-wallet-contract requires --node.validator.use-smart-contract-wallet")
 		}
-		l1Reader, err := headerreader.New(ctx, l1Client, func() *headerreader.Config { return &liveNodeConfig.Get().Node.L1Reader })
+		l1Reader, err := headerreader.New(ctx, l1Client, func() *headerreader.Config { return &liveNodeConfig.Get().Node.ParentChainReader })
 		if err != nil {
 			log.Crit("failed to get L1 headerreader", "error", err)
 
 		}
 
 		// Just create validator smart wallet if needed then exit
-		deployInfo, err := chaininfo.GetRollupAddressesConfig(nodeConfig.L2.ChainID, nodeConfig.L2.ChainName, combinedL2ChainInfoFile, nodeConfig.L2.ChainInfoJson)
+		deployInfo, err := chaininfo.GetRollupAddressesConfig(nodeConfig.Chain.ID, nodeConfig.Chain.Name, combinedL2ChainInfoFile, nodeConfig.Chain.InfoJson)
 		if err != nil {
 			log.Crit("error getting rollup addresses config", "err", err)
 		}
@@ -388,7 +388,7 @@ func mainImpl() int {
 			log.Crit("error opening L2 dev wallet", "err", err)
 		}
 		if devAddr != (common.Address{}) {
-			nodeConfig.Init.DevInitAddr = devAddr.String()
+			nodeConfig.Init.DevInitAddress = devAddr.String()
 		}
 	}
 
@@ -404,7 +404,7 @@ func mainImpl() int {
 		}
 	}()
 
-	chainDb, l2BlockChain, err := openInitializeChainDb(ctx, stack, nodeConfig, new(big.Int).SetUint64(nodeConfig.L2.ChainID), execution.DefaultCacheConfigFor(stack, &nodeConfig.Node.Caching), l1Client, rollupAddrs)
+	chainDb, l2BlockChain, err := openInitializeChainDb(ctx, stack, nodeConfig, new(big.Int).SetUint64(nodeConfig.Chain.ID), execution.DefaultCacheConfigFor(stack, &nodeConfig.Node.Caching), l1Client, rollupAddrs)
 	if l2BlockChain != nil {
 		deferFuncs = append(deferFuncs, func() { l2BlockChain.Stop() })
 	}
@@ -422,7 +422,7 @@ func mainImpl() int {
 		return 1
 	}
 
-	if nodeConfig.Init.ThenQuit && nodeConfig.Init.ResetToMsg < 0 {
+	if nodeConfig.Init.ThenQuit && nodeConfig.Init.ResetToMessage < 0 {
 		return 0
 	}
 
@@ -517,8 +517,8 @@ func mainImpl() int {
 
 	exitCode := 0
 
-	if err == nil && nodeConfig.Init.ResetToMsg > 0 {
-		err = currentNode.TxStreamer.ReorgTo(arbutil.MessageIndex(nodeConfig.Init.ResetToMsg))
+	if err == nil && nodeConfig.Init.ResetToMessage > 0 {
+		err = currentNode.TxStreamer.ReorgTo(arbutil.MessageIndex(nodeConfig.Init.ResetToMessage))
 		if err != nil {
 			fatalErrChan <- fmt.Errorf("error reseting message: %w", err)
 			exitCode = 1
@@ -549,8 +549,8 @@ type NodeConfig struct {
 	Conf          genericconf.ConfConfig          `koanf:"conf" reload:"hot"`
 	Node          arbnode.Config                  `koanf:"node" reload:"hot"`
 	Validation    valnode.Config                  `koanf:"validation" reload:"hot"`
-	L1            conf.L1Config                   `koanf:"parent-chain" reload:"hot"`
-	L2            conf.L2Config                   `koanf:"chain"`
+	ParentChain   conf.L1Config                   `koanf:"parent-chain" reload:"hot"`
+	Chain         conf.L2Config                   `koanf:"chain"`
 	LogLevel      int                             `koanf:"log-level" reload:"hot"`
 	LogType       string                          `koanf:"log-type" reload:"hot"`
 	FileLogging   genericconf.FileLoggingConfig   `koanf:"file-logging" reload:"hot"`
@@ -558,7 +558,7 @@ type NodeConfig struct {
 	HTTP          genericconf.HTTPConfig          `koanf:"http"`
 	WS            genericconf.WSConfig            `koanf:"ws"`
 	IPC           genericconf.IPCConfig           `koanf:"ipc"`
-	AuthRPC       genericconf.AuthRPCConfig       `koanf:"auth"`
+	Auth          genericconf.AuthRPCConfig       `koanf:"auth"`
 	GraphQL       genericconf.GraphQLConfig       `koanf:"graphql"`
 	Metrics       bool                            `koanf:"metrics"`
 	MetricsServer genericconf.MetricsServerConfig `koanf:"metrics-server"`
@@ -571,8 +571,8 @@ type NodeConfig struct {
 var NodeConfigDefault = NodeConfig{
 	Conf:          genericconf.ConfConfigDefault,
 	Node:          arbnode.ConfigDefault,
-	L1:            conf.L1ConfigDefault,
-	L2:            conf.L2ConfigDefault,
+	ParentChain:   conf.L1ConfigDefault,
+	Chain:         conf.L2ConfigDefault,
 	LogLevel:      int(log.LvlInfo),
 	LogType:       "plaintext",
 	Persistent:    conf.PersistentConfigDefault,
@@ -614,8 +614,8 @@ func (c *NodeConfig) ResolveDirectoryNames() error {
 	if err != nil {
 		return err
 	}
-	c.L1.ResolveDirectoryNames(c.Persistent.Chain)
-	c.L2.ResolveDirectoryNames(c.Persistent.Chain)
+	c.ParentChain.ResolveDirectoryNames(c.Persistent.Chain)
+	c.Chain.ResolveDirectoryNames(c.Persistent.Chain)
 
 	return nil
 }
@@ -659,7 +659,7 @@ func (c *NodeConfig) CanReload(new *NodeConfig) error {
 }
 
 func (c *NodeConfig) Validate() error {
-	if err := c.L1.Validate(); err != nil {
+	if err := c.ParentChain.Validate(); err != nil {
 		return err
 	}
 	return c.Node.Validate()
@@ -733,10 +733,10 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 	}
 
 	// Don't pass around wallet contents with normal configuration
-	l1Wallet := nodeConfig.L1.Wallet
-	l2DevWallet := nodeConfig.L2.DevWallet
-	nodeConfig.L1.Wallet = genericconf.WalletConfigDefault
-	nodeConfig.L2.DevWallet = genericconf.WalletConfigDefault
+	l1Wallet := nodeConfig.ParentChain.Wallet
+	l2DevWallet := nodeConfig.Chain.DevWallet
+	nodeConfig.ParentChain.Wallet = genericconf.WalletConfigDefault
+	nodeConfig.Chain.DevWallet = genericconf.WalletConfigDefault
 
 	err = nodeConfig.Validate()
 	if err != nil {

--- a/cmd/relay/config_test.go
+++ b/cmd/relay/config_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestRelayConfig(t *testing.T) {
-	args := strings.Split("--node.feed.output.port 9652 --node.feed.input.url ws://sequencer:9642/feed", " ")
+	args := strings.Split("--node.feed.output.port 9652 --node.feed.input.urls ws://sequencer:9642/feed", " ")
 	_, err := relay.ParseRelay(context.Background(), args)
 	testhelpers.RequireImpl(t, err)
 }

--- a/cmd/relay/config_test.go
+++ b/cmd/relay/config_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestRelayConfig(t *testing.T) {
-	args := strings.Split("--node.feed.output.port 9652 --node.feed.input.urls ws://sequencer:9642/feed", " ")
+	args := strings.Split("--node.feed.output.port 9652 --node.feed.input.url ws://sequencer:9642/feed", " ")
 	_, err := relay.ParseRelay(context.Background(), args)
 	testhelpers.RequireImpl(t, err)
 }

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -63,7 +63,7 @@ func startup() error {
 	ctx := context.Background()
 
 	relayConfig, err := relay.ParseRelay(ctx, os.Args[1:])
-	if err != nil || len(relayConfig.Node.Feed.Input.URLs) == 0 || relayConfig.Node.Feed.Input.URLs[0] == "" || relayConfig.Chain.ID == 0 {
+	if err != nil || len(relayConfig.Node.Feed.Input.URL) == 0 || relayConfig.Node.Feed.Input.URL[0] == "" || relayConfig.Chain.ID == 0 {
 		confighelpers.PrintErrorAndExit(err, printSampleUsage)
 	}
 

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -63,7 +63,7 @@ func startup() error {
 	ctx := context.Background()
 
 	relayConfig, err := relay.ParseRelay(ctx, os.Args[1:])
-	if err != nil || len(relayConfig.Node.Feed.Input.URLs) == 0 || relayConfig.Node.Feed.Input.URLs[0] == "" || relayConfig.L2.ChainId == 0 {
+	if err != nil || len(relayConfig.Node.Feed.Input.URLs) == 0 || relayConfig.Node.Feed.Input.URLs[0] == "" || relayConfig.Chain.ID == 0 {
 		confighelpers.PrintErrorAndExit(err, printSampleUsage)
 	}
 

--- a/cmd/util/keystore.go
+++ b/cmd/util/keystore.go
@@ -79,7 +79,7 @@ func openKeystore(ks *keystore.KeyStore, description string, walletConfig *gener
 	if !creatingNew && walletConfig.OnlyCreateKey {
 		return nil, fmt.Errorf("wallet key already created, backup key (%s) and remove --%s.wallet.only-create-key to run normally", walletConfig.Pathname, description)
 	}
-	passOpt := walletConfig.Password()
+	passOpt := walletConfig.Pwd()
 	var password string
 	if passOpt != nil {
 		password = *passOpt

--- a/cmd/util/keystore_test.go
+++ b/cmd/util/keystore_test.go
@@ -29,7 +29,7 @@ func createWallet(t *testing.T, pathname string) {
 	walletConf := genericconf.WalletConfigDefault
 	walletConf.Pathname = pathname
 	walletConf.OnlyCreateKey = true
-	walletConf.PasswordImpl = "foo"
+	walletConf.Password = "foo"
 
 	testPassCalled := false
 	testPass := func() (string, error) {
@@ -69,7 +69,7 @@ func TestExistingKeystoreNoCreate(t *testing.T) {
 	walletConf := genericconf.WalletConfigDefault
 	walletConf.Pathname = pathname
 	walletConf.OnlyCreateKey = true
-	walletConf.PasswordImpl = "foo"
+	walletConf.Password = "foo"
 
 	testPassCalled := false
 	testPass := func() (string, error) {

--- a/das/aggregator.go
+++ b/das/aggregator.go
@@ -82,10 +82,10 @@ func NewServiceDetails(service DataAvailabilityServiceWriter, pubKey blsSignatur
 }
 
 func NewAggregator(ctx context.Context, config DataAvailabilityConfig, services []ServiceDetails) (*Aggregator, error) {
-	if config.L1NodeURL == "none" {
+	if config.ParentChainNodeURL == "none" {
 		return NewAggregatorWithSeqInboxCaller(config, services, nil)
 	}
-	l1client, err := GetL1Client(ctx, config.L1ConnectionAttempts, config.L1NodeURL)
+	l1client, err := GetL1Client(ctx, config.ParentChainConnectionAttempts, config.ParentChainNodeURL)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func NewAggregatorWithSeqInboxCaller(
 	seqInboxCaller *bridgegen.SequencerInboxCaller,
 ) (*Aggregator, error) {
 
-	keysetHash, keysetBytes, err := KeysetHashFromServices(services, uint64(config.AggregatorConfig.AssumedHonest))
+	keysetHash, keysetBytes, err := KeysetHashFromServices(services, uint64(config.RPCAggregator.AssumedHonest))
 	if err != nil {
 		return nil, err
 	}
@@ -129,11 +129,11 @@ func NewAggregatorWithSeqInboxCaller(
 	}
 
 	return &Aggregator{
-		config:                         config.AggregatorConfig,
+		config:                         config.RPCAggregator,
 		services:                       services,
 		requestTimeout:                 config.RequestTimeout,
-		requiredServicesForStore:       len(services) + 1 - config.AggregatorConfig.AssumedHonest,
-		maxAllowedServiceStoreFailures: config.AggregatorConfig.AssumedHonest - 1,
+		requiredServicesForStore:       len(services) + 1 - config.RPCAggregator.AssumedHonest,
+		maxAllowedServiceStoreFailures: config.RPCAggregator.AssumedHonest - 1,
 		keysetHash:                     keysetHash,
 		keysetBytes:                    keysetBytes,
 		bpVerifier:                     bpVerifier,

--- a/das/aggregator_test.go
+++ b/das/aggregator_test.go
@@ -34,10 +34,10 @@ func TestDAS_BasicAggregationLocal(t *testing.T) {
 
 		config := DataAvailabilityConfig{
 			Enable: true,
-			KeyConfig: KeyConfig{
+			Key: KeyConfig{
 				PrivKey: privKey,
 			},
-			L1NodeURL: "none",
+			ParentChainNodeURL: "none",
 		}
 
 		storageServices = append(storageServices, NewMemoryBackedStorageService(ctx))
@@ -49,7 +49,7 @@ func TestDAS_BasicAggregationLocal(t *testing.T) {
 		backends = append(backends, *details)
 	}
 
-	aggregator, err := NewAggregator(ctx, DataAvailabilityConfig{AggregatorConfig: AggregatorConfig{AssumedHonest: 1}, L1NodeURL: "none"}, backends)
+	aggregator, err := NewAggregator(ctx, DataAvailabilityConfig{RPCAggregator: AggregatorConfig{AssumedHonest: 1}, ParentChainNodeURL: "none"}, backends)
 	Require(t, err)
 
 	rawMsg := []byte("It's time for you to see the fnords.")
@@ -187,10 +187,10 @@ func testConfigurableStorageFailures(t *testing.T, shouldFailAggregation bool) {
 
 		config := DataAvailabilityConfig{
 			Enable: true,
-			KeyConfig: KeyConfig{
+			Key: KeyConfig{
 				PrivKey: privKey,
 			},
-			L1NodeURL: "none",
+			ParentChainNodeURL: "none",
 		}
 
 		storageServices = append(storageServices, NewMemoryBackedStorageService(ctx))
@@ -205,9 +205,9 @@ func testConfigurableStorageFailures(t *testing.T, shouldFailAggregation bool) {
 	aggregator, err := NewAggregator(
 		ctx,
 		DataAvailabilityConfig{
-			AggregatorConfig: AggregatorConfig{AssumedHonest: assumedHonest},
-			L1NodeURL:        "none",
-			RequestTimeout:   time.Millisecond * 2000,
+			RPCAggregator:      AggregatorConfig{AssumedHonest: assumedHonest},
+			ParentChainNodeURL: "none",
+			RequestTimeout:     time.Millisecond * 2000,
 		}, backends)
 	Require(t, err)
 

--- a/das/das.go
+++ b/das/das.go
@@ -40,22 +40,22 @@ type DataAvailabilityConfig struct {
 
 	RequestTimeout time.Duration `koanf:"request-timeout"`
 
-	LocalCacheConfig BigCacheConfig `koanf:"local-cache"`
-	RedisCacheConfig RedisConfig    `koanf:"redis-cache"`
+	LocalCache BigCacheConfig `koanf:"local-cache"`
+	RedisCache RedisConfig    `koanf:"redis-cache"`
 
-	LocalDBStorageConfig     LocalDBStorageConfig     `koanf:"local-db-storage"`
-	LocalFileStorageConfig   LocalFileStorageConfig   `koanf:"local-file-storage"`
-	S3StorageServiceConfig   S3StorageServiceConfig   `koanf:"s3-storage"`
-	IpfsStorageServiceConfig IpfsStorageServiceConfig `koanf:"ipfs-storage"`
-	RegularSyncStorageConfig RegularSyncStorageConfig `koanf:"regular-sync-storage"`
+	LocalDBStorage     LocalDBStorageConfig     `koanf:"local-db-storage"`
+	LocalFileStorage   LocalFileStorageConfig   `koanf:"local-file-storage"`
+	S3Storage          S3StorageServiceConfig   `koanf:"s3-storage"`
+	IpfsStorage        IpfsStorageServiceConfig `koanf:"ipfs-storage"`
+	RegularSyncStorage RegularSyncStorageConfig `koanf:"regular-sync-storage"`
 
-	KeyConfig KeyConfig `koanf:"key"`
+	Key KeyConfig `koanf:"key"`
 
-	AggregatorConfig              AggregatorConfig              `koanf:"rpc-aggregator"`
-	RestfulClientAggregatorConfig RestfulClientAggregatorConfig `koanf:"rest-aggregator"`
+	RPCAggregator  AggregatorConfig              `koanf:"rpc-aggregator"`
+	RestAggregator RestfulClientAggregatorConfig `koanf:"rest-aggregator"`
 
-	L1NodeURL                       string `koanf:"parent-chain-node-url"`
-	L1ConnectionAttempts            int    `koanf:"parent-chain-connection-attempts"`
+	ParentChainNodeURL              string `koanf:"parent-chain-node-url"`
+	ParentChainConnectionAttempts   int    `koanf:"parent-chain-connection-attempts"`
 	SequencerInboxAddress           string `koanf:"sequencer-inbox-address"`
 	ExtraSignatureCheckingPublicKey string `koanf:"extra-signature-checking-public-key"`
 
@@ -66,8 +66,8 @@ type DataAvailabilityConfig struct {
 var DefaultDataAvailabilityConfig = DataAvailabilityConfig{
 	RequestTimeout:                5 * time.Second,
 	Enable:                        false,
-	RestfulClientAggregatorConfig: DefaultRestfulClientAggregatorConfig,
-	L1ConnectionAttempts:          15,
+	RestAggregator:                DefaultRestfulClientAggregatorConfig,
+	ParentChainConnectionAttempts: 15,
 	PanicOnError:                  false,
 }
 
@@ -132,8 +132,8 @@ func dataAvailabilityConfigAddOptions(prefix string, f *flag.FlagSet, r role) {
 	IpfsStorageServiceConfigAddOptions(prefix+".ipfs-storage", f)
 	RestfulClientAggregatorConfigAddOptions(prefix+".rest-aggregator", f)
 
-	f.String(prefix+".parent-chain-node-url", DefaultDataAvailabilityConfig.L1NodeURL, "URL for L1 node, only used in standalone daserver; when running as part of a node that node's L1 configuration is used")
-	f.Int(prefix+".parent-chain-connection-attempts", DefaultDataAvailabilityConfig.L1ConnectionAttempts, "layer 1 RPC connection attempts (spaced out at least 1 second per attempt, 0 to retry infinitely), only used in standalone daserver; when running as part of a node that node's L1 configuration is used")
+	f.String(prefix+".parent-chain-node-url", DefaultDataAvailabilityConfig.ParentChainNodeURL, "URL for L1 node, only used in standalone daserver; when running as part of a node that node's L1 configuration is used")
+	f.Int(prefix+".parent-chain-connection-attempts", DefaultDataAvailabilityConfig.ParentChainConnectionAttempts, "layer 1 RPC connection attempts (spaced out at least 1 second per attempt, 0 to retry infinitely), only used in standalone daserver; when running as part of a node that node's L1 configuration is used")
 	f.String(prefix+".sequencer-inbox-address", DefaultDataAvailabilityConfig.SequencerInboxAddress, "L1 address of SequencerInbox contract")
 }
 

--- a/das/das_test.go
+++ b/das/das_test.go
@@ -32,18 +32,18 @@ func testDASStoreRetrieveMultipleInstances(t *testing.T, storageType string) {
 
 	config := DataAvailabilityConfig{
 		Enable: true,
-		KeyConfig: KeyConfig{
+		Key: KeyConfig{
 			KeyDir: dbPath,
 		},
-		LocalFileStorageConfig: LocalFileStorageConfig{
+		LocalFileStorage: LocalFileStorageConfig{
 			Enable:  enableFileStorage,
 			DataDir: dbPath,
 		},
-		LocalDBStorageConfig: LocalDBStorageConfig{
+		LocalDBStorage: LocalDBStorageConfig{
 			Enable:  enableDbStorage,
 			DataDir: dbPath,
 		},
-		L1NodeURL: "none",
+		ParentChainNodeURL: "none",
 	}
 
 	var syncFromStorageServicesFirst []*IterableStorageService
@@ -124,18 +124,18 @@ func testDASMissingMessage(t *testing.T, storageType string) {
 
 	config := DataAvailabilityConfig{
 		Enable: true,
-		KeyConfig: KeyConfig{
+		Key: KeyConfig{
 			KeyDir: dbPath,
 		},
-		LocalFileStorageConfig: LocalFileStorageConfig{
+		LocalFileStorage: LocalFileStorageConfig{
 			Enable:  enableFileStorage,
 			DataDir: dbPath,
 		},
-		LocalDBStorageConfig: LocalDBStorageConfig{
+		LocalDBStorage: LocalDBStorageConfig{
 			Enable:  enableDbStorage,
 			DataDir: dbPath,
 		},
-		L1NodeURL: "none",
+		ParentChainNodeURL: "none",
 	}
 
 	var syncFromStorageServices []*IterableStorageService

--- a/das/db_storage_service.go
+++ b/das/db_storage_service.go
@@ -20,11 +20,11 @@ import (
 )
 
 type LocalDBStorageConfig struct {
-	Enable                  bool   `koanf:"enable"`
-	DataDir                 string `koanf:"data-dir"`
-	DiscardAfterTimeout     bool   `koanf:"discard-after-timeout"`
-	SyncFromStorageServices bool   `koanf:"sync-from-storage-service"`
-	SyncToStorageServices   bool   `koanf:"sync-to-storage-service"`
+	Enable                 bool   `koanf:"enable"`
+	DataDir                string `koanf:"data-dir"`
+	DiscardAfterTimeout    bool   `koanf:"discard-after-timeout"`
+	SyncFromStorageService bool   `koanf:"sync-from-storage-service"`
+	SyncToStorageService   bool   `koanf:"sync-to-storage-service"`
 }
 
 var DefaultLocalDBStorageConfig = LocalDBStorageConfig{}
@@ -33,8 +33,8 @@ func LocalDBStorageConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultLocalDBStorageConfig.Enable, "enable storage/retrieval of sequencer batch data from a database on the local filesystem")
 	f.String(prefix+".data-dir", DefaultLocalDBStorageConfig.DataDir, "directory in which to store the database")
 	f.Bool(prefix+".discard-after-timeout", DefaultLocalDBStorageConfig.DiscardAfterTimeout, "discard data after its expiry timeout")
-	f.Bool(prefix+".sync-from-storage-service", DefaultLocalDBStorageConfig.SyncFromStorageServices, "enable db storage to be used as a source for regular sync storage")
-	f.Bool(prefix+".sync-to-storage-service", DefaultLocalDBStorageConfig.SyncToStorageServices, "enable db storage to be used as a sink for regular sync storage")
+	f.Bool(prefix+".sync-from-storage-service", DefaultLocalDBStorageConfig.SyncFromStorageService, "enable db storage to be used as a source for regular sync storage")
+	f.Bool(prefix+".sync-to-storage-service", DefaultLocalDBStorageConfig.SyncToStorageService, "enable db storage to be used as a sink for regular sync storage")
 }
 
 type DBStorageService struct {

--- a/das/local_file_storage_service.go
+++ b/das/local_file_storage_service.go
@@ -22,10 +22,10 @@ import (
 )
 
 type LocalFileStorageConfig struct {
-	Enable                  bool   `koanf:"enable"`
-	DataDir                 string `koanf:"data-dir"`
-	SyncFromStorageServices bool   `koanf:"sync-from-storage-service"`
-	SyncToStorageServices   bool   `koanf:"sync-to-storage-service"`
+	Enable                 bool   `koanf:"enable"`
+	DataDir                string `koanf:"data-dir"`
+	SyncFromStorageService bool   `koanf:"sync-from-storage-service"`
+	SyncToStorageService   bool   `koanf:"sync-to-storage-service"`
 }
 
 var DefaultLocalFileStorageConfig = LocalFileStorageConfig{
@@ -35,8 +35,8 @@ var DefaultLocalFileStorageConfig = LocalFileStorageConfig{
 func LocalFileStorageConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultLocalFileStorageConfig.Enable, "enable storage/retrieval of sequencer batch data from a directory of files, one per batch")
 	f.String(prefix+".data-dir", DefaultLocalFileStorageConfig.DataDir, "local data directory")
-	f.Bool(prefix+".sync-from-storage-service", DefaultLocalFileStorageConfig.SyncFromStorageServices, "enable local storage to be used as a source for regular sync storage")
-	f.Bool(prefix+".sync-to-storage-service", DefaultLocalFileStorageConfig.SyncToStorageServices, "enable local storage to be used as a sink for regular sync storage")
+	f.Bool(prefix+".sync-from-storage-service", DefaultLocalFileStorageConfig.SyncFromStorageService, "enable local storage to be used as a source for regular sync storage")
+	f.Bool(prefix+".sync-to-storage-service", DefaultLocalFileStorageConfig.SyncToStorageService, "enable local storage to be used as a sink for regular sync storage")
 }
 
 type LocalFileStorageService struct {

--- a/das/redis_storage_service.go
+++ b/das/redis_storage_service.go
@@ -24,27 +24,27 @@ import (
 )
 
 type RedisConfig struct {
-	Enable                  bool          `koanf:"enable"`
-	RedisUrl                string        `koanf:"redis-url"`
-	Expiration              time.Duration `koanf:"redis-expiration"`
-	KeyConfig               string        `koanf:"redis-key-config"`
-	SyncFromStorageServices bool          `koanf:"sync-from-storage-service"`
-	SyncToStorageServices   bool          `koanf:"sync-to-storage-service"`
+	Enable                 bool          `koanf:"enable"`
+	Url                    string        `koanf:"url"`
+	Expiration             time.Duration `koanf:"expiration"`
+	KeyConfig              string        `koanf:"key-config"`
+	SyncFromStorageService bool          `koanf:"sync-from-storage-service"`
+	SyncToStorageService   bool          `koanf:"sync-to-storage-service"`
 }
 
 var DefaultRedisConfig = RedisConfig{
-	RedisUrl:   "",
+	Url:        "",
 	Expiration: time.Hour,
 	KeyConfig:  "",
 }
 
 func RedisConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultRedisConfig.Enable, "enable Redis caching of sequencer batch data")
-	f.String(prefix+".redis-url", DefaultRedisConfig.RedisUrl, "Redis url")
-	f.Duration(prefix+".redis-expiration", DefaultRedisConfig.Expiration, "Redis expiration")
-	f.String(prefix+".redis-key-config", DefaultRedisConfig.KeyConfig, "Redis key config")
-	f.Bool(prefix+".sync-from-storage-service", DefaultRedisConfig.SyncFromStorageServices, "enable Redis to be used as a source for regular sync storage")
-	f.Bool(prefix+".sync-to-storage-service", DefaultRedisConfig.SyncToStorageServices, "enable Redis to be used as a sink for regular sync storage")
+	f.String(prefix+".url", DefaultRedisConfig.Url, "Redis url")
+	f.Duration(prefix+".expiration", DefaultRedisConfig.Expiration, "Redis expiration")
+	f.String(prefix+".key-config", DefaultRedisConfig.KeyConfig, "Redis key config")
+	f.Bool(prefix+".sync-from-storage-service", DefaultRedisConfig.SyncFromStorageService, "enable Redis to be used as a source for regular sync storage")
+	f.Bool(prefix+".sync-to-storage-service", DefaultRedisConfig.SyncToStorageService, "enable Redis to be used as a sink for regular sync storage")
 }
 
 type RedisStorageService struct {
@@ -55,7 +55,7 @@ type RedisStorageService struct {
 }
 
 func NewRedisStorageService(redisConfig RedisConfig, baseStorageService StorageService) (StorageService, error) {
-	redisClient, err := redisutil.RedisClientFromURL(redisConfig.RedisUrl)
+	redisClient, err := redisutil.RedisClientFromURL(redisConfig.Url)
 	if err != nil {
 		return nil, err
 	}

--- a/das/redis_storage_service_test.go
+++ b/das/redis_storage_service_test.go
@@ -23,7 +23,7 @@ func TestRedisStorageService(t *testing.T) {
 	redisService, err := NewRedisStorageService(
 		RedisConfig{
 			Enable:     true,
-			RedisUrl:   "redis://" + server.Addr(),
+			Url:        "redis://" + server.Addr(),
 			Expiration: time.Hour,
 			KeyConfig:  "b561f5d5d98debc783aa8a1472d67ec3bcd532a1c8d95e5cb23caa70c649f7c9",
 		}, baseStorageService)
@@ -75,7 +75,7 @@ func TestRedisStorageService(t *testing.T) {
 	redisServiceWithEmptyBaseStorage, err := NewRedisStorageService(
 		RedisConfig{
 			Enable:     true,
-			RedisUrl:   "redis://" + server.Addr(),
+			Url:        "redis://" + server.Addr(),
 			Expiration: time.Hour,
 			KeyConfig:  "b561f5d5d98debc783aa8a1472d67ec3bcd532a1c8d95e5cb23caa70c649f7c9",
 		}, emptyBaseStorageService)

--- a/das/rpc_aggregator.go
+++ b/das/rpc_aggregator.go
@@ -28,7 +28,7 @@ type BackendConfig struct {
 }
 
 func NewRPCAggregator(ctx context.Context, config DataAvailabilityConfig) (*Aggregator, error) {
-	services, err := ParseServices(config.AggregatorConfig)
+	services, err := ParseServices(config.RPCAggregator)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func NewRPCAggregator(ctx context.Context, config DataAvailabilityConfig) (*Aggr
 }
 
 func NewRPCAggregatorWithL1Info(config DataAvailabilityConfig, l1client arbutil.L1Interface, seqInboxAddress common.Address) (*Aggregator, error) {
-	services, err := ParseServices(config.AggregatorConfig)
+	services, err := ParseServices(config.RPCAggregator)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func NewRPCAggregatorWithL1Info(config DataAvailabilityConfig, l1client arbutil.
 }
 
 func NewRPCAggregatorWithSeqInboxCaller(config DataAvailabilityConfig, seqInboxCaller *bridgegen.SequencerInboxCaller) (*Aggregator, error) {
-	services, err := ParseServices(config.AggregatorConfig)
+	services, err := ParseServices(config.RPCAggregator)
 	if err != nil {
 		return nil, err
 	}

--- a/das/rpc_test.go
+++ b/das/rpc_test.go
@@ -35,15 +35,15 @@ func TestRPC(t *testing.T) {
 
 	config := DataAvailabilityConfig{
 		Enable: true,
-		KeyConfig: KeyConfig{
+		Key: KeyConfig{
 			KeyDir: keyDir,
 		},
-		LocalFileStorageConfig: LocalFileStorageConfig{
+		LocalFileStorage: LocalFileStorageConfig{
 			Enable:  true,
 			DataDir: dataDir,
 		},
-		L1NodeURL:      "none",
-		RequestTimeout: 5 * time.Second,
+		ParentChainNodeURL: "none",
+		RequestTimeout:     5 * time.Second,
 	}
 
 	var syncFromStorageServices []*IterableStorageService
@@ -51,7 +51,7 @@ func TestRPC(t *testing.T) {
 	storageService, lifecycleManager, err := CreatePersistentStorageService(ctx, &config, &syncFromStorageServices, &syncToStorageServices)
 	testhelpers.RequireImpl(t, err)
 	defer lifecycleManager.StopAndWaitUntil(time.Second)
-	privKey, err := config.KeyConfig.BLSPrivKey()
+	privKey, err := config.Key.BLSPrivKey()
 	testhelpers.RequireImpl(t, err)
 	localDas, err := NewSignAfterStoreDASWriterWithSeqInboxCaller(privKey, nil, storageService, "")
 	testhelpers.RequireImpl(t, err)
@@ -71,7 +71,7 @@ func TestRPC(t *testing.T) {
 	backendsJsonByte, err := json.Marshal([]BackendConfig{beConfig})
 	testhelpers.RequireImpl(t, err)
 	aggConf := DataAvailabilityConfig{
-		AggregatorConfig: AggregatorConfig{
+		RPCAggregator: AggregatorConfig{
 			AssumedHonest: 1,
 			Backends:      string(backendsJsonByte),
 		},

--- a/das/s3_storage_service.go
+++ b/das/s3_storage_service.go
@@ -34,15 +34,15 @@ type S3Downloader interface {
 }
 
 type S3StorageServiceConfig struct {
-	Enable                  bool   `koanf:"enable"`
-	AccessKey               string `koanf:"access-key"`
-	Bucket                  string `koanf:"bucket"`
-	ObjectPrefix            string `koanf:"object-prefix"`
-	Region                  string `koanf:"region"`
-	SecretKey               string `koanf:"secret-key"`
-	DiscardAfterTimeout     bool   `koanf:"discard-after-timeout"`
-	SyncFromStorageServices bool   `koanf:"sync-from-storage-service"`
-	SyncToStorageServices   bool   `koanf:"sync-to-storage-service"`
+	Enable                 bool   `koanf:"enable"`
+	AccessKey              string `koanf:"access-key"`
+	Bucket                 string `koanf:"bucket"`
+	ObjectPrefix           string `koanf:"object-prefix"`
+	Region                 string `koanf:"region"`
+	SecretKey              string `koanf:"secret-key"`
+	DiscardAfterTimeout    bool   `koanf:"discard-after-timeout"`
+	SyncFromStorageService bool   `koanf:"sync-from-storage-service"`
+	SyncToStorageService   bool   `koanf:"sync-to-storage-service"`
 }
 
 var DefaultS3StorageServiceConfig = S3StorageServiceConfig{}
@@ -55,8 +55,8 @@ func S3ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".region", DefaultS3StorageServiceConfig.Region, "S3 region")
 	f.String(prefix+".secret-key", DefaultS3StorageServiceConfig.SecretKey, "S3 secret key")
 	f.Bool(prefix+".discard-after-timeout", DefaultS3StorageServiceConfig.DiscardAfterTimeout, "discard data after its expiry timeout")
-	f.Bool(prefix+".sync-from-storage-service", DefaultRedisConfig.SyncFromStorageServices, "enable s3 to be used as a source for regular sync storage")
-	f.Bool(prefix+".sync-to-storage-service", DefaultRedisConfig.SyncToStorageServices, "enable s3 to be used as a sink for regular sync storage")
+	f.Bool(prefix+".sync-from-storage-service", DefaultRedisConfig.SyncFromStorageService, "enable s3 to be used as a source for regular sync storage")
+	f.Bool(prefix+".sync-to-storage-service", DefaultRedisConfig.SyncToStorageService, "enable s3 to be used as a sink for regular sync storage")
 }
 
 type S3StorageService struct {

--- a/das/sign_after_store_das_writer.go
+++ b/das/sign_after_store_das_writer.go
@@ -86,14 +86,14 @@ type SignAfterStoreDASWriter struct {
 }
 
 func NewSignAfterStoreDASWriter(ctx context.Context, config DataAvailabilityConfig, storageService StorageService) (*SignAfterStoreDASWriter, error) {
-	privKey, err := config.KeyConfig.BLSPrivKey()
+	privKey, err := config.Key.BLSPrivKey()
 	if err != nil {
 		return nil, err
 	}
-	if config.L1NodeURL == "none" {
+	if config.ParentChainNodeURL == "none" {
 		return NewSignAfterStoreDASWriterWithSeqInboxCaller(privKey, nil, storageService, config.ExtraSignatureCheckingPublicKey)
 	}
-	l1client, err := GetL1Client(ctx, config.L1ConnectionAttempts, config.L1NodeURL)
+	l1client, err := GetL1Client(ctx, config.ParentChainConnectionAttempts, config.ParentChainNodeURL)
 	if err != nil {
 		return nil, err
 	}

--- a/das/simple_das_reader_aggregator.go
+++ b/das/simple_das_reader_aggregator.go
@@ -25,28 +25,28 @@ import (
 // RestfulDasClients, so the configuration and factory function are given more
 // specific names.
 type RestfulClientAggregatorConfig struct {
-	Enable                             bool                               `koanf:"enable"`
-	Urls                               []string                           `koanf:"urls"`
-	OnlineUrlList                      string                             `koanf:"online-url-list"`
-	OnlineUrlListFetchInterval         time.Duration                      `koanf:"online-url-list-fetch-interval"`
-	Strategy                           string                             `koanf:"strategy"`
-	StrategyUpdateInterval             time.Duration                      `koanf:"strategy-update-interval"`
-	WaitBeforeTryNext                  time.Duration                      `koanf:"wait-before-try-next"`
-	MaxPerEndpointStats                int                                `koanf:"max-per-endpoint-stats"`
-	SimpleExploreExploitStrategyConfig SimpleExploreExploitStrategyConfig `koanf:"simple-explore-exploit-strategy"`
-	SyncToStorageConfig                SyncToStorageConfig                `koanf:"sync-to-storage"`
+	Enable                       bool                               `koanf:"enable"`
+	Urls                         []string                           `koanf:"urls"`
+	OnlineUrlList                string                             `koanf:"online-url-list"`
+	OnlineUrlListFetchInterval   time.Duration                      `koanf:"online-url-list-fetch-interval"`
+	Strategy                     string                             `koanf:"strategy"`
+	StrategyUpdateInterval       time.Duration                      `koanf:"strategy-update-interval"`
+	WaitBeforeTryNext            time.Duration                      `koanf:"wait-before-try-next"`
+	MaxPerEndpointStats          int                                `koanf:"max-per-endpoint-stats"`
+	SimpleExploreExploitStrategy SimpleExploreExploitStrategyConfig `koanf:"simple-explore-exploit-strategy"`
+	SyncToStorage                SyncToStorageConfig                `koanf:"sync-to-storage"`
 }
 
 var DefaultRestfulClientAggregatorConfig = RestfulClientAggregatorConfig{
-	Urls:                               []string{},
-	OnlineUrlList:                      "",
-	OnlineUrlListFetchInterval:         1 * time.Hour,
-	Strategy:                           "simple-explore-exploit",
-	StrategyUpdateInterval:             10 * time.Second,
-	WaitBeforeTryNext:                  2 * time.Second,
-	MaxPerEndpointStats:                20,
-	SimpleExploreExploitStrategyConfig: DefaultSimpleExploreExploitStrategyConfig,
-	SyncToStorageConfig:                DefaultSyncToStorageConfig,
+	Urls:                         []string{},
+	OnlineUrlList:                "",
+	OnlineUrlListFetchInterval:   1 * time.Hour,
+	Strategy:                     "simple-explore-exploit",
+	StrategyUpdateInterval:       10 * time.Second,
+	WaitBeforeTryNext:            2 * time.Second,
+	MaxPerEndpointStats:          20,
+	SimpleExploreExploitStrategy: DefaultSimpleExploreExploitStrategyConfig,
+	SyncToStorage:                DefaultSyncToStorageConfig,
 }
 
 type SimpleExploreExploitStrategyConfig struct {
@@ -120,8 +120,8 @@ func NewRestfulClientAggregator(ctx context.Context, config *RestfulClientAggreg
 	switch strings.ToLower(config.Strategy) {
 	case "simple-explore-exploit":
 		a.strategy = &simpleExploreExploitStrategy{
-			exploreIterations: uint32(config.SimpleExploreExploitStrategyConfig.ExploreIterations),
-			exploitIterations: uint32(config.SimpleExploreExploitStrategyConfig.ExploitIterations),
+			exploreIterations: uint32(config.SimpleExploreExploitStrategy.ExploreIterations),
+			exploitIterations: uint32(config.SimpleExploreExploitStrategy.ExploitIterations),
 		}
 	case "testing-sequential":
 		a.strategy = &testingSequentialStrategy{}

--- a/das/syncing_fallback_storage.go
+++ b/das/syncing_fallback_storage.go
@@ -57,32 +57,32 @@ func init() {
 }
 
 type SyncToStorageConfig struct {
-	CheckAlreadyExists   bool          `koanf:"check-already-exists"`
-	Eager                bool          `koanf:"eager"`
-	EagerLowerBoundBlock uint64        `koanf:"eager-lower-bound-block"`
-	RetentionPeriod      time.Duration `koanf:"retention-period"`
-	DelayOnError         time.Duration `koanf:"delay-on-error"`
-	IgnoreWriteErrors    bool          `koanf:"ignore-write-errors"`
-	L1BlocksPerRead      uint64        `koanf:"parent-chain-blocks-per-read"`
-	StateDir             string        `koanf:"state-dir"`
+	CheckAlreadyExists       bool          `koanf:"check-already-exists"`
+	Eager                    bool          `koanf:"eager"`
+	EagerLowerBoundBlock     uint64        `koanf:"eager-lower-bound-block"`
+	RetentionPeriod          time.Duration `koanf:"retention-period"`
+	DelayOnError             time.Duration `koanf:"delay-on-error"`
+	IgnoreWriteErrors        bool          `koanf:"ignore-write-errors"`
+	ParentChainBlocksPerRead uint64        `koanf:"parent-chain-blocks-per-read"`
+	StateDir                 string        `koanf:"state-dir"`
 }
 
 var DefaultSyncToStorageConfig = SyncToStorageConfig{
-	CheckAlreadyExists:   true,
-	Eager:                false,
-	EagerLowerBoundBlock: 0,
-	RetentionPeriod:      time.Duration(math.MaxInt64),
-	DelayOnError:         time.Second,
-	IgnoreWriteErrors:    true,
-	L1BlocksPerRead:      100,
-	StateDir:             "",
+	CheckAlreadyExists:       true,
+	Eager:                    false,
+	EagerLowerBoundBlock:     0,
+	RetentionPeriod:          time.Duration(math.MaxInt64),
+	DelayOnError:             time.Second,
+	IgnoreWriteErrors:        true,
+	ParentChainBlocksPerRead: 100,
+	StateDir:                 "",
 }
 
 func SyncToStorageConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".check-already-exists", DefaultSyncToStorageConfig.CheckAlreadyExists, "check if the data already exists in this DAS's storage. Must be disabled for fast sync with an IPFS backend")
 	f.Bool(prefix+".eager", DefaultSyncToStorageConfig.Eager, "eagerly sync batch data to this DAS's storage from the rest endpoints, using L1 as the index of batch data hashes; otherwise only sync lazily")
 	f.Uint64(prefix+".eager-lower-bound-block", DefaultSyncToStorageConfig.EagerLowerBoundBlock, "when eagerly syncing, start indexing forward from this L1 block. Only used if there is no sync state")
-	f.Uint64(prefix+".parent-chain-blocks-per-read", DefaultSyncToStorageConfig.L1BlocksPerRead, "when eagerly syncing, max l1 blocks to read per poll")
+	f.Uint64(prefix+".parent-chain-blocks-per-read", DefaultSyncToStorageConfig.ParentChainBlocksPerRead, "when eagerly syncing, max l1 blocks to read per poll")
 	f.Duration(prefix+".retention-period", DefaultSyncToStorageConfig.RetentionPeriod, "period to retain synced data (defaults to forever)")
 	f.Duration(prefix+".delay-on-error", DefaultSyncToStorageConfig.DelayOnError, "time to wait if encountered an error before retrying")
 	f.Bool(prefix+".ignore-write-errors", DefaultSyncToStorageConfig.IgnoreWriteErrors, "log only on failures to write when syncing; otherwise treat it as an error")
@@ -346,9 +346,9 @@ func (s *l1SyncService) readMore(ctx context.Context) error {
 			}
 		}
 	}
-	if highBlockNr > s.lowBlockNr+s.config.L1BlocksPerRead {
+	if highBlockNr > s.lowBlockNr+s.config.ParentChainBlocksPerRead {
 		s.catchingUp = true
-		highBlockNr = s.lowBlockNr + s.config.L1BlocksPerRead
+		highBlockNr = s.lowBlockNr + s.config.ParentChainBlocksPerRead
 		if finalizedHighBlockNr > highBlockNr {
 			finalizedHighBlockNr = highBlockNr
 		}

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -52,7 +52,7 @@ func NewRelay(config *Config, feedErrChan chan error) (*Relay, error) {
 
 	clients, err := broadcastclients.NewBroadcastClients(
 		func() *broadcastclient.Config { return &config.Node.Feed.Input },
-		config.L2.ChainId,
+		config.Chain.ID,
 		0,
 		&q,
 		confirmedSequenceNumberListener,
@@ -70,7 +70,7 @@ func NewRelay(config *Config, feedErrChan chan error) (*Relay, error) {
 		return nil, errors.New("relay attempted to sign feed message")
 	}
 	return &Relay{
-		broadcaster:                 broadcaster.NewBroadcaster(func() *wsbroadcastserver.BroadcasterConfig { return &config.Node.Feed.Output }, config.L2.ChainId, feedErrChan, dataSignerErr),
+		broadcaster:                 broadcaster.NewBroadcaster(func() *wsbroadcastserver.BroadcasterConfig { return &config.Node.Feed.Output }, config.Chain.ID, feedErrChan, dataSignerErr),
 		broadcastClients:            clients,
 		confirmedSequenceNumberChan: confirmedSequenceNumberListener,
 		messageChan:                 q.queue,
@@ -141,7 +141,7 @@ func (r *Relay) StopAndWait() {
 
 type Config struct {
 	Conf          genericconf.ConfConfig          `koanf:"conf"`
-	L2            L2Config                        `koanf:"chain"`
+	Chain         L2Config                        `koanf:"chain"`
 	LogLevel      int                             `koanf:"log-level"`
 	LogType       string                          `koanf:"log-type"`
 	Metrics       bool                            `koanf:"metrics"`
@@ -154,7 +154,7 @@ type Config struct {
 
 var ConfigDefault = Config{
 	Conf:          genericconf.ConfConfigDefault,
-	L2:            L2ConfigDefault,
+	Chain:         L2ConfigDefault,
 	LogLevel:      int(log.LvlInfo),
 	LogType:       "plaintext",
 	Metrics:       false,
@@ -191,15 +191,15 @@ func NodeConfigAddOptions(prefix string, f *flag.FlagSet) {
 }
 
 type L2Config struct {
-	ChainId uint64 `koanf:"id"`
+	ID uint64 `koanf:"id"`
 }
 
 var L2ConfigDefault = L2Config{
-	ChainId: 0,
+	ID: 0,
 }
 
 func L2ConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Uint64(prefix+".id", L2ConfigDefault.ChainId, "L2 chain ID")
+	f.Uint64(prefix+".id", L2ConfigDefault.ID, "L2 chain ID")
 }
 
 func ParseRelay(_ context.Context, args []string) (*Config, error) {

--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -81,7 +81,7 @@ type BlockValidator struct {
 type BlockValidatorConfig struct {
 	Enable                   bool                          `koanf:"enable"`
 	ValidationServer         rpcclient.ClientConfig        `koanf:"validation-server" reload:"hot"`
-	ValidationPoll           time.Duration                 `koanf:"check-validations-poll" reload:"hot"`
+	ValidationPoll           time.Duration                 `koanf:"validation-poll" reload:"hot"`
 	PrerecordedBlocks        uint64                        `koanf:"prerecorded-blocks" reload:"hot"`
 	ForwardBlocks            uint64                        `koanf:"forward-blocks" reload:"hot"`
 	CurrentModuleRoot        string                        `koanf:"current-module-root"`         // TODO(magic) requires reinitialization on hot reload
@@ -107,7 +107,7 @@ type BlockValidatorConfigFetcher func() *BlockValidatorConfig
 func BlockValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultBlockValidatorConfig.Enable, "enable block-by-block validation")
 	rpcclient.RPCClientAddOptions(prefix+".validation-server", f, &DefaultBlockValidatorConfig.ValidationServer)
-	f.Duration(prefix+".check-validations-poll", DefaultBlockValidatorConfig.ValidationPoll, "poll time to check validations")
+	f.Duration(prefix+".validation-poll", DefaultBlockValidatorConfig.ValidationPoll, "poll time to check validations")
 	f.Uint64(prefix+".forward-blocks", DefaultBlockValidatorConfig.ForwardBlocks, "prepare entries for up to that many blocks ahead of validation (small footprint)")
 	f.Uint64(prefix+".prerecorded-blocks", DefaultBlockValidatorConfig.PrerecordedBlocks, "record that many blocks ahead of validation (larger footprint)")
 	f.String(prefix+".current-module-root", DefaultBlockValidatorConfig.CurrentModuleRoot, "current wasm module root ('current' read from chain, 'latest' from machines/latest dir, or provide hash)")

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -69,20 +69,20 @@ func L1PostingStrategyAddOptions(prefix string, f *flag.FlagSet) {
 }
 
 type L1ValidatorConfig struct {
-	Enable                   bool                     `koanf:"enable"`
-	Strategy                 string                   `koanf:"strategy"`
-	StakerInterval           time.Duration            `koanf:"staker-interval"`
-	MakeAssertionInterval    time.Duration            `koanf:"make-assertion-interval"`
-	L1PostingStrategy        L1PostingStrategy        `koanf:"posting-strategy"`
-	DisableChallenge         bool                     `koanf:"disable-challenge"`
-	ConfirmationBlocks       int64                    `koanf:"confirmation-blocks"`
-	UseSmartContractWallet   bool                     `koanf:"use-smart-contract-wallet"`
-	OnlyCreateWalletContract bool                     `koanf:"only-create-wallet-contract"`
-	StartFromStaked          bool                     `koanf:"start-validation-from-staked"`
-	ContractWalletAddress    string                   `koanf:"contract-wallet-address"`
-	GasRefunderAddress       string                   `koanf:"gas-refunder-address"`
-	Dangerous                DangerousConfig          `koanf:"dangerous"`
-	L1Wallet                 genericconf.WalletConfig `koanf:"parent-chain-wallet"`
+	Enable                    bool                     `koanf:"enable"`
+	Strategy                  string                   `koanf:"strategy"`
+	StakerInterval            time.Duration            `koanf:"staker-interval"`
+	MakeAssertionInterval     time.Duration            `koanf:"make-assertion-interval"`
+	PostingStrategy           L1PostingStrategy        `koanf:"posting-strategy"`
+	DisableChallenge          bool                     `koanf:"disable-challenge"`
+	ConfirmationBlocks        int64                    `koanf:"confirmation-blocks"`
+	UseSmartContractWallet    bool                     `koanf:"use-smart-contract-wallet"`
+	OnlyCreateWalletContract  bool                     `koanf:"only-create-wallet-contract"`
+	StartValidationFromStaked bool                     `koanf:"start-validation-from-staked"`
+	ContractWalletAddress     string                   `koanf:"contract-wallet-address"`
+	GasRefunderAddress        string                   `koanf:"gas-refunder-address"`
+	Dangerous                 DangerousConfig          `koanf:"dangerous"`
+	ParentChainWallet         genericconf.WalletConfig `koanf:"parent-chain-wallet"`
 
 	strategy    StakerStrategy
 	gasRefunder common.Address
@@ -132,25 +132,25 @@ func (c *L1ValidatorConfig) Validate() error {
 }
 
 var DefaultL1ValidatorConfig = L1ValidatorConfig{
-	Enable:                   true,
-	Strategy:                 "Watchtower",
-	StakerInterval:           time.Minute,
-	MakeAssertionInterval:    time.Hour,
-	L1PostingStrategy:        L1PostingStrategy{},
-	DisableChallenge:         false,
-	ConfirmationBlocks:       12,
-	UseSmartContractWallet:   false,
-	OnlyCreateWalletContract: false,
-	StartFromStaked:          true,
-	ContractWalletAddress:    "",
-	GasRefunderAddress:       "",
-	Dangerous:                DefaultDangerousConfig,
-	L1Wallet:                 DefaultValidatorL1WalletConfig,
+	Enable:                    true,
+	Strategy:                  "Watchtower",
+	StakerInterval:            time.Minute,
+	MakeAssertionInterval:     time.Hour,
+	PostingStrategy:           L1PostingStrategy{},
+	DisableChallenge:          false,
+	ConfirmationBlocks:        12,
+	UseSmartContractWallet:    false,
+	OnlyCreateWalletContract:  false,
+	StartValidationFromStaked: true,
+	ContractWalletAddress:     "",
+	GasRefunderAddress:        "",
+	Dangerous:                 DefaultDangerousConfig,
+	ParentChainWallet:         DefaultValidatorL1WalletConfig,
 }
 
 var DefaultValidatorL1WalletConfig = genericconf.WalletConfig{
 	Pathname:      "validator-wallet",
-	PasswordImpl:  genericconf.WalletConfigDefault.PasswordImpl,
+	Password:      genericconf.WalletConfigDefault.Password,
 	PrivateKey:    genericconf.WalletConfigDefault.PrivateKey,
 	Account:       genericconf.WalletConfigDefault.Account,
 	OnlyCreateKey: genericconf.WalletConfigDefault.OnlyCreateKey,
@@ -166,11 +166,11 @@ func L1ValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Int64(prefix+".confirmation-blocks", DefaultL1ValidatorConfig.ConfirmationBlocks, "confirmation blocks")
 	f.Bool(prefix+".use-smart-contract-wallet", DefaultL1ValidatorConfig.UseSmartContractWallet, "use a smart contract wallet instead of an EOA address")
 	f.Bool(prefix+".only-create-wallet-contract", DefaultL1ValidatorConfig.OnlyCreateWalletContract, "only create smart wallet contract and exit")
-	f.Bool(prefix+".start-validation-from-staked", DefaultL1ValidatorConfig.StartFromStaked, "assume staked nodes are valid")
+	f.Bool(prefix+".start-validation-from-staked", DefaultL1ValidatorConfig.StartValidationFromStaked, "assume staked nodes are valid")
 	f.String(prefix+".contract-wallet-address", DefaultL1ValidatorConfig.ContractWalletAddress, "validator smart contract wallet public address")
 	f.String(prefix+".gas-refunder-address", DefaultL1ValidatorConfig.GasRefunderAddress, "The gas refunder contract address (optional)")
 	DangerousConfigAddOptions(prefix+".dangerous", f)
-	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultL1ValidatorConfig.L1Wallet.Pathname)
+	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultL1ValidatorConfig.ParentChainWallet.Pathname)
 }
 
 type DangerousConfig struct {
@@ -242,7 +242,7 @@ func NewStaker(
 		return nil, err
 	}
 	stakerLastSuccessfulActionGauge.Update(time.Now().Unix())
-	if config.StartFromStaked && blockValidator != nil {
+	if config.StartValidationFromStaked && blockValidator != nil {
 		stakedNotifiers = append(stakedNotifiers, blockValidator)
 	}
 	return &Staker{
@@ -252,7 +252,7 @@ func NewStaker(
 		confirmedNotifiers:      confirmedNotifiers,
 		baseCallOpts:            callOpts,
 		config:                  config,
-		highGasBlocksBuffer:     big.NewInt(config.L1PostingStrategy.HighGasDelayBlocks),
+		highGasBlocksBuffer:     big.NewInt(config.PostingStrategy.HighGasDelayBlocks),
 		lastActCalledBlock:      nil,
 		inboxReader:             statelessBlockValidator.inboxReader,
 		statelessBlockValidator: statelessBlockValidator,
@@ -269,7 +269,7 @@ func (s *Staker) Initialize(ctx context.Context) error {
 	if walletAddressOrZero != (common.Address{}) {
 		s.updateStakerBalanceMetric(ctx)
 	}
-	if s.blockValidator != nil && s.config.StartFromStaked {
+	if s.blockValidator != nil && s.config.StartValidationFromStaked {
 		latestStaked, _, err := s.validatorUtils.LatestStaked(&s.baseCallOpts, s.rollupAddress, walletAddressOrZero)
 		if err != nil {
 			return err
@@ -450,7 +450,7 @@ func (s *Staker) shouldAct(ctx context.Context) bool {
 		log.Warn("error getting gas price", "err", err)
 	} else {
 		gasPriceFloat = float64(gasPrice.Int64()) / 1e9
-		if gasPriceFloat >= s.config.L1PostingStrategy.HighGasThreshold {
+		if gasPriceFloat >= s.config.PostingStrategy.HighGasThreshold {
 			gasPriceHigh = true
 		}
 	}
@@ -475,14 +475,14 @@ func (s *Staker) shouldAct(ctx context.Context) bool {
 	// Clamp `s.highGasBlocksBuffer` to between 0 and HighGasDelayBlocks
 	if s.highGasBlocksBuffer.Sign() < 0 {
 		s.highGasBlocksBuffer.SetInt64(0)
-	} else if s.highGasBlocksBuffer.Cmp(big.NewInt(s.config.L1PostingStrategy.HighGasDelayBlocks)) > 0 {
-		s.highGasBlocksBuffer.SetInt64(s.config.L1PostingStrategy.HighGasDelayBlocks)
+	} else if s.highGasBlocksBuffer.Cmp(big.NewInt(s.config.PostingStrategy.HighGasDelayBlocks)) > 0 {
+		s.highGasBlocksBuffer.SetInt64(s.config.PostingStrategy.HighGasDelayBlocks)
 	}
 	if gasPriceHigh && s.highGasBlocksBuffer.Sign() > 0 {
 		log.Warn(
 			"not acting yet as gas price is high",
 			"gasPrice", gasPriceFloat,
-			"highGasPriceConfig", s.config.L1PostingStrategy.HighGasThreshold,
+			"highGasPriceConfig", s.config.PostingStrategy.HighGasThreshold,
 			"highGasBuffer", s.highGasBlocksBuffer,
 		)
 		return false

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -76,7 +76,7 @@ func testBatchPosterParallel(t *testing.T, useRedis bool) {
 	Require(t, err)
 	seqTxOpts := l1info.GetDefaultTransactOpts("Sequencer", ctx)
 	conf.BatchPoster.Enable = true
-	conf.BatchPoster.MaxBatchSize = len(firstTxData) * 2
+	conf.BatchPoster.MaxSize = len(firstTxData) * 2
 	startL1Block, err := l1client.BlockNumber(ctx)
 	Require(t, err)
 	for i := 0; i < parallelBatchPosters; i++ {
@@ -175,7 +175,7 @@ func TestBatchPosterKeepsUp(t *testing.T) {
 
 	conf := arbnode.ConfigDefaultL1Test()
 	conf.BatchPoster.CompressionLevel = brotli.BestCompression
-	conf.BatchPoster.MaxBatchPostDelay = time.Hour
+	conf.BatchPoster.MaxDelay = time.Hour
 	conf.RPC.RPCTxFeeCap = 1000.
 	l2info, nodeA, l2clientA, _, _, _, l1stack := createTestNodeOnL1WithConfig(t, ctx, true, conf, nil, nil)
 	defer requireClose(t, l1stack)

--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -46,7 +46,7 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, workloadLoops 
 
 	var delayEvery int
 	if workloadLoops > 1 {
-		l1NodeConfigA.BatchPoster.MaxBatchPostDelay = time.Millisecond * 500
+		l1NodeConfigA.BatchPoster.MaxDelay = time.Millisecond * 500
 		delayEvery = workloadLoops / 3
 	}
 
@@ -59,7 +59,7 @@ func testBlockValidatorSimple(t *testing.T, dasModeString string, workloadLoops 
 	validatorConfig := arbnode.ConfigDefaultL1NonSequencerTest()
 	validatorConfig.BlockValidator.Enable = true
 	validatorConfig.DataAvailability = l1NodeConfigA.DataAvailability
-	validatorConfig.DataAvailability.AggregatorConfig.Enable = false
+	validatorConfig.DataAvailability.RPCAggregator.Enable = false
 	AddDefaultValNode(t, ctx, validatorConfig, !arbitrator)
 	l2clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, l1info, &l2info.ArbInitData, validatorConfig, nil)
 	defer nodeB.StopAndWait()

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -831,19 +831,19 @@ func setupConfigWithDAS(
 
 	dasConfig := &das.DataAvailabilityConfig{
 		Enable: enableDas,
-		KeyConfig: das.KeyConfig{
+		Key: das.KeyConfig{
 			KeyDir: dbPath,
 		},
-		LocalFileStorageConfig: das.LocalFileStorageConfig{
+		LocalFileStorage: das.LocalFileStorageConfig{
 			Enable:  enableFileStorage,
 			DataDir: dbPath,
 		},
-		LocalDBStorageConfig: das.LocalDBStorageConfig{
+		LocalDBStorage: das.LocalDBStorageConfig{
 			Enable:  enableDbStorage,
 			DataDir: dbPath,
 		},
 		RequestTimeout:           5 * time.Second,
-		L1NodeURL:                "none",
+		ParentChainNodeURL:       "none",
 		SequencerInboxAddress:    "none",
 		PanicOnError:             true,
 		DisableSignatureChecking: true,
@@ -872,12 +872,12 @@ func setupConfigWithDAS(
 			PubKeyBase64Encoded: blsPubToBase64(dasSignerKey),
 			SignerMask:          1,
 		}
-		l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, beConfigA)
+		l1NodeConfigA.DataAvailability.RPCAggregator = aggConfigForBackend(t, beConfigA)
 		l1NodeConfigA.DataAvailability.Enable = true
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Enable = true
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{"http://" + restLis.Addr().String()}
-		l1NodeConfigA.DataAvailability.L1NodeURL = "none"
+		l1NodeConfigA.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
+		l1NodeConfigA.DataAvailability.RestAggregator.Enable = true
+		l1NodeConfigA.DataAvailability.RestAggregator.Urls = []string{"http://" + restLis.Addr().String()}
+		l1NodeConfigA.DataAvailability.ParentChainNodeURL = "none"
 	}
 
 	return chainConfig, l1NodeConfigA, lifecycleManager, dbPath, dasSignerKey

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -45,15 +45,15 @@ func startLocalDASServer(
 
 	config := das.DataAvailabilityConfig{
 		Enable: true,
-		KeyConfig: das.KeyConfig{
+		Key: das.KeyConfig{
 			KeyDir: keyDir,
 		},
-		LocalFileStorageConfig: das.LocalFileStorageConfig{
+		LocalFileStorage: das.LocalFileStorageConfig{
 			Enable:  true,
 			DataDir: dataDir,
 		},
-		L1NodeURL:      "none",
-		RequestTimeout: 5 * time.Second,
+		ParentChainNodeURL: "none",
+		RequestTimeout:     5 * time.Second,
 	}
 
 	var syncFromStorageServices []*das.IterableStorageService
@@ -64,7 +64,7 @@ func startLocalDASServer(
 	Require(t, err)
 	seqInboxCaller, err := bridgegen.NewSequencerInboxCaller(seqInboxAddress, l1client)
 	Require(t, err)
-	privKey, err := config.KeyConfig.BLSPrivKey()
+	privKey, err := config.Key.BLSPrivKey()
 	Require(t, err)
 	daWriter, err := das.NewSignAfterStoreDASWriterWithSeqInboxCaller(privKey, seqInboxCaller, storageService, "")
 	Require(t, err)
@@ -132,11 +132,11 @@ func TestDASRekey(t *testing.T) {
 		// Setup DAS config
 
 		l1NodeConfigA.DataAvailability.Enable = true
-		l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, backendConfigA)
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Enable = true
-		l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{restServerUrlA}
-		l1NodeConfigA.DataAvailability.L1NodeURL = "none"
+		l1NodeConfigA.DataAvailability.RPCAggregator = aggConfigForBackend(t, backendConfigA)
+		l1NodeConfigA.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
+		l1NodeConfigA.DataAvailability.RestAggregator.Enable = true
+		l1NodeConfigA.DataAvailability.RestAggregator.Urls = []string{restServerUrlA}
+		l1NodeConfigA.DataAvailability.ParentChainNodeURL = "none"
 
 		nodeA, err := arbnode.CreateNode(ctx, l2stackA, l2chainDb, l2arbDb, NewFetcherFromConfig(l1NodeConfigA), l2blockchain, l1client, addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, nil, feedErrChan)
 		Require(t, err)
@@ -145,11 +145,11 @@ func TestDASRekey(t *testing.T) {
 
 		l1NodeConfigB.BlockValidator.Enable = false
 		l1NodeConfigB.DataAvailability.Enable = true
-		l1NodeConfigB.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
-		l1NodeConfigB.DataAvailability.RestfulClientAggregatorConfig.Enable = true
-		l1NodeConfigB.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{restServerUrlA}
+		l1NodeConfigB.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
+		l1NodeConfigB.DataAvailability.RestAggregator.Enable = true
+		l1NodeConfigB.DataAvailability.RestAggregator.Urls = []string{restServerUrlA}
 
-		l1NodeConfigB.DataAvailability.L1NodeURL = "none"
+		l1NodeConfigB.DataAvailability.ParentChainNodeURL = "none"
 
 		l2clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, l1info, &l2info.ArbInitData, l1NodeConfigB, nil)
 		checkBatchPosting(t, ctx, l1client, l2clientA, l1info, l2info, big.NewInt(1e12), l2clientB)
@@ -179,7 +179,7 @@ func TestDASRekey(t *testing.T) {
 
 	l2blockchain, err := execution.GetBlockChain(l2chainDb, nil, chainConfig, arbnode.ConfigDefaultL2Test().TxLookupLimit)
 	Require(t, err)
-	l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, backendConfigB)
+	l1NodeConfigA.DataAvailability.RPCAggregator = aggConfigForBackend(t, backendConfigB)
 	nodeA, err := arbnode.CreateNode(ctx, l2stackA, l2chainDb, l2arbDb, NewFetcherFromConfig(l1NodeConfigA), l2blockchain, l1client, addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, nil, feedErrChan)
 	Require(t, err)
 	Require(t, nodeA.Start(ctx))
@@ -247,18 +247,18 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 	serverConfig := das.DataAvailabilityConfig{
 		Enable: true,
 
-		LocalCacheConfig: das.TestBigCacheConfig,
+		LocalCache: das.TestBigCacheConfig,
 
-		LocalFileStorageConfig: das.LocalFileStorageConfig{
+		LocalFileStorage: das.LocalFileStorageConfig{
 			Enable:  true,
 			DataDir: fileDataDir,
 		},
-		LocalDBStorageConfig: das.LocalDBStorageConfig{
+		LocalDBStorage: das.LocalDBStorageConfig{
 			Enable:  true,
 			DataDir: dbDataDir,
 		},
 
-		KeyConfig: das.KeyConfig{
+		Key: das.KeyConfig{
 			KeyDir: keyDir,
 		},
 
@@ -293,11 +293,11 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 		PubKeyBase64Encoded: blsPubToBase64(pubkey),
 		SignerMask:          1,
 	}
-	l1NodeConfigA.DataAvailability.AggregatorConfig = aggConfigForBackend(t, beConfigA)
-	l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
-	l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Enable = true
-	l1NodeConfigA.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{"http://" + restLis.Addr().String()}
-	l1NodeConfigA.DataAvailability.L1NodeURL = "none"
+	l1NodeConfigA.DataAvailability.RPCAggregator = aggConfigForBackend(t, beConfigA)
+	l1NodeConfigA.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
+	l1NodeConfigA.DataAvailability.RestAggregator.Enable = true
+	l1NodeConfigA.DataAvailability.RestAggregator.Urls = []string{"http://" + restLis.Addr().String()}
+	l1NodeConfigA.DataAvailability.ParentChainNodeURL = "none"
 
 	dataSigner := signature.DataSignerFromPrivateKey(l1info.Accounts["Sequencer"].PrivateKey)
 
@@ -321,16 +321,16 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 
 		// AggregatorConfig set up below
 
-		L1NodeURL:      "none",
-		RequestTimeout: 5 * time.Second,
+		ParentChainNodeURL: "none",
+		RequestTimeout:     5 * time.Second,
 	}
 
 	l1NodeConfigB.BlockValidator.Enable = false
 	l1NodeConfigB.DataAvailability.Enable = true
-	l1NodeConfigB.DataAvailability.RestfulClientAggregatorConfig = das.DefaultRestfulClientAggregatorConfig
-	l1NodeConfigB.DataAvailability.RestfulClientAggregatorConfig.Enable = true
-	l1NodeConfigB.DataAvailability.RestfulClientAggregatorConfig.Urls = []string{"http://" + restLis.Addr().String()}
-	l1NodeConfigB.DataAvailability.L1NodeURL = "none"
+	l1NodeConfigB.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
+	l1NodeConfigB.DataAvailability.RestAggregator.Enable = true
+	l1NodeConfigB.DataAvailability.RestAggregator.Urls = []string{"http://" + restLis.Addr().String()}
+	l1NodeConfigB.DataAvailability.ParentChainNodeURL = "none"
 	l2clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, l1info, &l2info.ArbInitData, l1NodeConfigB, nil)
 
 	checkBatchPosting(t, ctx, l1client, l2clientA, l1info, l2info, big.NewInt(1e12), l2clientB)

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -48,7 +48,7 @@ func TestStaticForwarder(t *testing.T) {
 	nodeConfigB.Sequencer.Enable = false
 	nodeConfigB.DelayedSequencer.Enable = false
 	nodeConfigB.Forwarder.RedisUrl = ""
-	nodeConfigB.ForwardingTargetImpl = ipcPath
+	nodeConfigB.ForwardingTarget = ipcPath
 	nodeConfigB.BatchPoster.Enable = false
 
 	clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, l1info, &l2info.ArbInitData, nodeConfigB, nil)
@@ -104,7 +104,7 @@ func fallbackSequencer(
 	nodeConfig := arbnode.ConfigDefaultL1Test()
 	nodeConfig.SeqCoordinator.Enable = opts.enableSecCoordinator
 	nodeConfig.SeqCoordinator.RedisUrl = opts.redisUrl
-	nodeConfig.SeqCoordinator.MyUrlImpl = opts.ipcPath
+	nodeConfig.SeqCoordinator.MyUrl = opts.ipcPath
 	return createTestNodeOnL1WithConfig(t, ctx, true, nodeConfig, nil, stackConfig)
 }
 
@@ -128,7 +128,7 @@ func createForwardingNode(
 	nodeConfig.Sequencer.Enable = false
 	nodeConfig.DelayedSequencer.Enable = false
 	nodeConfig.Forwarder.RedisUrl = redisUrl
-	nodeConfig.ForwardingTargetImpl = fallbackPath
+	nodeConfig.ForwardingTarget = fallbackPath
 	//	nodeConfig.Feed.Output.Enable = false
 
 	return Create2ndNodeWithConfig(t, ctx, first, l1stack, l1info, l2InitData, nodeConfig, stackConfig)
@@ -151,7 +151,7 @@ func createSequencer(
 	nodeConfig.BatchPoster.Enable = true
 	nodeConfig.SeqCoordinator.Enable = true
 	nodeConfig.SeqCoordinator.RedisUrl = redisUrl
-	nodeConfig.SeqCoordinator.MyUrlImpl = ipcPath
+	nodeConfig.SeqCoordinator.MyUrl = ipcPath
 
 	return Create2ndNodeWithConfig(t, ctx, first, l1stack, l1info, l2InitData, nodeConfig, stackConfig)
 }

--- a/system_tests/seq_coordinator_test.go
+++ b/system_tests/seq_coordinator_test.go
@@ -61,7 +61,7 @@ func TestRedisSeqCoordinatorPriorities(t *testing.T) {
 	initRedisForTest(t, ctx, nodeConfig.SeqCoordinator.RedisUrl, nodeNames)
 
 	createStartNode := func(nodeNum int) {
-		nodeConfig.SeqCoordinator.MyUrlImpl = nodeNames[nodeNum]
+		nodeConfig.SeqCoordinator.MyUrl = nodeNames[nodeNum]
 		_, node, _ := CreateTestL2WithConfig(t, ctx, l2Info, nodeConfig, false)
 		nodes[nodeNum] = node
 	}
@@ -277,7 +277,7 @@ func testCoordinatorMessageSync(t *testing.T, successCase bool) {
 
 	initRedisForTest(t, ctx, nodeConfig.SeqCoordinator.RedisUrl, nodeNames)
 
-	nodeConfig.SeqCoordinator.MyUrlImpl = nodeNames[0]
+	nodeConfig.SeqCoordinator.MyUrl = nodeNames[0]
 	l2Info, nodeA, clientA, l1info, _, _, l1stack := createTestNodeOnL1WithConfig(t, ctx, true, nodeConfig, params.ArbitrumDevTestChainConfig(), nil)
 	defer requireClose(t, l1stack)
 	defer nodeA.StopAndWait()
@@ -302,10 +302,10 @@ func testCoordinatorMessageSync(t *testing.T, successCase bool) {
 	nodeConfigDup := *nodeConfig
 	nodeConfig = &nodeConfigDup
 
-	nodeConfig.SeqCoordinator.MyUrlImpl = nodeNames[1]
+	nodeConfig.SeqCoordinator.MyUrl = nodeNames[1]
 	if !successCase {
-		nodeConfig.SeqCoordinator.Signing.ECDSA.AcceptSequencer = false
-		nodeConfig.SeqCoordinator.Signing.ECDSA.AllowedAddresses = []string{l2Info.GetAddress("User2").Hex()}
+		nodeConfig.SeqCoordinator.Signer.ECDSA.AcceptSequencer = false
+		nodeConfig.SeqCoordinator.Signer.ECDSA.AllowedAddresses = []string{l2Info.GetAddress("User2").Hex()}
 	}
 	clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, l1info, &l2Info.ArbInitData, nodeConfig, nil)
 	defer nodeB.StopAndWait()

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -27,9 +27,9 @@ func newBroadcasterConfigTest() *wsbroadcastserver.BroadcasterConfig {
 
 func newBroadcastClientConfigTest(port int) *broadcastclient.Config {
 	return &broadcastclient.Config{
-		URLs:    []string{fmt.Sprintf("ws://localhost:%d/feed", port)},
+		URL:     []string{fmt.Sprintf("ws://localhost:%d/feed", port)},
 		Timeout: 200 * time.Millisecond,
-		Verifier: signature.VerifierConfig{
+		Verify: signature.VerifierConfig{
 			Dangerous: signature.DangerousVerifierConfig{
 				AcceptMissing: true,
 			},

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -89,7 +89,7 @@ func TestRelayedSequencerFeed(t *testing.T) {
 	port := nodeA.BroadcastServer.ListenerAddr().(*net.TCPAddr).Port
 	config.Node.Feed.Input = *newBroadcastClientConfigTest(port)
 	config.Node.Feed.Output = *newBroadcasterConfigTest()
-	config.L2.ChainId = bigChainId.Uint64()
+	config.Chain.ID = bigChainId.Uint64()
 
 	feedErrChan := make(chan error, 10)
 	currentRelay, err := relay.NewRelay(&config, feedErrChan)
@@ -145,7 +145,7 @@ func testLyingSequencer(t *testing.T, dasModeStr string) {
 	nodeConfigC := arbnode.ConfigDefaultL1Test()
 	nodeConfigC.BatchPoster.Enable = false
 	nodeConfigC.DataAvailability = nodeConfigA.DataAvailability
-	nodeConfigC.DataAvailability.AggregatorConfig.Enable = false
+	nodeConfigC.DataAvailability.RPCAggregator.Enable = false
 	nodeConfigC.Feed.Output = *newBroadcasterConfigTest()
 	l2clientC, nodeC := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, l1info, &l2infoA.ArbInitData, nodeConfigC, nil)
 	defer nodeC.StopAndWait()
@@ -157,7 +157,7 @@ func testLyingSequencer(t *testing.T, dasModeStr string) {
 	nodeConfigB.Feed.Output.Enable = false
 	nodeConfigB.Feed.Input = *newBroadcastClientConfigTest(port)
 	nodeConfigB.DataAvailability = nodeConfigA.DataAvailability
-	nodeConfigB.DataAvailability.AggregatorConfig.Enable = false
+	nodeConfigB.DataAvailability.RPCAggregator.Enable = false
 	l2clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, l1info, &l2infoA.ArbInitData, nodeConfigB, nil)
 	defer nodeB.StopAndWait()
 

--- a/system_tests/twonodes_test.go
+++ b/system_tests/twonodes_test.go
@@ -26,7 +26,7 @@ func testTwoNodesSimple(t *testing.T, dasModeStr string) {
 
 	authorizeDASKeyset(t, ctx, dasSignerKey, l1info, l1client)
 	l1NodeConfigBDataAvailability := l1NodeConfigA.DataAvailability
-	l1NodeConfigBDataAvailability.AggregatorConfig.Enable = false
+	l1NodeConfigBDataAvailability.RPCAggregator.Enable = false
 	l2clientB, nodeB := Create2ndNode(t, ctx, nodeA, l1stack, l1info, &l2info.ArbInitData, &l1NodeConfigBDataAvailability)
 	defer nodeB.StopAndWait()
 

--- a/system_tests/twonodeslong_test.go
+++ b/system_tests/twonodeslong_test.go
@@ -48,7 +48,7 @@ func testTwoNodesLong(t *testing.T, dasModeStr string) {
 	authorizeDASKeyset(t, ctx, dasSignerKey, l1info, l1client)
 
 	l1NodeConfigBDataAvailability := l1NodeConfigA.DataAvailability
-	l1NodeConfigBDataAvailability.AggregatorConfig.Enable = false
+	l1NodeConfigBDataAvailability.RPCAggregator.Enable = false
 	l2clientB, nodeB := Create2ndNode(t, ctx, nodeA, l1stack, l1info, &l2info.ArbInitData, &l1NodeConfigBDataAvailability)
 	defer nodeB.StopAndWait()
 

--- a/system_tests/validation_mock_test.go
+++ b/system_tests/validation_mock_test.go
@@ -325,7 +325,7 @@ func TestExecutionKeepAlive(t *testing.T) {
 	defer cancel()
 	_, validationDefault := createMockValidationNode(t, ctx, nil)
 	shortTimeoutConfig := server_arb.DefaultArbitratorSpawnerConfig
-	shortTimeoutConfig.ExecRunTimeout = time.Second
+	shortTimeoutConfig.ExecutionRunTimeout = time.Second
 	_, validationShortTO := createMockValidationNode(t, ctx, &shortTimeoutConfig)
 	configFetcher := StaticFetcherFrom(t, &rpcclient.TestClientConfig)
 

--- a/validator/server_api/valiation_api.go
+++ b/validator/server_api/valiation_api.go
@@ -91,7 +91,7 @@ func (a *ExecServerAPI) LatestWasmModuleRoot(ctx context.Context) (common.Hash, 
 }
 
 func (a *ExecServerAPI) removeOldRuns(ctx context.Context) time.Duration {
-	oldestKept := time.Now().Add(-1 * a.config().ExecRunTimeout)
+	oldestKept := time.Now().Add(-1 * a.config().ExecutionRunTimeout)
 	a.runIdLock.Lock()
 	defer a.runIdLock.Unlock()
 	for id, entry := range a.runs {
@@ -99,7 +99,7 @@ func (a *ExecServerAPI) removeOldRuns(ctx context.Context) time.Duration {
 			delete(a.runs, id)
 		}
 	}
-	return a.config().ExecRunTimeout / 5
+	return a.config().ExecutionRunTimeout / 5
 }
 
 func (a *ExecServerAPI) Start(ctx_in context.Context) {

--- a/validator/server_arb/validator_spawner.go
+++ b/validator/server_arb/validator_spawner.go
@@ -23,24 +23,24 @@ import (
 )
 
 type ArbitratorSpawnerConfig struct {
-	Workers        int                `koanf:"workers" reload:"hot"`
-	OutputPath     string             `koanf:"output-path" reload:"hot"`
-	Execution      MachineCacheConfig `koanf:"execution" reload:"hot"` // hot reloading for new executions only
-	ExecRunTimeout time.Duration      `koanf:"exec-run-timeout" reload:"hot"`
+	Workers             int                `koanf:"workers" reload:"hot"`
+	OutputPath          string             `koanf:"output-path" reload:"hot"`
+	Execution           MachineCacheConfig `koanf:"execution" reload:"hot"` // hot reloading for new executions only
+	ExecutionRunTimeout time.Duration      `koanf:"execution-run-timeout" reload:"hot"`
 }
 
 type ArbitratorSpawnerConfigFecher func() *ArbitratorSpawnerConfig
 
 var DefaultArbitratorSpawnerConfig = ArbitratorSpawnerConfig{
-	Workers:        0,
-	OutputPath:     "./target/output",
-	Execution:      DefaultMachineCacheConfig,
-	ExecRunTimeout: time.Minute * 15,
+	Workers:             0,
+	OutputPath:          "./target/output",
+	Execution:           DefaultMachineCacheConfig,
+	ExecutionRunTimeout: time.Minute * 15,
 }
 
 func ArbitratorSpawnerConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Int(prefix+".workers", DefaultArbitratorSpawnerConfig.Workers, "number of concurrent validation threads")
-	f.Duration(prefix+".execution-run-timeout", DefaultArbitratorSpawnerConfig.ExecRunTimeout, "timeout before discarding execution run")
+	f.Duration(prefix+".execution-run-timeout", DefaultArbitratorSpawnerConfig.ExecutionRunTimeout, "timeout before discarding execution run")
 	f.String(prefix+".output-path", DefaultArbitratorSpawnerConfig.OutputPath, "path to write machines to")
 	MachineCacheConfigConfigAddOptions(prefix+".execution", f)
 }

--- a/validator/server_arb/validator_spawner.go
+++ b/validator/server_arb/validator_spawner.go
@@ -26,7 +26,7 @@ type ArbitratorSpawnerConfig struct {
 	Workers        int                `koanf:"workers" reload:"hot"`
 	OutputPath     string             `koanf:"output-path" reload:"hot"`
 	Execution      MachineCacheConfig `koanf:"execution" reload:"hot"` // hot reloading for new executions only
-	ExecRunTimeout time.Duration      `koanf:"execution-run-timeout" reload:"hot"`
+	ExecRunTimeout time.Duration      `koanf:"exec-run-timeout" reload:"hot"`
 }
 
 type ArbitratorSpawnerConfigFecher func() *ArbitratorSpawnerConfig


### PR DESCRIPTION
For the sake of not making breaking changes, I've renamed struct fields to match flags (even when it would make more sense to do it other way around, e.g. ` URL  []string 'koanf:"url"'` instead of `URLS []string 'koanf:"urls"'`)
