### PR TITLE
Fix batch poster fixAccErr not resetting when the error stops

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -56,20 +56,20 @@ type batchPosterPosition struct {
 
 type BatchPoster struct {
 	stopwaiter.StopWaiter
-	l1Reader     *headerreader.HeaderReader
-	inbox        *InboxTracker
-	streamer     *TransactionStreamer
-	config       BatchPosterConfigFetcher
-	seqInbox     *bridgegen.SequencerInbox
-	bridge       *bridgegen.Bridge
-	syncMonitor  *SyncMonitor
-	seqInboxABI  *abi.ABI
-	seqInboxAddr common.Address
-	building     *buildingBatch
-	daWriter     das.DataAvailabilityServiceWriter
-	dataPoster   *dataposter.DataPoster
-	redisLock    *redislock.Simple
-	firstAccErr  time.Time // first time a continuous missing accumulator occurred
+	l1Reader            *headerreader.HeaderReader
+	inbox               *InboxTracker
+	streamer            *TransactionStreamer
+	config              BatchPosterConfigFetcher
+	seqInbox            *bridgegen.SequencerInbox
+	bridge              *bridgegen.Bridge
+	syncMonitor         *SyncMonitor
+	seqInboxABI         *abi.ABI
+	seqInboxAddr        common.Address
+	building            *buildingBatch
+	daWriter            das.DataAvailabilityServiceWriter
+	dataPoster          *dataposter.DataPoster
+	redisLock           *redislock.Simple
+	firstEphemeralError time.Time // first time a continuous error suspected to be ephemeral occurred
 	// An estimate of the number of batches we want to post but haven't yet.
 	// This doesn't include batches which we don't want to post yet due to the L1 bounds.
 	backlog         uint64
@@ -972,7 +972,7 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 		posted, err := b.maybePostSequencerBatch(ctx)
 		ephemeralError := errors.Is(err, AccumulatorNotFoundErr) || errors.Is(err, storage.ErrStorageRace)
 		if !ephemeralError {
-			b.firstAccErr = time.Time{}
+			b.firstEphemeralError = time.Time{}
 		}
 		if err != nil {
 			b.building = nil
@@ -980,10 +980,10 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 			if ephemeralError {
 				// Likely the inbox tracker just isn't caught up.
 				// Let's see if this error disappears naturally.
-				if b.firstAccErr == (time.Time{}) {
-					b.firstAccErr = time.Now()
+				if b.firstEphemeralError == (time.Time{}) {
+					b.firstEphemeralError = time.Now()
 					logLevel = log.Debug
-				} else if time.Since(b.firstAccErr) < time.Minute {
+				} else if time.Since(b.firstEphemeralError) < time.Minute {
 					logLevel = log.Debug
 				}
 			}


### PR DESCRIPTION
As the comment on the `firstAccErr` field (now renamed to `firstEphemeralError`) states, it's supposed to be the "first time a continuous missing accumulator occurred". However, this code only reset it if a different type of error occurred. If the ephemeral error happened once, stopped for 5 minutes during which no errors occurred, and then the ephemeral error reoccurred, it would log it as an error because it wouldn't have reset its tracking of when the last time it continuously occurred was.