### PR TITLE
Fix data poster noop storage check in batch poster

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -491,7 +491,7 @@ func (b *BatchPoster) checkReverts(ctx context.Context, to int64) (bool, error) 
 					return false, fmt.Errorf("getting a receipt for transaction: %v, %w", tx.Hash, err)
 				}
 				if r.Status == types.ReceiptStatusFailed {
-					shouldHalt := !b.config().DataPoster.UseNoOpStorage
+					shouldHalt := !b.dataPoster.UsingNoOpStorage()
 					logLevel := log.Warn
 					if shouldHalt {
 						logLevel = log.Error

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -304,6 +304,10 @@ func (p *DataPoster) MaxMempoolTransactions() uint64 {
 	return arbmath.MinInt(config.MaxMempoolTransactions, config.MaxMempoolWeight)
 }
 
+func (p *DataPoster) UsingNoOpStorage() bool {
+	return p.usingNoOpStorage
+}
+
 var ErrExceedsMaxMempoolSize = errors.New("posting this transaction will exceed max mempool size")
 
 // Does basic check whether posting transaction with specified nonce would


### PR DESCRIPTION
`usingNoOpStorage` is also set to true for L3 chains, but the config itself doesn't have it set.