### PR TITLE
Fix getL1Confirmations on L3s

### DIFF
--- a/wsbroadcastserver/clientconnection.go
+++ b/wsbroadcastserver/clientconnection.go
@@ -140,6 +140,9 @@ func (cc *ClientConnection) writeBacklog(ctx context.Context, segment backlog.Ba
 				msgs = msgs[requestedIdx:]
 			}
 		}
+		if len(msgs) == 0 {
+			break
+		}
 		isFirstSegment = false
 		bm := &m.BroadcastMessage{
 			Version:  m.V1,


### PR DESCRIPTION
With this PR, it'll now call getL1Confirmations on the L2 RPC with the L2 block that contains the L3 batch to get the L1 confirmations instead of just returning the number of L2 blocks that have passed.