### PR TITLE
Gate 4844 Batch Posting on ArbOS 20

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -954,7 +954,6 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 	if dbBatchCount > batchPosition.NextSeqNum {
 		return false, fmt.Errorf("attempting to post batch %v, but the local inbox tracker database already has %v batches", batchPosition.NextSeqNum, dbBatchCount)
 	}
-
 	if b.building == nil || b.building.startMsgCount != batchPosition.MessageCount {
 		latestHeader, err := b.l1Reader.LastHeader(ctx)
 		if err != nil {
@@ -963,7 +962,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		var use4844 bool
 		config := b.config()
 		if config.Post4844Blobs && latestHeader.ExcessBlobGas != nil && latestHeader.BlobGasUsed != nil {
-			arbOSVersion, err := b.arbOSVersionGetter.ArbOSVersionForMessageNumber(batchPosition.MessageCount)
+			arbOSVersion, err := b.arbOSVersionGetter.ArbOSVersionForMessageNumber(arbutil.MessageIndex(arbmath.SaturatingUSub(uint64(batchPosition.MessageCount), 1)))
 			if err != nil {
 				return false, err
 			}

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -41,6 +41,7 @@ import (
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/das"
+	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/util"
 	"github.com/offchainlabs/nitro/util/arbmath"
@@ -71,16 +72,12 @@ type batchPosterPosition struct {
 	NextSeqNum          uint64
 }
 
-type ArbOSVersionGetter interface {
-	ArbOSVersionForMessageNumber(messageNum arbutil.MessageIndex) (uint64, error)
-}
-
 type BatchPoster struct {
 	stopwaiter.StopWaiter
 	l1Reader           *headerreader.HeaderReader
 	inbox              *InboxTracker
 	streamer           *TransactionStreamer
-	arbOSVersionGetter ArbOSVersionGetter
+	arbOSVersionGetter execution.FullExecutionClient
 	config             BatchPosterConfigFetcher
 	seqInbox           *bridgegen.SequencerInbox
 	bridge             *bridgegen.Bridge
@@ -260,7 +257,7 @@ type BatchPosterOpts struct {
 	L1Reader      *headerreader.HeaderReader
 	Inbox         *InboxTracker
 	Streamer      *TransactionStreamer
-	VersionGetter ArbOSVersionGetter
+	VersionGetter execution.FullExecutionClient
 	SyncMonitor   *SyncMonitor
 	Config        BatchPosterConfigFetcher
 	DeployInfo    *chaininfo.RollupAddresses

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -179,7 +179,7 @@ type BatchPosterConfigFetcher func() *BatchPosterConfig
 
 func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultBatchPosterConfig.Enable, "enable posting batches to l1")
-	f.Bool(prefix+".disable-das-fallback-store-data-on-chain", DefaultBatchPosterConfig.DisableDasFallbackStoreDataOnChain, "If unable to batch to AS, disable fallback storing data on chain")
+	f.Bool(prefix+".disable-das-fallback-store-data-on-chain", DefaultBatchPosterConfig.DisableDasFallbackStoreDataOnChain, "If unable to batch to DAS, disable fallback storing data on chain")
 	f.Int(prefix+".max-size", DefaultBatchPosterConfig.MaxSize, "maximum batch size")
 	f.Int(prefix+".max-4844-batch-size", DefaultBatchPosterConfig.Max4844BatchSize, "maximum 4844 blob enabled batch size")
 	f.Duration(prefix+".max-delay", DefaultBatchPosterConfig.MaxDelay, "maximum batch posting delay")

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -341,7 +341,7 @@ func StakerDataposter(
 func createNodeImpl(
 	ctx context.Context,
 	stack *node.Node,
-	exec execution.FullExecutionClient,
+	exec *gethexec.ExecutionNode,
 	arbDb ethdb.Database,
 	configFetcher ConfigFetcher,
 	l2Config *params.ChainConfig,
@@ -654,6 +654,7 @@ func createNodeImpl(
 			L1Reader:      l1Reader,
 			Inbox:         inboxTracker,
 			Streamer:      txStreamer,
+			VersionGetter: exec.ExecEngine,
 			SyncMonitor:   syncMonitor,
 			Config:        func() *BatchPosterConfig { return &configFetcher.Get().BatchPoster },
 			DeployInfo:    deployInfo,
@@ -707,7 +708,7 @@ func (n *Node) OnConfigReload(_ *Config, _ *Config) error {
 func CreateNode(
 	ctx context.Context,
 	stack *node.Node,
-	exec execution.FullExecutionClient,
+	exec *gethexec.ExecutionNode,
 	arbDb ethdb.Database,
 	configFetcher ConfigFetcher,
 	l2Config *params.ChainConfig,

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -348,7 +348,7 @@ func StakerDataposter(
 func createNodeImpl(
 	ctx context.Context,
 	stack *node.Node,
-	exec *gethexec.ExecutionNode,
+	exec execution.FullExecutionClient,
 	arbDb ethdb.Database,
 	configFetcher ConfigFetcher,
 	l2Config *params.ChainConfig,
@@ -661,7 +661,7 @@ func createNodeImpl(
 			L1Reader:      l1Reader,
 			Inbox:         inboxTracker,
 			Streamer:      txStreamer,
-			VersionGetter: exec.ExecEngine,
+			VersionGetter: exec,
 			SyncMonitor:   syncMonitor,
 			Config:        func() *BatchPosterConfig { return &configFetcher.Get().BatchPoster },
 			DeployInfo:    deployInfo,
@@ -715,7 +715,7 @@ func (n *Node) OnConfigReload(_ *Config, _ *Config) error {
 func CreateNode(
 	ctx context.Context,
 	stack *node.Node,
-	exec *gethexec.ExecutionNode,
+	exec execution.FullExecutionClient,
 	arbDb ethdb.Database,
 	configFetcher ConfigFetcher,
 	l2Config *params.ChainConfig,

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -101,7 +101,7 @@ func (s *ExecutionEngine) Reorg(count arbutil.MessageIndex, newMessages []arbost
 	resequencing := false
 	defer func() {
 		// if we are resequencing old messages - don't release the lock
-		// lock will be relesed by thread listening to resequenceChan
+		// lock will be released by thread listening to resequenceChan
 		if !resequencing {
 			s.createBlocksMutex.Unlock()
 		}
@@ -599,6 +599,15 @@ func (s *ExecutionEngine) digestMessageWithBlockMutex(num arbutil.MessageIndex, 
 	default:
 	}
 	return nil
+}
+
+func (s *ExecutionEngine) ArbOSVersionForMessageNumber(messageNum arbutil.MessageIndex) (uint64, error) {
+	block := s.bc.GetBlockByNumber(s.MessageIndexToBlockNumber(messageNum))
+	if block == nil {
+		return 0, fmt.Errorf("couldn't find block for message number %d", messageNum)
+	}
+	extra := types.DeserializeHeaderExtraInformation(block.Header())
+	return extra.ArbOSFormatVersion, nil
 }
 
 func (s *ExecutionEngine) Start(ctx_in context.Context) {

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -332,6 +332,9 @@ func (n *ExecutionNode) SequenceDelayedMessage(message *arbostypes.L1IncomingMes
 func (n *ExecutionNode) ResultAtPos(pos arbutil.MessageIndex) (*execution.MessageResult, error) {
 	return n.ExecEngine.ResultAtPos(pos)
 }
+func (n *ExecutionNode) ArbOSVersionForMessageNumber(messageNum arbutil.MessageIndex) (uint64, error) {
+	return n.ExecEngine.ArbOSVersionForMessageNumber(messageNum)
+}
 
 func (n *ExecutionNode) RecordBlockCreation(
 	ctx context.Context,

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -69,6 +69,8 @@ type FullExecutionClient interface {
 
 	// TODO: only used to get safe/finalized block numbers
 	MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) uint64
+
+	ArbOSVersionForMessageNumber(messageNum arbutil.MessageIndex) (uint64, error)
 }
 
 // not implemented in execution, used as input

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -166,6 +166,7 @@ func testBatchPosterParallel(t *testing.T, useRedis bool) {
 				L1Reader:      builder.L2.ConsensusNode.L1Reader,
 				Inbox:         builder.L2.ConsensusNode.InboxTracker,
 				Streamer:      builder.L2.ConsensusNode.TxStreamer,
+				VersionGetter: builder.L2.ExecNode.ExecEngine,
 				SyncMonitor:   builder.L2.ConsensusNode.SyncMonitor,
 				Config:        func() *arbnode.BatchPosterConfig { return &batchPosterConfig },
 				DeployInfo:    builder.L2.ConsensusNode.DeployInfo,

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -166,7 +166,7 @@ func testBatchPosterParallel(t *testing.T, useRedis bool) {
 				L1Reader:      builder.L2.ConsensusNode.L1Reader,
 				Inbox:         builder.L2.ConsensusNode.InboxTracker,
 				Streamer:      builder.L2.ConsensusNode.TxStreamer,
-				VersionGetter: builder.L2.ExecNode.ExecEngine,
+				VersionGetter: builder.L2.ExecNode,
 				SyncMonitor:   builder.L2.ConsensusNode.SyncMonitor,
 				Config:        func() *arbnode.BatchPosterConfig { return &batchPosterConfig },
 				DeployInfo:    builder.L2.ConsensusNode.DeployInfo,


### PR DESCRIPTION
Plumb ExecutionEngine to BatchPoster as the ArbOSVersionGetter interface so that it can post 4844 batches for only ArbOS 20 and above. BatchPoster finds if ArbOS 20 or greater was already enabled as of MessageIndex of the first message in the batch using the ArbOSVersionGetter interface.

# Testing done
Unit tests pass.

The following manual test was performed to check that batches are posted when ArbOS 20 is detected. It wasn't tested if the version was less than ArbOS 20 because the test setup is even more complex and hopefully code review is enough to satisfy us here.

## Start L1 devnet
Use https://github.com/kasey/eth-envs/blob/main/deneb-interop/run.sh
## Deploy rollup
```
# Deploys the rollup
/home/tristan/offchain/nitro/target/bin/deploy -l1conn http://localhost:8545 -l1privatekey <hardhat private key 0>  -l1chainid 32382 -l1deployment $DATADIR/deploy.json -l2chaininfo $DATADIR/chaininfo.json -l2chainname tristan-devnet -log_dir $DATADIR/nitro -ownerAddress 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 -l2chainconfig /home/tristan/offchain/4844/devnet-12-data/l2_chain_config.json
echo "rollup deployed"

# deposit some eth to hardhat address 1
cast send 0xcbd5431cc04031d089c90e7c83288183a6fe545d 'depositEth()' --value 1ether --nonce 0 -r http://localhost:8545 --private-key <hardhat private key 1>
echo "eth deposited to l2"

# set hardhat address 0 to be a batch poster
cast send 0x0826223156ff61f9abf620d2f58a06177da664cc 'executeCall(address,bytes)' -r http://localhost:8545 --private-key <hardhat private key 0>  0xdad42d43ece0f6e8da8c2bcbc6a25ff6b3922c58 0x6e7df3e7000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000001
echo "enable batchposter address"

# Set up config for nitro
cp nodeconfig.json $DATADIR/nodeconfig.json
sed -i -e 's@DATADIR@'$DATADIR'@' $DATADIR/nodeconfig.json
echo "nitro config for this network set up"
```
## Start nitro
Start nitro with 4844 batch posting disabled
```
./target/bin/nitro --conf.file $DATADIR/nodeconfig.json --http.api net,web3,eth,txpool,debug --persistent.global-config $DATADIR/arbitrum-data
```

## Send some txs on L2 from hardhat 1 to 2
```
cast send 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc -r http://localhost:8547 --private-key <hardhat ardress 1> --value 0.01ether
```

## Observe batch types posted
The batch locations indicates whether the batch data was posted in the TxInput, a separate event (for chain init), or a blob. Here is the enum:
```
0 = TxInput
1 = SeparateBatchEvent
2 = NoData
3 = Blob
```

This command checks the sequencer-inbox contract for SequencerBatchDelivered events and then parses the response for batch number and data location. 
```
for i in `cast logs --address 0xdad42d43ece0f6e8da8c2bcbc6a25ff6b3922c58 -r http://localhost:8545 --from-block earliest --to-block latest  "SequencerBatchDelivered(uint256,bytes32,bytes32,bytes32,uint256,(uint64,uint64,uint64,uint64),uint8)" -j | jq -r '.[] |  (.topics[1:4] | join(",")) + "," + .data ' | sed 's/,0x//g'`; do cast abi-decode -i "SequencerBatchDelivered(uint256,bytes32,bytes32,bytes32,uint256,(uint64,uint64,uint64,uint64),uint8)" $i | awk 'NR==1 {print "batchSequenceNumber: " $0} NR==7 {print "\tdataLocation: " $0}'; done
batchSequenceNumber: 0
        dataLocation: 1
batchSequenceNumber: 1
        dataLocation: 0
batchSequenceNumber: 2
        dataLocation: 0
```

## Change batch poster nodeconfig to post 4844 blobs, restart nitro
```
    "batch-poster": {
 ...
		"post-4844-blobs": true,
		"force-post-4844-blobs": true,
```

```
./target/bin/nitro --conf.file $DATADIR/nodeconfig.json --http.api net,web3,eth,txpool,debug --persistent.global-config $DATADIR/arbitrum-data
```

## Send some txs on L2 from hardhat 1 to 2
```
cast send 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc -r http://localhost:8547 --private-key <hardhat ardress 1> --value 0.01ether
```

## Observe batch types posted
```
for i in `cast logs --address 0xdad42d43ece0f6e8da8c2bcbc6a25ff6b3922c58 -r http://localhost:8545 --from-block earliest --to-block latest  "SequencerBatchDelivered(uint256,bytes32,bytes32,bytes32,uint256,(uint64,uint64,uint64,uint64),uint8)" -j | jq -r '.[] |  (.topics[1:4] | join(",")) + "," + .data ' | sed 's/,0x//g'`; do cast abi-decode -i "SequencerBatchDelivered(uint256,bytes32,bytes32,bytes32,uint256,(uint64,uint64,uint64,uint64),uint8)" $i | awk 'NR==1 {print "batchSequenceNumber: " $0} NR==7 {print "\tdataLocation: " $0}'; done
batchSequenceNumber: 0
        dataLocation: 1
batchSequenceNumber: 1
        dataLocation: 0
batchSequenceNumber: 2
        dataLocation: 0
batchSequenceNumber: 3
        dataLocation: 3
batchSequenceNumber: 4
        dataLocation: 3

```

