### PR TITLE
Stop using actions-rs

### DIFF
--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -49,23 +49,18 @@ jobs:
           cache-dependency-path: '**/yarn.lock'
 
       - name: Install rust stable
-        uses: actions-rs/toolchain@v1
-        id: install-rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: "stable"
-          override: true
           components: 'llvm-tools-preview, rustfmt, clippy'
+          targets: 'wasm32-wasi, wasm32-unknown-unknown'
 
       - name: Install grcov
-        uses: actions-rs/install@v0.1
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
-          crate: grcov
-          version: latest
-          use-tool-cache: true
-
-      - name: Install rust wasm targets
-        run: rustup target add wasm32-wasi wasm32-unknown-unknown
+          repo: mozilla/grcov
+          tag: v0.8.18
+          extension: "\\.bz2"
+          cache: enable
 
       - name: Cache Rust intermediate build products
         uses: actions/cache@v3
@@ -148,22 +143,13 @@ jobs:
           echo RUSTDOCFLAGS="-Cpanic=abort" >> $GITHUB_ENV
 
       - name: Clippy check
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all --manifest-path arbitrator/Cargo.toml -- -D warnings
+        run: cargo clippy --all --manifest-path arbitrator/Cargo.toml -- -D warnings
 
       - name: Run rust tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all --manifest-path arbitrator/Cargo.toml
+        run: cargo test --all --manifest-path arbitrator/Cargo.toml
 
       - name: Rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --manifest-path arbitrator/Cargo.toml -- --check
+        run: cargo fmt --all --manifest-path arbitrator/Cargo.toml -- --check
 
       - name: Make proofs from test cases
         run: make -j test-gen-proofs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -53,27 +53,10 @@ jobs:
           sudo apt-get update && sudo apt-get install -y lld-14
           sudo ln -s /usr/bin/wasm-ld-14 /usr/local/bin/wasm-ld
 
-      - name: Install rust wasm32-unknown-unknown
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: "stable"
-          target: wasm32-unknown-unknown
-
-      - name: Install rust wasm32-wasi
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: "stable"
-          target: wasm32-wasi
-
       - name: Install rust stable
-        uses: actions-rs/toolchain@v1
-        id: install-rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: "stable"
-          override: true
+          targets: 'wasm32-unknown-unknown, wasm32-wasi'
 
       - name: Cache Build Products
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,6 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          skip-go-installation: true
           skip-pkg-cache: true
       - name: Custom Lint
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         run: make -j build-node-deps
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           skip-go-installation: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,6 @@ jobs:
       contents: read
       security-events: write
     env:
-      CODEQL_EXTRACTOR_GO_BUILD_TRACING: 'on'
       WABT_VERSION: 1.0.32
 
     strategy:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -74,12 +74,7 @@ jobs:
         go-version: 1.20.x
 
     - name: Install rust stable
-      uses: actions-rs/toolchain@v1
-      id: install-rust
-      with:
-        profile: minimal
-        toolchain: "stable"
-        override: true
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Cache Rust Build Products
       uses: actions/cache@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
 
@@ -40,7 +40,7 @@ jobs:
           restore-keys: ${{ runner.os }}-buildx-
 
       - name: Build nitro-node docker
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           target: nitro-node
           push: true
@@ -50,7 +50,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
       - name: Build nitro-node-dev docker
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           target: nitro-node-dev
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
`actions-rs` is no longer maintained, and uses github actions features that are deprecated.
Also updated to use latest versions of various 3rd party actions