### PR TITLE
chore(arbitrator): typo fix

### DIFF
--- a/arbitrator/prover/src/machine.rs
+++ b/arbitrator/prover/src/machine.rs
@@ -410,7 +410,7 @@ impl Module {
             };
             ensure!(
                 memory_index == 0,
-                "Attempted to write to nonexistant memory"
+                "Attempted to write to nonexistent memory"
             );
 
             let offset = match (init.read()?, init.read()?, init.eof()) {
@@ -1893,7 +1893,7 @@ impl Machine {
                     let ptr = self.value_stack.pop().unwrap().assume_u32();
                     let msg_num = self.value_stack.pop().unwrap().assume_u64();
                     let inbox_identifier =
-                        argument_data_to_inbox(inst.argument_data).expect("Bad inbox indentifier");
+                        argument_data_to_inbox(inst.argument_data).expect("Bad inbox identifier");
                     if let Some(message) = self.inbox_contents.get(&(inbox_identifier, msg_num)) {
                         if ptr as u64 + 32 > module.memory.size() {
                             error!();
@@ -2304,7 +2304,7 @@ impl Machine {
                             .unwrap()
                             .assume_u64();
                         let inbox_identifier = argument_data_to_inbox(next_inst.argument_data)
-                            .expect("Bad inbox indentifier");
+                            .expect("Bad inbox identifier");
                         if let Some(msg_data) =
                             self.inbox_contents.get(&(inbox_identifier, msg_idx))
                         {

--- a/arbitrator/prover/src/machine.rs
+++ b/arbitrator/prover/src/machine.rs
@@ -314,7 +314,7 @@ impl Module {
                 code.push(func);
                 host_call_hooks.push(Some((import.module.into(), import.name.into())));
             } else {
-                bail!("Unsupport import kind {:?}", import);
+                bail!("Unsupported import kind {:?}", import);
             }
         }
         func_type_idxs.extend(bin.functions.iter());

--- a/arbitrator/prover/src/main.rs
+++ b/arbitrator/prover/src/main.rs
@@ -34,7 +34,7 @@ struct Opts {
     inbox_add_stub_headers: bool,
     #[structopt(long)]
     always_merkleize: bool,
-    /// profile output instead of generting proofs
+    /// profile output instead of generating proofs
     #[structopt(short = "p", long)]
     profile_run: bool,
     /// simple summary of hot opcodes


### PR DESCRIPTION
Fixed a few typo, mainly error messages.
This shouldn't require testing or changelog entry.
Have a nice week-end.