### PR TITLE
Add badgerdb memory options

### DIFF
--- a/das/das_test.go
+++ b/das/das_test.go
@@ -30,6 +30,10 @@ func testDASStoreRetrieveMultipleInstances(t *testing.T, storageType string) {
 		Fail(t, "unknown storage type")
 	}
 
+	dbConfig := DefaultLocalDBStorageConfig
+	dbConfig.Enable = enableDbStorage
+	dbConfig.DataDir = dbPath
+
 	config := DataAvailabilityConfig{
 		Enable: true,
 		Key: KeyConfig{
@@ -39,10 +43,7 @@ func testDASStoreRetrieveMultipleInstances(t *testing.T, storageType string) {
 			Enable:  enableFileStorage,
 			DataDir: dbPath,
 		},
-		LocalDBStorage: LocalDBStorageConfig{
-			Enable:  enableDbStorage,
-			DataDir: dbPath,
-		},
+		LocalDBStorage:     dbConfig,
 		ParentChainNodeURL: "none",
 	}
 
@@ -122,6 +123,10 @@ func testDASMissingMessage(t *testing.T, storageType string) {
 		Fail(t, "unknown storage type")
 	}
 
+	dbConfig := DefaultLocalDBStorageConfig
+	dbConfig.Enable = enableDbStorage
+	dbConfig.DataDir = dbPath
+
 	config := DataAvailabilityConfig{
 		Enable: true,
 		Key: KeyConfig{
@@ -131,10 +136,7 @@ func testDASMissingMessage(t *testing.T, storageType string) {
 			Enable:  enableFileStorage,
 			DataDir: dbPath,
 		},
-		LocalDBStorage: LocalDBStorageConfig{
-			Enable:  enableDbStorage,
-			DataDir: dbPath,
-		},
+		LocalDBStorage:     dbConfig,
 		ParentChainNodeURL: "none",
 	}
 

--- a/das/db_storage_service.go
+++ b/das/db_storage_service.go
@@ -25,9 +25,32 @@ type LocalDBStorageConfig struct {
 	DiscardAfterTimeout    bool   `koanf:"discard-after-timeout"`
 	SyncFromStorageService bool   `koanf:"sync-from-storage-service"`
 	SyncToStorageService   bool   `koanf:"sync-to-storage-service"`
+
+	// BadgerDB options
+	NumMemtables            int   `koanf:"num-memtables"`
+	NumLevelZeroTables      int   `koanf:"num-level-zero-tables"`
+	NumLevelZeroTablesStall int   `koanf:"num-level-zero-tables-stall"`
+	NumCompactors           int   `koanf:"num-compactors"`
+	BaseTableSize           int64 `koanf:"base-table-size"`
+	ValueLogFileSize        int64 `koanf:"value-log-file-size"`
 }
 
-var DefaultLocalDBStorageConfig = LocalDBStorageConfig{}
+var badgerDefaultOptions = badger.DefaultOptions("")
+
+var DefaultLocalDBStorageConfig = LocalDBStorageConfig{
+	Enable:                 false,
+	DataDir:                "",
+	DiscardAfterTimeout:    false,
+	SyncFromStorageService: false,
+	SyncToStorageService:   false,
+
+	NumMemtables:            badgerDefaultOptions.NumMemtables,
+	NumLevelZeroTables:      badgerDefaultOptions.NumLevelZeroTables,
+	NumLevelZeroTablesStall: badgerDefaultOptions.NumLevelZeroTablesStall,
+	NumCompactors:           badgerDefaultOptions.NumCompactors,
+	BaseTableSize:           badgerDefaultOptions.BaseTableSize,
+	ValueLogFileSize:        badgerDefaultOptions.ValueLogFileSize,
+}
 
 func LocalDBStorageConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultLocalDBStorageConfig.Enable, "enable storage/retrieval of sequencer batch data from a database on the local filesystem")
@@ -35,6 +58,14 @@ func LocalDBStorageConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".discard-after-timeout", DefaultLocalDBStorageConfig.DiscardAfterTimeout, "discard data after its expiry timeout")
 	f.Bool(prefix+".sync-from-storage-service", DefaultLocalDBStorageConfig.SyncFromStorageService, "enable db storage to be used as a source for regular sync storage")
 	f.Bool(prefix+".sync-to-storage-service", DefaultLocalDBStorageConfig.SyncToStorageService, "enable db storage to be used as a sink for regular sync storage")
+
+	f.Int(prefix+".num-memtables", DefaultLocalDBStorageConfig.NumMemtables, "BadgerDB option: sets the maximum number of tables to keep in memory before stalling")
+	f.Int(prefix+".num-level-zero-tables", DefaultLocalDBStorageConfig.NumLevelZeroTables, "BadgerDB option: sets the maximum number of Level 0 tables before compaction starts")
+	f.Int(prefix+".num-level-zero-tables-stall", DefaultLocalDBStorageConfig.NumLevelZeroTablesStall, "BadgerDB option: sets the number of Level 0 tables that once reached causes the DB to stall until compaction succeeds")
+	f.Int(prefix+".num-compactors", DefaultLocalDBStorageConfig.NumCompactors, "BadgerDB option: Sets the number of compaction workers to run concurrently")
+	f.Int64(prefix+".base-table-size", DefaultLocalDBStorageConfig.BaseTableSize, "BadgerDB option: sets the maximum size in bytes for LSM table or file in the base level")
+	f.Int64(prefix+".value-log-file-size", DefaultLocalDBStorageConfig.ValueLogFileSize, "BadgerDB option: sets the maximum size of a single log file")
+
 }
 
 type DBStorageService struct {
@@ -44,16 +75,23 @@ type DBStorageService struct {
 	stopWaiter          stopwaiter.StopWaiterSafe
 }
 
-func NewDBStorageService(ctx context.Context, dirPath string, discardAfterTimeout bool) (StorageService, error) {
-	db, err := badger.Open(badger.DefaultOptions(dirPath))
+func NewDBStorageService(ctx context.Context, config *LocalDBStorageConfig) (StorageService, error) {
+	options := badger.DefaultOptions(config.DataDir).
+		WithNumMemtables(config.NumMemtables).
+		WithNumLevelZeroTables(config.NumLevelZeroTables).
+		WithNumLevelZeroTablesStall(config.NumLevelZeroTablesStall).
+		WithNumCompactors(config.NumCompactors).
+		WithBaseTableSize(config.BaseTableSize).
+		WithValueLogFileSize(config.ValueLogFileSize)
+	db, err := badger.Open(options)
 	if err != nil {
 		return nil, err
 	}
 
 	ret := &DBStorageService{
 		db:                  db,
-		discardAfterTimeout: discardAfterTimeout,
-		dirPath:             dirPath,
+		discardAfterTimeout: config.DiscardAfterTimeout,
+		dirPath:             config.DataDir,
 	}
 	if err := ret.stopWaiter.Start(ctx, ret); err != nil {
 		return nil, err

--- a/das/factory.go
+++ b/das/factory.go
@@ -28,7 +28,7 @@ func CreatePersistentStorageService(
 	storageServices := make([]StorageService, 0, 10)
 	var lifecycleManager LifecycleManager
 	if config.LocalDBStorage.Enable {
-		s, err := NewDBStorageService(ctx, config.LocalDBStorage.DataDir, config.LocalDBStorage.DiscardAfterTimeout)
+		s, err := NewDBStorageService(ctx, &config.LocalDBStorage)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -1031,6 +1031,10 @@ func setupConfigWithDAS(
 	dasSignerKey, _, err := das.GenerateAndStoreKeys(dbPath)
 	Require(t, err)
 
+	dbConfig := das.DefaultLocalDBStorageConfig
+	dbConfig.Enable = enableDbStorage
+	dbConfig.DataDir = dbPath
+
 	dasConfig := &das.DataAvailabilityConfig{
 		Enable: enableDas,
 		Key: das.KeyConfig{
@@ -1040,10 +1044,7 @@ func setupConfigWithDAS(
 			Enable:  enableFileStorage,
 			DataDir: dbPath,
 		},
-		LocalDBStorage: das.LocalDBStorageConfig{
-			Enable:  enableDbStorage,
-			DataDir: dbPath,
-		},
+		LocalDBStorage:           dbConfig,
 		RequestTimeout:           5 * time.Second,
 		ParentChainNodeURL:       "none",
 		SequencerInboxAddress:    "none",

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -253,6 +253,10 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 	pubkey, _, err := das.GenerateAndStoreKeys(keyDir)
 	Require(t, err)
 
+	dbConfig := das.DefaultLocalDBStorageConfig
+	dbConfig.Enable = true
+	dbConfig.DataDir = dbDataDir
+
 	serverConfig := das.DataAvailabilityConfig{
 		Enable: true,
 
@@ -262,10 +266,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 			Enable:  true,
 			DataDir: fileDataDir,
 		},
-		LocalDBStorage: das.LocalDBStorageConfig{
-			Enable:  true,
-			DataDir: dbDataDir,
-		},
+		LocalDBStorage: dbConfig,
 
 		Key: das.KeyConfig{
 			KeyDir: keyDir,


### PR DESCRIPTION
This commit adds the options listed in the badgerdb docs for controlling memory usage: https://dgraph.io/docs/badger/get-started/#memory-usage