### PR TITLE
Fix Start/Stop of the staker wallet's data poster

### DIFF
--- a/staker/eoa_validator_wallet.go
+++ b/staker/eoa_validator_wallet.go
@@ -15,11 +15,9 @@ import (
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/solgen/go/challengegen"
 	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
-	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
 type EoaValidatorWallet struct {
-	stopwaiter.StopWaiter
 	auth                    *bind.TransactOpts
 	client                  arbutil.L1Interface
 	rollupAddress           common.Address
@@ -129,11 +127,9 @@ func (w *EoaValidatorWallet) AuthIfEoa() *bind.TransactOpts {
 
 func (w *EoaValidatorWallet) Start(ctx context.Context) {
 	w.dataPoster.Start(ctx)
-	w.StopWaiter.Start(ctx, w)
 }
 
 func (b *EoaValidatorWallet) StopAndWait() {
-	b.StopWaiter.StopAndWait()
 	b.dataPoster.StopAndWait()
 }
 

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -372,11 +372,15 @@ func (s *Staker) getLatestStakedState(ctx context.Context, staker common.Address
 
 func (s *Staker) StopAndWait() {
 	s.StopWaiter.StopAndWait()
-	s.wallet.StopAndWait()
+	if s.Strategy() != WatchtowerStrategy {
+		s.wallet.StopAndWait()
+	}
 }
 
 func (s *Staker) Start(ctxIn context.Context) {
-	s.wallet.Start(ctxIn)
+	if s.Strategy() != WatchtowerStrategy {
+		s.wallet.Start(ctxIn)
+	}
 	s.StopWaiter.Start(ctxIn, s)
 	backoff := time.Second
 	s.CallIteratively(func(ctx context.Context) (returningWait time.Duration) {

--- a/staker/validator_wallet.go
+++ b/staker/validator_wallet.go
@@ -24,7 +24,6 @@ import (
 	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
 	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/headerreader"
-	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
 var validatorABI abi.ABI
@@ -66,7 +65,6 @@ type ValidatorWalletInterface interface {
 }
 
 type ContractValidatorWallet struct {
-	stopwaiter.StopWaiter
 	con                     *rollupgen.ValidatorWallet
 	address                 atomic.Pointer[common.Address]
 	onWalletCreated         func(common.Address)
@@ -413,11 +411,11 @@ func (v *ContractValidatorWallet) AuthIfEoa() *bind.TransactOpts {
 }
 
 func (w *ContractValidatorWallet) Start(ctx context.Context) {
-	w.StopWaiter.Start(ctx, w)
+	w.dataPoster.Start(ctx)
 }
 
 func (b *ContractValidatorWallet) StopAndWait() {
-	b.StopWaiter.StopAndWait()
+	b.dataPoster.StopAndWait()
 }
 
 func (b *ContractValidatorWallet) DataPoster() *dataposter.DataPoster {


### PR DESCRIPTION
This PR fixes 3 things:
- Don't start or stop the wallet if using the watchtower strategy (it was already not initialized)
- Start and stop the data poster for the contract validator wallet (as far as I can tell it wasn't RBFing before this)
- Get rid of the validator wallets' StopWaiters because they were unused