### PR TITLE
Allow the TxForwarder to be empty

### DIFF
--- a/execution/gethexec/forwarder.go
+++ b/execution/gethexec/forwarder.go
@@ -161,7 +161,7 @@ const maxHealthTimeout = 10 * time.Second
 
 // CheckHealth returns health of the highest priority forwarding target
 func (f *TxForwarder) CheckHealth(inctx context.Context) error {
-	// If f.enabled is false, len(f.rpcClients) should always be greater than zero,
+	// If f.enabled is true, len(f.rpcClients) should always be greater than zero,
 	// but better safe than sorry.
 	if !f.enabled.Load() || len(f.rpcClients) == 0 {
 		return ErrNoSequencer

--- a/execution/gethexec/forwarder.go
+++ b/execution/gethexec/forwarder.go
@@ -151,7 +151,7 @@ func (f *TxForwarder) PublishTransaction(inctx context.Context, tx *types.Transa
 		if err == nil || !f.tryNewForwarderErrors.MatchString(err.Error()) {
 			return err
 		}
-		log.Info("error forwarding transaction to a backup target", "target", f.targets[pos], "err", err)
+		log.Warn("error forwarding transaction to a backup target", "target", f.targets[pos], "err", err)
 	}
 	return errors.New("failed to publish transaction to any of the forwarding targets")
 }
@@ -161,7 +161,9 @@ const maxHealthTimeout = 10 * time.Second
 
 // CheckHealth returns health of the highest priority forwarding target
 func (f *TxForwarder) CheckHealth(inctx context.Context) error {
-	if !f.enabled.Load() {
+	// If f.enabled is false, len(f.rpcClients) should always be greater than zero,
+	// but better safe than sorry.
+	if !f.enabled.Load() || len(f.rpcClients) == 0 {
 		return ErrNoSequencer
 	}
 	f.healthMutex.Lock()
@@ -205,8 +207,6 @@ func (f *TxForwarder) Initialize(inctx context.Context) error {
 	f.targets = targets
 	if len(f.rpcClients) > 0 {
 		f.enabled.Store(true)
-	} else if lastError == nil {
-		return errors.New("no non-empty forwarding targets specified")
 	} else {
 		return lastError
 	}
@@ -230,6 +230,14 @@ func (f *TxForwarder) StopAndWait() {
 
 func (f *TxForwarder) Started() bool {
 	return true
+}
+
+// Returns the URL of the first forwarding target, or an empty string if none are set.
+func (f *TxForwarder) PrimaryTarget() string {
+	if len(f.targets) == 0 {
+		return ""
+	}
+	return f.targets[0]
 }
 
 type TxDropper struct{}

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -487,17 +487,17 @@ func (s *Sequencer) CheckHealth(ctx context.Context) error {
 func (s *Sequencer) ForwardTarget() string {
 	s.activeMutex.Lock()
 	defer s.activeMutex.Unlock()
-	if s.forwarder == nil || len(s.forwarder.targets) == 0 {
+	if s.forwarder == nil {
 		return ""
 	}
-	return s.forwarder.targets[0]
+	return s.forwarder.PrimaryTarget()
 }
 
 func (s *Sequencer) ForwardTo(url string) error {
 	s.activeMutex.Lock()
 	defer s.activeMutex.Unlock()
 	if s.forwarder != nil {
-		if len(s.forwarder.targets) > 0 && s.forwarder.targets[0] == url {
+		if s.forwarder.PrimaryTarget() == url {
 			log.Warn("attempted to update sequencer forward target with existing target", "url", url)
 			return nil
 		}


### PR DESCRIPTION
This is a follow-up to https://github.com/OffchainLabs/nitro/pull/2058

This better matches previous behavior in allowing Initialize to succeed even when there's no non-empty targets specified. Instead, it will just remain disabled but without any error. Now, the only codepath changes from the last release are those where it would've panicked on the last release, so this can't hurt things. I also updated an info log to a warn while reading through the tx forwarder.