### PR TITLE
Add support for consensus v11.1 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -165,6 +165,7 @@ RUN ./download-machine.sh consensus-v10.1 0xda4e3ad5e7feacb817c21c8d0220da7650fe
 RUN ./download-machine.sh consensus-v10.2 0x0754e09320c381566cc0449904c377a52bd34a6b9404432e80afd573b67f7b17
 RUN ./download-machine.sh consensus-v10.3 0xf559b6d4fa869472dabce70fe1c15221bdda837533dfd891916836975b434dec
 RUN ./download-machine.sh consensus-v11 0xf4389b835497a910d7ba3ebfb77aa93da985634f3c052de1290360635be40c4a
+RUN ./download-machine.sh consensus-v11.1 0x68e4fe5023f792d4ef584796c84d710303a5e12ea02d6e37e2b5e9c4332507c4
 
 FROM golang:1.20-bullseye as node-builder
 WORKDIR /workspace


### PR DESCRIPTION
Consensus v11.1 release notes: https://github.com/OffchainLabs/nitro/releases/tag/consensus-v11.1