### PR TITLE
Only warn if we hit an issue polling for batch reverts

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -331,7 +331,7 @@ func (b *BatchPoster) pollForReverts(ctx context.Context) {
 
 			reverted, err := b.checkReverts(ctx, blockNum)
 			if err != nil {
-				logLevel := log.Error
+				logLevel := log.Warn
 				if strings.Contains(err.Error(), "not found") {
 					// Just parent chain node inconsistency
 					// One node sent us a block, but another didn't have it


### PR DESCRIPTION
We saw this on a testnet where we got the "wrong range" error because a reorg meant the block number went backwards. An error here is fine, because we'll just retry polling this block again next iteration. It could also happen for other reasons, like an unreliable L1 node. Therefore, I think a warning is more appropriate here.