### PR TITLE
Remove unnecessary memory size check in JIT validator

### DIFF
--- a/arbitrator/jit/src/wavmio.rs
+++ b/arbitrator/jit/src/wavmio.rs
@@ -126,9 +126,6 @@ fn inbox_message_impl(sp: &GoStack, inbox: &Inbox, name: &str) -> MaybeEscape {
         None => error!("missing inbox message {msg_num} in {name}"),
     };
 
-    if out_ptr + 32 > sp.memory_size() {
-        error!("unknown message type in {name}");
-    }
     let offset = match u32::try_from(offset) {
         Ok(offset) => offset as usize,
         Err(_) => error!("bad offset {offset} in {name}"),


### PR DESCRIPTION
We don't check memory bounds anywhere else because we don't need to. Panicking on out-of-bounds memory access is perfectly fine here, because it'll just be returned as an error to the validation service via the socket closing (and the panic will be printed to stderr).