### PR TITLE
Use a moving average to determine messages per batch

### DIFF
--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -47,14 +47,14 @@ type Float interface {
 	~float32 | ~float64
 }
 
-// Ordered is anything that implements comparison operators such as `<` and `>`.
+// Number is anything that implements operators such as `<`, `+` and `/`.
 // Unfortunately, that doesn't include big ints.
-type Ordered interface {
+type Number interface {
 	Integer | Float
 }
 
 // MinInt the minimum of two ints
-func MinInt[T Ordered](value, ceiling T) T {
+func MinInt[T Number](value, ceiling T) T {
 	if value > ceiling {
 		return ceiling
 	}
@@ -62,7 +62,7 @@ func MinInt[T Ordered](value, ceiling T) T {
 }
 
 // MaxInt the maximum of two ints
-func MaxInt[T Ordered](value, floor T) T {
+func MaxInt[T Number](value, floor T) T {
 	if value < floor {
 		return floor
 	}

--- a/util/arbmath/moving_average.go
+++ b/util/arbmath/moving_average.go
@@ -3,36 +3,37 @@
 
 package arbmath
 
+import "fmt"
+
 // A simple moving average of a generic number type.
 type MovingAverage[T Number] struct {
-	period         int
 	buffer         []T
 	bufferPosition int
 	sum            T
 }
 
-func NewMovingAverage[T Number](period int) *MovingAverage[T] {
+func NewMovingAverage[T Number](period int) (*MovingAverage[T], error) {
 	if period <= 0 {
-		panic("MovingAverage period must be positive")
+		return nil, fmt.Errorf("MovingAverage period specified as %v but it must be positive", period)
 	}
 	return &MovingAverage[T]{
-		period: period,
 		buffer: make([]T, 0, period),
-	}
+	}, nil
 }
 
 func (a *MovingAverage[T]) Update(value T) {
-	if a.period <= 0 {
+	period := cap(a.buffer)
+	if period == 0 {
 		return
 	}
-	if len(a.buffer) < a.period {
+	if len(a.buffer) < period {
 		a.buffer = append(a.buffer, value)
 		a.sum += value
 	} else {
 		a.sum += value
 		a.sum -= a.buffer[a.bufferPosition]
 		a.buffer[a.bufferPosition] = value
-		a.bufferPosition = (a.bufferPosition + 1) % a.period
+		a.bufferPosition = (a.bufferPosition + 1) % period
 	}
 }
 

--- a/util/arbmath/moving_average.go
+++ b/util/arbmath/moving_average.go
@@ -1,0 +1,45 @@
+// Copyright 2023, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package arbmath
+
+// A simple moving average of a generic number type.
+type MovingAverage[T Number] struct {
+	period         int
+	buffer         []T
+	bufferPosition int
+	sum            T
+}
+
+func NewMovingAverage[T Number](period int) *MovingAverage[T] {
+	if period <= 0 {
+		panic("MovingAverage period must be positive")
+	}
+	return &MovingAverage[T]{
+		period: period,
+		buffer: make([]T, 0, period),
+	}
+}
+
+func (a *MovingAverage[T]) Update(value T) {
+	if a.period <= 0 {
+		return
+	}
+	if len(a.buffer) < a.period {
+		a.buffer = append(a.buffer, value)
+		a.sum += value
+	} else {
+		a.sum += value
+		a.sum -= a.buffer[a.bufferPosition]
+		a.buffer[a.bufferPosition] = value
+		a.bufferPosition = (a.bufferPosition + 1) % a.period
+	}
+}
+
+// Average returns the current moving average, or zero if no values have been added.
+func (a *MovingAverage[T]) Average() T {
+	if len(a.buffer) == 0 {
+		return 0
+	}
+	return a.sum / T(len(a.buffer))
+}

--- a/util/arbmath/moving_average_test.go
+++ b/util/arbmath/moving_average_test.go
@@ -6,30 +6,42 @@ package arbmath
 import "testing"
 
 func TestMovingAverage(t *testing.T) {
-	ma := NewMovingAverage[int](5)
+	_, err := NewMovingAverage[int](0)
+	if err == nil {
+		t.Error("Expected error when creating moving average of period 0")
+	}
+	_, err = NewMovingAverage[int](-1)
+	if err == nil {
+		t.Error("Expected error when creating moving average of period -1")
+	}
+
+	ma, err := NewMovingAverage[int](5)
+	if err != nil {
+		t.Fatalf("Error creating moving average of period 5: %v", err)
+	}
 	if ma.Average() != 0 {
-		t.Errorf("moving average should be 0 at start, got %v", ma.Average())
+		t.Errorf("Average() = %v, want 0", ma.Average())
 	}
 	ma.Update(2)
 	if ma.Average() != 2 {
-		t.Errorf("moving average should be 2, got %v", ma.Average())
+		t.Errorf("Average() = %v, want 2", ma.Average())
 	}
 	ma.Update(4)
 	if ma.Average() != 3 {
-		t.Errorf("moving average should be 3, got %v", ma.Average())
+		t.Errorf("Average() = %v, want 3", ma.Average())
 	}
 
 	for i := 0; i < 5; i++ {
 		ma.Update(10)
 	}
 	if ma.Average() != 10 {
-		t.Errorf("moving average should be 10, got %v", ma.Average())
+		t.Errorf("Average() = %v, want 10", ma.Average())
 	}
 
 	for i := 0; i < 5; i++ {
 		ma.Update(0)
 	}
 	if ma.Average() != 0 {
-		t.Errorf("moving average should be 0, got %v", ma.Average())
+		t.Errorf("Average() = %v, want 0", ma.Average())
 	}
 }

--- a/util/arbmath/moving_average_test.go
+++ b/util/arbmath/moving_average_test.go
@@ -1,0 +1,35 @@
+// Copyright 2023, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package arbmath
+
+import "testing"
+
+func TestMovingAverage(t *testing.T) {
+	ma := NewMovingAverage[int](5)
+	if ma.Average() != 0 {
+		t.Errorf("moving average should be 0 at start, got %v", ma.Average())
+	}
+	ma.Update(2)
+	if ma.Average() != 2 {
+		t.Errorf("moving average should be 2, got %v", ma.Average())
+	}
+	ma.Update(4)
+	if ma.Average() != 3 {
+		t.Errorf("moving average should be 3, got %v", ma.Average())
+	}
+
+	for i := 0; i < 5; i++ {
+		ma.Update(10)
+	}
+	if ma.Average() != 10 {
+		t.Errorf("moving average should be 10, got %v", ma.Average())
+	}
+
+	for i := 0; i < 5; i++ {
+		ma.Update(0)
+	}
+	if ma.Average() != 0 {
+		t.Errorf("moving average should be 0, got %v", ma.Average())
+	}
+}


### PR DESCRIPTION
Occasionally, large messages mean that there are a only a few messages in a batch, which makes the batch poster think that it has a large backlog when it really doesn't. To help mitigate the problem, this PR adds a moving average of length 20 to more accurately determine the batch backlog.