### PR TITLE
Track pricing data in sequencer and batch poster. Add option to decline incoming transactions during extreme l1 pricing conditions

### DIFF
--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -195,6 +195,23 @@ func (ps *L1PricingState) SetUnitsSinceUpdate(units uint64) error {
 	return ps.unitsSinceUpdate.Set(units)
 }
 
+func (ps *L1PricingState) GetL1PricingSurplus() (*big.Int, error) {
+	fundsDueForRefunds, err := ps.BatchPosterTable().TotalFundsDue()
+	if err != nil {
+		return nil, err
+	}
+	fundsDueForRewards, err := ps.FundsDueForRewards()
+	if err != nil {
+		return nil, err
+	}
+	haveFunds, err := ps.L1FeesAvailable()
+	if err != nil {
+		return nil, err
+	}
+	needFunds := arbmath.BigAdd(fundsDueForRefunds, fundsDueForRewards)
+	return arbmath.BigSub(haveFunds, needFunds), nil
+}
+
 func (ps *L1PricingState) LastSurplus() (*big.Int, error) {
 	return ps.lastSurplus.Get()
 }

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -365,6 +365,8 @@ func (s *ExecutionEngine) sequenceTransactionsWithBlockMutex(header *arbostypes.
 		return nil, err
 	}
 
+	s.cacheL1PriceDataOfMsg(pos, receipts, block)
+
 	return block, nil
 }
 
@@ -503,6 +505,55 @@ func (s *ExecutionEngine) resultFromHeader(header *types.Header) (*execution.Mes
 
 func (s *ExecutionEngine) ResultAtPos(pos arbutil.MessageIndex) (*execution.MessageResult, error) {
 	return s.resultFromHeader(s.bc.GetHeaderByNumber(s.MessageIndexToBlockNumber(pos)))
+}
+
+func (s *ExecutionEngine) GetL1GasPriceEstimate() (uint64, error) {
+	bc := s.bc
+	latestHeader := bc.CurrentBlock()
+	latestState, err := bc.StateAt(latestHeader.Root)
+	if err != nil {
+		return 0, errors.New("error getting latest statedb while fetching l2 Estimate of L1 GasPrice")
+	}
+	arbState, err := arbosState.OpenSystemArbosState(latestState, nil, true)
+	if err != nil {
+		return 0, errors.New("error opening system arbos state while fetching l2 Estimate of L1 GasPrice")
+	}
+	l2EstimateL1GasPrice, err := arbState.L1PricingState().PricePerUnit()
+	if err != nil {
+		return 0, errors.New("error fetching l2 Estimate of L1 GasPrice")
+	}
+	return l2EstimateL1GasPrice.Uint64(), nil
+}
+
+func (s *ExecutionEngine) getL1PricingSurplus() (int64, error) {
+	bc := s.bc
+	latestHeader := bc.CurrentBlock()
+	latestState, err := bc.StateAt(latestHeader.Root)
+	if err != nil {
+		return 0, errors.New("error getting latest statedb while fetching l2 Estimate of L1 GasPrice")
+	}
+	arbState, err := arbosState.OpenSystemArbosState(latestState, nil, true)
+	if err != nil {
+		return 0, errors.New("error opening system arbos state while fetching l2 Estimate of L1 GasPrice")
+	}
+	surplus, err := arbState.L1PricingState().GetL1PricingSurplus()
+	if err != nil {
+		return 0, errors.New("error fetching l2 Estimate of L1 GasPrice")
+	}
+	return surplus.Int64(), nil
+}
+
+func (s *ExecutionEngine) cacheL1PriceDataOfMsg(num arbutil.MessageIndex, receipts types.Receipts, block *types.Block) {
+	var gasUsedForL1 uint64
+	for i := 1; i < len(receipts); i++ {
+		gasUsedForL1 += receipts[i].GasUsedForL1
+	}
+	gasChargedForL1 := gasUsedForL1 * block.BaseFee().Uint64()
+	var callDataUnits uint64
+	for _, tx := range block.Transactions() {
+		callDataUnits += tx.CalldataUnits
+	}
+	s.streamer.CacheL1PriceDataOfMsg(num, callDataUnits, gasChargedForL1)
 }
 
 // DigestMessage is used to create a block by executing msg against the latest state and storing it.

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -253,6 +253,10 @@ func CreateExecutionNode(
 
 }
 
+func (n *ExecutionNode) GetL1GasPriceEstimate() (uint64, error) {
+	return n.ExecEngine.GetL1GasPriceEstimate()
+}
+
 func (n *ExecutionNode) Initialize(ctx context.Context, arbnode interface{}, sync arbitrum.SyncProgressBackend) error {
 	n.ArbInterface.Initialize(arbnode)
 	err := n.Backend.Start()

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"math/big"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -25,10 +26,12 @@ import (
 	"github.com/ethereum/go-ethereum/arbitrum"
 	"github.com/ethereum/go-ethereum/arbitrum_types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
@@ -51,21 +54,30 @@ var (
 	successfulBlocksCounter                 = metrics.NewRegisteredCounter("arb/sequencer/block/successful", nil)
 	conditionalTxRejectedBySequencerCounter = metrics.NewRegisteredCounter("arb/sequencer/condtionaltx/rejected", nil)
 	conditionalTxAcceptedBySequencerCounter = metrics.NewRegisteredCounter("arb/sequencer/condtionaltx/accepted", nil)
+	l1GasPriceGauge                         = metrics.NewRegisteredGauge("arb/sequencer/l1gasprice", nil)
+	callDataUnitsBacklogGauge               = metrics.NewRegisteredGauge("arb/sequencer/calldataunitsbacklog", nil)
+	unusedL1GasChargeGauge                  = metrics.NewRegisteredGauge("arb/sequencer/unusedl1gascharge", nil)
+	currentSurplusGauge                     = metrics.NewRegisteredGauge("arb/sequencer/currentsurplus", nil)
+	expectedSurplusGauge                    = metrics.NewRegisteredGauge("arb/sequencer/expectedsurplus", nil)
 )
 
 type SequencerConfig struct {
-	Enable                      bool            `koanf:"enable"`
-	MaxBlockSpeed               time.Duration   `koanf:"max-block-speed" reload:"hot"`
-	MaxRevertGasReject          uint64          `koanf:"max-revert-gas-reject" reload:"hot"`
-	MaxAcceptableTimestampDelta time.Duration   `koanf:"max-acceptable-timestamp-delta" reload:"hot"`
-	SenderWhitelist             string          `koanf:"sender-whitelist"`
-	Forwarder                   ForwarderConfig `koanf:"forwarder"`
-	QueueSize                   int             `koanf:"queue-size"`
-	QueueTimeout                time.Duration   `koanf:"queue-timeout" reload:"hot"`
-	NonceCacheSize              int             `koanf:"nonce-cache-size" reload:"hot"`
-	MaxTxDataSize               int             `koanf:"max-tx-data-size" reload:"hot"`
-	NonceFailureCacheSize       int             `koanf:"nonce-failure-cache-size" reload:"hot"`
-	NonceFailureCacheExpiry     time.Duration   `koanf:"nonce-failure-cache-expiry" reload:"hot"`
+	Enable                       bool            `koanf:"enable"`
+	MaxBlockSpeed                time.Duration   `koanf:"max-block-speed" reload:"hot"`
+	MaxRevertGasReject           uint64          `koanf:"max-revert-gas-reject" reload:"hot"`
+	MaxAcceptableTimestampDelta  time.Duration   `koanf:"max-acceptable-timestamp-delta" reload:"hot"`
+	SenderWhitelist              string          `koanf:"sender-whitelist"`
+	Forwarder                    ForwarderConfig `koanf:"forwarder"`
+	QueueSize                    int             `koanf:"queue-size"`
+	QueueTimeout                 time.Duration   `koanf:"queue-timeout" reload:"hot"`
+	NonceCacheSize               int             `koanf:"nonce-cache-size" reload:"hot"`
+	MaxTxDataSize                int             `koanf:"max-tx-data-size" reload:"hot"`
+	NonceFailureCacheSize        int             `koanf:"nonce-failure-cache-size" reload:"hot"`
+	NonceFailureCacheExpiry      time.Duration   `koanf:"nonce-failure-cache-expiry" reload:"hot"`
+	ExpectedSurplusSoftThreshold string          `koanf:"expected-surplus-soft-threshold" reload:"hot"`
+	ExpectedSurplusHardThreshold string          `koanf:"expected-surplus-hard-threshold" reload:"hot"`
+	expectedSurplusSoftThreshold int
+	expectedSurplusHardThreshold int
 }
 
 func (c *SequencerConfig) Validate() error {
@@ -77,6 +89,20 @@ func (c *SequencerConfig) Validate() error {
 		if !common.IsHexAddress(address) {
 			return fmt.Errorf("sequencer sender whitelist entry \"%v\" is not a valid address", address)
 		}
+	}
+	var err error
+	if c.ExpectedSurplusSoftThreshold != "default" {
+		if c.expectedSurplusSoftThreshold, err = strconv.Atoi(c.ExpectedSurplusSoftThreshold); err != nil {
+			return fmt.Errorf("invalid expected-surplus-soft-threshold value provided in batchposter config %w", err)
+		}
+	}
+	if c.ExpectedSurplusHardThreshold != "default" {
+		if c.expectedSurplusHardThreshold, err = strconv.Atoi(c.ExpectedSurplusHardThreshold); err != nil {
+			return fmt.Errorf("invalid expected-surplus-hard-threshold value provided in batchposter config %w", err)
+		}
+	}
+	if c.expectedSurplusSoftThreshold < c.expectedSurplusHardThreshold {
+		return errors.New("expected-surplus-soft-threshold cannot be lower than expected-surplus-hard-threshold")
 	}
 	return nil
 }
@@ -94,24 +120,28 @@ var DefaultSequencerConfig = SequencerConfig{
 	NonceCacheSize:              1024,
 	// 95% of the default batch poster limit, leaving 5KB for headers and such
 	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go
-	MaxTxDataSize:           95000,
-	NonceFailureCacheSize:   1024,
-	NonceFailureCacheExpiry: time.Second,
+	MaxTxDataSize:                95000,
+	NonceFailureCacheSize:        1024,
+	NonceFailureCacheExpiry:      time.Second,
+	ExpectedSurplusSoftThreshold: "default",
+	ExpectedSurplusHardThreshold: "default",
 }
 
 var TestSequencerConfig = SequencerConfig{
-	Enable:                      true,
-	MaxBlockSpeed:               time.Millisecond * 10,
-	MaxRevertGasReject:          params.TxGas + 10000,
-	MaxAcceptableTimestampDelta: time.Hour,
-	SenderWhitelist:             "",
-	Forwarder:                   DefaultTestForwarderConfig,
-	QueueSize:                   128,
-	QueueTimeout:                time.Second * 5,
-	NonceCacheSize:              4,
-	MaxTxDataSize:               95000,
-	NonceFailureCacheSize:       1024,
-	NonceFailureCacheExpiry:     time.Second,
+	Enable:                       true,
+	MaxBlockSpeed:                time.Millisecond * 10,
+	MaxRevertGasReject:           params.TxGas + 10000,
+	MaxAcceptableTimestampDelta:  time.Hour,
+	SenderWhitelist:              "",
+	Forwarder:                    DefaultTestForwarderConfig,
+	QueueSize:                    128,
+	QueueTimeout:                 time.Second * 5,
+	NonceCacheSize:               4,
+	MaxTxDataSize:                95000,
+	NonceFailureCacheSize:        1024,
+	NonceFailureCacheExpiry:      time.Second,
+	ExpectedSurplusSoftThreshold: "default",
+	ExpectedSurplusHardThreshold: "default",
 }
 
 func SequencerConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -127,6 +157,8 @@ func SequencerConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Int(prefix+".max-tx-data-size", DefaultSequencerConfig.MaxTxDataSize, "maximum transaction size the sequencer will accept")
 	f.Int(prefix+".nonce-failure-cache-size", DefaultSequencerConfig.NonceFailureCacheSize, "number of transactions with too high of a nonce to keep in memory while waiting for their predecessor")
 	f.Duration(prefix+".nonce-failure-cache-expiry", DefaultSequencerConfig.NonceFailureCacheExpiry, "maximum amount of time to wait for a predecessor before rejecting a tx with nonce too high")
+	f.String(prefix+".expected-surplus-soft-threshold", DefaultSequencerConfig.ExpectedSurplusSoftThreshold, "if expected surplus is lower than this value, warnings are posted")
+	f.String(prefix+".expected-surplus-hard-threshold", DefaultSequencerConfig.ExpectedSurplusHardThreshold, "if expected surplus is lower than this value, no new batches are posted")
 }
 
 type txQueueItem struct {
@@ -291,6 +323,9 @@ type Sequencer struct {
 	activeMutex sync.Mutex
 	pauseChan   chan struct{}
 	forwarder   *TxForwarder
+
+	expectedSurplus          int64
+	expectedSurplusHardCheck bool
 }
 
 func NewSequencer(execEngine *ExecutionEngine, l1Reader *headerreader.HeaderReader, configFetcher SequencerConfigFetcher) (*Sequencer, error) {
@@ -364,6 +399,10 @@ func ctxWithTimeout(ctx context.Context, timeout time.Duration) (context.Context
 }
 
 func (s *Sequencer) PublishTransaction(parentCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions) error {
+	if s.expectedSurplusHardCheck && s.expectedSurplus < int64(s.config().expectedSurplusHardThreshold) {
+		return errors.New("currently not accepting transactions due to expected surplus being below threshold")
+	}
+
 	sequencerBacklogGauge.Inc(1)
 	defer sequencerBacklogGauge.Dec(1)
 
@@ -944,13 +983,80 @@ func (s *Sequencer) Initialize(ctx context.Context) error {
 	return nil
 }
 
+var (
+	usableBytesInBlob    = big.NewInt(int64(len(kzg4844.Blob{}) * 31 / 32))
+	blobTxBlobGasPerBlob = big.NewInt(params.BlobTxBlobGasPerBlob)
+)
+
+func (s *Sequencer) updateExpectedSurplus(ctx context.Context) error {
+	header, err := s.l1Reader.LastHeader(ctx)
+	if err != nil {
+		return fmt.Errorf("error encountered getting latest header from l1reader while updating expectedSurplus: %w", err)
+	}
+	l1GasPrice := header.BaseFee.Uint64()
+	if header.BlobGasUsed != nil {
+		if header.ExcessBlobGas != nil {
+			blobFeePerByte := eip4844.CalcBlobFee(eip4844.CalcExcessBlobGas(*header.ExcessBlobGas, *header.BlobGasUsed))
+			blobFeePerByte.Mul(blobFeePerByte, blobTxBlobGasPerBlob)
+			blobFeePerByte.Div(blobFeePerByte, usableBytesInBlob)
+			if l1GasPrice > blobFeePerByte.Uint64()/16 {
+				l1GasPrice = blobFeePerByte.Uint64() / 16
+			}
+		}
+	}
+	surplus, err := s.execEngine.getL1PricingSurplus()
+	if err != nil {
+		return fmt.Errorf("error encountered getting l1 pricing surplus while updating expectedSurplus: %w", err)
+	}
+	backlogL1GasCharged := int64(s.execEngine.streamer.BacklogL1GasCharged())
+	backlogCallDataUnits := int64(s.execEngine.streamer.BacklogCallDataUnits())
+	s.expectedSurplus = int64(surplus) + backlogL1GasCharged - backlogCallDataUnits*int64(l1GasPrice)
+	// update metrics
+	l1GasPriceGauge.Update(int64(l1GasPrice))
+	callDataUnitsBacklogGauge.Update(backlogCallDataUnits)
+	unusedL1GasChargeGauge.Update(backlogL1GasCharged)
+	currentSurplusGauge.Update(surplus)
+	expectedSurplusGauge.Update(s.expectedSurplus)
+	if s.config().ExpectedSurplusSoftThreshold != "default" && s.expectedSurplus < int64(s.config().expectedSurplusSoftThreshold) {
+		log.Warn("expected surplus is below soft threshold", "value", s.expectedSurplus, "threshold", s.config().expectedSurplusSoftThreshold)
+	}
+	return nil
+}
+
 func (s *Sequencer) Start(ctxIn context.Context) error {
 	s.StopWaiter.Start(ctxIn, s)
+
+	if (s.config().ExpectedSurplusHardThreshold != "default" || s.config().ExpectedSurplusSoftThreshold != "default") && s.l1Reader == nil {
+		return errors.New("expected surplus soft/hard thresholds are enabled but l1Reader is nil")
+	}
+	initialExpectedSurplusHardCheck := s.l1Reader != nil && s.config().ExpectedSurplusHardThreshold != "default"
+	s.expectedSurplusHardCheck = initialExpectedSurplusHardCheck
+
 	if s.l1Reader != nil {
 		initialBlockNr := atomic.LoadUint64(&s.l1BlockNumber)
 		if initialBlockNr == 0 {
 			return errors.New("sequencer not initialized")
 		}
+
+		if err := s.updateExpectedSurplus(ctxIn); err != nil {
+			if s.config().ExpectedSurplusHardThreshold != "default" {
+				return fmt.Errorf("expected-surplus-hard-threshold is enabled but error fetching initial expected surplus value: %w", err)
+			}
+			log.Error("error fetching initial expected surplus value", "err", err)
+		}
+		s.CallIteratively(func(ctx context.Context) time.Duration {
+			if err := s.updateExpectedSurplus(ctx); err != nil {
+				if initialExpectedSurplusHardCheck {
+					log.Error("expected-surplus-hard-threshold is enabled but unable to fetch latest expected surplus. Disabling expected-surplus-hard-threshold check and retrying immediately", "err", err)
+					s.expectedSurplusHardCheck = false
+				} else {
+					log.Error("expected-surplus-soft-threshold is enabled but unable to fetch latest expected surplus, retrying", "err", err)
+				}
+				return 0
+			}
+			s.expectedSurplusHardCheck = initialExpectedSurplusHardCheck
+			return 5 * time.Second
+		})
 
 		headerChan, cancel := s.l1Reader.Subscribe(false)
 

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -55,6 +55,7 @@ type ExecutionSequencer interface {
 	SequenceDelayedMessage(message *arbostypes.L1IncomingMessage, delayedSeqNum uint64) error
 	NextDelayedMessageNumber() (uint64, error)
 	SetTransactionStreamer(streamer TransactionStreamer)
+	GetL1GasPriceEstimate() (uint64, error)
 }
 
 type FullExecutionClient interface {
@@ -82,4 +83,7 @@ type TransactionStreamer interface {
 	BatchFetcher
 	WriteMessageFromSequencer(pos arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata) error
 	ExpectChosenSequencer() error
+	CacheL1PriceDataOfMsg(pos arbutil.MessageIndex, callDataUnits uint64, l1GasCharged uint64)
+	BacklogL1GasCharged() uint64
+	BacklogCallDataUnits() uint64
 }

--- a/precompiles/ArbGasInfo.go
+++ b/precompiles/ArbGasInfo.go
@@ -202,20 +202,7 @@ func (con ArbGasInfo) GetL1PricingSurplus(c ctx, evm mech) (*big.Int, error) {
 		return con._preversion10_GetL1PricingSurplus(c, evm)
 	}
 	ps := c.State.L1PricingState()
-	fundsDueForRefunds, err := ps.BatchPosterTable().TotalFundsDue()
-	if err != nil {
-		return nil, err
-	}
-	fundsDueForRewards, err := ps.FundsDueForRewards()
-	if err != nil {
-		return nil, err
-	}
-	haveFunds, err := ps.L1FeesAvailable()
-	if err != nil {
-		return nil, err
-	}
-	needFunds := arbmath.BigAdd(fundsDueForRefunds, fundsDueForRewards)
-	return arbmath.BigSub(haveFunds, needFunds), nil
+	return ps.GetL1PricingSurplus()
 }
 
 func (con ArbGasInfo) _preversion10_GetL1PricingSurplus(c ctx, evm mech) (*big.Int, error) {


### PR DESCRIPTION
This PR adds following metrics to batchposter
* `l1gasprice` - current L1 gas price i.e `min(baseFee, blobFee/16)`
* `l1gaspriceestimate` - L2 estimation of L1 gas price
* `latestbatchsurplus` - surplus on latest batch

Adds following metrics to sequencer
* `l1gasprice` - current L1 gas price i.e `min(baseFee, blobFee/16)`
* `calldataunitsbacklog` - total size of transactions in call data units that are not yet posted to L1
* `unusedl1gascharge` - total L1 gas charged from L2 transactions not yet posted to L1
* `currentsurplus` - current L1 pricing surplus 
* `expectedsurplus` - expected value for surplus which is `currentsurplus + (total L1 gas charged from L2 transactions not yet posted to L1) - (L1 charge if we post all txs to L1 in current price)`

Adds an option in Sequencer 
* to log warnings when `expectedsurplus` is below a given threshold value configurable by `--execution.sequencer.expected-surplus-soft-threshold` flag
* to deny incoming transactions when `expectedsurplus` is below a given threshold value configurable by `--execution.sequencer.expected-surplus-hard-threshold` flag