### PR TITLE
Avoid deadlocking sender account w/ diff type txs

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -1105,9 +1105,7 @@ func (p *DataPoster) Start(ctxIn context.Context) {
 		for _, tx := range queueContents {
 			previouslyUnsent := !tx.Sent
 			sendAttempted := false
-			replacing := false
 			if now.After(tx.NextReplacement) {
-				replacing = true
 				nonceBacklog := arbmath.SaturatingUSub(latestNonce, tx.FullTx.Nonce())
 				weightBacklog := arbmath.SaturatingUSub(latestCumulativeWeight, tx.CumulativeWeight())
 				err := p.replaceTx(ctx, tx, arbmath.MaxInt(nonceBacklog, weightBacklog))
@@ -1117,7 +1115,7 @@ func (p *DataPoster) Start(ctxIn context.Context) {
 			if nextCheck.After(tx.NextReplacement) {
 				nextCheck = tx.NextReplacement
 			}
-			if !replacing && previouslyUnsent {
+			if !sendAttempted && previouslyUnsent {
 				err := p.sendTx(ctx, tx, tx)
 				sendAttempted = true
 				p.maybeLogError(err, tx, "failed to re-send transaction")

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -832,6 +832,37 @@ func (p *DataPoster) sendTx(ctx context.Context, prevTx *storage.QueuedTransacti
 	if err := p.saveTx(ctx, prevTx, newTx); err != nil {
 		return err
 	}
+
+	// The following check is to avoid sending transactions of a different type (eg DynamicFeeTxType vs BlobTxType)
+	// to the previous tx if the previous tx is not yet included in a reorg resistant block, in order to avoid issues
+	// where eventual consistency of parent chain mempools causes a tx with higher nonce blocking a tx of a
+	// different type with a lower nonce.
+	// If we decide not to send this tx yet, just leave it queued and with Sent set to false.
+	// The resending/repricing loop in DataPoster.Start will keep trying.
+	if !newTx.Sent {
+		precedingTx, err := p.queue.Get(ctx, arbmath.SaturatingUSub(newTx.FullTx.Nonce(), 1))
+		if err != nil {
+			return fmt.Errorf("couldn't get preceding tx in DataPoster to check if should send tx with nonce %d: %w", newTx.FullTx.Nonce(), err)
+		}
+		if precedingTx != nil && // precedingTx == nil -> the actual preceding tx was already confirmed
+			precedingTx.FullTx.Type() != newTx.FullTx.Type() {
+			latestBlockNumber, err := p.client.BlockNumber(ctx)
+			if err != nil {
+				return fmt.Errorf("couldn't get block number in DataPoster to check if should send tx with nonce %d: %w", newTx.FullTx.Nonce(), err)
+			}
+			prevBlockNumber := arbmath.SaturatingUSub(latestBlockNumber, 1)
+			reorgResistantNonce, err := p.client.NonceAt(ctx, p.Sender(), new(big.Int).SetUint64(prevBlockNumber))
+			if err != nil {
+				return fmt.Errorf("couldn't determine reorg resistant nonce in DataPoster to check if should send tx with nonce %d: %w", newTx.FullTx.Nonce(), err)
+			}
+
+			if precedingTx.FullTx.Nonce() > reorgResistantNonce {
+				log.Info("DataPoster is holding off on sending a transaction of different type to the previous transaction until the previous transaction has been included in a reorg resistant block (it remains queued and will be retried)", "nonce", newTx.FullTx.Nonce(), "prevType", precedingTx.FullTx.Type(), "type", newTx.FullTx.Type())
+				return nil
+			}
+		}
+	}
+
 	if err := p.client.SendTransaction(ctx, newTx.FullTx); err != nil {
 		if !rpcclient.IsAlreadyKnownError(err) && !strings.Contains(err.Error(), "nonce too low") {
 			log.Warn("DataPoster failed to send transaction", "err", err, "nonce", newTx.FullTx.Nonce(), "feeCap", newTx.FullTx.GasFeeCap(), "tipCap", newTx.FullTx.GasTipCap(), "blobFeeCap", newTx.FullTx.BlobGasFeeCap(), "gas", newTx.FullTx.Gas())
@@ -1072,19 +1103,23 @@ func (p *DataPoster) Start(ctxIn context.Context) {
 			latestNonce = latestQueued.FullTx.Nonce()
 		}
 		for _, tx := range queueContents {
+			previouslyUnsent := !tx.Sent
+			sendAttempted := false
 			replacing := false
 			if now.After(tx.NextReplacement) {
 				replacing = true
 				nonceBacklog := arbmath.SaturatingUSub(latestNonce, tx.FullTx.Nonce())
 				weightBacklog := arbmath.SaturatingUSub(latestCumulativeWeight, tx.CumulativeWeight())
 				err := p.replaceTx(ctx, tx, arbmath.MaxInt(nonceBacklog, weightBacklog))
+				sendAttempted = true
 				p.maybeLogError(err, tx, "failed to replace-by-fee transaction")
 			}
 			if nextCheck.After(tx.NextReplacement) {
 				nextCheck = tx.NextReplacement
 			}
-			if !replacing && !tx.Sent {
+			if !replacing && previouslyUnsent {
 				err := p.sendTx(ctx, tx, tx)
+				sendAttempted = true
 				p.maybeLogError(err, tx, "failed to re-send transaction")
 				if err != nil {
 					nextSend := time.Now().Add(time.Minute)
@@ -1092,6 +1127,12 @@ func (p *DataPoster) Start(ctxIn context.Context) {
 						nextCheck = nextSend
 					}
 				}
+			}
+			if previouslyUnsent && sendAttempted {
+				// Don't try to send more than 1 unsent transaction, to play nicely with parent chain mempools.
+				// Transactions will be unsent if there was some error when originally sending them,
+				// or if transaction type changes and the prior tx is not yet reorg resistant.
+				break
 			}
 		}
 		wait := time.Until(nextCheck)

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -839,7 +839,7 @@ func (p *DataPoster) sendTx(ctx context.Context, prevTx *storage.QueuedTransacti
 	// different type with a lower nonce.
 	// If we decide not to send this tx yet, just leave it queued and with Sent set to false.
 	// The resending/repricing loop in DataPoster.Start will keep trying.
-	if !newTx.Sent {
+	if !newTx.Sent && newTx.FullTx.Nonce() > 0 {
 		precedingTx, err := p.queue.Get(ctx, arbmath.SaturatingUSub(newTx.FullTx.Nonce(), 1))
 		if err != nil {
 			return fmt.Errorf("couldn't get preceding tx in DataPoster to check if should send tx with nonce %d: %w", newTx.FullTx.Nonce(), err)


### PR DESCRIPTION
geth's current mempool implementation doesn't allow both blob and non-blob txs at the same time for the same account. It has has separate pools for each tx type, with a layer aggregating them and rejecting new txs for an account if there are already txs for that account in the pool of the other type.

This poses a hazard where Nitro could send batch txs of one type that are evicted before being included in a block (eg due to GasFeeCap or BlobFeeCap being too low), then for a new batch Nitro switches batch type and sends a tx with higher nonce which is not rejected because the parent mempool is currently empty. Then the presence of that tx would prevent the earlier txs from being able to be re-sent. A similar situation could arise where the mempool is gapped due to eventual consistency between p2p nodes.

This commit makes it so a tx of a different type to the previous will only be sent by the DataPoster if the previous tx has been included in a block that has some reorg resistance (head-1). The BatchPoster will continue making new batch txs and requesting the DataPoster to send them, but if they fail this check they will just be queued and sent in the DataPoster.Start loop.