### PR TITLE
Fix signed saturating math functions

### DIFF
--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -74,14 +74,6 @@ func MaxInt[T Number](values ...T) T {
 	return max
 }
 
-// AbsValue the absolute value of a number
-func AbsValue[T Number](value T) T {
-	if value < 0 {
-		return -value // never happens for unsigned types
-	}
-	return value
-}
-
 // Checks if two ints are sufficiently close to one another
 func Within[T Unsigned](a, b, bound T) bool {
 	min := MinInt(a, b)
@@ -267,14 +259,32 @@ func BigFloatMulByUint(multiplicand *big.Float, multiplier uint64) *big.Float {
 	return new(big.Float).Mul(multiplicand, UintToBigFloat(multiplier))
 }
 
+func MaxIntValue[T Integer]() T {
+	allBits := ^T(0)
+	if allBits < 0 {
+		// This is a signed integer
+		return T((uint64(1) << (8*unsafe.Sizeof(allBits) - 1)) - 1)
+	}
+	return allBits
+}
+
+func MinIntValue[T Integer]() T {
+	allBits := ^T(0)
+	if allBits < 0 {
+		// This is a signed integer
+		return T(uint64(1) << ((8 * unsafe.Sizeof(allBits)) - 1))
+	}
+	return 0
+}
+
 // SaturatingAdd add two integers without overflow
 func SaturatingAdd[T Signed](a, b T) T {
 	sum := a + b
 	if b > 0 && sum < a {
-		sum = ^T(0) >> 1
+		sum = MaxIntValue[T]()
 	}
 	if b < 0 && sum > a {
-		sum = (^T(0) >> 1) + 1
+		sum = MinIntValue[T]()
 	}
 	return sum
 }
@@ -290,7 +300,11 @@ func SaturatingUAdd[T Unsigned](a, b T) T {
 
 // SaturatingSub subtract an int64 from another without overflow
 func SaturatingSub(minuend, subtrahend int64) int64 {
-	return SaturatingAdd(minuend, -subtrahend)
+	if subtrahend == math.MinInt64 {
+		// The absolute value of MinInt64 is one greater than MaxInt64
+		return SaturatingAdd(SaturatingAdd(minuend, math.MaxInt64), 1)
+	}
+	return SaturatingAdd(minuend, SaturatingNeg(subtrahend))
 }
 
 // SaturatingUSub subtract an integer from another without underflow
@@ -315,9 +329,9 @@ func SaturatingMul[T Signed](a, b T) T {
 	product := a * b
 	if b != 0 && product/b != a {
 		if (a > 0 && b > 0) || (a < 0 && b < 0) {
-			product = ^T(0) >> 1
+			product = MaxIntValue[T]()
 		} else {
-			product = (^T(0) >> 1) + 1
+			product = MinIntValue[T]()
 		}
 	}
 	return product
@@ -367,8 +381,8 @@ func SaturatingCastToUint(value *big.Int) uint64 {
 
 // Negates an int without underflow
 func SaturatingNeg[T Signed](value T) T {
-	if value == ^T(0) {
-		return (^T(0)) >> 1
+	if value < 0 && value == MinIntValue[T]() {
+		return MaxIntValue[T]()
 	}
 	return -value
 }

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -259,32 +259,22 @@ func BigFloatMulByUint(multiplicand *big.Float, multiplier uint64) *big.Float {
 	return new(big.Float).Mul(multiplicand, UintToBigFloat(multiplier))
 }
 
-func MaxIntValue[T Integer]() T {
-	allBits := ^T(0)
-	if allBits < 0 {
-		// This is a signed integer
-		return T((uint64(1) << (8*unsafe.Sizeof(allBits) - 1)) - 1)
-	}
-	return allBits
+func MaxSignedValue[T Signed]() T {
+	return T((uint64(1) << (8*unsafe.Sizeof(T(0)) - 1)) - 1)
 }
 
-func MinIntValue[T Integer]() T {
-	allBits := ^T(0)
-	if allBits < 0 {
-		// This is a signed integer
-		return T(uint64(1) << ((8 * unsafe.Sizeof(allBits)) - 1))
-	}
-	return 0
+func MinSignedValue[T Signed]() T {
+	return T(uint64(1) << ((8 * unsafe.Sizeof(T(0))) - 1))
 }
 
 // SaturatingAdd add two integers without overflow
 func SaturatingAdd[T Signed](a, b T) T {
 	sum := a + b
 	if b > 0 && sum < a {
-		sum = MaxIntValue[T]()
+		sum = MaxSignedValue[T]()
 	}
 	if b < 0 && sum > a {
-		sum = MinIntValue[T]()
+		sum = MinSignedValue[T]()
 	}
 	return sum
 }
@@ -329,9 +319,9 @@ func SaturatingMul[T Signed](a, b T) T {
 	product := a * b
 	if b != 0 && product/b != a {
 		if (a > 0 && b > 0) || (a < 0 && b < 0) {
-			product = MaxIntValue[T]()
+			product = MaxSignedValue[T]()
 		} else {
-			product = MinIntValue[T]()
+			product = MinSignedValue[T]()
 		}
 	}
 	return product
@@ -381,8 +371,8 @@ func SaturatingCastToUint(value *big.Int) uint64 {
 
 // Negates an int without underflow
 func SaturatingNeg[T Signed](value T) T {
-	if value < 0 && value == MinIntValue[T]() {
-		return MaxIntValue[T]()
+	if value < 0 && value == MinSignedValue[T]() {
+		return MaxSignedValue[T]()
 	}
 	return -value
 }

--- a/util/arbmath/math_fuzz_test.go
+++ b/util/arbmath/math_fuzz_test.go
@@ -1,0 +1,112 @@
+// Copyright 2024, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package arbmath
+
+import (
+	"math/big"
+	"testing"
+)
+
+func toBig[T Signed](a T) *big.Int {
+	return big.NewInt(int64(a))
+}
+
+func saturatingBigToInt[T Signed](a *big.Int) T {
+	// MinIntValue and MaxIntValue are already separately tested
+	if a.Cmp(toBig(MaxIntValue[T]())) > 0 {
+		return MaxIntValue[T]()
+	}
+	if a.Cmp(toBig(MinIntValue[T]())) < 0 {
+		return MinIntValue[T]()
+	}
+	return T(a.Int64())
+}
+
+func fuzzSaturatingAdd[T Signed](f *testing.F) {
+	f.Fuzz(func(t *testing.T, a, b T) {
+		got := SaturatingAdd(a, b)
+		expected := saturatingBigToInt[T](new(big.Int).Add(toBig(a), toBig(b)))
+		if got != expected {
+			t.Errorf("SaturatingAdd(%v, %v) = %v, expected %v", a, b, got, expected)
+		}
+	})
+}
+
+func fuzzSaturatingMul[T Signed](f *testing.F) {
+	f.Fuzz(func(t *testing.T, a, b T) {
+		got := SaturatingMul(a, b)
+		expected := saturatingBigToInt[T](new(big.Int).Mul(toBig(a), toBig(b)))
+		if got != expected {
+			t.Errorf("SaturatingMul(%v, %v) = %v, expected %v", a, b, got, expected)
+		}
+	})
+}
+
+func fuzzSaturatingNeg[T Signed](f *testing.F) {
+	f.Fuzz(func(t *testing.T, a T) {
+		got := SaturatingNeg(a)
+		expected := saturatingBigToInt[T](new(big.Int).Neg(toBig(a)))
+		if got != expected {
+			t.Errorf("SaturatingNeg(%v) = %v, expected %v", a, got, expected)
+		}
+	})
+}
+
+func FuzzSaturatingAddInt8(f *testing.F) {
+	fuzzSaturatingAdd[int8](f)
+}
+
+func FuzzSaturatingAddInt16(f *testing.F) {
+	fuzzSaturatingAdd[int16](f)
+}
+
+func FuzzSaturatingAddInt32(f *testing.F) {
+	fuzzSaturatingAdd[int32](f)
+}
+
+func FuzzSaturatingAddInt64(f *testing.F) {
+	fuzzSaturatingAdd[int64](f)
+}
+
+func FuzzSaturatingSub(f *testing.F) {
+	f.Fuzz(func(t *testing.T, a, b int64) {
+		got := SaturatingSub(a, b)
+		expected := saturatingBigToInt[int64](new(big.Int).Sub(toBig(a), toBig(b)))
+		if got != expected {
+			t.Errorf("SaturatingSub(%v, %v) = %v, expected %v", a, b, got, expected)
+		}
+	})
+}
+
+func FuzzSaturatingMulInt8(f *testing.F) {
+	fuzzSaturatingMul[int8](f)
+}
+
+func FuzzSaturatingMulInt16(f *testing.F) {
+	fuzzSaturatingMul[int16](f)
+}
+
+func FuzzSaturatingMulInt32(f *testing.F) {
+	fuzzSaturatingMul[int32](f)
+}
+
+func FuzzSaturatingMulInt64(f *testing.F) {
+	fuzzSaturatingMul[int64](f)
+}
+
+func FuzzSaturatingNegInt8(f *testing.F) {
+	fuzzSaturatingNeg[int8](f)
+}
+
+func FuzzSaturatingNegInt16(f *testing.F) {
+	fuzzSaturatingNeg[int16](f)
+}
+
+func FuzzSaturatingNegInt32(f *testing.F) {
+	fuzzSaturatingNeg[int32](f)
+}
+
+func FuzzSaturatingNegInt64(f *testing.F) {
+	fuzzSaturatingNeg[int64](f)
+}

--- a/util/arbmath/math_fuzz_test.go
+++ b/util/arbmath/math_fuzz_test.go
@@ -13,12 +13,12 @@ func toBig[T Signed](a T) *big.Int {
 }
 
 func saturatingBigToInt[T Signed](a *big.Int) T {
-	// MinIntValue and MaxIntValue are already separately tested
-	if a.Cmp(toBig(MaxIntValue[T]())) > 0 {
-		return MaxIntValue[T]()
+	// MinSignedValue and MaxSignedValue are already separately tested
+	if a.Cmp(toBig(MaxSignedValue[T]())) > 0 {
+		return MaxSignedValue[T]()
 	}
-	if a.Cmp(toBig(MinIntValue[T]())) < 0 {
-		return MinIntValue[T]()
+	if a.Cmp(toBig(MinSignedValue[T]())) < 0 {
+		return MinSignedValue[T]()
 	}
 	return T(a.Int64())
 }

--- a/util/arbmath/math_test.go
+++ b/util/arbmath/math_test.go
@@ -121,26 +121,22 @@ func TestSlices(t *testing.T) {
 	assert_eq(SliceWithRunoff(data, 7, 8), []uint8{})
 }
 
-func testMinMaxValues[T Integer](t *testing.T, min T, max T) {
-	gotMin := MinIntValue[T]()
+func testMinMaxSignedValues[T Signed](t *testing.T, min T, max T) {
+	gotMin := MinSignedValue[T]()
 	if gotMin != min {
 		Fail(t, "expected min", min, "but got", gotMin)
 	}
-	gotMax := MaxIntValue[T]()
+	gotMax := MaxSignedValue[T]()
 	if gotMax != max {
 		Fail(t, "expected max", max, "but got", gotMax)
 	}
 }
 
-func TestMinMaxValues(t *testing.T) {
-	testMinMaxValues[uint8](t, 0, math.MaxUint8)
-	testMinMaxValues[uint16](t, 0, math.MaxUint16)
-	testMinMaxValues[uint32](t, 0, math.MaxUint32)
-	testMinMaxValues[uint64](t, 0, math.MaxUint64)
-	testMinMaxValues[int8](t, math.MinInt8, math.MaxInt8)
-	testMinMaxValues[int16](t, math.MinInt16, math.MaxInt16)
-	testMinMaxValues[int32](t, math.MinInt32, math.MaxInt32)
-	testMinMaxValues[int64](t, math.MinInt64, math.MaxInt64)
+func TestMinMaxSignedValues(t *testing.T) {
+	testMinMaxSignedValues[int8](t, math.MinInt8, math.MaxInt8)
+	testMinMaxSignedValues[int16](t, math.MinInt16, math.MaxInt16)
+	testMinMaxSignedValues[int32](t, math.MinInt32, math.MaxInt32)
+	testMinMaxSignedValues[int64](t, math.MinInt64, math.MaxInt64)
 }
 
 func TestSaturatingAdd(t *testing.T) {


### PR DESCRIPTION
In addition to the test cases, I ran each of the fuzzers for 2 minutes:
```sh
for f in FuzzSaturatingAddInt8 FuzzSaturatingAddInt16 FuzzSaturatingAddInt32 FuzzSaturatingAddInt64 FuzzSaturatingSub FuzzSaturatingMulInt8 FuzzSaturatingMulInt16 FuzzSaturatingMulInt32 FuzzSaturatingMulInt64 FuzzSaturatingNegInt8 FuzzSaturatingNegInt16 FuzzSaturatingNegInt32 FuzzSaturatingNegInt64; do go test ./util/arbmath -fuzz "$f" -fuzztime 2m || break; done
```

I'll run them for longer overnight to make sure but I'm pretty confident in it given this testing.