### PR TITLE
Fix running a watchtower staker without a wallet

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -543,8 +543,13 @@ func checkArbDbSchemaVersion(arbDb ethdb.Database) error {
 	return nil
 }
 
-func ValidatorDataposter(db ethdb.Database, l1Reader *headerreader.HeaderReader,
-	transactOpts *bind.TransactOpts, cfgFetcher ConfigFetcher, syncMonitor *SyncMonitor) (*dataposter.DataPoster, error) {
+func ValidatorDataposter(
+	db ethdb.Database, l1Reader *headerreader.HeaderReader,
+	transactOpts *bind.TransactOpts, cfgFetcher ConfigFetcher, syncMonitor *SyncMonitor,
+) (*dataposter.DataPoster, error) {
+	if transactOpts == nil {
+		return nil, nil
+	}
 	cfg := cfgFetcher.Get()
 	mdRetriever := func(ctx context.Context, blockNum *big.Int) ([]byte, error) {
 		return nil, nil


### PR DESCRIPTION
The data poster is not used for a watchtower validator, which is allowed to run without a wallet. However, attempting to create a data poster from nil transact opts will result in a nil pointer deref in the data poster code. To mitigate this, we simply don't create a data poster and return nil, as the data poster will not be used for watchtower validators. This matches behavior with the transactOpts being nil as they were previously used. Longer term, we should consider creating a WatchtowerValidatorWallet that implements the ValidatorWallet interface but returns an error if the staker tries to use it at all.