### PR TITLE
Don't confirmDataPosterIsReady if watchtower

### DIFF
--- a/staker/staker.go
+++ b/staker/staker.go
@@ -552,11 +552,11 @@ func (s *Staker) confirmDataPosterIsReady(ctx context.Context) error {
 }
 
 func (s *Staker) Act(ctx context.Context) (*types.Transaction, error) {
-	err := s.confirmDataPosterIsReady(ctx)
-	if err != nil {
-		return nil, err
-	}
 	if s.config.strategy != WatchtowerStrategy {
+		err := s.confirmDataPosterIsReady(ctx)
+		if err != nil {
+			return nil, err
+		}
 		whitelisted, err := s.IsWhitelisted(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error checking if whitelisted: %w", err)


### PR DESCRIPTION
I missed this when disabling the data poster for watchtower validators