### PR TITLE
Prevent double `v` in reported version

### DIFF
--- a/cmd/daserver/daserver.go
+++ b/cmd/daserver/daserver.go
@@ -239,7 +239,7 @@ func startup() error {
 		dasLifecycleManager.Register(&L1ReaderCloser{l1Reader})
 	}
 
-	vcsRevision, vcsTime := confighelpers.GetVersion()
+	vcsRevision, _, vcsTime := confighelpers.GetVersion()
 	var rpcServer *http.Server
 	if serverConfig.EnableRPC {
 		log.Info("Starting HTTP-RPC server", "addr", serverConfig.RPCAddr, "port", serverConfig.RPCPort, "revision", vcsRevision, "vcs.time", vcsTime)

--- a/cmd/genericconf/getversion18.go
+++ b/cmd/genericconf/getversion18.go
@@ -7,7 +7,7 @@ package genericconf
 
 import "runtime/debug"
 
-func GetVersion(definedVersion string, definedTime string, definedModified string) (string, string) {
+func GetVersion(definedVersion string, definedTime string, definedModified string) (string, string, string) {
 	vcsVersion := "development"
 	vcsTime := "development"
 	vcsModified := "false"
@@ -43,5 +43,10 @@ func GetVersion(definedVersion string, definedTime string, definedModified strin
 		vcsVersion = vcsVersion + "-modified"
 	}
 
-	return vcsVersion, vcsTime
+	strippedVersion := vcsVersion
+	if len(strippedVersion) > 0 && strippedVersion[0] == 'v' {
+		strippedVersion = strippedVersion[1:]
+	}
+
+	return vcsVersion, strippedVersion, vcsTime
 }

--- a/cmd/nitro-val/nitro_val.go
+++ b/cmd/nitro-val/nitro_val.go
@@ -75,6 +75,10 @@ func mainImpl() int {
 	stackConf.P2P.NoDiscovery = true
 	vcsRevision, vcsTime := confighelpers.GetVersion()
 	stackConf.Version = vcsRevision
+	if stackConf.Version[0] == 'v' {
+		// Skip leading "v" in version string
+		stackConf.Version = stackConf.Version[1:]
+	}
 
 	pathResolver := func(workdir string) func(string) string {
 		if workdir == "" {

--- a/cmd/nitro-val/nitro_val.go
+++ b/cmd/nitro-val/nitro_val.go
@@ -73,12 +73,8 @@ func mainImpl() int {
 	stackConf.P2P.ListenAddr = ""
 	stackConf.P2P.NoDial = true
 	stackConf.P2P.NoDiscovery = true
-	vcsRevision, vcsTime := confighelpers.GetVersion()
-	stackConf.Version = vcsRevision
-	if stackConf.Version[0] == 'v' {
-		// Skip leading "v" in version string
-		stackConf.Version = stackConf.Version[1:]
-	}
+	vcsRevision, strippedRevision, vcsTime := confighelpers.GetVersion()
+	stackConf.Version = strippedRevision
 
 	pathResolver := func(workdir string) func(string) string {
 		if workdir == "" {

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -179,6 +179,10 @@ func mainImpl() int {
 	stackConf.P2P.NoDiscovery = true
 	vcsRevision, vcsTime := confighelpers.GetVersion()
 	stackConf.Version = vcsRevision
+	if stackConf.Version[0] == 'v' {
+		// Skip leading "v" in version string
+		stackConf.Version = stackConf.Version[1:]
+	}
 
 	pathResolver := func(workdir string) func(string) string {
 		if workdir == "" {

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -177,12 +177,8 @@ func mainImpl() int {
 	stackConf.P2P.ListenAddr = ""
 	stackConf.P2P.NoDial = true
 	stackConf.P2P.NoDiscovery = true
-	vcsRevision, vcsTime := confighelpers.GetVersion()
-	stackConf.Version = vcsRevision
-	if stackConf.Version[0] == 'v' {
-		// Skip leading "v" in version string
-		stackConf.Version = stackConf.Version[1:]
-	}
+	vcsRevision, strippedRevision, vcsTime := confighelpers.GetVersion()
+	stackConf.Version = strippedRevision
 
 	pathResolver := func(workdir string) func(string) string {
 		if workdir == "" {

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -76,7 +76,7 @@ func startup() error {
 	glogger.Verbosity(log.Lvl(relayConfig.LogLevel))
 	log.Root().SetHandler(glogger)
 
-	vcsRevision, vcsTime := confighelpers.GetVersion()
+	vcsRevision, _, vcsTime := confighelpers.GetVersion()
 	log.Info("Running Arbitrum nitro relay", "revision", vcsRevision, "vcs.time", vcsTime)
 
 	defer log.Info("Cleanly shutting down relay")

--- a/cmd/util/confighelpers/configuration.go
+++ b/cmd/util/confighelpers/configuration.go
@@ -118,12 +118,12 @@ func loadS3Variables(k *koanf.Koanf) error {
 
 var ErrVersion = errors.New("configuration: version requested")
 
-func GetVersion() (string, string) {
+func GetVersion() (string, string, string) {
 	return genericconf.GetVersion(version, datetime, modified)
 }
 
 func PrintErrorAndExit(err error, usage func(string)) {
-	vcsRevision, vcsTime := GetVersion()
+	vcsRevision, _, vcsTime := GetVersion()
 	fmt.Printf("Version: %v, time: %v\n", vcsRevision, vcsTime)
 	if err != nil && errors.Is(err, ErrVersion) {
 		// Already printed version, just exit


### PR DESCRIPTION
https://github.com/OffchainLabs/nitro/issues/1935

Ensure that `web3_clientVersion` does not have extra `v` included
