### PR TITLE
Fix pollForReverts channel reading

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -309,8 +309,8 @@ func (b *BatchPoster) pollForReverts(ctx context.Context) {
 		// - polling is through context, or
 		// - we see a transaction in the block from dataposter that was reverted.
 		select {
-		case h, closed := <-headerCh:
-			if closed {
+		case h, ok := <-headerCh:
+			if !ok {
 				log.Info("L1 headers channel has been closed")
 				return
 			}


### PR DESCRIPTION
The ok value was backwards:

> The value of ok is true if the value received was delivered by a successful send operation to the channel, or false if it is a zero value generated because the channel is closed and empty.

https://go.dev/ref/spec#Receive_operator