### PR TITLE
Add support for nethermind's version of "execution reverted"

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -14,7 +14,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -546,7 +545,6 @@ func mainImpl() int {
 	// Validate sequencer's MaxTxDataSize and batchPoster's MaxSize params.
 	// SequencerInbox's maxDataSize is defaulted to 117964 which is 90% of Geth's 128KB tx size limit, leaving ~13KB for proving.
 	seqInboxMaxDataSize := 117964
-	executionRevertedRegexp := regexp.MustCompile("(?i)execution reverted")
 	if nodeConfig.Node.ParentChainReader.Enable {
 		seqInbox, err := bridgegen.NewSequencerInbox(rollupAddrs.SequencerInbox, l1Client)
 		if err != nil {
@@ -556,7 +554,7 @@ func mainImpl() int {
 		res, err := seqInbox.MaxDataSize(&bind.CallOpts{Context: ctx})
 		if err == nil {
 			seqInboxMaxDataSize = int(res.Int64())
-		} else if !executionRevertedRegexp.MatchString(err.Error()) {
+		} else if !headerreader.ExecutionRevertedRegexp.MatchString(err.Error()) {
 			log.Error("error fetching MaxDataSize from sequencer inbox", "err", err)
 			return 1
 		}

--- a/util/headerreader/execution_reverted_test.go
+++ b/util/headerreader/execution_reverted_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, Offchain Labs, Inc.
+// Copyright 2021-2023, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
 package headerreader

--- a/util/headerreader/execution_reverted_test.go
+++ b/util/headerreader/execution_reverted_test.go
@@ -1,4 +1,7 @@
-package staker
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package headerreader
 
 import (
 	"io"
@@ -13,14 +16,16 @@ func TestExecutionRevertedRegexp(t *testing.T) {
 		"execution reverted: FOO",
 		// besu returns "Execution reverted"
 		"Execution reverted",
+		// nethermind returns "VM execution error."
+		"VM execution error.",
 	}
 	for _, errString := range executionRevertedErrors {
-		if !executionRevertedRegexp.MatchString(errString) {
+		if !ExecutionRevertedRegexp.MatchString(errString) {
 			t.Fatalf("execution reverted regexp didn't match %q", errString)
 		}
 	}
 	// This regexp should not match random IO errors
-	if executionRevertedRegexp.MatchString(io.ErrUnexpectedEOF.Error()) {
+	if ExecutionRevertedRegexp.MatchString(io.ErrUnexpectedEOF.Error()) {
 		t.Fatal("execution reverted regexp matched unexpected EOF")
 	}
 }

--- a/util/headerreader/header_reader.go
+++ b/util/headerreader/header_reader.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"regexp"
 	"sync"
 	"time"
 
@@ -21,6 +22,9 @@ import (
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 	flag "github.com/spf13/pflag"
 )
+
+// A regexp matching "execution reverted" errors returned from the parent chain RPC.
+var ExecutionRevertedRegexp = regexp.MustCompile(`(?i)execution reverted|VM execution error\.?`)
 
 type ArbSysInterface interface {
 	ArbBlockNumber(*bind.CallOpts) (*big.Int, error)


### PR DESCRIPTION
This PR also moves the execution reverted regexp to headerreader so it can be used in other places