### PR TITLE
Don't wait on the prefetcher to complete before producing the next block

### DIFF
--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -609,11 +609,8 @@ func (s *ExecutionEngine) digestMessageWithBlockMutex(num arbutil.MessageIndex, 
 	}
 
 	startTime := time.Now()
-	var wg sync.WaitGroup
 	if s.prefetchBlock && msgForPrefetch != nil {
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
 			_, _, _, err := s.createBlockFromNextMessage(msgForPrefetch)
 			if err != nil {
 				return
@@ -625,7 +622,6 @@ func (s *ExecutionEngine) digestMessageWithBlockMutex(num arbutil.MessageIndex, 
 	if err != nil {
 		return err
 	}
-	wg.Wait()
 	err = s.appendBlock(block, statedb, receipts, time.Since(startTime))
 	if err != nil {
 		return err


### PR DESCRIPTION
In this scheme we'll move on to the next block regardless, even if we're executing the next parts of the block in parallel. Hopefully that prefetching is still useful. Even if not, we have plenty of parallelism to spare, the bottlenecks are sequential execution not parallel throughput.