### PR TITLE
TEMP: test multiple val-nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -247,7 +247,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 USER user
 
-FROM nitro-node as nitro-node-dev
+FROM nitro-node as nitro-node-temp
 USER root
 # Copy in latest WASM module root
 RUN rm -f /home/user/target/machines/latest
@@ -271,12 +271,15 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 USER user
 
-FROM nitro-node-dev as nitro-node-split
+FROM nitro-node-temp as nitro-node-dev
 USER root
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y xxd netcat-traditional
+RUN mkdir -p /home/user/machines-old && \
+    mv /home/user/target/machines/0x* /home/user/machines-old/ && \
+    chmod -R 555 /home/user/machines-old/
 COPY scripts/split-val-entry.sh /usr/local/bin
 ENTRYPOINT [ "/usr/local/bin/split-val-entry.sh" ]
 USER user

--- a/scripts/split-val-entry.sh
+++ b/scripts/split-val-entry.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 xxd -l 32 -ps -c 40 /dev/urandom > /tmp/nitro-val.jwt
-
 echo launching validation servers
 # To add validation server:
 # > launch them here with a different port and --validation.wasm.root-path
 # add their port to wait loop
 # edit validation-server-configs-list to include the other nodes
 /usr/local/bin/nitro-val --file-logging.enable=false --auth.addr 127.0.0.10 --auth.origins 127.0.0.1 --auth.jwtsecret /tmp/nitro-val.jwt --auth.port 52000 &
-for port in 52000; do
+/usr/local/bin/nitro-val --file-logging.enable=false --auth.addr 127.0.0.10 --auth.origins 127.0.0.1 --auth.jwtsecret /tmp/nitro-val.jwt --auth.port 52001 --validation.wasm.root-path /home/user/machines-old/ &
+for port in 52000 52001; do
     while ! nc -w1 -z 127.0.0.10 $port; do
         echo waiting for validation port $port
         sleep 1
     done
 done
 echo launching nitro-node
-/usr/local/bin/nitro --node.block-validator.pending-upgrade-module-root="0x8b104a2e80ac6165dc58b9048de12f301d70b02a0ab51396c22b4b4b802a16a4" --node.block-validator.validation-server-configs-list='[{"jwtsecret":"/tmp/nitro-val.jwt","url":"http://127.0.0.10:52000"}]' "$@"
+/usr/local/bin/nitro --node.block-validator.pending-upgrade-module-root="0x8b104a2e80ac6165dc58b9048de12f301d70b02a0ab51396c22b4b4b802a16a4" --node.block-validator.validation-server-configs-list='[{"jwtsecret":"/tmp/nitro-val.jwt","url":"http://127.0.0.10:52000"}, {"jwtsecret":"/tmp/nitro-val.jwt","url":"http://127.0.0.10:52001"}]' "$@"


### PR DESCRIPTION
This PR can be used to test a multi-exec docker image

to test: Add this diff to nitro-testnode:
```
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -214,12 +214,12 @@ function writeConfigs(argv: any) {
                     "wait-for-l1-finality": false
                 }
             },
-            "block-validator": {
-                "execution-server": {
-                    "url": argv.validationNodeUrl,
-                    "jwtsecret": valJwtSecret,
-                }
-            }
+            // "block-validator": {
+            //     "execution-server": {
+            //         "url": argv.validationNodeUrl,
+            //         "jwtsecret": valJwtSecret,
+            //     }
+            // }
         },
         "execution": {
             "sequencer": {
@@ -247,7 +247,7 @@ function writeConfigs(argv: any) {
         let simpleConfig = JSON.parse(baseConfJSON)
         simpleConfig.node.staker.enable = true
         simpleConfig.node.staker["use-smart-contract-wallet"] = true
-        simpleConfig.node.staker.dangerous["without-block-validator"] = true
+        //simpleConfig.node.staker.dangerous["without-block-validator"] = true
         simpleConfig.node.sequencer = true
         simpleConfig.node.dangerous["no-sequencer-coordinator"] = true
         simpleConfig.node["delayed-sequencer"].enable = true
```

And start testnode with: ./test-node.bash --init --dev nitro --detach --simple

We have here a separate val-node running "old" machines, and a separate one running "latest", both succeed to validate