### PR TITLE
Fix the check for duplicate sequencerBatches in inbox_reader

### DIFF
--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -435,11 +435,11 @@ func (r *InboxReader) run(ctx context.Context, hadError bool) error {
 						} else if err != nil {
 							// Unknown error (database error?)
 							return err
-						} else if haveAcc == batch.BeforeInboxAcc {
+						} else if haveAcc == batch.AfterInboxAcc {
 							// Skip this batch, as we already have it in the database
 							sequencerBatches = sequencerBatches[1:]
 						} else {
-							// The first batch BeforeInboxAcc matches, but this batch doesn't,
+							// The first batch AfterInboxAcc matches, but this batch doesn't,
 							// so we'll successfully reorg it when we hit the addMessages
 							break
 						}


### PR DESCRIPTION
Currently inbox_reader checks for duplicate sequencer batches by comparing `r.tracker.GetBatchAcc(batch.SequenceNumber)` with `batch.BeforeInboxAcc` this is incorrect because Accumulator of BatchMetadata is initialized to `AfterInboxAcc` and not `BeforeInboxAcc`. 
This bug was causing duplicate sequencer batches to be processed again with rewriting of BatchMetadata and finally being detected and handled inside txStreamer's `countDuplicateMessages`. This PR fixes this check.