### PR TITLE
Fix changing the basefee in non-mutating calls

### DIFF
--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -677,7 +677,7 @@ func (p *TxProcessor) GetPaidGasPrice() *big.Int {
 	if version != 9 {
 		gasPrice = p.evm.Context.BaseFee
 		if p.msg.TxRunMode != core.MessageCommitMode && p.msg.GasFeeCap.Sign() == 0 {
-			gasPrice.SetInt64(0) // gasprice zero behavior
+			gasPrice = common.Big0
 		}
 	}
 	return gasPrice


### PR DESCRIPTION
We accidentally changed the tx's basefee in this function when we were just meaning to change the return value. Luckily this code only happens for non-mutating RPC calls, not real transactions. It manifested in a `total cost < poster cost` log line with `basefee=0`, but I don't think it had any other impact.