### PR TITLE
Fix linter error where we implicitly alias memory in for loop

### DIFF
--- a/arbos/arbosState/initialize.go
+++ b/arbos/arbosState/initialize.go
@@ -189,7 +189,8 @@ func initializeRetryables(statedb *state.StateDB, rs *retryables.RetryableState,
 	for _, r := range retryablesList {
 		var to *common.Address
 		if r.To != (common.Address{}) {
-			to = &r.To
+			addr := r.To
+			to = &addr
 		}
 		statedb.AddBalance(retryables.RetryableEscrowAddress(r.Id), r.Callvalue)
 		_, err := rs.CreateRetryable(r.Id, r.Timeout, r.From, to, r.Callvalue, r.Beneficiary, r.Calldata)


### PR DESCRIPTION
 golangci-lint v1.54.2 complains on this like with:
 
`Error: G601: Implicit memory aliasing in for loop. (gosec)`