### PR TITLE
Fix broken NodeInterface methods

### DIFF
--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -248,7 +248,7 @@ func CreateExecutionNode(
 }
 
 func (n *ExecutionNode) Initialize(ctx context.Context, arbnode interface{}, sync arbitrum.SyncProgressBackend) error {
-	n.ArbInterface.Initialize(n)
+	n.ArbInterface.Initialize(arbnode)
 	err := n.Backend.Start()
 	if err != nil {
 		return fmt.Errorf("error starting geth backend: %w", err)

--- a/system_tests/nodeinterface_test.go
+++ b/system_tests/nodeinterface_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/offchainlabs/nitro/arbos/util"
 	"github.com/offchainlabs/nitro/solgen/go/node_interfacegen"
@@ -71,5 +72,41 @@ func TestL2BlockRangeForL1(t *testing.T) {
 	// Test invalid case.
 	if _, err := nodeInterface.L2BlockRangeForL1(&bind.CallOpts{}, 1e5); err == nil {
 		t.Fatalf("GetL2BlockRangeForL1 didn't fail for an invalid input")
+	}
+}
+
+func TestGetL1Confirmations(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	cleanup := builder.Build(t)
+	defer cleanup()
+
+	nodeInterface, err := node_interfacegen.NewNodeInterface(types.NodeInterfaceAddress, builder.L2.Client)
+	Require(t, err)
+
+	genesisBlock, err := builder.L2.Client.BlockByNumber(ctx, big.NewInt(0))
+	Require(t, err)
+	l1Confs, err := nodeInterface.GetL1Confirmations(&bind.CallOpts{}, genesisBlock.Hash())
+	Require(t, err)
+
+	numTransactions := 200
+
+	if l1Confs >= uint64(numTransactions) {
+		t.Fatalf("L1Confirmations for latest block %v is already %v (over %v)", genesisBlock.Number(), l1Confs, numTransactions)
+	}
+
+	for i := 0; i < numTransactions; i++ {
+		builder.L1.TransferBalance(t, "User", "User", common.Big0, builder.L1Info)
+	}
+
+	l1Confs, err = nodeInterface.GetL1Confirmations(&bind.CallOpts{}, genesisBlock.Hash())
+	Require(t, err)
+
+	// Allow a gap of 10 for asynchronicity, just in case
+	if l1Confs+10 < uint64(numTransactions) {
+		t.Fatalf("L1Confirmations for latest block %v is only %v (did not hit expected %v)", genesisBlock.Number(), l1Confs, numTransactions)
 	}
 }


### PR DESCRIPTION
ArbInterface was started with the execution node instead of the arbnode. This PR fixes that and adds a test of the GetL1Confirmations NodeInterface method, which failed on the previous version due to this issue.