### PR TITLE
Check that the nonce is correct in the data poster

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -648,6 +648,12 @@ var DefaultDataPosterConfig = DataPosterConfig{
 	UseNoOpStorage:         false,
 }
 
+var DefaultDataPosterConfigForValidator = func() DataPosterConfig {
+	config := DefaultDataPosterConfig
+	config.MaxMempoolTransactions = 1 // the validator cannot queue transactions
+	return config
+}()
+
 var TestDataPosterConfig = DataPosterConfig{
 	ReplacementTimes:       "1s,2s,5s,10s,20s,30s,1m,5m",
 	RedisSigner:            signature.TestSimpleHmacConfig,
@@ -662,3 +668,9 @@ var TestDataPosterConfig = DataPosterConfig{
 	UseLevelDB:             false,
 	UseNoOpStorage:         false,
 }
+
+var TestDataPosterConfigForValidator = func() DataPosterConfig {
+	config := TestDataPosterConfig
+	config.MaxMempoolTransactions = 1 // the validator cannot queue transactions
+	return config
+}()

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -157,46 +157,59 @@ func (p *DataPoster) canPostWithNonce(ctx context.Context, nextNonce uint64) err
 	return nil
 }
 
-// GetNextNonceAndMeta retrieves generates next nonce, validates that a
-// transaction can be posted with that nonce, and fetches "Meta" either last
-// queued iterm (if queue isn't empty) or retrieves with last block.
-func (p *DataPoster) GetNextNonceAndMeta(ctx context.Context) (uint64, []byte, error) {
+// Requires the caller hold the mutex.
+// Returns the next nonce, its metadata if stored, a bool indicating if the metadata is present, and an error.
+// Unlike GetNextNonceAndMeta, this does not call the metadataRetriever if the metadata is not stored in the queue.
+func (p *DataPoster) getNextNonceAndMaybeMeta(ctx context.Context) (uint64, []byte, bool, error) {
 	config := p.config()
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
 	// Ensure latest finalized block state is available.
 	blockNum, err := p.client.BlockNumber(ctx)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, false, err
 	}
 	lastQueueItem, err := p.queue.FetchLast(ctx)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, false, err
 	}
 	if lastQueueItem != nil {
 		nextNonce := lastQueueItem.Data.Nonce + 1
 		if err := p.canPostWithNonce(ctx, nextNonce); err != nil {
-			return 0, nil, err
+			return 0, nil, false, err
 		}
-		return nextNonce, lastQueueItem.Meta, nil
+		return nextNonce, lastQueueItem.Meta, true, nil
 	}
 
 	if err := p.updateNonce(ctx); err != nil {
 		if !p.queue.IsPersistent() && config.WaitForL1Finality {
-			return 0, nil, fmt.Errorf("error getting latest finalized nonce (and queue is not persistent): %w", err)
+			return 0, nil, false, fmt.Errorf("error getting latest finalized nonce (and queue is not persistent): %w", err)
 		}
 		// Fall back to using a recent block to get the nonce. This is safe because there's nothing in the queue.
 		nonceQueryBlock := arbmath.UintToBig(arbmath.SaturatingUSub(blockNum, 1))
 		log.Warn("failed to update nonce with queue empty; falling back to using a recent block", "recentBlock", nonceQueryBlock, "err", err)
 		nonce, err := p.client.NonceAt(ctx, p.sender, nonceQueryBlock)
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to get nonce at block %v: %w", nonceQueryBlock, err)
+			return 0, nil, false, fmt.Errorf("failed to get nonce at block %v: %w", nonceQueryBlock, err)
 		}
 		p.lastBlock = nonceQueryBlock
 		p.nonce = nonce
 	}
-	meta, err := p.metadataRetriever(ctx, p.lastBlock)
-	return p.nonce, meta, err
+	return p.nonce, nil, false, nil
+}
+
+// GetNextNonceAndMeta retrieves generates next nonce, validates that a
+// transaction can be posted with that nonce, and fetches "Meta" either last
+// queued iterm (if queue isn't empty) or retrieves with last block.
+func (p *DataPoster) GetNextNonceAndMeta(ctx context.Context) (uint64, []byte, error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	nonce, meta, hasMeta, err := p.getNextNonceAndMaybeMeta(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+	if !hasMeta {
+		meta, err = p.metadataRetriever(ctx, p.lastBlock)
+	}
+	return nonce, meta, err
 }
 
 const minRbfIncrease = arbmath.OneInBips * 11 / 10
@@ -299,7 +312,16 @@ func (p *DataPoster) feeAndTipCaps(ctx context.Context, nonce uint64, gasLimit u
 func (p *DataPoster) PostTransaction(ctx context.Context, dataCreatedAt time.Time, nonce uint64, meta []byte, to common.Address, calldata []byte, gasLimit uint64, value *big.Int) (*types.Transaction, error) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-	err := p.updateBalance(ctx)
+
+	expectedNonce, _, _, err := p.getNextNonceAndMaybeMeta(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if nonce != expectedNonce {
+		return nil, fmt.Errorf("data poster expected next transaction to have nonce %v but was requested to post transaction with nonce %v", expectedNonce, nonce)
+	}
+
+	err = p.updateBalance(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update data poster balance: %w", err)
 	}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -434,6 +434,7 @@ func ConfigDefaultL1NonSequencerTest() *Config {
 	config.BatchPoster.Enable = false
 	config.SeqCoordinator.Enable = false
 	config.BlockValidator = staker.TestBlockValidatorConfig
+	config.Staker = staker.TestL1ValidatorConfig
 	config.Staker.Enable = false
 	config.BlockValidator.ValidationServer.URL = ""
 	config.Forwarder = execution.DefaultTestForwarderConfig
@@ -451,6 +452,7 @@ func ConfigDefaultL2Test() *Config {
 	config.Feed.Output.Signed = false
 	config.SeqCoordinator.Signer.ECDSA.AcceptSequencer = false
 	config.SeqCoordinator.Signer.ECDSA.Dangerous.AcceptMissing = true
+	config.Staker = staker.TestL1ValidatorConfig
 	config.Staker.Enable = false
 	config.BlockValidator.ValidationServer.URL = ""
 	config.TransactionStreamer = DefaultTransactionStreamerConfig
@@ -554,19 +556,19 @@ func ValidatorDataposter(
 	mdRetriever := func(ctx context.Context, blockNum *big.Int) ([]byte, error) {
 		return nil, nil
 	}
-	redisC, err := redisutil.RedisClientFromURL(cfg.BlockValidator.RedisUrl)
+	redisC, err := redisutil.RedisClientFromURL(cfg.Staker.RedisUrl)
 	if err != nil {
 		return nil, fmt.Errorf("creating redis client from url: %w", err)
 	}
 	lockCfgFetcher := func() *redislock.SimpleCfg {
-		return &cfg.BlockValidator.RedisLock
+		return &cfg.Staker.RedisLock
 	}
 	redisLock, err := redislock.NewSimple(redisC, lockCfgFetcher, func() bool { return syncMonitor.Synced() })
 	if err != nil {
 		return nil, err
 	}
 	dpCfg := func() *dataposter.DataPosterConfig {
-		return &cfg.BlockValidator.DataPoster
+		return &cfg.Staker.DataPoster
 	}
 	return dataposter.NewDataPoster(db, l1Reader, transactOpts, redisC, redisLock, dpCfg, mdRetriever)
 }

--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -19,8 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/offchainlabs/nitro/arbnode/dataposter"
-	"github.com/offchainlabs/nitro/arbnode/redislock"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/util/containers"
 	"github.com/offchainlabs/nitro/util/rpcclient"
@@ -88,9 +86,6 @@ type BlockValidatorConfig struct {
 	PendingUpgradeModuleRoot string                        `koanf:"pending-upgrade-module-root"` // TODO(magic) requires StatelessBlockValidator recreation on hot reload
 	FailureIsFatal           bool                          `koanf:"failure-is-fatal" reload:"hot"`
 	Dangerous                BlockValidatorDangerousConfig `koanf:"dangerous"`
-	DataPoster               dataposter.DataPosterConfig   `koanf:"data-poster" reload:"hot"`
-	RedisUrl                 string                        `koanf:"redis-url"`
-	RedisLock                redislock.SimpleCfg           `koanf:"redis-lock" reload:"hot"`
 }
 
 func (c *BlockValidatorConfig) Validate() error {
@@ -113,9 +108,6 @@ func BlockValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".pending-upgrade-module-root", DefaultBlockValidatorConfig.PendingUpgradeModuleRoot, "pending upgrade wasm module root to additionally validate (hash, 'latest' or empty)")
 	f.Bool(prefix+".failure-is-fatal", DefaultBlockValidatorConfig.FailureIsFatal, "failing a validation is treated as a fatal error")
 	BlockValidatorDangerousConfigAddOptions(prefix+".dangerous", f)
-	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f)
-	f.String(prefix+".redis-url", DefaultBlockValidatorConfig.RedisUrl, "redis url for block validator")
-	redislock.AddConfigOptions(prefix+".redis-lock", f)
 }
 
 func BlockValidatorDangerousConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -132,9 +124,6 @@ var DefaultBlockValidatorConfig = BlockValidatorConfig{
 	PendingUpgradeModuleRoot: "latest",
 	FailureIsFatal:           true,
 	Dangerous:                DefaultBlockValidatorDangerousConfig,
-	DataPoster:               dataposter.DefaultDataPosterConfig,
-	RedisUrl:                 "",
-	RedisLock:                redislock.DefaultCfg,
 }
 
 var TestBlockValidatorConfig = BlockValidatorConfig{
@@ -147,9 +136,6 @@ var TestBlockValidatorConfig = BlockValidatorConfig{
 	PendingUpgradeModuleRoot: "latest",
 	FailureIsFatal:           true,
 	Dangerous:                DefaultBlockValidatorDangerousConfig,
-	DataPoster:               dataposter.TestDataPosterConfig,
-	RedisUrl:                 "",
-	RedisLock:                redislock.DefaultCfg,
 }
 
 var DefaultBlockValidatorDangerousConfig = BlockValidatorDangerousConfig{

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -20,6 +20,8 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	flag "github.com/spf13/pflag"
 
+	"github.com/offchainlabs/nitro/arbnode/dataposter"
+	"github.com/offchainlabs/nitro/arbnode/redislock"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/util/arbmath"
@@ -69,21 +71,24 @@ func L1PostingStrategyAddOptions(prefix string, f *flag.FlagSet) {
 }
 
 type L1ValidatorConfig struct {
-	Enable                    bool                     `koanf:"enable"`
-	Strategy                  string                   `koanf:"strategy"`
-	StakerInterval            time.Duration            `koanf:"staker-interval"`
-	MakeAssertionInterval     time.Duration            `koanf:"make-assertion-interval"`
-	PostingStrategy           L1PostingStrategy        `koanf:"posting-strategy"`
-	DisableChallenge          bool                     `koanf:"disable-challenge"`
-	ConfirmationBlocks        int64                    `koanf:"confirmation-blocks"`
-	UseSmartContractWallet    bool                     `koanf:"use-smart-contract-wallet"`
-	OnlyCreateWalletContract  bool                     `koanf:"only-create-wallet-contract"`
-	StartValidationFromStaked bool                     `koanf:"start-validation-from-staked"`
-	ContractWalletAddress     string                   `koanf:"contract-wallet-address"`
-	GasRefunderAddress        string                   `koanf:"gas-refunder-address"`
-	ExtraGas                  uint64                   `koanf:"extra-gas" reload:"hot"`
-	Dangerous                 DangerousConfig          `koanf:"dangerous"`
-	ParentChainWallet         genericconf.WalletConfig `koanf:"parent-chain-wallet"`
+	Enable                    bool                        `koanf:"enable"`
+	Strategy                  string                      `koanf:"strategy"`
+	StakerInterval            time.Duration               `koanf:"staker-interval"`
+	MakeAssertionInterval     time.Duration               `koanf:"make-assertion-interval"`
+	PostingStrategy           L1PostingStrategy           `koanf:"posting-strategy"`
+	DisableChallenge          bool                        `koanf:"disable-challenge"`
+	ConfirmationBlocks        int64                       `koanf:"confirmation-blocks"`
+	UseSmartContractWallet    bool                        `koanf:"use-smart-contract-wallet"`
+	OnlyCreateWalletContract  bool                        `koanf:"only-create-wallet-contract"`
+	StartValidationFromStaked bool                        `koanf:"start-validation-from-staked"`
+	ContractWalletAddress     string                      `koanf:"contract-wallet-address"`
+	GasRefunderAddress        string                      `koanf:"gas-refunder-address"`
+	DataPoster                dataposter.DataPosterConfig `koanf:"data-poster" reload:"hot"`
+	RedisUrl                  string                      `koanf:"redis-url"`
+	RedisLock                 redislock.SimpleCfg         `koanf:"redis-lock" reload:"hot"`
+	ExtraGas                  uint64                      `koanf:"extra-gas" reload:"hot"`
+	Dangerous                 DangerousConfig             `koanf:"dangerous"`
+	ParentChainWallet         genericconf.WalletConfig    `koanf:"parent-chain-wallet"`
 
 	strategy    StakerStrategy
 	gasRefunder common.Address
@@ -145,6 +150,30 @@ var DefaultL1ValidatorConfig = L1ValidatorConfig{
 	StartValidationFromStaked: true,
 	ContractWalletAddress:     "",
 	GasRefunderAddress:        "",
+	DataPoster:                dataposter.DefaultDataPosterConfigForValidator,
+	RedisUrl:                  "",
+	RedisLock:                 redislock.DefaultCfg,
+	ExtraGas:                  50000,
+	Dangerous:                 DefaultDangerousConfig,
+	ParentChainWallet:         DefaultValidatorL1WalletConfig,
+}
+
+var TestL1ValidatorConfig = L1ValidatorConfig{
+	Enable:                    true,
+	Strategy:                  "Watchtower",
+	StakerInterval:            time.Millisecond * 10,
+	MakeAssertionInterval:     0,
+	PostingStrategy:           L1PostingStrategy{},
+	DisableChallenge:          false,
+	ConfirmationBlocks:        0,
+	UseSmartContractWallet:    false,
+	OnlyCreateWalletContract:  false,
+	StartValidationFromStaked: true,
+	ContractWalletAddress:     "",
+	GasRefunderAddress:        "",
+	DataPoster:                dataposter.TestDataPosterConfigForValidator,
+	RedisUrl:                  "",
+	RedisLock:                 redislock.DefaultCfg,
 	ExtraGas:                  50000,
 	Dangerous:                 DefaultDangerousConfig,
 	ParentChainWallet:         DefaultValidatorL1WalletConfig,
@@ -171,7 +200,10 @@ func L1ValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".start-validation-from-staked", DefaultL1ValidatorConfig.StartValidationFromStaked, "assume staked nodes are valid")
 	f.String(prefix+".contract-wallet-address", DefaultL1ValidatorConfig.ContractWalletAddress, "validator smart contract wallet public address")
 	f.String(prefix+".gas-refunder-address", DefaultL1ValidatorConfig.GasRefunderAddress, "The gas refunder contract address (optional)")
+	f.String(prefix+".redis-url", DefaultL1ValidatorConfig.RedisUrl, "redis url for L1 validator")
 	f.Uint64(prefix+".extra-gas", DefaultL1ValidatorConfig.ExtraGas, "use this much more gas than estimation says is necessary to post transactions")
+	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f)
+	redislock.AddConfigOptions(prefix+".redis-lock", f)
 	DangerousConfigAddOptions(prefix+".dangerous", f)
 	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultL1ValidatorConfig.ParentChainWallet.Pathname)
 }

--- a/staker/validator_wallet.go
+++ b/staker/validator_wallet.go
@@ -61,6 +61,8 @@ type ValidatorWalletInterface interface {
 	AuthIfEoa() *bind.TransactOpts
 	Start(context.Context)
 	StopAndWait()
+	// May be nil
+	DataPoster() *dataposter.DataPoster
 }
 
 type ContractValidatorWallet struct {
@@ -416,6 +418,10 @@ func (w *ContractValidatorWallet) Start(ctx context.Context) {
 
 func (b *ContractValidatorWallet) StopAndWait() {
 	b.StopWaiter.StopAndWait()
+}
+
+func (b *ContractValidatorWallet) DataPoster() *dataposter.DataPoster {
+	return b.dataPoster
 }
 
 func GetValidatorWalletContract(

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -127,6 +127,7 @@ func createForwardingNode(
 	nodeConfig := arbnode.ConfigDefaultL1Test()
 	nodeConfig.Sequencer.Enable = false
 	nodeConfig.DelayedSequencer.Enable = false
+	nodeConfig.BatchPoster.Enable = false
 	nodeConfig.Forwarder.RedisUrl = redisUrl
 	nodeConfig.ForwardingTarget = fallbackPath
 	//	nodeConfig.Feed.Output.Enable = false
@@ -148,7 +149,7 @@ func createSequencer(
 	ipcConfig.Path = ipcPath
 	ipcConfig.Apply(stackConfig)
 	nodeConfig := arbnode.ConfigDefaultL1Test()
-	nodeConfig.BatchPoster.Enable = true
+	nodeConfig.BatchPoster.Enable = false
 	nodeConfig.SeqCoordinator.Enable = true
 	nodeConfig.SeqCoordinator.RedisUrl = redisUrl
 	nodeConfig.SeqCoordinator.MyUrl = ipcPath

--- a/system_tests/retryable_test.go
+++ b/system_tests/retryable_test.go
@@ -319,7 +319,7 @@ func TestSubmissionGasCosts(t *testing.T) {
 	usefulGas := params.TxGas
 	excessGasLimit := uint64(808)
 
-	maxSubmissionFee := big.NewInt(1e13)
+	maxSubmissionFee := big.NewInt(1e14)
 	retryableGas := arbmath.UintToBig(usefulGas + excessGasLimit) // will only burn the intrinsic cost
 	retryableL2CallValue := big.NewInt(1e4)
 	retryableCallData := []byte{}
@@ -358,8 +358,10 @@ func TestSubmissionGasCosts(t *testing.T) {
 	if redeemReceipt.Status != types.ReceiptStatusSuccessful {
 		Fatal(t, "first retry tx failed")
 	}
+	redeemBlock, err := l2client.HeaderByNumber(ctx, redeemReceipt.BlockNumber)
+	Require(t, err)
 
-	l2BaseFee := GetBaseFee(t, l2client, ctx)
+	l2BaseFee := redeemBlock.BaseFee
 	excessGasPrice := arbmath.BigSub(gasFeeCap, l2BaseFee)
 	excessWei := arbmath.BigMulByUint(l2BaseFee, excessGasLimit)
 	excessWei.Add(excessWei, arbmath.BigMul(excessGasPrice, retryableGas))

--- a/system_tests/staker_test.go
+++ b/system_tests/staker_test.go
@@ -128,13 +128,13 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 	validatorUtils, err := rollupgen.NewValidatorUtils(l2nodeA.DeployInfo.ValidatorUtils, l1client)
 	Require(t, err)
 
-	valConfig := staker.L1ValidatorConfig{}
+	valConfig := staker.TestL1ValidatorConfig
 
 	dpA, err := arbnode.ValidatorDataposter(rawdb.NewTable(l2nodeB.ArbDB, storage.BlockValidatorPrefix), l2nodeA.L1Reader, &l1authA, NewFetcherFromConfig(arbnode.ConfigDefaultL1NonSequencerTest()), nil)
 	if err != nil {
 		t.Fatalf("Error creating validator dataposter: %v", err)
 	}
-	valWalletA, err := staker.NewContractValidatorWallet(dpA, nil, l2nodeA.DeployInfo.ValidatorWalletCreator, l2nodeA.DeployInfo.Rollup, l2nodeA.L1Reader, &l1authA, 0, func(common.Address) {}, func() uint64 { return 10000 })
+	valWalletA, err := staker.NewContractValidatorWallet(dpA, nil, l2nodeA.DeployInfo.ValidatorWalletCreator, l2nodeA.DeployInfo.Rollup, l2nodeA.L1Reader, &l1authA, 0, func(common.Address) {}, func() uint64 { return valConfig.ExtraGas })
 	Require(t, err)
 	if honestStakerInactive {
 		valConfig.Strategy = "Defensive"


### PR DESCRIPTION
This PR is made up of 3 commits that I'd recommend reviewing independently:
- Check that the nonce is correct in the data poster
  - This adds code to PostTransaction to require that the nonce is what the data poster expects, and adds code to the staker which replaces the eoa-wallet specific code to wait for the correct nonce.
- Fix flaky tests
  - Does what it says on the tin. I was doing a lot of testing on the previous commit and ran into some race conditions in other tests.
- Move data poster config from BlockValidatorConfig to L1ValidatorConfig
  - Also sets the default MaxMempoolTransactions for the staker to 1, because it can't queue up stuff in the mempool. This should make https://github.com/OffchainLabs/nitro/pull/1818 work better with the validator.