### PR TITLE
Mem limit count active pages

### DIFF
--- a/arbnode/resourcemanager/resource_management.go
+++ b/arbnode/resourcemanager/resource_management.go
@@ -97,7 +97,7 @@ var DefaultConfig = Config{
 
 // ConfigAddOptions adds the configuration options for resourcemanager.
 func ConfigAddOptions(prefix string, f *pflag.FlagSet) {
-	f.String(prefix+".mem-free-limit", DefaultConfig.MemFreeLimit, "RPC calls are throttled if free system memory is below this amount, expressed in bytes or multiples of bytes with suffix B, K, M, G")
+	f.String(prefix+".mem-free-limit", DefaultConfig.MemFreeLimit, "RPC calls are throttled if free system memory excluding the page cache is below this amount, expressed in bytes or multiples of bytes with suffix B, K, M, G. The limit should be set such that sufficient free memory is left for the page cache in order for the system to be performant")
 }
 
 // httpServer implements http.Handler and wraps calls to inner with a resource
@@ -168,7 +168,7 @@ func (_ trivialLimitChecker) String() string { return "trivial" }
 
 type cgroupsMemoryFiles struct {
 	limitFile, usageFile, statsFile string
-	inactiveRe                      *regexp.Regexp
+	activeRe, inactiveRe            *regexp.Regexp
 }
 
 const defaultCgroupsV1MemoryDirectory = "/sys/fs/cgroup/memory/"
@@ -178,13 +178,15 @@ var cgroupsV1MemoryFiles = cgroupsMemoryFiles{
 	limitFile:  defaultCgroupsV1MemoryDirectory + "/memory.limit_in_bytes",
 	usageFile:  defaultCgroupsV1MemoryDirectory + "/memory.usage_in_bytes",
 	statsFile:  defaultCgroupsV1MemoryDirectory + "/memory.stat",
-	inactiveRe: regexp.MustCompile(`total_inactive_file (\d+)`),
+	activeRe:   regexp.MustCompile(`^total_active_file (\d+)`),
+	inactiveRe: regexp.MustCompile(`^total_inactive_file (\d+)`),
 }
 var cgroupsV2MemoryFiles = cgroupsMemoryFiles{
 	limitFile:  defaultCgroupsV2MemoryDirectory + "/memory.max",
 	usageFile:  defaultCgroupsV2MemoryDirectory + "/memory.current",
 	statsFile:  defaultCgroupsV2MemoryDirectory + "/memory.stat",
-	inactiveRe: regexp.MustCompile(`inactive_file (\d+)`),
+	activeRe:   regexp.MustCompile(`^active_file (\d+)`),
+	inactiveRe: regexp.MustCompile(`^inactive_file (\d+)`),
 }
 
 type cgroupsMemoryLimitChecker struct {
@@ -200,12 +202,28 @@ func newCgroupsMemoryLimitChecker(files cgroupsMemoryFiles, memLimitBytes int) *
 }
 
 // isLimitExceeded checks if the system memory free is less than the limit.
+// It returns true if the limit is exceeded.
 //
-// See the following page for details of calculating the memory used,
-// which is reported as container_memory_working_set_bytes in prometheus:
+// container_memory_working_set_bytes in prometheus is calculated as
+// memory.usage_in_bytes - inactive page cache bytes, see
 // https://mihai-albert.com/2022/02/13/out-of-memory-oom-in-kubernetes-part-3-memory-metrics-sources-and-tools-to-collect-them/
+// This metric is used by kubernetes to report memory in use by the pod,
+// but memory.usage_in_bytes also includes the active page cache, which
+// can be evicted by the kernel when more memory is needed, see
+// https://github.com/kubernetes/kubernetes/issues/43916
+// The kernel cannot be guaranteed to move a page from a file from
+// active to inactive even when the file is closed, or Nitro is exited.
+// For larger chains, Nitro's page cache can grow quite large due to
+// the large amount of state that is randomly accessed from disk as each
+// block is added. So in checking the limit we also include the active
+// page cache.
+//
+// The limit should be set such that the system has a reasonable amount of
+// free memory for the page cache, to avoid cache thrashing on chain state
+// access. How much "reasonable" is will depend on access patterns, state
+// size, and your application's tolerance for latency.
 func (c *cgroupsMemoryLimitChecker) isLimitExceeded() (bool, error) {
-	var limit, usage, inactive int
+	var limit, usage, active, inactive int
 	var err error
 	if limit, err = readIntFromFile(c.files.limitFile); err != nil {
 		return false, err
@@ -213,10 +231,13 @@ func (c *cgroupsMemoryLimitChecker) isLimitExceeded() (bool, error) {
 	if usage, err = readIntFromFile(c.files.usageFile); err != nil {
 		return false, err
 	}
-	if inactive, err = readInactive(c.files.statsFile, c.files.inactiveRe); err != nil {
+	if active, err = readFromMemStats(c.files.statsFile, c.files.activeRe); err != nil {
 		return false, err
 	}
-	return limit-(usage-inactive) <= c.memLimitBytes, nil
+	if inactive, err = readFromMemStats(c.files.statsFile, c.files.inactiveRe); err != nil {
+		return false, err
+	}
+	return limit-(usage-(active+inactive)) <= c.memLimitBytes, nil
 }
 
 func (c cgroupsMemoryLimitChecker) String() string {
@@ -236,7 +257,7 @@ func readIntFromFile(fileName string) (int, error) {
 	return limit, nil
 }
 
-func readInactive(fileName string, re *regexp.Regexp) (int, error) {
+func readFromMemStats(fileName string, re *regexp.Regexp) (int, error) {
 	file, err := os.Open(fileName)
 	if err != nil {
 		return 0, err

--- a/arbnode/resourcemanager/resource_management.go
+++ b/arbnode/resourcemanager/resource_management.go
@@ -46,7 +46,7 @@ func Init(conf *Config) error {
 		var c limitChecker
 		c, err := newCgroupsMemoryLimitCheckerIfSupported(limit)
 		if errors.Is(err, errNotSupported) {
-			log.Error("No method for determining memory usage and limits was discovered, disabled memory limit RPC throttling")
+			log.Error("no method for determining memory usage and limits was discovered, disabled memory limit RPC throttling")
 			c = &trivialLimitChecker{}
 		}
 
@@ -60,8 +60,7 @@ func parseMemLimit(limitStr string) (int, error) {
 		limit int = 1
 		s     string
 	)
-	_, err := fmt.Sscanf(limitStr, "%d%s", &limit, &s)
-	if err != nil {
+	if _, err := fmt.Sscanf(limitStr, "%d%s", &limit, &s); err != nil {
 		return 0, err
 	}
 
@@ -76,7 +75,7 @@ func parseMemLimit(limitStr string) (int, error) {
 		limit <<= 40
 	case "B":
 	default:
-		return 0, fmt.Errorf("Unsupported memory limit suffix string %s", s)
+		return 0, fmt.Errorf("unsupported memory limit suffix string %s", s)
 	}
 
 	return limit, nil
@@ -118,7 +117,7 @@ func (s *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	exceeded, err := s.c.isLimitExceeded()
 	limitCheckDurationHistogram.Update(time.Since(start).Nanoseconds())
 	if err != nil {
-		log.Error("Error checking memory limit", "err", err, "checker", s.c)
+		log.Error("error checking memory limit", "err", err, "checker", s.c)
 	} else if exceeded {
 		http.Error(w, "Too many requests", http.StatusTooManyRequests)
 		limitCheckFailureCounter.Inc(1)


### PR DESCRIPTION
We had been trying to calculate the free memory based on the metrics that kubernetes uses for its view of how much memory a pod is using, reported as `container_memory_working_set_bytes` in prometheus. This is incorrect for Nitro as it does not include the size of the kernel's active page cache, which is freeable by the kernel when more memory is requested from userspace than is free. This change includes the active page cache size in calculating how much memory is considered free by Nitro. The limit should be set such that sufficient free memory is left for the page cache in order for the system to be performant (how much this is will depend on your chain's state size, access patterns of your node, and your tolerance for latency). See below for more discussion: 

The kernel doesn't frequently perform sweeps of the active page cache LRU list to see if the pages in the list are still really active or not. As Nitro runs, there are random accesses into leveldb database, which is a directory of many ~2MB files, bringing the pages of those files into the page cache. If you force the kernel to drop the cache with sudo `sync && sudo bash -c 'echo 1 > /proc/sys/vm/drop_caches'` you can watch individual files with the fincore tool (which uses mincore under the hood) go to being mostly in the cache, to not at all in the cache, to starting to be back in the cache as they are randomly accessed over time.

Interestingly the close syscall doesn't even guarantee that the kernel will drop that file's pages from the active page cache, or even stopping the nitro executable! When more memory is requested from the kernel by userspace programs, it may sweep the active and inactive lists and release the pages from the cache, which explains what we have seen in our installation with the working set size metric dropping after its gets close to the system limit.

There is a lot of discussion of this issue here: https://github.com/kubernetes/kubernetes/issues/43916
Some pertinent quotes from @bitglue, who did a lot of great research for this issue:
"The problem, and the topic of this bug, is if you then run a process which uses a lot of cache, kubernetes will then decide the node is experiencing "memory pressure" and evict pods, even though the kernel could evict that cache if there was any actual memory pressure. This is because the kubernetes logic ("active" pages probably aren't reclaimable) is not in line with the reality in the kernel logic (an "active" page is anything that's been used twice)."

"So my advice is to determine (or at least make an informed guess) how much cache a process needs to meet performance and cost objectives, then set the memory request and limit to that number."

# Testing done
Unit tests pass

