### PR TITLE
Improve batch poster reliability for L3s

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -92,21 +92,26 @@ func parseReplacementTimes(val string) ([]time.Duration, error) {
 }
 
 func NewDataPoster(db ethdb.Database, headerReader *headerreader.HeaderReader, auth *bind.TransactOpts, redisClient redis.UniversalClient, redisLock AttemptLocker, config ConfigFetcher, metadataRetriever func(ctx context.Context, blockNum *big.Int) ([]byte, error)) (*DataPoster, error) {
-	replacementTimes, err := parseReplacementTimes(config().ReplacementTimes)
+	initConfig := config()
+	replacementTimes, err := parseReplacementTimes(initConfig.ReplacementTimes)
 	if err != nil {
 		return nil, err
 	}
+	if headerReader.IsParentChainArbitrum() && !initConfig.UseNoOpStorage {
+		initConfig.UseNoOpStorage = true
+		log.Info("Disabling data poster storage, as parent chain appears to be an Arbitrum chain without a mempool")
+	}
 	var queue QueueStorage
 	switch {
-	case config().UseLevelDB:
-		queue = leveldb.New(db)
-	case config().UseNoOpStorage:
+	case initConfig.UseNoOpStorage:
 		queue = &noop.Storage{}
+	case initConfig.UseLevelDB:
+		queue = leveldb.New(db)
 	case redisClient == nil:
 		queue = slice.NewStorage()
 	default:
 		var err error
-		queue, err = redisstorage.NewStorage(redisClient, "data-poster.queue", &config().RedisSigner)
+		queue, err = redisstorage.NewStorage(redisClient, "data-poster.queue", &initConfig.RedisSigner)
 		if err != nil {
 			return nil, err
 		}
@@ -587,8 +592,8 @@ type DataPosterConfig struct {
 	MaxTipCapGwei          float64                    `koanf:"max-tip-cap-gwei" reload:"hot"`
 	NonceRbfSoftConfs      uint64                     `koanf:"nonce-rbf-soft-confs" reload:"hot"`
 	AllocateMempoolBalance bool                       `koanf:"allocate-mempool-balance" reload:"hot"`
-	UseLevelDB             bool                       `koanf:"use-leveldb" reload:"hot"`
-	UseNoOpStorage         bool                       `koanf:"use-noop-storage" reload:"hot"`
+	UseLevelDB             bool                       `koanf:"use-leveldb"`
+	UseNoOpStorage         bool                       `koanf:"use-noop-storage"`
 }
 
 // ConfigFetcher function type is used instead of directly passing config so

--- a/arbutil/wait_for_l1.go
+++ b/arbutil/wait_for_l1.go
@@ -12,8 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 )
 
 type L1Interface interface {
@@ -88,7 +88,7 @@ func DetailTxError(ctx context.Context, client L1Interface, tx *types.Transactio
 	}
 	_, err = SendTxAsCall(ctx, client, tx, from, txRes.BlockNumber, true)
 	if err == nil {
-		return fmt.Errorf("%w for tx hash %v", core.ErrGasLimitReached, tx.Hash())
+		return fmt.Errorf("%w for tx hash %v", vm.ErrOutOfGas, tx.Hash())
 	}
 	return fmt.Errorf("SendTxAsCall got: %w for tx hash %v", err, tx.Hash())
 }

--- a/util/headerreader/header_reader.go
+++ b/util/headerreader/header_reader.go
@@ -462,6 +462,10 @@ func (s *HeaderReader) UseFinalityData() bool {
 	return s.config().UseFinalityData
 }
 
+func (s *HeaderReader) IsParentChainArbitrum() bool {
+	return s.isParentChainArbitrum
+}
+
 func (s *HeaderReader) Start(ctxIn context.Context) {
 	s.StopWaiter.Start(ctxIn, s)
 	s.LaunchThread(s.broadcastLoop)


### PR DESCRIPTION
There are two key differences for batch posting to an L2 vs batch posting to an L1:
- Arbitrum doesn't maintain a mempool (except insofar as transactions are "in flight" before a response is returned), so replace-by-fee doesn't make sense
- Transactions might revert if the L1 basefee increases

Luckily, both of these concerns are avoidable by simply enabling the data poster's noop storage mode. This PR does that automatically for L3s.

It also waits to get a receipt from the last batch if noop storage mode is enabled before posting the next batch. That helps ensure that it doesn't accidentally try to post the same batch twice.