### PR TITLE
Change default sequencer MaxBlockSpeed to 250ms

### DIFF
--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -85,7 +85,7 @@ type SequencerConfigFetcher func() *SequencerConfig
 
 var DefaultSequencerConfig = SequencerConfig{
 	Enable:                      false,
-	MaxBlockSpeed:               time.Millisecond * 100,
+	MaxBlockSpeed:               time.Millisecond * 250,
 	MaxRevertGasReject:          params.TxGas + 10000,
 	MaxAcceptableTimestampDelta: time.Hour,
 	Forwarder:                   DefaultSequencerForwarderConfig,


### PR DESCRIPTION
This is how it's usually configured, and is a better value than 100ms for most chains.