### PR TITLE
Make the default data poster storage backend LevelDB

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -111,16 +111,16 @@ func NewDataPoster(db ethdb.Database, headerReader *headerreader.HeaderReader, a
 	switch {
 	case initConfig.UseNoOpStorage:
 		queue = &noop.Storage{}
-	case initConfig.UseLevelDB:
-		queue = leveldb.New(db, func() storage.EncoderDecoderInterface { return &storage.EncoderDecoder{} })
-	case redisClient == nil:
-		queue = slice.NewStorage(func() storage.EncoderDecoderInterface { return &storage.EncoderDecoder{} })
-	default:
+	case redisClient != nil:
 		var err error
 		queue, err = redisstorage.NewStorage(redisClient, "data-poster.queue", &initConfig.RedisSigner, encF)
 		if err != nil {
 			return nil, err
 		}
+	case initConfig.UseLevelDB:
+		queue = leveldb.New(db, func() storage.EncoderDecoderInterface { return &storage.EncoderDecoder{} })
+	default:
+		queue = slice.NewStorage(func() storage.EncoderDecoderInterface { return &storage.EncoderDecoder{} })
 	}
 	return &DataPoster{
 		headerReader:      headerReader,
@@ -665,7 +665,7 @@ var DefaultDataPosterConfig = DataPosterConfig{
 	MaxTipCapGwei:          5,
 	NonceRbfSoftConfs:      1,
 	AllocateMempoolBalance: true,
-	UseLevelDB:             false,
+	UseLevelDB:             true,
 	UseNoOpStorage:         false,
 	LegacyStorageEncoding:  true,
 }

--- a/arbnode/dataposter/storage/storage.go
+++ b/arbnode/dataposter/storage/storage.go
@@ -15,6 +15,7 @@ var (
 	ErrStorageRace = errors.New("storage race error")
 
 	BlockValidatorPrefix string = "v" // the prefix for all block validator keys
+	StakerPrefix         string = "S" // the prefix for all staker keys
 	BatchPosterPrefix    string = "b" // the prefix for all batch poster keys
 	// TODO(anodar): move everything else from schema.go file to here once
 	// execution split is complete.

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -538,7 +538,7 @@ func checkArbDbSchemaVersion(arbDb ethdb.Database) error {
 	return nil
 }
 
-func ValidatorDataposter(
+func StakerDataposter(
 	db ethdb.Database, l1Reader *headerreader.HeaderReader,
 	transactOpts *bind.TransactOpts, cfgFetcher ConfigFetcher, syncMonitor *SyncMonitor,
 ) (*dataposter.DataPoster, error) {
@@ -802,8 +802,8 @@ func createNodeImpl(
 	var messagePruner *MessagePruner
 
 	if config.Staker.Enable {
-		dp, err := ValidatorDataposter(
-			rawdb.NewTable(arbDb, storage.BlockValidatorPrefix),
+		dp, err := StakerDataposter(
+			rawdb.NewTable(arbDb, storage.StakerPrefix),
 			l1Reader,
 			txOptsValidator,
 			configFetcher,

--- a/system_tests/staker_test.go
+++ b/system_tests/staker_test.go
@@ -130,7 +130,7 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 
 	valConfig := staker.TestL1ValidatorConfig
 
-	dpA, err := arbnode.ValidatorDataposter(rawdb.NewTable(l2nodeB.ArbDB, storage.BlockValidatorPrefix), l2nodeA.L1Reader, &l1authA, NewFetcherFromConfig(arbnode.ConfigDefaultL1NonSequencerTest()), nil)
+	dpA, err := arbnode.StakerDataposter(rawdb.NewTable(l2nodeB.ArbDB, storage.StakerPrefix), l2nodeA.L1Reader, &l1authA, NewFetcherFromConfig(arbnode.ConfigDefaultL1NonSequencerTest()), nil)
 	if err != nil {
 		t.Fatalf("Error creating validator dataposter: %v", err)
 	}
@@ -178,7 +178,7 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 	}
 	Require(t, err)
 
-	dpB, err := arbnode.ValidatorDataposter(rawdb.NewTable(l2nodeB.ArbDB, storage.BlockValidatorPrefix), l2nodeB.L1Reader, &l1authB, NewFetcherFromConfig(arbnode.ConfigDefaultL1NonSequencerTest()), nil)
+	dpB, err := arbnode.StakerDataposter(rawdb.NewTable(l2nodeB.ArbDB, storage.StakerPrefix), l2nodeB.L1Reader, &l1authB, NewFetcherFromConfig(arbnode.ConfigDefaultL1NonSequencerTest()), nil)
 	if err != nil {
 		t.Fatalf("Error creating validator dataposter: %v", err)
 	}
@@ -217,7 +217,7 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 		err = valWalletB.Initialize(ctx)
 		Require(t, err)
 	}
-	dpC, err := arbnode.ValidatorDataposter(rawdb.NewTable(l2nodeB.ArbDB, storage.BlockValidatorPrefix), l2nodeA.L1Reader, &l1authA, NewFetcherFromConfig(arbnode.ConfigDefaultL1NonSequencerTest()), nil)
+	dpC, err := arbnode.StakerDataposter(rawdb.NewTable(l2nodeB.ArbDB, storage.StakerPrefix), l2nodeA.L1Reader, &l1authA, NewFetcherFromConfig(arbnode.ConfigDefaultL1NonSequencerTest()), nil)
 	if err != nil {
 		t.Fatalf("Error creating validator dataposter: %v", err)
 	}


### PR DESCRIPTION
This PR sets UseLevelDB to true by default, and reorders the switch statement a bit so that redis is still used if enabled. Note that this default won't matter for L3s, where the IsParentChainArbitrum check will set UseNoOpStorage to true.

This PR also uses a new prefix for the staker's data poster, to avoid collisions with block validator db entries.