### PR TITLE
Require beacon client RPC

### DIFF
--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -45,6 +45,7 @@ type BlobReader interface {
 		batchBlockHash common.Hash,
 		versionedHashes []common.Hash,
 	) ([]kzg4844.Blob, error)
+	Initialize(ctx context.Context) error
 }
 
 type sequencerMessage struct {

--- a/cmd/conf/chain.go
+++ b/cmd/conf/chain.go
@@ -7,14 +7,16 @@ import (
 	"time"
 
 	"github.com/offchainlabs/nitro/cmd/genericconf"
+	"github.com/offchainlabs/nitro/util/headerreader"
 	"github.com/offchainlabs/nitro/util/rpcclient"
 	flag "github.com/spf13/pflag"
 )
 
-type L1Config struct {
-	ID         uint64                   `koanf:"id"`
-	Connection rpcclient.ClientConfig   `koanf:"connection" reload:"hot"`
-	Wallet     genericconf.WalletConfig `koanf:"wallet"`
+type ParentChainConfig struct {
+	ID         uint64                        `koanf:"id"`
+	Connection rpcclient.ClientConfig        `koanf:"connection" reload:"hot"`
+	Wallet     genericconf.WalletConfig      `koanf:"wallet"`
+	BlobClient headerreader.BlobClientConfig `koanf:"blob-client"`
 }
 
 var L1ConnectionConfigDefault = rpcclient.ClientConfig{
@@ -25,10 +27,11 @@ var L1ConnectionConfigDefault = rpcclient.ClientConfig{
 	ArgLogLimit:    2048,
 }
 
-var L1ConfigDefault = L1Config{
+var L1ConfigDefault = ParentChainConfig{
 	ID:         0,
 	Connection: L1ConnectionConfigDefault,
 	Wallet:     DefaultL1WalletConfig,
+	BlobClient: headerreader.DefaultBlobClientConfig,
 }
 
 var DefaultL1WalletConfig = genericconf.WalletConfig{
@@ -43,13 +46,14 @@ func L1ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Uint64(prefix+".id", L1ConfigDefault.ID, "if set other than 0, will be used to validate database and L1 connection")
 	rpcclient.RPCClientAddOptions(prefix+".connection", f, &L1ConfigDefault.Connection)
 	genericconf.WalletConfigAddOptions(prefix+".wallet", f, L1ConfigDefault.Wallet.Pathname)
+	headerreader.BlobClientAddOptions(prefix+".blob-client", f)
 }
 
-func (c *L1Config) ResolveDirectoryNames(chain string) {
+func (c *ParentChainConfig) ResolveDirectoryNames(chain string) {
 	c.Wallet.ResolveDirectoryNames(chain)
 }
 
-func (c *L1Config) Validate() error {
+func (c *ParentChainConfig) Validate() error {
 	return c.Connection.Validate()
 }
 

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbnode/resourcemanager"
+	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/arbutil"
 	blocksreexecutor "github.com/offchainlabs/nitro/blocks_reexecutor"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
@@ -329,6 +330,8 @@ func mainImpl() int {
 
 	var rollupAddrs chaininfo.RollupAddresses
 	var l1Client *ethclient.Client
+	var l1Reader *headerreader.HeaderReader
+	var blobReader arbstate.BlobReader
 	if nodeConfig.Node.ParentChainReader.Enable {
 		confFetcher := func() *rpcclient.ClientConfig { return &liveNodeConfig.Get().ParentChain.Connection }
 		rpcClient := rpcclient.NewRpcClient(confFetcher, nil)
@@ -351,6 +354,22 @@ func mainImpl() int {
 		if err != nil {
 			log.Crit("error getting rollup addresses", "err", err)
 		}
+		arbSys, _ := precompilesgen.NewArbSys(types.ArbSysAddress, l1Client)
+		l1Reader, err = headerreader.New(ctx, l1Client, func() *headerreader.Config { return &liveNodeConfig.Get().Node.ParentChainReader }, arbSys)
+		if err != nil {
+			log.Crit("failed to get L1 headerreader", "err", err)
+		}
+		if !l1Reader.IsParentChainArbitrum() && !nodeConfig.Node.Dangerous.DisableBlobReader {
+			if nodeConfig.ParentChain.BlobClient.BeaconUrl == "" {
+				flag.Usage()
+				log.Crit("a beacon chain RPC URL is required to read batches, but it was not configured (CLI argument: --node.parent-chain.blob-client.beacon-url [URL])")
+			}
+			blobClient, err := headerreader.NewBlobClient(nodeConfig.ParentChain.BlobClient, l1Client)
+			if err != nil {
+				log.Crit("failed to initialize blob client", "err", err)
+			}
+			blobReader = blobClient
+		}
 	}
 
 	if nodeConfig.Node.Staker.OnlyCreateWalletContract {
@@ -358,12 +377,10 @@ func mainImpl() int {
 			flag.Usage()
 			log.Crit("--node.validator.only-create-wallet-contract requires --node.validator.use-smart-contract-wallet")
 		}
-		arbSys, _ := precompilesgen.NewArbSys(types.ArbSysAddress, l1Client)
-		l1Reader, err := headerreader.New(ctx, l1Client, func() *headerreader.Config { return &liveNodeConfig.Get().Node.ParentChainReader }, arbSys)
-		if err != nil {
-			log.Crit("failed to get L1 headerreader", "error", err)
+		if l1Reader == nil {
+			flag.Usage()
+			log.Crit("--node.validator.only-create-wallet-contract conflicts with --node.dangerous.no-l1-listener")
 		}
-
 		// Just create validator smart wallet if needed then exit
 		deployInfo, err := chaininfo.GetRollupAddressesConfig(nodeConfig.Chain.ID, nodeConfig.Chain.Name, combinedL2ChainInfoFile, nodeConfig.Chain.InfoJson)
 		if err != nil {
@@ -536,6 +553,7 @@ func mainImpl() int {
 		dataSigner,
 		fatalErrChan,
 		big.NewInt(int64(nodeConfig.ParentChain.ID)),
+		blobReader,
 	)
 	if err != nil {
 		log.Error("failed to create node", "err", err)
@@ -667,7 +685,7 @@ type NodeConfig struct {
 	Node             arbnode.Config                  `koanf:"node" reload:"hot"`
 	Execution        gethexec.Config                 `koanf:"execution" reload:"hot"`
 	Validation       valnode.Config                  `koanf:"validation" reload:"hot"`
-	ParentChain      conf.L1Config                   `koanf:"parent-chain" reload:"hot"`
+	ParentChain      conf.ParentChainConfig          `koanf:"parent-chain" reload:"hot"`
 	Chain            conf.L2Config                   `koanf:"chain"`
 	LogLevel         int                             `koanf:"log-level" reload:"hot"`
 	LogType          string                          `koanf:"log-type" reload:"hot"`

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -362,7 +362,7 @@ func mainImpl() int {
 		if !l1Reader.IsParentChainArbitrum() && !nodeConfig.Node.Dangerous.DisableBlobReader {
 			if nodeConfig.ParentChain.BlobClient.BeaconUrl == "" {
 				flag.Usage()
-				log.Crit("a beacon chain RPC URL is required to read batches, but it was not configured (CLI argument: --node.parent-chain.blob-client.beacon-url [URL])")
+				log.Crit("a beacon chain RPC URL is required to read batches, but it was not configured (CLI argument: --parent-chain.blob-client.beacon-url [URL])")
 			}
 			blobClient, err := headerreader.NewBlobClient(nodeConfig.ParentChain.BlobClient, l1Client)
 			if err != nil {

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -143,6 +143,10 @@ func (r *BlobPreimageReader) GetBlobs(
 	return blobs, nil
 }
 
+func (r *BlobPreimageReader) Initialize(ctx context.Context) error {
+	return nil
+}
+
 // To generate:
 // key, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000001")
 // sig, _ := crypto.Sign(make([]byte, 32), key)

--- a/system_tests/blocks_reexecutor_test.go
+++ b/system_tests/blocks_reexecutor_test.go
@@ -26,7 +26,7 @@ func TestBlocksReExecutorModes(t *testing.T) {
 
 	parentChainID := big.NewInt(1234)
 	feedErrChan := make(chan error, 10)
-	node, err := arbnode.CreateNode(ctx, stack, execNode, arbDb, NewFetcherFromConfig(arbnode.ConfigDefaultL2Test()), blockchain.Config(), nil, nil, nil, nil, nil, feedErrChan, parentChainID)
+	node, err := arbnode.CreateNode(ctx, stack, execNode, arbDb, NewFetcherFromConfig(arbnode.ConfigDefaultL2Test()), blockchain.Config(), nil, nil, nil, nil, nil, feedErrChan, parentChainID, nil)
 	Require(t, err)
 	err = node.TxStreamer.AddFakeInitMessage()
 	Require(t, err)

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -789,7 +789,7 @@ func createTestNodeWithL1(
 	Require(t, err)
 	currentNode, err = arbnode.CreateNode(
 		ctx, l2stack, execNode, l2arbDb, NewFetcherFromConfig(nodeConfig), l2blockchain.Config(), l1client,
-		addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, dataSigner, fatalErrChan, big.NewInt(1337),
+		addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, dataSigner, fatalErrChan, big.NewInt(1337), nil,
 	)
 	Require(t, err)
 
@@ -825,7 +825,7 @@ func createTestNode(
 	execNode, err := gethexec.CreateExecutionNode(ctx, stack, chainDb, blockchain, nil, execConfigFetcher)
 	Require(t, err)
 
-	currentNode, err := arbnode.CreateNode(ctx, stack, execNode, arbDb, NewFetcherFromConfig(nodeConfig), blockchain.Config(), nil, nil, nil, nil, nil, feedErrChan, big.NewInt(1337))
+	currentNode, err := arbnode.CreateNode(ctx, stack, execNode, arbDb, NewFetcherFromConfig(nodeConfig), blockchain.Config(), nil, nil, nil, nil, nil, feedErrChan, big.NewInt(1337), nil)
 	Require(t, err)
 
 	// Give the node an init message
@@ -930,7 +930,7 @@ func Create2ndNodeWithConfig(
 	currentExec, err := gethexec.CreateExecutionNode(ctx, l2stack, l2chainDb, l2blockchain, l1client, configFetcher)
 	Require(t, err)
 
-	currentNode, err := arbnode.CreateNode(ctx, l2stack, currentExec, l2arbDb, NewFetcherFromConfig(nodeConfig), l2blockchain.Config(), l1client, first.DeployInfo, &txOpts, &txOpts, dataSigner, feedErrChan, big.NewInt(1337))
+	currentNode, err := arbnode.CreateNode(ctx, l2stack, currentExec, l2arbDb, NewFetcherFromConfig(nodeConfig), l2blockchain.Config(), l1client, first.DeployInfo, &txOpts, &txOpts, dataSigner, feedErrChan, big.NewInt(1337), nil)
 	Require(t, err)
 
 	err = currentNode.Start(ctx)

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -141,7 +141,7 @@ func TestDASRekey(t *testing.T) {
 		l1NodeConfigA.DataAvailability.ParentChainNodeURL = "none"
 		execA, err := gethexec.CreateExecutionNode(ctx, l2stackA, l2chainDb, l2blockchain, l1client, gethexec.ConfigDefaultTest)
 		Require(t, err)
-		nodeA, err := arbnode.CreateNode(ctx, l2stackA, execA, l2arbDb, NewFetcherFromConfig(l1NodeConfigA), l2blockchain.Config(), l1client, addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, nil, feedErrChan, parentChainID)
+		nodeA, err := arbnode.CreateNode(ctx, l2stackA, execA, l2arbDb, NewFetcherFromConfig(l1NodeConfigA), l2blockchain.Config(), l1client, addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, nil, feedErrChan, parentChainID, nil)
 		Require(t, err)
 		Require(t, nodeA.Start(ctx))
 		l2clientA := ClientForStack(t, l2stackA)
@@ -188,7 +188,7 @@ func TestDASRekey(t *testing.T) {
 	Require(t, err)
 
 	l1NodeConfigA.DataAvailability.RPCAggregator = aggConfigForBackend(t, backendConfigB)
-	nodeA, err := arbnode.CreateNode(ctx, l2stackA, execA, l2arbDb, NewFetcherFromConfig(l1NodeConfigA), l2blockchain.Config(), l1client, addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, nil, feedErrChan, parentChainID)
+	nodeA, err := arbnode.CreateNode(ctx, l2stackA, execA, l2arbDb, NewFetcherFromConfig(l1NodeConfigA), l2blockchain.Config(), l1client, addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, nil, feedErrChan, parentChainID, nil)
 	Require(t, err)
 	Require(t, nodeA.Start(ctx))
 	l2clientA := ClientForStack(t, l2stackA)
@@ -321,7 +321,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 
 	sequencerTxOpts := l1info.GetDefaultTransactOpts("Sequencer", ctx)
 	sequencerTxOptsPtr := &sequencerTxOpts
-	nodeA, err := arbnode.CreateNode(ctx, l2stackA, execA, l2arbDb, NewFetcherFromConfig(l1NodeConfigA), l2blockchain.Config(), l1client, addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, dataSigner, feedErrChan, big.NewInt(1337))
+	nodeA, err := arbnode.CreateNode(ctx, l2stackA, execA, l2arbDb, NewFetcherFromConfig(l1NodeConfigA), l2blockchain.Config(), l1client, addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, dataSigner, feedErrChan, big.NewInt(1337), nil)
 	Require(t, err)
 	Require(t, nodeA.Start(ctx))
 	l2clientA := ClientForStack(t, l2stackA)

--- a/system_tests/full_challenge_impl_test.go
+++ b/system_tests/full_challenge_impl_test.go
@@ -285,7 +285,7 @@ func RunChallengeTest(t *testing.T, asserterIsCorrect bool, useStubs bool, chall
 	asserterExec, err := gethexec.CreateExecutionNode(ctx, asserterL2Stack, asserterL2ChainDb, asserterL2Blockchain, l1Backend, gethexec.ConfigDefaultTest)
 	Require(t, err)
 	parentChainID := big.NewInt(1337)
-	asserterL2, err := arbnode.CreateNode(ctx, asserterL2Stack, asserterExec, asserterL2ArbDb, NewFetcherFromConfig(conf), chainConfig, l1Backend, asserterRollupAddresses, nil, nil, nil, fatalErrChan, parentChainID)
+	asserterL2, err := arbnode.CreateNode(ctx, asserterL2Stack, asserterExec, asserterL2ArbDb, NewFetcherFromConfig(conf), chainConfig, l1Backend, asserterRollupAddresses, nil, nil, nil, fatalErrChan, parentChainID, nil)
 	Require(t, err)
 	err = asserterL2.Start(ctx)
 	Require(t, err)
@@ -296,7 +296,7 @@ func RunChallengeTest(t *testing.T, asserterIsCorrect bool, useStubs bool, chall
 	challengerRollupAddresses.SequencerInbox = challengerSeqInboxAddr
 	challengerExec, err := gethexec.CreateExecutionNode(ctx, challengerL2Stack, challengerL2ChainDb, challengerL2Blockchain, l1Backend, gethexec.ConfigDefaultTest)
 	Require(t, err)
-	challengerL2, err := arbnode.CreateNode(ctx, challengerL2Stack, challengerExec, challengerL2ArbDb, NewFetcherFromConfig(conf), chainConfig, l1Backend, &challengerRollupAddresses, nil, nil, nil, fatalErrChan, parentChainID)
+	challengerL2, err := arbnode.CreateNode(ctx, challengerL2Stack, challengerExec, challengerL2ArbDb, NewFetcherFromConfig(conf), chainConfig, l1Backend, &challengerRollupAddresses, nil, nil, nil, fatalErrChan, parentChainID, nil)
 	Require(t, err)
 	err = challengerL2.Start(ctx)
 	Require(t, err)

--- a/system_tests/recreatestate_rpc_test.go
+++ b/system_tests/recreatestate_rpc_test.go
@@ -335,7 +335,7 @@ func testSkippingSavingStateAndRecreatingAfterRestart(t *testing.T, cacheConfig 
 	Require(t, err)
 
 	parentChainID := big.NewInt(1337)
-	node, err := arbnode.CreateNode(ctx1, stack, execNode, arbDb, NewFetcherFromConfig(arbnode.ConfigDefaultL2Test()), blockchain.Config(), nil, nil, nil, nil, nil, feedErrChan, parentChainID)
+	node, err := arbnode.CreateNode(ctx1, stack, execNode, arbDb, NewFetcherFromConfig(arbnode.ConfigDefaultL2Test()), blockchain.Config(), nil, nil, nil, nil, nil, feedErrChan, parentChainID, nil)
 	Require(t, err)
 	err = node.TxStreamer.AddFakeInitMessage()
 	Require(t, err)
@@ -376,7 +376,7 @@ func testSkippingSavingStateAndRecreatingAfterRestart(t *testing.T, cacheConfig 
 	execNode, err = gethexec.CreateExecutionNode(ctx1, stack, chainDb, blockchain, nil, execConfigFetcher)
 	Require(t, err)
 
-	node, err = arbnode.CreateNode(ctx, stack, execNode, arbDb, NewFetcherFromConfig(arbnode.ConfigDefaultL2Test()), blockchain.Config(), nil, node.DeployInfo, nil, nil, nil, feedErrChan, parentChainID)
+	node, err = arbnode.CreateNode(ctx, stack, execNode, arbDb, NewFetcherFromConfig(arbnode.ConfigDefaultL2Test()), blockchain.Config(), nil, node.DeployInfo, nil, nil, nil, feedErrChan, parentChainID, nil)
 	Require(t, err)
 	Require(t, node.Start(ctx))
 	client = ClientForStack(t, stack)

--- a/util/headerreader/blob_client.go
+++ b/util/headerreader/blob_client.go
@@ -1,7 +1,7 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-package arbnode
+package headerreader
 
 import (
 	"context"
@@ -35,19 +35,19 @@ type BlobClient struct {
 }
 
 type BlobClientConfig struct {
-	BeaconChainUrl string `koanf:"beacon-chain-url"`
+	BeaconUrl string `koanf:"beacon-url"`
 }
 
 var DefaultBlobClientConfig = BlobClientConfig{
-	BeaconChainUrl: "",
+	BeaconUrl: "",
 }
 
 func BlobClientAddOptions(prefix string, f *pflag.FlagSet) {
-	f.String(prefix+".beacon-chain-url", DefaultBlobClientConfig.BeaconChainUrl, "Beacon Chain url to use for fetching blobs (normally on port 3500)")
+	f.String(prefix+".beacon-url", DefaultBlobClientConfig.BeaconUrl, "Beacon Chain RPC URL to use for fetching blobs (normally on port 3500)")
 }
 
 func NewBlobClient(config BlobClientConfig, ec arbutil.L1Interface) (*BlobClient, error) {
-	beaconUrl, err := url.Parse(config.BeaconChainUrl)
+	beaconUrl, err := url.Parse(config.BeaconUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse beacon chain URL: %w", err)
 	}
@@ -189,16 +189,16 @@ type getSpecResponse struct {
 func (b *BlobClient) Initialize(ctx context.Context) error {
 	genesis, err := beaconRequest[genesisResponse](b, ctx, "/eth/v1/beacon/genesis")
 	if err != nil {
-		return fmt.Errorf("error calling beacon client in genesisTime: %w", err)
+		return fmt.Errorf("error calling beacon client to get genesisTime: %w", err)
 	}
 	b.genesisTime = uint64(genesis.GenesisTime)
 
 	spec, err := beaconRequest[getSpecResponse](b, ctx, "/eth/v1/config/spec")
 	if err != nil {
-		return fmt.Errorf("error calling beacon client in secondsPerSlot: %w", err)
+		return fmt.Errorf("error calling beacon client to get secondsPerSlot: %w", err)
 	}
 	if spec.SecondsPerSlot == 0 {
-		return errors.New("Got SECONDS_PER_SLOT of zero from beacon client")
+		return errors.New("got SECONDS_PER_SLOT of zero from beacon client")
 	}
 	b.secondsPerSlot = uint64(spec.SecondsPerSlot)
 


### PR DESCRIPTION
By requiring the RPC be configured at the time of upgrade to this new node version, instead of when ArbOS 20 goes live and blobs are actually being posted, node operators should be prepared for the change and avoid downtime.

As part of that, this PR also fetches the beacon chain parameters on startup instead of lazily as necessary, so that the beacon chain endpoint is validated on startup.

Pulls in https://github.com/OffchainLabs/nitro-testnode/pull/40