### PR TITLE
Fix Broadcaster BroadcastMessages sequence numbers

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -731,8 +731,6 @@ func CreateNode(
 }
 
 func (n *Node) Start(ctx context.Context) error {
-	// config is the static config at start, not a dynamic config
-	config := n.configFetcher.Get()
 	execClient, ok := n.Execution.(*gethexec.ExecutionNode)
 	if !ok {
 		execClient = nil

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -764,7 +764,7 @@ func (n *Node) Start(ctx context.Context) error {
 			return fmt.Errorf("error initializing feed broadcast server: %w", err)
 		}
 	}
-	if n.InboxTracker != nil && n.BroadcastServer != nil && config.Sequencer {
+	if n.InboxTracker != nil && n.BroadcastServer != nil {
 		// Even if the sequencer coordinator will populate this backlog,
 		// we want to make sure it's populated before any clients connect.
 		err = n.InboxTracker.PopulateFeedBacklog(n.BroadcastServer)

--- a/broadcaster/broadcaster.go
+++ b/broadcaster/broadcaster.go
@@ -89,8 +89,8 @@ func (b *Broadcaster) BroadcastMessages(messages []arbostypes.MessageWithMetadat
 		}
 	}()
 	var feedMessages []*m.BroadcastFeedMessage
-	for _, msg := range messages {
-		bfm, err := b.NewBroadcastFeedMessage(msg, seq)
+	for i, msg := range messages {
+		bfm, err := b.NewBroadcastFeedMessage(msg, seq+arbutil.MessageIndex(i))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Also, now that non-sequencers can output the feed too, populates the feed backlog for all nodes which have a feed output enabled.