### PR TITLE
Error early when missing asm

### DIFF
--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -114,6 +114,11 @@ func callProgram(
 	asm := db.GetActivatedAsm(moduleHash)
 	debug := stylusParams.debugMode
 
+	if len(asm) == 0 {
+		log.Error("missing asm", "program", address, "module", moduleHash)
+		panic("missing asm")
+	}
+
 	if db, ok := db.(*state.StateDB); ok {
 		db.RecordProgram(moduleHash)
 	}


### PR DESCRIPTION
Panics in Go rather than in Rust when missing an asm