### PR TITLE
Return RollupAddress from NoOp validator wallet and add test

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -820,7 +820,7 @@ func createNodeImpl(
 		getExtraGas := func() uint64 { return configFetcher.Get().Staker.ExtraGas }
 		// TODO: factor this out into separate helper, and split rest of node
 		// creation into multiple helpers.
-		var wallet staker.ValidatorWalletInterface = validatorwallet.NewNoOp(l1client)
+		var wallet staker.ValidatorWalletInterface = validatorwallet.NewNoOp(l1client, deployInfo.Rollup)
 		if !strings.EqualFold(config.Staker.Strategy, "watchtower") {
 			if config.Staker.UseSmartContractWallet || txOptsValidator == nil {
 				var existingWalletAddress *common.Address

--- a/staker/validatorwallet/noop.go
+++ b/staker/validatorwallet/noop.go
@@ -17,11 +17,15 @@ import (
 
 // NoOp validator wallet is used for watchtower mode.
 type NoOp struct {
-	l1Client arbutil.L1Interface
+	l1Client      arbutil.L1Interface
+	rollupAddress common.Address
 }
 
-func NewNoOp(l1Client arbutil.L1Interface) *NoOp {
-	return &NoOp{l1Client: l1Client}
+func NewNoOp(l1Client arbutil.L1Interface, rollupAddress common.Address) *NoOp {
+	return &NoOp{
+		l1Client:      l1Client,
+		rollupAddress: rollupAddress,
+	}
 }
 
 func (*NoOp) Initialize(context.Context) error { return nil }
@@ -44,7 +48,7 @@ func (*NoOp) TimeoutChallenges(ctx context.Context, challenges []uint64) (*types
 
 func (n *NoOp) L1Client() arbutil.L1Interface { return n.l1Client }
 
-func (*NoOp) RollupAddress() common.Address { return common.Address{} }
+func (n *NoOp) RollupAddress() common.Address { return n.rollupAddress }
 
 func (*NoOp) ChallengeManagerAddress() common.Address { return common.Address{} }
 

--- a/system_tests/staker_test.go
+++ b/system_tests/staker_test.go
@@ -218,12 +218,7 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 		err = valWalletB.Initialize(ctx)
 		Require(t, err)
 	}
-	dpC, err := arbnode.StakerDataposter(ctx, rawdb.NewTable(l2nodeB.ArbDB, storage.StakerPrefix), l2nodeA.L1Reader, &l1authA, NewFetcherFromConfig(arbnode.ConfigDefaultL1NonSequencerTest()), nil)
-	if err != nil {
-		t.Fatalf("Error creating validator dataposter: %v", err)
-	}
-	valWalletC, err := validatorwallet.NewContract(dpC, nil, l2nodeA.DeployInfo.ValidatorWalletCreator, l2nodeA.DeployInfo.Rollup, l2nodeA.L1Reader, nil, 0, func(common.Address) {}, func() uint64 { return 10000 })
-	Require(t, err)
+	valWalletC := validatorwallet.NewNoOp(l1client, l2nodeA.DeployInfo.Rollup)
 	valConfig.Strategy = "Watchtower"
 	stakerC, err := staker.NewStaker(
 		l2nodeA.L1Reader,


### PR DESCRIPTION
Stakers using the noop validator wallet were previously failing with "no contract code at given address" because they thought the rollup was at address zero. This fixes that and adds the noop validator wallet to the staker test, which I confirmed catches the issue on master. I also confirmed that the ChallengeManagerAddress is never for a noop wallet because it can never enter a challenge (specifically, AddressOrZero always returns zero, which means that rawInfo is nil, which means that handleConflict is never called).