### PR TITLE
Add batch parsing version tracking

### DIFF
--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -138,7 +138,12 @@ func (t *InboxTracker) Initialize() error {
 	return nil
 }
 
-// clearUnprocessedBatches reorgs to the batch of the latest block
+// clearUnprocessedBatches reorgs to the batch of the latest block.
+// This will reorg out any batches which have not been executed and processed into a block.
+// The purpose of this is to clear out any batches which may have been parsed on an out of date node version.
+// That out of date node version may have incorrectly parsed old batches and produced incorrect messages.
+// The out of date node version also wouldn't be able to upgrade to the new ArbOS version,
+// which is why we use the latest block as a reference point for what to clear.
 func (t *InboxTracker) clearUnprocessedBatches() error {
 	batchCount, err := t.GetBatchCount()
 	if err != nil {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -288,6 +288,11 @@ func checkArbDbSchemaVersion(arbDb ethdb.Database) error {
 			// No database updates are necessary for database format version 0->1.
 			// This version adds a new format for delayed messages in the inbox tracker,
 			// but it can still read the old format for old messages.
+		case 1:
+			// Database format version 1->2 adds a batch parsing version field.
+			// That code already gracefully handles the field not existing in the db,
+			// so there's no need to insert the field here.
+			// The new version is present to prevent downgrading batch parsing versions.
 		default:
 			return fmt.Errorf("unsupported database format version %v", version)
 		}

--- a/arbnode/schema.go
+++ b/arbnode/schema.go
@@ -15,6 +15,8 @@ var (
 	delayedMessageCountKey []byte = []byte("_delayedMessageCount") // contains the current delayed message count
 	sequencerBatchCountKey []byte = []byte("_sequencerBatchCount") // contains the current sequencer message count
 	dbSchemaVersion        []byte = []byte("_schemaVersion")       // contains a uint64 representing the database schema version
+	batchParsingVersion    []byte = []byte("_batchParsingVersion") // contains the batch parsing version
 )
 
-const currentDbSchemaVersion uint64 = 1
+const currentDbSchemaVersion uint64 = 2
+const currentBatchParsingVersion uint64 = 1

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -252,6 +252,13 @@ func (s *TransactionStreamer) reorg(batch ethdb.Batch, count arbutil.MessageInde
 	if count == 0 {
 		return errors.New("cannot reorg out init message")
 	}
+	// If not started, use a background context.
+	// This can happening when reorging on startup using the init flag.
+	ctx := context.Background()
+	if s.Started() {
+		ctx = s.GetContext()
+	}
+
 	lastDelayedSeqNum, err := s.getPrevPrevDelayedRead(count)
 	if err != nil {
 		return err
@@ -308,7 +315,7 @@ func (s *TransactionStreamer) reorg(batch ethdb.Batch, count arbutil.MessageInde
 					continue
 				}
 				msgBlockNum := new(big.Int).SetUint64(oldMessage.Message.Header.BlockNumber)
-				delayedInBlock, err := s.delayedBridge.LookupMessagesInRange(s.GetContext(), msgBlockNum, msgBlockNum, nil)
+				delayedInBlock, err := s.delayedBridge.LookupMessagesInRange(ctx, msgBlockNum, msgBlockNum, nil)
 				if err != nil {
 					log.Error("reorg-resequence: failed to serialize old delayed message from database", "err", err)
 					continue


### PR DESCRIPTION
The main purpose of this is to ensure that out of date node parsing of EIP-4844 batches don't cause a divergence after upgrading to a compatible version.