### PR TITLE
Disable feed output compression by default

### DIFF
--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -123,7 +123,7 @@ var DefaultBroadcasterConfig = BroadcasterConfig{
 	DisableSigning:     true,
 	LogConnect:         false,
 	LogDisconnect:      false,
-	EnableCompression:  true,
+	EnableCompression:  false,
 	RequireCompression: false,
 	LimitCatchup:       false,
 	MaxCatchup:         -1,


### PR DESCRIPTION
This is still useful when hosting a public feed, but it isn't worth the overhead for internal communication, so it makes sense to disable it by default