### PR TITLE
Fix --init.reset-to-message option (especially with large distances)

### DIFF
--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -308,7 +308,13 @@ func (s *TransactionStreamer) reorg(batch ethdb.Batch, count arbutil.MessageInde
 					continue
 				}
 				msgBlockNum := new(big.Int).SetUint64(oldMessage.Message.Header.BlockNumber)
-				delayedInBlock, err := s.delayedBridge.LookupMessagesInRange(s.GetContext(), msgBlockNum, msgBlockNum, nil)
+				// If not started, use a background context.
+				// This can happening when reorging on startup using the init flag.
+				ctx := context.Background()
+				if s.Started() {
+					ctx = s.GetContext()
+				}
+				delayedInBlock, err := s.delayedBridge.LookupMessagesInRange(ctx, msgBlockNum, msgBlockNum, nil)
 				if err != nil {
 					log.Error("reorg-resequence: failed to serialize old delayed message from database", "err", err)
 					continue

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -26,18 +26,6 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-type DangerousConfig struct {
-	ReorgToBlock int64 `koanf:"reorg-to-block"`
-}
-
-var DefaultDangerousConfig = DangerousConfig{
-	ReorgToBlock: -1,
-}
-
-func DangerousConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Int64(prefix+".reorg-to-block", DefaultDangerousConfig.ReorgToBlock, "DANGEROUS! forces a reorg to an old block height. To be used for testing only. -1 to disable")
-}
-
 type Config struct {
 	ParentChainReader         headerreader.Config              `koanf:"parent-chain-reader" reload:"hot"`
 	Sequencer                 SequencerConfig                  `koanf:"sequencer" reload:"hot"`
@@ -49,7 +37,6 @@ type Config struct {
 	Caching                   CachingConfig                    `koanf:"caching"`
 	RPC                       arbitrum.Config                  `koanf:"rpc"`
 	TxLookupLimit             uint64                           `koanf:"tx-lookup-limit"`
-	Dangerous                 DangerousConfig                  `koanf:"dangerous"`
 
 	forwardingTarget string
 }
@@ -83,7 +70,6 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	TxPreCheckerConfigAddOptions(prefix+".tx-pre-checker", f)
 	CachingConfigAddOptions(prefix+".caching", f)
 	f.Uint64(prefix+".tx-lookup-limit", ConfigDefault.TxLookupLimit, "retain the ability to lookup transactions by hash for the past N blocks (0 = all blocks)")
-	DangerousConfigAddOptions(prefix+".dangerous", f)
 }
 
 var ConfigDefault = Config{
@@ -96,7 +82,6 @@ var ConfigDefault = Config{
 	TxPreChecker:              DefaultTxPreCheckerConfig,
 	TxLookupLimit:             126_230_400, // 1 year at 4 blocks per second
 	Caching:                   DefaultCachingConfig,
-	Dangerous:                 DefaultDangerousConfig,
 	Forwarder:                 DefaultNodeForwarderConfig,
 }
 


### PR DESCRIPTION
The primary thing this does is loop in the inbox tracker which was previously not aware of the reorg, causing the inbox reader to get stuck. Now, after reorging to an old message, the inbox reader is able to pick up from there and resync.

This PR also removes the old reorg to block flag which didn't do anything.