### PR TITLE
Disable EIP-4844 batch posting by default for now

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -211,7 +211,7 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	DASRetentionPeriod: time.Hour * 24 * 15,
 	GasRefunderAddress: "",
 	ExtraBatchGas:      50_000,
-	Post4844Blobs:      true,
+	Post4844Blobs:      false,
 	ForcePost4844Blobs: false,
 	DataPoster:         dataposter.DefaultDataPosterConfig,
 	ParentChainWallet:  DefaultBatchPosterL1WalletConfig,


### PR DESCRIPTION
Right now, it'll try to post 4844 batches whenever the parent chain supports it, even if the smart contracts (e.g. the sequencer inbox) aren't upgraded to support it. We'll want to implement a better activation method soon (such as only enabling it after ArbOS 20), but for now, it's best to just disable 4844 support by default so we can safely upgrade batch posters to new versions without explicitly disabling 4844 batch posting.