### PR TITLE
Implement legacy storage encoding with hot-reload flag to change encoding strategy on the fly

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -101,17 +101,23 @@ func NewDataPoster(db ethdb.Database, headerReader *headerreader.HeaderReader, a
 		initConfig.UseNoOpStorage = true
 		log.Info("Disabling data poster storage, as parent chain appears to be an Arbitrum chain without a mempool")
 	}
+	encF := func() storage.EncoderDecoderInterface {
+		if config().LegacyStorageEncoding {
+			return &storage.LegacyEncoderDecoder{}
+		}
+		return &storage.EncoderDecoder{}
+	}
 	var queue QueueStorage
 	switch {
 	case initConfig.UseNoOpStorage:
 		queue = &noop.Storage{}
 	case initConfig.UseLevelDB:
-		queue = leveldb.New(db)
+		queue = leveldb.New(db, encF)
 	case redisClient == nil:
-		queue = slice.NewStorage()
+		queue = slice.NewStorage(encF)
 	default:
 		var err error
-		queue, err = redisstorage.NewStorage(redisClient, "data-poster.queue", &initConfig.RedisSigner)
+		queue, err = redisstorage.NewStorage(redisClient, "data-poster.queue", &initConfig.RedisSigner, encF)
 		if err != nil {
 			return nil, err
 		}
@@ -174,7 +180,7 @@ func (p *DataPoster) getNextNonceAndMaybeMeta(ctx context.Context) (uint64, []by
 	}
 	lastQueueItem, err := p.queue.FetchLast(ctx)
 	if err != nil {
-		return 0, nil, false, err
+		return 0, nil, false, fmt.Errorf("fetching last element from queue: %w", err)
 	}
 	if lastQueueItem != nil {
 		nextNonce := lastQueueItem.Data.Nonce + 1
@@ -364,7 +370,10 @@ func (p *DataPoster) saveTx(ctx context.Context, prevTx, newTx *storage.QueuedTr
 	if prevTx != nil && prevTx.Data.Nonce != newTx.Data.Nonce {
 		return fmt.Errorf("prevTx nonce %v doesn't match newTx nonce %v", prevTx.Data.Nonce, newTx.Data.Nonce)
 	}
-	return p.queue.Put(ctx, newTx.Data.Nonce, prevTx, newTx)
+	if err := p.queue.Put(ctx, newTx.Data.Nonce, prevTx, newTx); err != nil {
+		return fmt.Errorf("putting new tx in the queue: %w", err)
+	}
+	return nil
 }
 
 func (p *DataPoster) sendTx(ctx context.Context, prevTx *storage.QueuedTransaction, newTx *storage.QueuedTransaction) error {
@@ -546,7 +555,7 @@ func (p *DataPoster) Start(ctxIn context.Context) {
 		// replacing them by fee.
 		queueContents, err := p.queue.FetchContents(ctx, unconfirmedNonce, maxTxsToRbf)
 		if err != nil {
-			log.Error("Failed to get tx queue contents", "err", err)
+			log.Error("Failed to fetch tx queue contents", "err", err)
 			return minWait
 		}
 		for index, tx := range queueContents {
@@ -616,6 +625,7 @@ type DataPosterConfig struct {
 	AllocateMempoolBalance bool                       `koanf:"allocate-mempool-balance" reload:"hot"`
 	UseLevelDB             bool                       `koanf:"use-leveldb"`
 	UseNoOpStorage         bool                       `koanf:"use-noop-storage"`
+	LegacyStorageEncoding  bool                       `koanf:"legacy-storage-encoding" reload:"hot"`
 }
 
 // ConfigFetcher function type is used instead of directly passing config so
@@ -636,6 +646,7 @@ func DataPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".allocate-mempool-balance", DefaultDataPosterConfig.AllocateMempoolBalance, "if true, don't put transactions in the mempool that spend a total greater than the batch poster's balance")
 	f.Bool(prefix+".use-leveldb", DefaultDataPosterConfig.UseLevelDB, "uses leveldb when enabled")
 	f.Bool(prefix+".use-noop-storage", DefaultDataPosterConfig.UseNoOpStorage, "uses noop storage, it doesn't store anything")
+	f.Bool(prefix+".legacy-storage-encoding", DefaultDataPosterConfig.LegacyStorageEncoding, "encodes items in a legacy way (as it was before dropping generics)")
 	signature.SimpleHmacConfigAddOptions(prefix+".redis-signer", f)
 }
 
@@ -651,6 +662,7 @@ var DefaultDataPosterConfig = DataPosterConfig{
 	AllocateMempoolBalance: true,
 	UseLevelDB:             false,
 	UseNoOpStorage:         false,
+	LegacyStorageEncoding:  true,
 }
 
 var DefaultDataPosterConfigForValidator = func() DataPosterConfig {

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -112,7 +112,7 @@ func NewDataPoster(db ethdb.Database, headerReader *headerreader.HeaderReader, a
 	case initConfig.UseNoOpStorage:
 		queue = &noop.Storage{}
 	case initConfig.UseLevelDB:
-		queue = leveldb.New(db, encF)
+		queue = leveldb.New(db, func() storage.EncoderDecoderInterface { return &storage.EncoderDecoder{} })
 	case redisClient == nil:
 		queue = slice.NewStorage(func() storage.EncoderDecoderInterface { return &storage.EncoderDecoder{} })
 	default:

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -114,7 +114,7 @@ func NewDataPoster(db ethdb.Database, headerReader *headerreader.HeaderReader, a
 	case initConfig.UseLevelDB:
 		queue = leveldb.New(db, encF)
 	case redisClient == nil:
-		queue = slice.NewStorage(encF)
+		queue = slice.NewStorage(func() storage.EncoderDecoderInterface { return &storage.EncoderDecoder{} })
 	default:
 		var err error
 		queue, err = redisstorage.NewStorage(redisClient, "data-poster.queue", &initConfig.RedisSigner, encF)

--- a/arbnode/dataposter/leveldb/leveldb.go
+++ b/arbnode/dataposter/leveldb/leveldb.go
@@ -12,14 +12,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/offchainlabs/nitro/arbnode/dataposter/storage"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
 // Storage implements leveldb based storage for batch poster.
 type Storage struct {
-	db ethdb.Database
+	db     ethdb.Database
+	encDec storage.EncoderDecoderF
 }
 
 var (
@@ -31,16 +31,8 @@ var (
 	countKey       = []byte(".count_key")
 )
 
-func New(db ethdb.Database) *Storage {
-	return &Storage{db: db}
-}
-
-func (s *Storage) decodeItem(data []byte) (*storage.QueuedTransaction, error) {
-	var item storage.QueuedTransaction
-	if err := rlp.DecodeBytes(data, &item); err != nil {
-		return nil, fmt.Errorf("decoding item: %w", err)
-	}
-	return &item, nil
+func New(db ethdb.Database, enc storage.EncoderDecoderF) *Storage {
+	return &Storage{db: db, encDec: enc}
 }
 
 func idxToKey(idx uint64) []byte {
@@ -55,7 +47,7 @@ func (s *Storage) FetchContents(_ context.Context, startingIndex uint64, maxResu
 		if !it.Next() {
 			break
 		}
-		item, err := s.decodeItem(it.Value())
+		item, err := s.encDec().Decode(it.Value())
 		if err != nil {
 			return nil, err
 		}
@@ -84,7 +76,7 @@ func (s *Storage) FetchLast(ctx context.Context) (*storage.QueuedTransaction, er
 	if err != nil {
 		return nil, err
 	}
-	return s.decodeItem(val)
+	return s.encDec().Decode(val)
 }
 
 func (s *Storage) Prune(ctx context.Context, until uint64) error {
@@ -117,7 +109,7 @@ func (s *Storage) valueAt(_ context.Context, key []byte) ([]byte, error) {
 	val, err := s.db.Get(key)
 	if err != nil {
 		if isErrNotFound(err) {
-			return rlp.EncodeToBytes((*storage.QueuedTransaction)(nil))
+			return s.encDec().Encode((*storage.QueuedTransaction)(nil))
 		}
 		return nil, err
 	}
@@ -130,14 +122,14 @@ func (s *Storage) Put(ctx context.Context, index uint64, prev, new *storage.Queu
 	if err != nil {
 		return err
 	}
-	prevEnc, err := rlp.EncodeToBytes(prev)
+	prevEnc, err := s.encDec().Encode(prev)
 	if err != nil {
 		return fmt.Errorf("encoding previous item: %w", err)
 	}
 	if !bytes.Equal(stored, prevEnc) {
 		return fmt.Errorf("replacing different item than expected at index: %v, stored: %v, prevEnc: %v", index, stored, prevEnc)
 	}
-	newEnc, err := rlp.EncodeToBytes(new)
+	newEnc, err := s.encDec().Encode(new)
 	if err != nil {
 		return fmt.Errorf("encoding new item: %w", err)
 	}

--- a/arbnode/dataposter/storage/storage.go
+++ b/arbnode/dataposter/storage/storage.go
@@ -103,11 +103,12 @@ func QueuedTransactionToLegacy(qt *QueuedTransaction) (*LegacyQueuedTransaction,
 func decode(data []byte) (*QueuedTransaction, error) {
 	var item QueuedTransaction
 	if err := rlp.DecodeBytes(data, &item); err != nil {
-		log.Warn("Failed to decode QueuedTransaction, attempting to decide legacy queued transaction", "error", err)
+		log.Debug("Failed to decode QueuedTransaction, attempting to decide legacy queued transaction", "error", err)
 		val, err := DecodeLegacyQueuedTransaction(data)
 		if err != nil {
 			return nil, fmt.Errorf("decoding legacy item: %w", err)
 		}
+		log.Debug("Succeeded decoding QueuedTransaction with legacy encoder")
 		return LegacyToQueuedTransaction(val)
 	}
 	return &item, nil

--- a/arbnode/dataposter/storage/storage.go
+++ b/arbnode/dataposter/storage/storage.go
@@ -21,7 +21,7 @@ var (
 )
 
 type QueuedTransaction struct {
-	FullTx          *types.Transaction `rlp:"nil"`
+	FullTx          *types.Transaction
 	Data            types.DynamicFeeTx
 	Meta            []byte
 	Sent            bool
@@ -35,7 +35,7 @@ type QueuedTransaction struct {
 // rlp encoding of Meta into queuedTransaction and rlp encoding it once more
 // to store it.
 type LegacyQueuedTransaction struct {
-	FullTx          *types.Transaction `rlp:"nil"`
+	FullTx          *types.Transaction
 	Data            types.DynamicFeeTx
 	Meta            BatchPosterPosition
 	Sent            bool
@@ -46,9 +46,7 @@ type LegacyQueuedTransaction struct {
 // This is also for legacy reason. Since Batchposter is in arbnode package,
 // we can't refer to BatchPosterPosition type there even if we export it (that
 // would create cyclic dependency).
-// Ideally we'll factor out Batch Poster from arbnode into separate package
-// and BatchPosterPosition into another separate package as well.
-// For the sake of minimal refactoring, that struct is duplicated here.
+// We'll drop this struct in a few releases when we drop legacy encoding.
 type BatchPosterPosition struct {
 	MessageCount        arbutil.MessageIndex
 	DelayedMessageCount uint64

--- a/arbnode/dataposter/storage/storage.go
+++ b/arbnode/dataposter/storage/storage.go
@@ -111,7 +111,6 @@ func decode(data []byte) (*QueuedTransaction, error) {
 		return LegacyToQueuedTransaction(val)
 	}
 	return &item, nil
-
 }
 
 type EncoderDecoder struct{}

--- a/arbnode/dataposter/storage_test.go
+++ b/arbnode/dataposter/storage_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -22,6 +23,7 @@ import (
 
 var ignoreData = cmp.Options{
 	cmpopts.IgnoreUnexported(
+		types.Transaction{},
 		types.DynamicFeeTx{},
 		big.Int{},
 	),
@@ -62,6 +64,13 @@ func valueOf(t *testing.T, i int) *storage.QueuedTransaction {
 		t.Fatalf("Encoding batch poster position, error: %v", err)
 	}
 	return &storage.QueuedTransaction{
+		FullTx: types.NewTransaction(
+			uint64(i),
+			common.Address{},
+			big.NewInt(int64(i)),
+			uint64(i),
+			big.NewInt(int64(i)),
+			[]byte{byte(i)}),
 		Meta: meta,
 		Data: types.DynamicFeeTx{
 			ChainID:    big.NewInt(int64(i)),

--- a/arbnode/dataposter/storage_test.go
+++ b/arbnode/dataposter/storage_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/offchainlabs/nitro/arbnode/dataposter/leveldb"
@@ -27,36 +28,41 @@ var ignoreData = cmp.Options{
 	cmpopts.IgnoreFields(types.Transaction{}, "hash", "size", "from"),
 }
 
-func newLevelDBStorage(t *testing.T) *leveldb.Storage {
+func newLevelDBStorage(t *testing.T, encF storage.EncoderDecoderF) *leveldb.Storage {
 	t.Helper()
 	db, err := rawdb.NewLevelDBDatabase(path.Join(t.TempDir(), "level.db"), 0, 0, "default", false)
 	if err != nil {
 		t.Fatalf("NewLevelDBDatabase() unexpected error: %v", err)
 	}
-	return leveldb.New(db)
+	return leveldb.New(db, encF)
 }
 
-func newSliceStorage() *slice.Storage {
-	return slice.NewStorage()
+func newSliceStorage(encF storage.EncoderDecoderF) *slice.Storage {
+	return slice.NewStorage(encF)
 }
 
-func newRedisStorage(ctx context.Context, t *testing.T) *redis.Storage {
+func newRedisStorage(ctx context.Context, t *testing.T, encF storage.EncoderDecoderF) *redis.Storage {
 	t.Helper()
 	redisUrl := redisutil.CreateTestRedis(ctx, t)
 	client, err := redisutil.RedisClientFromURL(redisUrl)
 	if err != nil {
 		t.Fatalf("RedisClientFromURL(%q) unexpected error: %v", redisUrl, err)
 	}
-	s, err := redis.NewStorage(client, "", &signature.TestSimpleHmacConfig)
+	s, err := redis.NewStorage(client, "", &signature.TestSimpleHmacConfig, encF)
 	if err != nil {
 		t.Fatalf("redis.NewStorage() unexpected error: %v", err)
 	}
 	return s
 }
 
-func valueOf(i int) *storage.QueuedTransaction {
+func valueOf(t *testing.T, i int) *storage.QueuedTransaction {
+	t.Helper()
+	meta, err := rlp.EncodeToBytes(storage.BatchPosterPosition{DelayedMessageCount: uint64(i)})
+	if err != nil {
+		t.Fatalf("Encoding batch poster position, error: %v", err)
+	}
 	return &storage.QueuedTransaction{
-		Meta: []byte{byte(i)},
+		Meta: meta,
 		Data: types.DynamicFeeTx{
 			ChainID:    big.NewInt(int64(i)),
 			Nonce:      uint64(i),
@@ -73,10 +79,10 @@ func valueOf(i int) *storage.QueuedTransaction {
 	}
 }
 
-func values(from, to int) []*storage.QueuedTransaction {
+func values(t *testing.T, from, to int) []*storage.QueuedTransaction {
 	var res []*storage.QueuedTransaction
 	for i := from; i <= to; i++ {
-		res = append(res, valueOf(i))
+		res = append(res, valueOf(t, i))
 	}
 	return res
 }
@@ -85,7 +91,7 @@ func values(from, to int) []*storage.QueuedTransaction {
 func initStorage(ctx context.Context, t *testing.T, s QueueStorage) QueueStorage {
 	t.Helper()
 	for i := 0; i < 20; i++ {
-		if err := s.Put(ctx, uint64(i), nil, valueOf(i)); err != nil {
+		if err := s.Put(ctx, uint64(i), nil, valueOf(t, i)); err != nil {
 			t.Fatalf("Error putting a key/value: %v", err)
 		}
 	}
@@ -95,10 +101,18 @@ func initStorage(ctx context.Context, t *testing.T, s QueueStorage) QueueStorage
 // Returns a map of all empty storages.
 func storages(t *testing.T) map[string]QueueStorage {
 	t.Helper()
+	f := func(enc storage.EncoderDecoderInterface) storage.EncoderDecoderF {
+		return func() storage.EncoderDecoderInterface {
+			return enc
+		}
+	}
 	return map[string]QueueStorage{
-		"levelDB": newLevelDBStorage(t),
-		"slice":   newSliceStorage(),
-		"redis":   newRedisStorage(context.Background(), t),
+		"levelDBLegacy": newLevelDBStorage(t, f(&storage.LegacyEncoderDecoder{})),
+		"sliceLegacy":   newSliceStorage(f(&storage.LegacyEncoderDecoder{})),
+		"redisLegacy":   newRedisStorage(context.Background(), t, f(&storage.LegacyEncoderDecoder{})),
+		"levelDB":       newLevelDBStorage(t, f(&storage.EncoderDecoder{})),
+		"slice":         newSliceStorage(f(&storage.EncoderDecoder{})),
+		"redis":         newRedisStorage(context.Background(), t, f(&storage.EncoderDecoder{})),
 	}
 }
 
@@ -125,13 +139,13 @@ func TestFetchContents(t *testing.T) {
 				desc:       "sequence with single digits",
 				startIdx:   5,
 				maxResults: 3,
-				want:       values(5, 7),
+				want:       values(t, 5, 7),
 			},
 			{
 				desc:       "corner case of single element",
 				startIdx:   0,
 				maxResults: 1,
-				want:       values(0, 0),
+				want:       values(t, 0, 0),
 			},
 			{
 				desc:       "no elements",
@@ -143,13 +157,13 @@ func TestFetchContents(t *testing.T) {
 				desc:       "sequence with variable number of digits",
 				startIdx:   9,
 				maxResults: 3,
-				want:       values(9, 11),
+				want:       values(t, 9, 11),
 			},
 			{
 				desc:       "max results goes over the last element",
 				startIdx:   13,
 				maxResults: 10,
-				want:       values(13, 19),
+				want:       values(t, 13, 19),
 			},
 		} {
 			t.Run(name+"_"+tc.desc, func(t *testing.T) {
@@ -171,7 +185,7 @@ func TestLast(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 			for i := 0; i < cnt; i++ {
-				val := valueOf(i)
+				val := valueOf(t, i)
 				if err := s.Put(ctx, uint64(i), nil, val); err != nil {
 					t.Fatalf("Error putting a key/value: %v", err)
 				}
@@ -185,12 +199,12 @@ func TestLast(t *testing.T) {
 
 			}
 		})
-		last := valueOf(cnt - 1)
+		last := valueOf(t, cnt-1)
 		t.Run(name+"_update_entries", func(t *testing.T) {
 			ctx := context.Background()
 			for i := 0; i < cnt-1; i++ {
-				prev := valueOf(i)
-				newVal := valueOf(cnt + i)
+				prev := valueOf(t, i)
+				newVal := valueOf(t, cnt+i)
 				if err := s.Put(ctx, uint64(i), prev, newVal); err != nil {
 					t.Fatalf("Error putting a key/value: %v, prev: %v, new: %v", err, prev, newVal)
 				}
@@ -227,17 +241,17 @@ func TestPrune(t *testing.T) {
 		{
 			desc:      "prune all but one",
 			pruneFrom: 19,
-			want:      values(19, 19),
+			want:      values(t, 19, 19),
 		},
 		{
 			desc:      "pruning first element",
 			pruneFrom: 1,
-			want:      values(1, 19),
+			want:      values(t, 1, 19),
 		},
 		{
 			desc:      "pruning first 11 elements",
 			pruneFrom: 11,
-			want:      values(11, 19),
+			want:      values(t, 11, 19),
 		},
 		{
 			desc:      "pruning from higher than biggest index",


### PR DESCRIPTION
Tested by running 3 batchposters, two legacy (offchainlabs/nitro-node:v2.1.0-beta.10-c028bf3) and one with current changes from https://github.com/OffchainLabs/nitro/pull/1844 (testnode changes for testing: https://github.com/OffchainLabs/nitro-testnode/pull/9/files).