### PR TITLE
Don't ignore target/machines for Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,9 @@ solgen/go
 **/node_modules
 
 target/**/*
+!target/machines
+!target/machines/*
+!target/machines/**/*
 brotli/buildfiles/**/*
 
 # these are used by environment outside the docker:


### PR DESCRIPTION
This isn't currently used by the Dockerfile, but the machines aren't too large, and it might be helpful to be able to copy in local machines to docker builds as I recommend in https://github.com/OffchainLabs/arbitrum-docs/pull/668