### PR TITLE
Enable system tests to work from VS Code Debugger.

### DIFF
--- a/validator/server_jit/machine_loader.go
+++ b/validator/server_jit/machine_loader.go
@@ -27,13 +27,16 @@ var DefaultJitMachineConfig = JitMachineConfig{
 func getJitPath() (string, error) {
 	var jitBinary string
 	executable, err := os.Executable()
+	println("executable: ", executable)
 	if err == nil {
-		if strings.Contains(filepath.Base(executable), "test") {
+		if strings.Contains(filepath.Base(executable), "test") || strings.Contains(filepath.Dir(executable), "system_tests") {
 			_, thisfile, _, _ := runtime.Caller(0)
 			projectDir := filepath.Dir(filepath.Dir(filepath.Dir(thisfile)))
+			println("projectDir: ", projectDir)
 			jitBinary = filepath.Join(projectDir, "target", "bin", "jit")
 		} else {
 			jitBinary = filepath.Join(filepath.Dir(executable), "jit")
+			println("inside else: ", jitBinary)
 		}
 		_, err = os.Stat(jitBinary)
 	}


### PR DESCRIPTION
Before this change, when launching some of the system tests from the VS Code debugger UI, the machine loader was unable to locate the jit binary because the system tests don't actually have "test" in path leading up to the test executable.