### PR TITLE
Fix sepolia-rollup feed connection scheme

### DIFF
--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -220,7 +220,7 @@
     "parent-chain-id": 11155111,
     "chain-name": "sepolia-rollup",
     "sequencer-url": "https://sepolia-rollup-sequencer.arbitrum.io/rpc",
-    "feed-url": "https://sepolia-rollup.arbitrum.io/feed",
+    "feed-url": "wss://sepolia-rollup.arbitrum.io/feed",
     "chain-config":
     {
       "chainId": 421614,


### PR DESCRIPTION
The feed is over websockets (wss for secure connections), which uses https to setup the initial connection, but it's not an https protocol and attempting to connect over it will result in an error:

```
failed connect to sequencer broadcast, waiting and retrying url=https://sepolia-rollup.arbitrum.io/feed err="broadcast client unable to connect: unexpected websocket scheme: \"https\""
```

I unfortunately missed this initially because it only happens after the node catches up to the chain. With the new URL I correctly get:

```
Feed connected                           feedServerVersion=2 chainId=421,614 requestedSeqNum=15
```