### PR TITLE
Add --dev flag to easily start up a local L2-only dev chain

### DIFF
--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"reflect"
 	"regexp"
 	"runtime"
 	"strings"
@@ -296,7 +297,7 @@ func findImportantRoots(ctx context.Context, chainDb ethdb.Database, stack *node
 		return nil, err
 	}
 	if initConfig.Prune == "validator" {
-		if l1Client == nil {
+		if l1Client == nil || reflect.ValueOf(l1Client).IsNil() {
 			return nil, errors.New("an L1 connection is required for validator pruning")
 		}
 		callOpts := bind.CallOpts{

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -61,7 +61,10 @@ import (
 )
 
 func printSampleUsage(name string) {
-	fmt.Printf("Sample usage: %s --help \n", name)
+	fmt.Printf("Sample usage: %s [OPTIONS] \n\n", name)
+	fmt.Printf("Options:\n")
+	fmt.Printf("  --help\n")
+	fmt.Printf("  --dev: Start a default L2-only dev chain\n")
 }
 
 func addUnlockWallet(accountManager *accounts.Manager, walletConf *genericconf.WalletConfig) (common.Address, error) {

--- a/cmd/util/confighelpers/configuration.go
+++ b/cmd/util/confighelpers/configuration.go
@@ -138,10 +138,32 @@ func PrintErrorAndExit(err error, usage func(string)) {
 	}
 }
 
+func devFlagArgs() []string {
+	args := []string{
+		"--init.dev-init",
+		"--init.dev-init-address", "0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E",
+		"--node.dangerous.no-l1-listener",
+		"--node.parent-chain-reader.enable=false",
+		"--parent-chain.id=1337",
+		"--chain.id=412346",
+		"--persistent.chain", "/tmp/dev-test",
+		"--node.sequencer",
+		"--node.dangerous.no-sequencer-coordinator",
+		"--node.staker.enable=false",
+		"--init.empty=false",
+		"--http.port", "8547",
+		"--http.addr", "127.0.0.1",
+	}
+	return args
+}
+
 func BeginCommonParse(f *flag.FlagSet, args []string) (*koanf.Koanf, error) {
 	for _, arg := range args {
 		if arg == "--version" || arg == "-v" {
 			return nil, ErrVersion
+		} else if arg == "--dev" {
+			args = devFlagArgs()
+			break
 		}
 	}
 	if err := f.Parse(args); err != nil {

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync/atomic"
 	"testing"
 
@@ -149,7 +150,7 @@ func CreateExecutionNode(
 	var sequencer *Sequencer
 
 	var parentChainReader *headerreader.HeaderReader
-	if l1client != nil {
+	if l1client != nil && !reflect.ValueOf(l1client).IsNil() {
 		arbSys, _ := precompilesgen.NewArbSys(types.ArbSysAddress, l1client)
 		parentChainReader, err = headerreader.New(ctx, l1client, func() *headerreader.Config { return &configFetcher().ParentChainReader }, arbSys)
 		if err != nil {


### PR DESCRIPTION
The default arguments are:
`--init.dev-init --init.dev-init-address 0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E --node.dangerous.no-l1-listener --node.parent-chain-reader.enable=false --parent-chain.id=1337 --chain.id=412346 --persistent.chain /tmp/dev-test --node.sequencer --node.dangerous.no-sequencer-coordinator --node.staker.enable=false --init.empty=false --http.port 8547 --http.addr 127.0.0.1`

Also fixes nil pointer dereference when a type with nil value is type casted into an interface when passed as argument.