### PR TITLE
[Configuration Changes] Improve batch size and tx size limit defaults for L3s

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -167,19 +167,20 @@ func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 var DefaultBatchPosterConfig = BatchPosterConfig{
 	Enable:                             false,
 	DisableDasFallbackStoreDataOnChain: false,
-	MaxSize:                            100000,
-	PollInterval:                       time.Second * 10,
-	ErrorDelay:                         time.Second * 10,
-	MaxDelay:                           time.Hour,
-	WaitForMaxDelay:                    false,
-	CompressionLevel:                   brotli.BestCompression,
-	DASRetentionPeriod:                 time.Hour * 24 * 15,
-	GasRefunderAddress:                 "",
-	ExtraBatchGas:                      50_000,
-	DataPoster:                         dataposter.DefaultDataPosterConfig,
-	ParentChainWallet:                  DefaultBatchPosterL1WalletConfig,
-	L1BlockBound:                       "",
-	L1BlockBoundBypass:                 time.Hour,
+	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go
+	MaxSize:            100000,
+	PollInterval:       time.Second * 10,
+	ErrorDelay:         time.Second * 10,
+	MaxDelay:           time.Hour,
+	WaitForMaxDelay:    false,
+	CompressionLevel:   brotli.BestCompression,
+	DASRetentionPeriod: time.Hour * 24 * 15,
+	GasRefunderAddress: "",
+	ExtraBatchGas:      50_000,
+	DataPoster:         dataposter.DefaultDataPosterConfig,
+	ParentChainWallet:  DefaultBatchPosterL1WalletConfig,
+	L1BlockBound:       "",
+	L1BlockBoundBypass: time.Hour,
 }
 
 var DefaultBatchPosterL1WalletConfig = genericconf.WalletConfig{

--- a/arbnode/execution/sequencer.go
+++ b/arbnode/execution/sequencer.go
@@ -110,6 +110,7 @@ var DefaultSequencerConfig = SequencerConfig{
 	NonceCacheSize:              1024,
 	Dangerous:                   DefaultDangerousSequencerConfig,
 	// 95% of the default batch poster limit, leaving 5KB for headers and such
+	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go
 	MaxTxDataSize:           95000,
 	NonceFailureCacheSize:   1024,
 	NonceFailureCacheExpiry: time.Second,

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -234,19 +234,12 @@ func GenerateRollupConfig(prod bool, wasmModuleRoot common.Hash, rollupOwner com
 	}
 }
 
-func DeployOnL1(ctx context.Context, l1client arbutil.L1Interface, deployAuth *bind.TransactOpts, batchPoster common.Address, authorizeValidators uint64, readerConfig headerreader.ConfigFetcher, config rollupgen.Config) (*chaininfo.RollupAddresses, error) {
-	l1Reader, err := headerreader.New(ctx, l1client, readerConfig)
-	if err != nil {
-		return nil, err
-	}
-	l1Reader.Start(ctx)
-	defer l1Reader.StopAndWait()
-
+func DeployOnL1(ctx context.Context, parentChainReader *headerreader.HeaderReader, deployAuth *bind.TransactOpts, batchPoster common.Address, authorizeValidators uint64, config rollupgen.Config) (*chaininfo.RollupAddresses, error) {
 	if config.WasmModuleRoot == (common.Hash{}) {
 		return nil, errors.New("no machine specified")
 	}
 
-	rollupCreator, _, validatorUtils, validatorWalletCreator, err := deployRollupCreator(ctx, l1Reader, deployAuth)
+	rollupCreator, _, validatorUtils, validatorWalletCreator, err := deployRollupCreator(ctx, parentChainReader, deployAuth)
 	if err != nil {
 		return nil, fmt.Errorf("error deploying rollup creator: %w", err)
 	}
@@ -265,7 +258,7 @@ func DeployOnL1(ctx context.Context, l1client arbutil.L1Interface, deployAuth *b
 	if err != nil {
 		return nil, fmt.Errorf("error submitting create rollup tx: %w", err)
 	}
-	receipt, err := l1Reader.WaitForTxApproval(ctx, tx)
+	receipt, err := parentChainReader.WaitForTxApproval(ctx, tx)
 	if err != nil {
 		return nil, fmt.Errorf("error executing create rollup tx: %w", err)
 	}

--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -2,6 +2,7 @@
   {
     "chain-name": "arb1",
     "parent-chain-id": 1,
+    "parent-chain-is-arbitrum": false,
     "sequencer-url": "https://arb1-sequencer.arbitrum.io/rpc",
     "feed-url": "wss://arb1.arbitrum.io/feed",
     "has-genesis-state": true,
@@ -51,6 +52,7 @@
   {
     "chain-name": "nova",
     "parent-chain-id": 1,
+    "parent-chain-is-arbitrum": false,
     "sequencer-url": "https://nova.arbitrum.io/rpc",
     "feed-url": "wss://nova.arbitrum.io/feed",
     "das-index-url": "https://nova.arbitrum.io/das-servers",
@@ -100,6 +102,7 @@
   {
     "chain-name": "goerli-rollup",
     "parent-chain-id": 5,
+    "parent-chain-is-arbitrum": false,
     "sequencer-url": "https://goerli-rollup.arbitrum.io/rpc",
     "feed-url": "wss://goerli-rollup.arbitrum.io/feed",
     "chain-config":
@@ -215,9 +218,10 @@
       }
     }
   },
-    {
+  {
     "chain-id": 421614,
     "parent-chain-id": 11155111,
+    "parent-chain-is-arbitrum": false,
     "chain-name": "sepolia-rollup",
     "sequencer-url": "https://sepolia-rollup-sequencer.arbitrum.io/rpc",
     "feed-url": "wss://sepolia-rollup.arbitrum.io/feed",

--- a/cmd/chaininfo/chain_info.go
+++ b/cmd/chaininfo/chain_info.go
@@ -18,8 +18,9 @@ import (
 var DefaultChainInfo []byte
 
 type ChainInfo struct {
-	ChainName     string `json:"chain-name"`
-	ParentChainId uint64 `json:"parent-chain-id"`
+	ChainName             string `json:"chain-name"`
+	ParentChainId         uint64 `json:"parent-chain-id"`
+	ParentChainIsArbitrum *bool  `json:"parent-chain-is-arbitrum"`
 	// This is the forwarding target to submit transactions to, called the sequencer URL for clarity
 	SequencerUrl    string              `json:"sequencer-url"`
 	FeedUrl         string              `json:"feed-url"`

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -797,9 +797,14 @@ func applyChainParameters(ctx context.Context, k *koanf.Koanf, chainId uint64, c
 		chainDefaults["init.empty"] = true
 	}
 	if parentChainIsArbitrum {
-		safeBatchSize := execution.DefaultSequencerConfig.MaxTxDataSize - 5000
+		l2MaxTxSize := execution.DefaultSequencerConfig.MaxTxDataSize
+		bufferSpace := 5000
+		if l2MaxTxSize < bufferSpace*2 {
+			return false, fmt.Errorf("not enough room in parent chain max tx size %v for bufferSpace %v * 2", l2MaxTxSize, bufferSpace)
+		}
+		safeBatchSize := l2MaxTxSize - bufferSpace
 		chainDefaults["node.batch-poster.max-size"] = safeBatchSize
-		chainDefaults["node.sequencer.max-tx-data-size"] = safeBatchSize - 5000
+		chainDefaults["node.sequencer.max-tx-data-size"] = safeBatchSize - bufferSpace
 	}
 	err = k.Load(confmap.Provider(chainDefaults, "."), nil)
 	if err != nil {

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -475,13 +475,18 @@ func DeployOnTestL1(
 	Require(t, err)
 	serializedChainConfig, err := json.Marshal(chainConfig)
 	Require(t, err)
+
+	l1Reader, err := headerreader.New(ctx, l1client, func() *headerreader.Config { return &headerreader.TestConfig })
+	Require(t, err)
+	l1Reader.Start(ctx)
+	defer l1Reader.StopAndWait()
+
 	addresses, err := arbnode.DeployOnL1(
 		ctx,
-		l1client,
+		l1Reader,
 		&l1TransactionOpts,
 		l1info.GetAddress("Sequencer"),
 		0,
-		func() *headerreader.Config { return &headerreader.TestConfig },
 		arbnode.GenerateRollupConfig(false, locator.LatestWasmModuleRoot(), l1info.GetAddress("RollupOwner"), chainConfig, serializedChainConfig, common.Address{}),
 	)
 	Require(t, err)


### PR DESCRIPTION
This PR also adds a new "parent-chain-is-arbitrum" chain information field, which determines whether or not these new config defaults are set. While currently we auto-fill this field if not present, in the future we'll expect it to be present in order for these new defaults to apply.