### PR TITLE
In the data poster, properly allocate fee spending across transactions

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -201,7 +201,7 @@ func (p *DataPoster) GetNextNonceAndMeta(ctx context.Context) (uint64, []byte, e
 
 const minRbfIncrease = arbmath.OneInBips * 11 / 10
 
-func (p *DataPoster) feeAndTipCaps(ctx context.Context, gasLimit uint64, lastFeeCap *big.Int, lastTipCap *big.Int, dataCreatedAt time.Time, backlogOfBatches uint64) (*big.Int, *big.Int, error) {
+func (p *DataPoster) feeAndTipCaps(ctx context.Context, nonce uint64, gasLimit uint64, lastFeeCap *big.Int, lastTipCap *big.Int, dataCreatedAt time.Time, backlogOfBatches uint64) (*big.Int, *big.Int, error) {
 	config := p.config()
 	latestHeader, err := p.headerReader.LastHeader(ctx)
 	if err != nil {
@@ -209,6 +209,11 @@ func (p *DataPoster) feeAndTipCaps(ctx context.Context, gasLimit uint64, lastFee
 	}
 	if latestHeader.BaseFee == nil {
 		return nil, nil, fmt.Errorf("latest parent chain block %v missing BaseFee (either the parent chain does not have EIP-1559 or the parent chain node is not synced)", latestHeader.Number)
+	}
+	softConfBlock := arbmath.BigSubByUint(latestHeader.Number, config.NonceRbfSoftConfs)
+	softConfNonce, err := p.client.NonceAt(ctx, p.sender, softConfBlock)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get latest nonce %v blocks ago (block %v): %w", config.NonceRbfSoftConfs, softConfBlock, err)
 	}
 	newFeeCap := new(big.Int).Mul(latestHeader.BaseFee, big.NewInt(2))
 	newFeeCap = arbmath.BigMax(newFeeCap, arbmath.FloatToBig(config.MinFeeCapGwei*params.GWei))
@@ -252,14 +257,29 @@ func (p *DataPoster) feeAndTipCaps(ctx context.Context, gasLimit uint64, lastFee
 		newFeeCap = maxFeeCap
 	}
 
-	balanceFeeCap := new(big.Int).Div(p.balance, new(big.Int).SetUint64(gasLimit))
+	latestBalance := p.balance
+	balanceForTx := new(big.Int).Set(latestBalance)
+	if !config.UseNoOpStorage {
+		// We reserve half the balance for the first transaction, and then split the remaining balance for all after that.
+		// With noop storage, we don't try to replace-by-fee, so we don't need to worry about this.
+		balanceForTx.Div(balanceForTx, common.Big2)
+		if nonce != softConfNonce && config.MaxMempoolTransactions > 1 {
+			// balanceForTx /= config.MaxMempoolTransactions-1
+			balanceForTx.Div(balanceForTx, arbmath.UintToBig(config.MaxMempoolTransactions-1))
+		}
+	}
+	balanceFeeCap := arbmath.BigDivByUint(balanceForTx, gasLimit)
 	if arbmath.BigGreaterThan(newFeeCap, balanceFeeCap) {
 		log.Error(
 			"lack of L1 balance prevents posting transaction with desired fee cap",
-			"balance", p.balance,
+			"balance", latestBalance,
+			"maxTransactions", config.MaxMempoolTransactions,
+			"balanceForTransaction", balanceForTx,
 			"gasLimit", gasLimit,
 			"desiredFeeCap", newFeeCap,
 			"balanceFeeCap", balanceFeeCap,
+			"nonce", nonce,
+			"softConfNonce", softConfNonce,
 		)
 		newFeeCap = balanceFeeCap
 	}
@@ -284,7 +304,7 @@ func (p *DataPoster) PostTransaction(ctx context.Context, dataCreatedAt time.Tim
 		return nil, fmt.Errorf("failed to update data poster balance: %w", err)
 	}
 
-	feeCap, tipCap, err := p.feeAndTipCaps(ctx, gasLimit, nil, nil, dataCreatedAt, 0)
+	feeCap, tipCap, err := p.feeAndTipCaps(ctx, nonce, gasLimit, nil, nil, dataCreatedAt, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +362,7 @@ func (p *DataPoster) sendTx(ctx context.Context, prevTx *storage.QueuedTransacti
 
 // The mutex must be held by the caller.
 func (p *DataPoster) replaceTx(ctx context.Context, prevTx *storage.QueuedTransaction, backlogOfBatches uint64) error {
-	newFeeCap, newTipCap, err := p.feeAndTipCaps(ctx, prevTx.Data.Gas, prevTx.Data.GasFeeCap, prevTx.Data.GasTipCap, prevTx.Created, backlogOfBatches)
+	newFeeCap, newTipCap, err := p.feeAndTipCaps(ctx, prevTx.Data.Nonce, prevTx.Data.Gas, prevTx.Data.GasFeeCap, prevTx.Data.GasTipCap, prevTx.Created, backlogOfBatches)
 	if err != nil {
 		return err
 	}
@@ -459,7 +479,7 @@ func (p *DataPoster) maybeLogError(err error, tx *storage.QueuedTransaction, msg
 	} else {
 		delete(p.errorCount, nonce)
 	}
-	logLevel(msg, "err", err, "nonce", nonce, "feeCap", tx.Data.GasFeeCap, "tipCap", tx.Data.GasTipCap)
+	logLevel(msg, "err", err, "nonce", nonce, "feeCap", tx.Data.GasFeeCap, "tipCap", tx.Data.GasTipCap, "gas", tx.Data.Gas)
 }
 
 const minWait = time.Second * 10
@@ -499,7 +519,7 @@ func (p *DataPoster) Start(ctxIn context.Context) {
 		// replacing them by fee.
 		queueContents, err := p.queue.FetchContents(ctx, unconfirmedNonce, maxTxsToRbf)
 		if err != nil {
-			log.Warn("Failed to get tx queue contents", "err", err)
+			log.Error("Failed to get tx queue contents", "err", err)
 			return minWait
 		}
 		for index, tx := range queueContents {
@@ -564,10 +584,10 @@ type DataPosterConfig struct {
 	UrgencyGwei            float64                    `koanf:"urgency-gwei" reload:"hot"`
 	MinFeeCapGwei          float64                    `koanf:"min-fee-cap-gwei" reload:"hot"`
 	MinTipCapGwei          float64                    `koanf:"min-tip-cap-gwei" reload:"hot"`
+	MaxTipCapGwei          float64                    `koanf:"max-tip-cap-gwei" reload:"hot"`
+	NonceRbfSoftConfs      uint64                     `koanf:"nonce-rbf-soft-confs" reload:"hot"`
 	UseLevelDB             bool                       `koanf:"use-leveldb" reload:"hot"`
 	UseNoOpStorage         bool                       `koanf:"use-noop-storage" reload:"hot"`
-	MaxTipCapGwei          float64                    `koanf:"max-tip-cap-gwei" reload:"hot"`
-	EnableLevelDB          bool                       `koanf:"enable-leveldb" reload:"hot"`
 }
 
 // ConfigFetcher function type is used instead of directly passing config so
@@ -582,7 +602,8 @@ func DataPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Float64(prefix+".target-price-gwei", DefaultDataPosterConfig.TargetPriceGwei, "the target price to use for maximum fee cap calculation")
 	f.Float64(prefix+".urgency-gwei", DefaultDataPosterConfig.UrgencyGwei, "the urgency to use for maximum fee cap calculation")
 	f.Float64(prefix+".min-fee-cap-gwei", DefaultDataPosterConfig.MinFeeCapGwei, "the minimum fee cap to post transactions at")
-	f.Float64(prefix+".min-tip-cap-gwei", DefaultDataPosterConfig.MinTipCapGwei, "the minimum tip cap to post transactions at")
+	f.Float64(prefix+".max-tip-cap-gwei", DefaultDataPosterConfig.MaxTipCapGwei, "the maximum tip cap to post transactions at")
+	f.Uint64(prefix+".nonce-rbf-soft-confs", DefaultDataPosterConfig.NonceRbfSoftConfs, "the maximum probable reorg depth, used to determine when a transaction will no longer likely need replaced-by-fee")
 	f.Bool(prefix+".use-leveldb", DefaultDataPosterConfig.UseLevelDB, "uses leveldb when enabled")
 	f.Bool(prefix+".use-noop-storage", DefaultDataPosterConfig.UseLevelDB, "uses noop storage, it doesn't store anything")
 	signature.SimpleHmacConfigAddOptions(prefix+".redis-signer", f)
@@ -593,12 +614,12 @@ var DefaultDataPosterConfig = DataPosterConfig{
 	WaitForL1Finality:      true,
 	TargetPriceGwei:        60.,
 	UrgencyGwei:            2.,
-	MaxMempoolTransactions: 64,
+	MaxMempoolTransactions: 10,
 	MinTipCapGwei:          0.05,
+	MaxTipCapGwei:          5,
+	NonceRbfSoftConfs:      2,
 	UseLevelDB:             false,
 	UseNoOpStorage:         false,
-	MaxTipCapGwei:          5,
-	EnableLevelDB:          false,
 }
 
 var TestDataPosterConfig = DataPosterConfig{
@@ -607,10 +628,10 @@ var TestDataPosterConfig = DataPosterConfig{
 	WaitForL1Finality:      false,
 	TargetPriceGwei:        60.,
 	UrgencyGwei:            2.,
-	MaxMempoolTransactions: 64,
+	MaxMempoolTransactions: 10,
 	MinTipCapGwei:          0.05,
+	MaxTipCapGwei:          5,
+	NonceRbfSoftConfs:      1,
 	UseLevelDB:             false,
 	UseNoOpStorage:         false,
-	MaxTipCapGwei:          5,
-	EnableLevelDB:          false,
 }

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -603,6 +603,7 @@ func DataPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Float64(prefix+".target-price-gwei", DefaultDataPosterConfig.TargetPriceGwei, "the target price to use for maximum fee cap calculation")
 	f.Float64(prefix+".urgency-gwei", DefaultDataPosterConfig.UrgencyGwei, "the urgency to use for maximum fee cap calculation")
 	f.Float64(prefix+".min-fee-cap-gwei", DefaultDataPosterConfig.MinFeeCapGwei, "the minimum fee cap to post transactions at")
+	f.Float64(prefix+".min-tip-cap-gwei", DefaultDataPosterConfig.MinTipCapGwei, "the minimum tip cap to post transactions at")
 	f.Float64(prefix+".max-tip-cap-gwei", DefaultDataPosterConfig.MaxTipCapGwei, "the maximum tip cap to post transactions at")
 	f.Uint64(prefix+".nonce-rbf-soft-confs", DefaultDataPosterConfig.NonceRbfSoftConfs, "the maximum probable reorg depth, used to determine when a transaction will no longer likely need replaced-by-fee")
 	f.Bool(prefix+".allocate-mempool-balance", DefaultDataPosterConfig.AllocateMempoolBalance, "if true, don't put transactions in the mempool that spend a total greater than the batch poster's balance")

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -175,6 +175,11 @@ func BigAddByUint(augend *big.Int, addend uint64) *big.Int {
 	return new(big.Int).Add(augend, UintToBig(addend))
 }
 
+// BigSub subtracts a uint from a huge
+func BigSubByUint(minuend *big.Int, subtrahend uint64) *big.Int {
+	return new(big.Int).Sub(minuend, UintToBig(subtrahend))
+}
+
 // BigMulByFrac multiply a huge by a rational
 func BigMulByFrac(value *big.Int, numerator, denominator int64) *big.Int {
 	value = new(big.Int).Set(value)


### PR DESCRIPTION
L1 go-ethereum requires that during a replace-by-fee, the total fees spent by transactions for the same address in the mempool doesn't exceed the balance of the address. However, due to the gas refunder model refunding the batch poster address for its gas funds after every transaction, the batch poster address doesn't immediately have enough gas funds in its account to pay for many future transactions that it has queued up. Therefore, we need to "allocate" balance spending across all transactions we put into the mempool. We let the first transaction not included in a block at least 2 blocks old (in case of shallow reorgs) take up half of that balance buffer, which helps ensure that the batch poster always makes progress, even if it can only replace-by-fee one transaction at a time.