### PR TITLE
Fix off by 1 in validator logging

### DIFF
--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -597,7 +597,7 @@ func (v *BlockValidator) iterativeValidationPrint(ctx context.Context) time.Dura
 	var batchMsgs arbutil.MessageIndex
 	var printedCount int64
 	if validated.GlobalState.Batch > 0 {
-		batchMsgs, err = v.inboxTracker.GetBatchMessageCount(validated.GlobalState.Batch)
+		batchMsgs, err = v.inboxTracker.GetBatchMessageCount(validated.GlobalState.Batch - 1)
 	}
 	if err != nil {
 		printedCount = -1


### PR DESCRIPTION
The batch message count is at the end of the batch, so we need to get the previous batch's message count, which I think is what this code was meaning to do based on the `if batch > 0`