### PR TITLE
Don't poll for reverts on L3 chains

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -955,7 +955,9 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 	b.dataPoster.Start(ctxIn)
 	b.redisLock.Start(ctxIn)
 	b.StopWaiter.Start(ctxIn, b)
-	b.LaunchThread(b.pollForReverts)
+	if !b.l1Reader.IsParentChainArbitrum() {
+		b.LaunchThread(b.pollForReverts)
+	}
 	b.CallIteratively(func(ctx context.Context) time.Duration {
 		var err error
 		if common.HexToAddress(b.config().GasRefunderAddress) != (common.Address{}) {


### PR DESCRIPTION
When an L3 chain posts a batch to L2, it might revert because of L1 gas price fluctuations, but this is expected and we should just try again. This also doesn't break the data poster because L3 chains enable the noop storage for the data poster.