### PR TITLE
Clear out the channel when resetting feed timers

### DIFF
--- a/broadcastclients/broadcastclients.go
+++ b/broadcastclients/broadcastclients.go
@@ -120,6 +120,18 @@ func (bcs *BroadcastClients) adjustCount(delta int32) {
 	}
 }
 
+// Clears out a ticker's channel and resets it to the interval
+func clearAndResetTicker(timer *time.Ticker, interval time.Duration) {
+	timer.Stop()
+	// Clear out any previous ticks
+	// A ticker's channel is only buffers one tick, so we don't need a loop here
+	select {
+	case <-timer.C:
+	default:
+	}
+	timer.Reset(interval)
+}
+
 func (bcs *BroadcastClients) Start(ctx context.Context) {
 	bcs.primaryRouter.StopWaiter.Start(ctx, bcs.primaryRouter)
 	bcs.secondaryRouter.StopWaiter.Start(ctx, bcs.secondaryRouter)
@@ -182,46 +194,46 @@ func (bcs *BroadcastClients) Start(ctx context.Context) {
 				return
 			// Primary feeds
 			case msg := <-bcs.primaryRouter.messageChan:
-				startSecondaryFeedTimer.Reset(MAX_FEED_INACTIVE_TIME)
-				primaryFeedIsDownTimer.Reset(MAX_FEED_INACTIVE_TIME)
+				clearAndResetTicker(startSecondaryFeedTimer, MAX_FEED_INACTIVE_TIME)
+				clearAndResetTicker(primaryFeedIsDownTimer, MAX_FEED_INACTIVE_TIME)
 				if err := msgHandler(msg, bcs.primaryRouter); err != nil {
 					log.Error("Error routing message from Primary Sequencer Feeds", "err", err)
 				}
 			case cs := <-bcs.primaryRouter.confirmedSequenceNumberChan:
-				startSecondaryFeedTimer.Reset(MAX_FEED_INACTIVE_TIME)
-				primaryFeedIsDownTimer.Reset(MAX_FEED_INACTIVE_TIME)
+				clearAndResetTicker(startSecondaryFeedTimer, MAX_FEED_INACTIVE_TIME)
+				clearAndResetTicker(primaryFeedIsDownTimer, MAX_FEED_INACTIVE_TIME)
 				confSeqHandler(cs, bcs.primaryRouter)
 			// Failed to get messages from primary feed for ~5 seconds, reset the timer responsible for stopping a secondary
 			case <-primaryFeedIsDownTimer.C:
-				stopSecondaryFeedTimer.Reset(PRIMARY_FEED_UPTIME)
+				clearAndResetTicker(stopSecondaryFeedTimer, PRIMARY_FEED_UPTIME)
 			default:
 				select {
 				case <-ctx.Done():
 					return
 				// Secondary Feeds
 				case msg := <-bcs.secondaryRouter.messageChan:
-					startSecondaryFeedTimer.Reset(MAX_FEED_INACTIVE_TIME)
+					clearAndResetTicker(startSecondaryFeedTimer, MAX_FEED_INACTIVE_TIME)
 					if err := msgHandler(msg, bcs.secondaryRouter); err != nil {
 						log.Error("Error routing message from Secondary Sequencer Feeds", "err", err)
 					}
 				case cs := <-bcs.secondaryRouter.confirmedSequenceNumberChan:
-					startSecondaryFeedTimer.Reset(MAX_FEED_INACTIVE_TIME)
+					clearAndResetTicker(startSecondaryFeedTimer, MAX_FEED_INACTIVE_TIME)
 					confSeqHandler(cs, bcs.secondaryRouter)
 
 				case msg := <-bcs.primaryRouter.messageChan:
-					startSecondaryFeedTimer.Reset(MAX_FEED_INACTIVE_TIME)
-					primaryFeedIsDownTimer.Reset(MAX_FEED_INACTIVE_TIME)
+					clearAndResetTicker(startSecondaryFeedTimer, MAX_FEED_INACTIVE_TIME)
+					clearAndResetTicker(primaryFeedIsDownTimer, MAX_FEED_INACTIVE_TIME)
 					if err := msgHandler(msg, bcs.primaryRouter); err != nil {
 						log.Error("Error routing message from Primary Sequencer Feeds", "err", err)
 					}
 				case cs := <-bcs.primaryRouter.confirmedSequenceNumberChan:
-					startSecondaryFeedTimer.Reset(MAX_FEED_INACTIVE_TIME)
-					primaryFeedIsDownTimer.Reset(MAX_FEED_INACTIVE_TIME)
+					clearAndResetTicker(startSecondaryFeedTimer, MAX_FEED_INACTIVE_TIME)
+					clearAndResetTicker(primaryFeedIsDownTimer, MAX_FEED_INACTIVE_TIME)
 					confSeqHandler(cs, bcs.primaryRouter)
 				case <-startSecondaryFeedTimer.C:
 					bcs.startSecondaryFeed(ctx)
 				case <-primaryFeedIsDownTimer.C:
-					stopSecondaryFeedTimer.Reset(PRIMARY_FEED_UPTIME)
+					clearAndResetTicker(stopSecondaryFeedTimer, PRIMARY_FEED_UPTIME)
 				}
 			}
 		}


### PR DESCRIPTION
Previously, we had issues where the following could happen:
- `msgHandler` takes 5 seconds (e.g. during database compaction or if there's a series of full blocks)
- During that time, the broadcast router has been adding messages to its channel
- However, also during that time, the 5 second `primaryFeedIsDownTimer` elapses and sends a tick through its channel
- After `msgHandler` finishes, the next loop of select statements begins again
- The first primary feed `<-bcs.primaryRouter.messageChan` select case gets hit, as the broadcast router has queued up messages in its channel
- `startSecondaryFeedTimer` gets reset, but before this PR, its channel was not cleared
- After a couple more iterations of the loop to clear out the primary router's message backlog, the `<-startSecondaryFeedTimer.C` select case gets hit, and the secondary feed is started, even though the primary feed wasn't down for 5 seconds (or any time at all)

With this PR, when we reset the `startSecondaryFeedTimer` (or any timer here), we also clear out its channel so we don't have a latent tick that makes us think the secondary feed is down.