### PR TITLE
Fix test timeouts in CI [NIT-2374]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,13 +130,13 @@ jobs:
         if: matrix.test-mode == 'defaults'
         run: |
           packages=`go list ./...`
-          gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 -- -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/...
+          gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 -- -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -timeout 20m
 
       - name: run tests with race detection
         if: matrix.test-mode == 'race'
         run:  |
           packages=`go list ./...`
-          gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 -- -race
+          gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 -- -race -timeout 30m
 
       - name: run redis tests
         if: matrix.test-mode == 'defaults'


### PR DESCRIPTION
It turns out the go test timeout flag is global, not per-test. We've recently started exceeding the 10 minute default timeout for all tests when using race detection in CI. See https://github.com/golang/go/issues/48157