### PR TITLE
Always broadcast feed, even when the node isn't the sequencer

### DIFF
--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -862,12 +862,6 @@ func (s *TransactionStreamer) WriteMessageFromSequencer(pos arbutil.MessageIndex
 		return err
 	}
 
-	if s.broadcastServer != nil {
-		if err := s.broadcastServer.BroadcastSingle(msgWithMeta, pos); err != nil {
-			log.Error("failed broadcasting message", "pos", pos, "err", err)
-		}
-	}
-
 	return nil
 }
 
@@ -925,6 +919,12 @@ func (s *TransactionStreamer) writeMessages(pos arbutil.MessageIndex, messages [
 	select {
 	case s.newMessageNotifier <- struct{}{}:
 	default:
+	}
+
+	if s.broadcastServer != nil {
+		if err := s.broadcastServer.BroadcastMessages(messages, pos); err != nil {
+			log.Error("failed broadcasting message", "pos", pos, "err", err)
+		}
 	}
 
 	return nil

--- a/broadcaster/broadcaster.go
+++ b/broadcaster/broadcaster.go
@@ -5,6 +5,7 @@ package broadcaster
 
 import (
 	"context"
+	"errors"
 	"net"
 
 	"github.com/gobwas/ws"
@@ -56,10 +57,11 @@ func (b *Broadcaster) NewBroadcastFeedMessage(message arbostypes.MessageWithMeta
 	}, nil
 }
 
-func (b *Broadcaster) BroadcastSingle(msg arbostypes.MessageWithMetadata, seq arbutil.MessageIndex) error {
+func (b *Broadcaster) BroadcastSingle(msg arbostypes.MessageWithMetadata, seq arbutil.MessageIndex) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Error("recovered error in BroadcastSingle", "recover", r)
+			err = errors.New("panic in BroadcastSingle")
 		}
 	}()
 	bfm, err := b.NewBroadcastFeedMessage(msg, seq)
@@ -77,6 +79,27 @@ func (b *Broadcaster) BroadcastSingleFeedMessage(bfm *m.BroadcastFeedMessage) {
 	broadcastFeedMessages = append(broadcastFeedMessages, bfm)
 
 	b.BroadcastFeedMessages(broadcastFeedMessages)
+}
+
+func (b *Broadcaster) BroadcastMessages(messages []arbostypes.MessageWithMetadata, seq arbutil.MessageIndex) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("recovered error in BroadcastMessages", "recover", r)
+			err = errors.New("panic in BroadcastMessages")
+		}
+	}()
+	var feedMessages []*m.BroadcastFeedMessage
+	for _, msg := range messages {
+		bfm, err := b.NewBroadcastFeedMessage(msg, seq)
+		if err != nil {
+			return err
+		}
+		feedMessages = append(feedMessages, bfm)
+	}
+
+	b.BroadcastFeedMessages(feedMessages)
+
+	return nil
 }
 
 func (b *Broadcaster) BroadcastFeedMessages(messages []*m.BroadcastFeedMessage) {


### PR DESCRIPTION
Previously, the node would only output a feed if it was the active sequencer. This PR changes that to make every node that has a feed enabled output it, even if it's not the active sequencer. This allows, for instance, nodes to also act as relays (though a relay is still better for this purpose, this is more intended as a backup option).