### PR TITLE
Set default --execution.sequencer.max-revert-gas-reject=0

### DIFF
--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -112,7 +112,7 @@ type SequencerConfigFetcher func() *SequencerConfig
 var DefaultSequencerConfig = SequencerConfig{
 	Enable:                      false,
 	MaxBlockSpeed:               time.Millisecond * 250,
-	MaxRevertGasReject:          params.TxGas + 10000,
+	MaxRevertGasReject:          0,
 	MaxAcceptableTimestampDelta: time.Hour,
 	Forwarder:                   DefaultSequencerForwarderConfig,
 	QueueSize:                   1024,


### PR DESCRIPTION
This is already the setting for the Arbitrum One and Arbitrum Nova sequencers

Resolves NIT-2383