### PR TITLE
Always initialize staker wallet

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -615,10 +615,8 @@ func createNodeImpl(
 		if err != nil {
 			return nil, err
 		}
-		if stakerObj.Strategy() == staker.WatchtowerStrategy {
-			if err := wallet.Initialize(ctx); err != nil {
-				return nil, err
-			}
+		if err := wallet.Initialize(ctx); err != nil {
+			return nil, err
 		}
 		var txValidatorSenderPtr *common.Address
 		if txOptsValidator != nil {


### PR DESCRIPTION
I think originally we initialized the wallet elsewhere, but I think this is now the only place we initialize the wallet, so we should always do it.