### PR TITLE
Pull in geth changes to parse ABI errors

### DIFF
--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -96,12 +96,8 @@ func RenderSolError(solErr abi.Error, data []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	valsRange, ok := vals.([]interface{})
-	if !ok {
-		return "", errors.New("unexpected unpack result")
-	}
-	strVals := make([]string, 0, len(valsRange))
-	for _, val := range valsRange {
+	strVals := make([]string, 0, len(vals))
+	for _, val := range vals {
 		strVals = append(strVals, fmt.Sprintf("%v", val))
 	}
 	return fmt.Sprintf("error %v(%v)", solErr.Name, strings.Join(strVals, ", ")), nil

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -5,6 +5,7 @@ package arbtest
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -67,7 +68,9 @@ func TestCustomSolidityErrors(t *testing.T) {
 		Fatal(t, "customRevert call should have errored")
 	}
 	observedMessage := customError.Error()
-	expectedMessage := "execution reverted: error Custom(1024, This spider family wards off bugs: /\\oo/\\ //\\(oo)/\\ /\\oo/\\, true)"
+	expectedError := "Custom(1024, This spider family wards off bugs: /\\oo/\\ //\\(oo)/\\ /\\oo/\\, true)"
+	// The first error is server side. The second error is client side ABI decoding.
+	expectedMessage := fmt.Sprintf("execution reverted: error %v: %v", expectedError, expectedError)
 	if observedMessage != expectedMessage {
 		Fatal(t, observedMessage)
 	}
@@ -79,7 +82,8 @@ func TestCustomSolidityErrors(t *testing.T) {
 		Fatal(t, "out of range ArbBlockHash call should have errored")
 	}
 	observedMessage = customError.Error()
-	expectedMessage = "execution reverted: error InvalidBlockNumber(1000000000, 1)"
+	expectedError = "InvalidBlockNumber(1000000000, 1)"
+	expectedMessage = fmt.Sprintf("execution reverted: error %v: %v", expectedError, expectedError)
 	if observedMessage != expectedMessage {
 		Fatal(t, observedMessage)
 	}

--- a/system_tests/retryable_test.go
+++ b/system_tests/retryable_test.go
@@ -121,7 +121,8 @@ func TestRetryableNoExist(t *testing.T) {
 	arbRetryableTx, err := precompilesgen.NewArbRetryableTx(common.HexToAddress("6e"), builder.L2.Client)
 	Require(t, err)
 	_, err = arbRetryableTx.GetTimeout(&bind.CallOpts{}, common.Hash{})
-	if err.Error() != "execution reverted: error NoTicketWithID()" {
+	// The first error is server side. The second error is client side ABI decoding.
+	if err.Error() != "execution reverted: error NoTicketWithID(): NoTicketWithID()" {
 		Fatal(t, "didn't get expected NoTicketWithID error")
 	}
 }


### PR DESCRIPTION
Pulls in https://github.com/OffchainLabs/go-ethereum/pull/287

As mentioned there, this allows for nice error messages like `execution reverted: NoSuchKeyset(0x0100000000000000000000000000000000000000000000000000000000000000)`

This PR also updates precompile.go now that Error's Unpack method returns a better type.