### PR TITLE
Add sepolia-rollup testnet chain information

### DIFF
--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -214,5 +214,54 @@
         "GenesisBlockNum": 0
       }
     }
+  },
+    {
+    "chain-id": 421614,
+    "parent-chain-id": 11155111,
+    "chain-name": "sepolia-rollup",
+    "sequencer-url": "https://sepolia-rollup-sequencer.arbitrum.io/rpc",
+    "feed-url": "https://sepolia-rollup.arbitrum.io/feed",
+    "chain-config":
+    {
+      "chainId": 421614,
+      "homesteadBlock": 0,
+      "daoForkBlock": null,
+      "daoForkSupport": true,
+      "eip150Block": 0,
+      "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "eip155Block": 0,
+      "eip158Block": 0,
+      "byzantiumBlock": 0,
+      "constantinopleBlock": 0,
+      "petersburgBlock": 0,
+      "istanbulBlock": 0,
+      "muirGlacierBlock": 0,
+      "berlinBlock": 0,
+      "londonBlock": 0,
+      "clique":
+      {
+        "period": 0,
+        "epoch": 0
+      },
+      "arbitrum":
+      {
+        "EnableArbOS": true,
+        "AllowDebugPrecompiles": false,
+        "DataAvailabilityCommittee": false,
+        "InitialArbOSVersion": 10,
+        "InitialChainOwner": "0x71B61c2E250AFa05dFc36304D6c91501bE0965D8",
+        "GenesisBlockNum": 0
+      }
+    },
+    "rollup":
+    {
+      "bridge": "0x38f918D0E9F1b721EDaA41302E399fa1B79333a9",
+      "inbox": "0xaAe29B0366299461418F5324a79Afc425BE5ae21",
+      "sequencer-inbox": "0x6c97864CE4bEf387dE0b3310A44230f7E3F1be0D",
+      "rollup": "0xd80810638dbDF9081b72C1B33c65375e807281C8",
+      "validator-utils": "0x1f6860C3cac255fFFa72B7410b1183c3a0D261e0",
+      "validator-wallet-creator": "0x894fC71fA0A666352824EC954B401573C861D664",
+      "deployed-at": 4139226
+    }
   }
 ]


### PR DESCRIPTION
This adds to the builtin chain info of the nitro node the new Sepolia rollup testnet. More info to come!