### PR TITLE
Fix missing ArgLogLimit in L1 RPC client

### DIFF
--- a/cmd/conf/chain.go
+++ b/cmd/conf/chain.go
@@ -22,6 +22,7 @@ var L1ConnectionConfigDefault = rpcclient.ClientConfig{
 	Retries:        2,
 	Timeout:        time.Minute,
 	ConnectionWait: time.Minute,
+	ArgLogLimit:    2048,
 }
 
 var L1ConfigDefault = L1Config{


### PR DESCRIPTION
This was resulting in being unable to look through batch poster logs because they'd have crazy long RPC response log lines for batches being submitted