### PR TITLE
Fix queued transaction time encoding

### DIFF
--- a/arbnode/dataposter/storage/rlp_test.go
+++ b/arbnode/dataposter/storage/rlp_test.go
@@ -1,0 +1,120 @@
+// Copyright 2021-2023, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package storage
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+func TestTimeEncoding(t *testing.T) {
+	now := RlpTime(time.Now())
+	enc, err := rlp.EncodeToBytes(now)
+	if err != nil {
+		t.Fatal("failed to encode time", err)
+	}
+	var dec RlpTime
+	err = rlp.DecodeBytes(enc, &dec)
+	if err != nil {
+		t.Fatal("failed to decode time", err)
+	}
+	if !time.Time(dec).Equal(time.Time(now)) {
+		t.Fatalf("time %v encoded then decoded to %v", now, dec)
+	}
+}
+
+func TestOldTimeEncoding(t *testing.T) {
+	type OldQueuedTransaction struct {
+		FullTx          *types.Transaction
+		Data            types.DynamicFeeTx
+		Meta            []byte
+		Sent            bool
+		Created         time.Time
+		NextReplacement time.Time
+	}
+
+	oldTx := OldQueuedTransaction{
+		FullTx: types.NewTx(&types.DynamicFeeTx{}),
+		Meta:   []byte{0},
+	}
+
+	enc, err := rlp.EncodeToBytes(oldTx)
+	if err != nil {
+		t.Fatal("failed to encode old queued tx", err)
+	}
+	var dec QueuedTransaction
+	err = rlp.DecodeBytes(enc, &dec)
+	if err != nil {
+		t.Fatal("failed to decode old queued tx", err)
+	}
+
+	if !bytes.Equal(oldTx.Meta, dec.Meta) {
+		t.Fatalf("meta %v encoded then decoded to %v", oldTx.Meta, dec.Meta)
+	}
+}
+
+func TestWeirdTimeEncoding(t *testing.T) {
+	type OldQueuedTransaction struct {
+		FullTx          *types.Transaction
+		Data            types.DynamicFeeTx
+		Meta            []byte
+		Sent            bool
+		Created         *RlpTime `rlp:"optional"`
+		NextReplacement *RlpTime `rlp:"optional"`
+	}
+
+	now := time.Now()
+	oldTx := OldQueuedTransaction{
+		FullTx:          types.NewTx(&types.DynamicFeeTx{}),
+		Meta:            []byte{0},
+		Created:         (*RlpTime)(&now),
+		NextReplacement: (*RlpTime)(&now),
+	}
+
+	enc, err := rlp.EncodeToBytes(oldTx)
+	if err != nil {
+		t.Fatal("failed to encode old queued tx", err)
+	}
+	var dec QueuedTransaction
+	err = rlp.DecodeBytes(enc, &dec)
+	if err != nil {
+		t.Fatal("failed to decode old queued tx", err)
+	}
+
+	if !bytes.Equal(oldTx.Meta, dec.Meta) {
+		t.Fatalf("meta %v encoded then decoded to %v", oldTx.Meta, dec.Meta)
+	}
+	if !(time.Time)(*oldTx.Created).Equal(dec.Created) {
+		t.Fatalf("created %v encoded then decoded to %v", oldTx.Created, dec.Created)
+	}
+}
+
+func TestNewQueuedTransactionEncoding(t *testing.T) {
+	oldTx := &QueuedTransaction{
+		FullTx:  types.NewTx(&types.DynamicFeeTx{}),
+		Meta:    []byte{0},
+		Created: time.Now(),
+	}
+
+	enc, err := rlp.EncodeToBytes(oldTx)
+	if err != nil {
+		t.Fatal("failed to encode old queued tx", err)
+	}
+	var dec QueuedTransaction
+	err = rlp.DecodeBytes(enc, &dec)
+	if err != nil {
+		t.Fatal("failed to decode old queued tx", err)
+	}
+
+	if !bytes.Equal(oldTx.Meta, dec.Meta) {
+		t.Fatalf("meta %v encoded then decoded to %v", oldTx.Meta, dec.Meta)
+	}
+	if !oldTx.Created.Equal(dec.Created) {
+		t.Fatalf("created %v encoded then decoded to %v", oldTx.Created, dec.Created)
+	}
+}

--- a/arbnode/dataposter/storage/storage.go
+++ b/arbnode/dataposter/storage/storage.go
@@ -39,8 +39,8 @@ type queuedTransactionForEncoding struct {
 	Data            types.DynamicFeeTx
 	Meta            []byte
 	Sent            bool
-	Created         *RlpTime `rlp:"optional"` // may be earlier than the tx was given to the tx poster
-	NextReplacement *RlpTime `rlp:"optional"`
+	Created         RlpTime
+	NextReplacement RlpTime
 }
 
 func (qt *QueuedTransaction) EncodeRLP(w io.Writer) error {
@@ -49,8 +49,8 @@ func (qt *QueuedTransaction) EncodeRLP(w io.Writer) error {
 		Data:            qt.Data,
 		Meta:            qt.Meta,
 		Sent:            qt.Sent,
-		Created:         (*RlpTime)(&qt.Created),
-		NextReplacement: (*RlpTime)(&qt.NextReplacement),
+		Created:         (RlpTime)(qt.Created),
+		NextReplacement: (RlpTime)(qt.NextReplacement),
 	})
 }
 
@@ -63,12 +63,8 @@ func (qt *QueuedTransaction) DecodeRLP(s *rlp.Stream) error {
 	qt.Data = qtEnc.Data
 	qt.Meta = qtEnc.Meta
 	qt.Sent = qtEnc.Sent
-	if qtEnc.Created != nil {
-		qt.Created = time.Time(*qtEnc.Created)
-	}
-	if qtEnc.NextReplacement != nil {
-		qt.NextReplacement = time.Time(*qtEnc.NextReplacement)
-	}
+	qt.Created = time.Time(qtEnc.Created)
+	qt.NextReplacement = time.Time(qtEnc.NextReplacement)
 	return nil
 }
 

--- a/arbnode/dataposter/storage/time.go
+++ b/arbnode/dataposter/storage/time.go
@@ -21,8 +21,16 @@ type rlpTimeEncoding struct {
 }
 
 func (b *RlpTime) DecodeRLP(s *rlp.Stream) error {
+	kind, size, err := s.Kind()
+	if err != nil {
+		return err
+	}
+	if kind == rlp.List && size == 0 {
+		// This is an old time.Time without any data
+		return s.Decode(&time.Time{})
+	}
 	var enc rlpTimeEncoding
-	err := s.Decode(&enc)
+	err = s.Decode(&enc)
 	if err != nil {
 		return err
 	}

--- a/arbnode/dataposter/storage_test.go
+++ b/arbnode/dataposter/storage_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021-2023, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
 package dataposter
 
 import (
@@ -5,7 +8,6 @@ import (
 	"math/big"
 	"path"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -365,21 +367,5 @@ func TestLength(t *testing.T) {
 			})
 		}
 
-	}
-}
-
-func TestTimeEncoding(t *testing.T) {
-	now := storage.RlpTime(time.Now())
-	enc, err := rlp.EncodeToBytes(now)
-	if err != nil {
-		t.Fatal("failed to encode time", err)
-	}
-	var dec storage.RlpTime
-	err = rlp.DecodeBytes(enc, &dec)
-	if err != nil {
-		t.Fatal("failed to decode time", err)
-	}
-	if !time.Time(dec).Equal(time.Time(now)) {
-		t.Fatalf("time %v encoded then decoded to %v", now, dec)
 	}
 }


### PR DESCRIPTION
In my previous PR https://github.com/OffchainLabs/nitro/pull/2014 I missed that a time.Time is not encoded as nothing, it's encoded as an empty list, an important difference. In that PR, the QueuedTransaction will fail to decode the previous version's QueuedTransaction. In this PR, I fix that, and add comprehensive tests that verify it's able to decode any of the types that were in use.