### PR TITLE
Fix testing machine

### DIFF
--- a/arbitrator/prover/test-cases/global-state-wrapper.wat
+++ b/arbitrator/prover/test-cases/global-state-wrapper.wat
@@ -6,6 +6,8 @@
 (import "env" "wavm_read_inbox_message" (func $readinbox (param i64) (param i32) (param i32) (result i32)))
 (import "env" "wavm_halt_and_set_finished" (func $halt))
 
+(memory 1)
+
 (export "env__wavm_set_globalstate_u64" (func $set))
 (export "env__wavm_get_globalstate_u64" (func $get))
 (export "env__wavm_read_inbox_message" (func $readinbox))

--- a/staker/challenge_test.go
+++ b/staker/challenge_test.go
@@ -298,3 +298,12 @@ func TestChallengeToFailedTooFar(t *testing.T) {
 	Require(t, machine.AddSequencerInboxMessage(10, []byte{0, 1, 2, 3}))
 	runChallengeTest(t, machine, incorrectMachine, true, false, 11)
 }
+
+func TestReadInboxMessage(t *testing.T) {
+	machine := createBaseMachine(t, "read-inboxmsg-10.wasm", []string{"global-state-wrapper.wasm"})
+	Require(t, machine.AddSequencerInboxMessage(10, []byte{0, 1, 2, 3}))
+	machine.Step(context.Background(), 100)
+	if machine.IsErrored() {
+		t.Fatal("fail to execute the read inbox message opcode")
+	}
+}


### PR DESCRIPTION
Hi! I am not working on the latest branch so I am not sure if this is still a bug.

I found that [this machine](https://github.com/OffchainLabs/nitro/blob/4dac70821b5bbb7c48b6e5c2460663dc0c07e011/staker/challenge_test.go#L287) in the test didn't work actually because of lack of memory for writing the message.

Open a PR just for clarity and feel free to close it.
If it has already been fixed or if there are other fixes in the future, please let me know and I would be very grateful.