### PR TITLE
Only lock redis in the batch poster when posting the batch

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1180,6 +1180,10 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 			b.firstEphemeralError = time.Time{}
 		}
 		if err != nil {
+			if ctx.Err() != nil {
+				// Shutting down. No need to print the context canceled error.
+				return 0
+			}
 			b.building = nil
 			logLevel := log.Error
 			if b.firstEphemeralError == (time.Time{}) {
@@ -1194,8 +1198,7 @@ func (b *BatchPoster) Start(ctxIn context.Context) {
 			ignoreAtFirst := errors.Is(err, dataposter.ErrExceedsMaxMempoolSize) ||
 				errors.Is(err, storage.ErrStorageRace) ||
 				errors.Is(err, ErrNormalGasEstimationFailed) ||
-				errors.Is(err, AccumulatorNotFoundErr) ||
-				errors.Is(err, context.Canceled)
+				errors.Is(err, AccumulatorNotFoundErr)
 			if sinceFirstEphemeralError < time.Minute {
 				if ignoreAtFirst {
 					logLevel = log.Debug

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -83,11 +83,6 @@ type DataPoster struct {
 // This can be local or external, hence the context parameter.
 type signerFn func(context.Context, common.Address, *types.Transaction) (*types.Transaction, error)
 
-type AttemptLocker interface {
-	AttemptLock(context.Context) bool
-	CouldAcquireLock(context.Context) (bool, error)
-}
-
 func parseReplacementTimes(val string) ([]time.Duration, error) {
 	var res []time.Duration
 	var lastReplacementTime time.Duration

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/offchainlabs/nitro/arbnode/dataposter"
 	"github.com/offchainlabs/nitro/arbnode/dataposter/storage"
-	"github.com/offchainlabs/nitro/arbnode/redislock"
 	"github.com/offchainlabs/nitro/arbnode/resourcemanager"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/broadcastclient"
@@ -313,13 +312,6 @@ func StakerDataposter(
 	if err != nil {
 		return nil, fmt.Errorf("creating redis client from url: %w", err)
 	}
-	lockCfgFetcher := func() *redislock.SimpleCfg {
-		return &cfg.Staker.RedisLock
-	}
-	redisLock, err := redislock.NewSimple(redisC, lockCfgFetcher, func() bool { return syncMonitor.Synced() })
-	if err != nil {
-		return nil, err
-	}
 	dpCfg := func() *dataposter.DataPosterConfig {
 		return &cfg.Staker.DataPoster
 	}
@@ -335,7 +327,6 @@ func StakerDataposter(
 			HeaderReader:      l1Reader,
 			Auth:              transactOpts,
 			RedisClient:       redisC,
-			RedisLock:         redisLock,
 			Config:            dpCfg,
 			MetadataRetriever: mdRetriever,
 			RedisKey:          sender + ".staker-data-poster.queue",

--- a/arbnode/simple_redis_lock_test.go
+++ b/arbnode/simple_redis_lock_test.go
@@ -48,6 +48,7 @@ func simpleRedisLockTest(t *testing.T, redisKeySuffix string, chosen int, backgo
 	Require(t, redisClient.Del(ctx, redisKey).Err())
 
 	conf := &redislock.SimpleCfg{
+		Enable:          true,
 		LockoutDuration: test_delay * test_attempts * 10,
 		RefreshDuration: test_delay * 2,
 		Key:             redisKey,

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -21,7 +21,6 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/offchainlabs/nitro/arbnode/dataposter"
-	"github.com/offchainlabs/nitro/arbnode/redislock"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/staker/txbuilder"
@@ -202,7 +201,6 @@ func L1ValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".redis-url", DefaultL1ValidatorConfig.RedisUrl, "redis url for L1 validator")
 	f.Uint64(prefix+".extra-gas", DefaultL1ValidatorConfig.ExtraGas, "use this much more gas than estimation says is necessary to post transactions")
 	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f, dataposter.DefaultDataPosterConfigForValidator)
-	redislock.AddConfigOptions(prefix+".redis-lock", f)
 	DangerousConfigAddOptions(prefix+".dangerous", f)
 	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultL1ValidatorConfig.ParentChainWallet.Pathname)
 }

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -87,7 +87,6 @@ type L1ValidatorConfig struct {
 	GasRefunderAddress        string                      `koanf:"gas-refunder-address"`
 	DataPoster                dataposter.DataPosterConfig `koanf:"data-poster" reload:"hot"`
 	RedisUrl                  string                      `koanf:"redis-url"`
-	RedisLock                 redislock.SimpleCfg         `koanf:"redis-lock" reload:"hot"`
 	ExtraGas                  uint64                      `koanf:"extra-gas" reload:"hot"`
 	Dangerous                 DangerousConfig             `koanf:"dangerous"`
 	ParentChainWallet         genericconf.WalletConfig    `koanf:"parent-chain-wallet"`
@@ -154,7 +153,6 @@ var DefaultL1ValidatorConfig = L1ValidatorConfig{
 	GasRefunderAddress:        "",
 	DataPoster:                dataposter.DefaultDataPosterConfigForValidator,
 	RedisUrl:                  "",
-	RedisLock:                 redislock.DefaultCfg,
 	ExtraGas:                  50000,
 	Dangerous:                 DefaultDangerousConfig,
 	ParentChainWallet:         DefaultValidatorL1WalletConfig,
@@ -175,7 +173,6 @@ var TestL1ValidatorConfig = L1ValidatorConfig{
 	GasRefunderAddress:        "",
 	DataPoster:                dataposter.TestDataPosterConfigForValidator,
 	RedisUrl:                  "",
-	RedisLock:                 redislock.DefaultCfg,
 	ExtraGas:                  50000,
 	Dangerous:                 DefaultDangerousConfig,
 	ParentChainWallet:         DefaultValidatorL1WalletConfig,


### PR DESCRIPTION
This helps prevent a scenario where a batch poster has the exclusive redis lock, but is unable to post batches due to e.g. an L1 node issue. By ensuring we only acquire the redis lock when we have a batch to post, this means that if a batch poster is unable to post batches, it will lose the lock to one which can post batches.