### PR TITLE
Add consensus-v20 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,6 +164,7 @@ RUN ./download-machine.sh consensus-v10.2 0x0754e09320c381566cc0449904c377a52bd3
 RUN ./download-machine.sh consensus-v10.3 0xf559b6d4fa869472dabce70fe1c15221bdda837533dfd891916836975b434dec
 RUN ./download-machine.sh consensus-v11 0xf4389b835497a910d7ba3ebfb77aa93da985634f3c052de1290360635be40c4a
 RUN ./download-machine.sh consensus-v11.1 0x68e4fe5023f792d4ef584796c84d710303a5e12ea02d6e37e2b5e9c4332507c4
+RUN ./download-machine.sh consensus-v20 0x8b104a2e80ac6165dc58b9048de12f301d70b02a0ab51396c22b4b4b802a16a4
 
 FROM golang:1.20-bookworm as node-builder
 WORKDIR /workspace


### PR DESCRIPTION
Consensus release: https://github.com/OffchainLabs/nitro/releases/tag/consensus-v20