### PR TITLE
fix: CleanCacheSize from hashdb.Config expects a value defined in byt…

### DIFF
--- a/cmd/staterecovery/staterecovery.go
+++ b/cmd/staterecovery/staterecovery.go
@@ -31,7 +31,7 @@ func RecreateMissingStates(chainDb ethdb.Database, bc *core.BlockChain, cacheCon
 		return fmt.Errorf("start block parent is missing, parent block number: %d", current-1)
 	}
 	hashConfig := *hashdb.Defaults
-	hashConfig.CleanCacheSize = cacheConfig.TrieCleanLimit
+	hashConfig.CleanCacheSize = cacheConfig.TrieCleanLimit * 1024 * 1024
 	trieConfig := &trie.Config{
 		Preimages: false,
 		HashDB:    &hashConfig,


### PR DESCRIPTION
fix: CleanCacheSize from hashdb.Config expects a value defined in bytes, and not in MB as TrieCleanLimit is defined