### PR TITLE
Fix delayed sequencer finality not recognizing Arbitrum

### DIFF
--- a/arbnode/delayed_sequencer.go
+++ b/arbnode/delayed_sequencer.go
@@ -100,7 +100,7 @@ func (d *DelayedSequencer) sequenceWithoutLockout(ctx context.Context, lastBlock
 	}
 
 	var finalized uint64
-	if config.UseMergeFinality && lastBlockHeader.Difficulty.Sign() == 0 {
+	if config.UseMergeFinality && headerreader.HeaderIndicatesFinalitySupport(lastBlockHeader) {
 		var err error
 		if config.RequireFullFinality {
 			finalized, err = d.l1Reader.LatestFinalizedBlockNr(ctx)

--- a/util/headerreader/header_reader.go
+++ b/util/headerreader/header_reader.go
@@ -436,7 +436,7 @@ func (s *HeaderReader) LastPendingCallBlockNr() uint64 {
 
 var ErrBlockNumberNotSupported = errors.New("block number not supported")
 
-func headerIndicatesFinalitySupport(header *types.Header) bool {
+func HeaderIndicatesFinalitySupport(header *types.Header) bool {
 	if header.Difficulty.Sign() == 0 {
 		// This is an Ethereum PoS chain
 		return true
@@ -466,7 +466,7 @@ func (s *HeaderReader) getCached(ctx context.Context, c *cachedHeader) (*types.H
 	if HeadersEqual(currentHead, c.headWhenCached) {
 		return c.header, nil
 	}
-	if !s.config().UseFinalityData || !headerIndicatesFinalitySupport(currentHead) {
+	if !s.config().UseFinalityData || !HeaderIndicatesFinalitySupport(currentHead) {
 		return nil, ErrBlockNumberNotSupported
 	}
 	header, err := s.client.HeaderByNumber(ctx, c.rpcBlockNum)


### PR DESCRIPTION
The delayed sequencer parent chain finality support check only recognized Eth PoS chains, not Arbitrum parent chains. This PR changes it to use the correct header reader's check which recognizes both Eth PoS chains and Arbitrum chains as having finality.