### PR TITLE
Remove the mutex in the merkle and use an UnsafeCell

### DIFF
--- a/arbitrator/prover/benches/merkle_bench.rs
+++ b/arbitrator/prover/benches/merkle_bench.rs
@@ -1,9 +1,9 @@
 use arbutil::Bytes32;
 use criterion::{criterion_group, criterion_main, Criterion};
-use prover::merkle::{Merkle, MerkleType};
+use prover::merkle::{DirtyMerkle, MerkleType};
 use rand::Rng;
 
-fn resize_and_set_leaves(merkle: Merkle, rng: &mut rand::rngs::ThreadRng) {
+fn resize_and_set_leaves(merkle: DirtyMerkle, rng: &mut rand::rngs::ThreadRng) {
     for _ in 0..100 {
         merkle.resize(merkle.len() + 5).expect("resize failed");
         for _ in 0..(merkle.len() / 10) {
@@ -27,7 +27,7 @@ fn merkle_benchmark(c: &mut Criterion) {
     // Perform many calls to set leaves to new values
     c.bench_function("resize_set_leaves_and_root", |b| {
         b.iter(|| {
-            let merkle = Merkle::new_advanced(MerkleType::Memory, leaves.clone(), 20);
+            let merkle = DirtyMerkle::new_advanced(MerkleType::Memory, leaves.clone(), 20);
             resize_and_set_leaves(merkle.clone(), &mut rng);
         })
     });
@@ -42,7 +42,7 @@ fn merkle_construction(c: &mut Criterion) {
 
     c.bench_function("merkle_construction", |b| {
         b.iter(|| {
-            let merkle = Merkle::new_advanced(MerkleType::Memory, leaves.clone(), 21);
+            let merkle = DirtyMerkle::new_advanced(MerkleType::Memory, leaves.clone(), 21);
             merkle.root();
         })
     });

--- a/arbitrator/prover/src/merkle.rs
+++ b/arbitrator/prover/src/merkle.rs
@@ -9,9 +9,15 @@ use enum_iterator::Sequence;
 #[cfg(feature = "counters")]
 use enum_iterator::all;
 use itertools::Itertools;
+use parking_lot::Once;
 
+use std::borrow::Borrow;
+use std::borrow::Cow;
+use std::cell::UnsafeCell;
 use std::cmp::max;
 
+use std::ops::Deref;
+use std::sync::atomic::AtomicBool;
 #[cfg(feature = "counters")]
 use std::sync::atomic::AtomicUsize;
 
@@ -30,8 +36,8 @@ use sha3::Keccak256;
 use std::{
     collections::HashSet,
     convert::{TryFrom, TryInto},
-    sync::{Arc, Mutex},
 };
+use parking_lot::Mutex;
 
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
@@ -149,6 +155,42 @@ impl MerkleType {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct DirtyMerkleData {
+    layers: Vec<Vec<Bytes32>>,
+    dirty_layers: Vec<HashSet<usize>>,
+}
+
+impl DirtyMerkleData {
+    fn rehash(&mut self, ty: MerkleType) {
+        if self.dirty_layers.is_empty() || self.dirty_layers[0].is_empty() {
+            return;
+        }
+        for layer_i in 1..self.layers.len() {
+            let dirty_i = layer_i - 1;
+            let dirt = self.dirty_layers[dirty_i].clone();
+            for idx in dirt.iter().sorted() {
+                let left_child_idx = idx << 1;
+                let right_child_idx = left_child_idx + 1;
+                let left = self.layers[layer_i - 1][left_child_idx];
+                let right = self.layers[layer_i - 1]
+                    .get(right_child_idx)
+                    .unwrap_or(empty_hash_at(ty, layer_i - 1));
+                let new_hash = hash_node(ty, left, right);
+                if *idx < self.layers[layer_i].len() {
+                    self.layers[layer_i][*idx] = new_hash;
+                } else {
+                    self.layers[layer_i].push(new_hash);
+                }
+                if layer_i < self.layers.len() - 1 {
+                    self.dirty_layers[dirty_i + 1].insert(idx >> 1);
+                }
+            }
+            self.dirty_layers[dirty_i].clear();
+        }
+    }
+}
+
 /// A Merkle tree with a fixed number of layers
 ///
 /// https://en.wikipedia.org/wiki/Merkle_tree
@@ -164,14 +206,40 @@ impl MerkleType {
 /// and passing a minimum depth.
 ///
 /// This structure does not contain the data itself, only the hashes.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct Merkle {
+#[derive(Debug, Default)]
+pub struct DirtyMerkle {
     ty: MerkleType,
-    #[serde(with = "arc_mutex_sedre")]
-    layers: Arc<Mutex<Vec<Vec<Bytes32>>>>,
     min_depth: usize,
-    #[serde(with = "arc_mutex_sedre")]
-    dirty_layers: Arc<Mutex<Vec<HashSet<usize>>>>,
+    clean: Once,
+    data: UnsafeCell<DirtyMerkleData>,
+}
+
+fn done_once() -> Once {
+    let once = Once::new();
+    once.call_once(|| {});
+    once
+}
+
+impl Clone for DirtyMerkle {
+    fn clone(&self) -> Self {
+        self.rehash();
+        // SAFETY: It's safe to read data with an immutable reference after a rehash
+        let data = unsafe {
+            (*self.data.get()).clone()
+        };
+        DirtyMerkle {
+            ty: self.ty,
+            min_depth: self.min_depth,
+            clean: done_once(),
+            data: UnsafeCell::new(data),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CleanMerkle<L: Borrow<Vec<Vec<Bytes32>>> = Vec<Vec<Bytes32>>> {
+    ty: MerkleType,
+    layers: L,
 }
 
 fn hash_node(ty: MerkleType, a: impl AsRef<[u8]>, b: impl AsRef<[u8]>) -> Bytes32 {
@@ -216,81 +284,212 @@ fn new_layer(ty: MerkleType, layer: &Vec<Bytes32>, empty_hash: &'static Bytes32)
     new_layer
 }
 
-impl Merkle {
-    /// Creates a new Merkle tree with the given type and leaf hashes.
-    /// The tree is built up to the minimum depth necessary to hold all the
-    /// leaves.
-    pub fn new(ty: MerkleType, hashes: Vec<Bytes32>) -> Merkle {
+impl CleanMerkle<Vec<Vec<Bytes32>>> {
+    pub fn new(ty: MerkleType, hashes: Vec<Bytes32>) -> CleanMerkle {
         Self::new_advanced(ty, hashes, 0)
     }
 
-    /// Creates a new Merkle tree with the given type, leaf hashes, a hash to
-    /// use for representing empty leaves, and a minimum depth.
-    pub fn new_advanced(ty: MerkleType, hashes: Vec<Bytes32>, min_depth: usize) -> Merkle {
-        #[cfg(feature = "counters")]
-        NEW_COUNTERS[&ty].fetch_add(1, Ordering::Relaxed);
+    pub fn new_advanced(ty: MerkleType, hashes: Vec<Bytes32>, min_depth: usize) -> CleanMerkle {
         if hashes.is_empty() && min_depth == 0 {
-            return Merkle::default();
+            return CleanMerkle::default();
         }
         let mut depth = (hashes.len() as f64).log2().ceil() as usize;
         depth = depth.max(min_depth);
         let mut layers: Vec<Vec<Bytes32>> = Vec::with_capacity(depth);
         layers.push(hashes);
-        let mut dirty_indices: Vec<HashSet<usize>> = Vec::with_capacity(depth);
         let mut layer_i = 0usize;
         while layers.last().unwrap().len() > 1 || layers.len() < min_depth {
             let layer = layers.last().unwrap();
             let empty_hash = empty_hash_at(ty, layer_i);
 
             let new_layer = new_layer(ty, layer, empty_hash);
-            dirty_indices.push(HashSet::with_capacity(new_layer.len()));
             layers.push(new_layer);
             layer_i += 1;
         }
-        let dirty_layers = Arc::new(Mutex::new(dirty_indices));
-        Merkle {
+        CleanMerkle { ty, layers }
+    }
+
+    pub fn to_cow(self) -> CleanMerkle<Cow<'static, Vec<Vec<Bytes32>>>> {
+        CleanMerkle {
+            ty: self.ty,
+            layers: Cow::Owned(self.layers),
+        }
+    }
+}
+
+impl<'a> CleanMerkle<&'a Vec<Vec<Bytes32>>> {
+    pub fn to_cow(self) -> CleanMerkle<Cow<'a, Vec<Vec<Bytes32>>>> {
+        CleanMerkle {
+            ty: self.ty,
+            layers: Cow::Borrowed(self.layers),
+        }
+    }
+}
+
+impl<'a> CleanMerkle<Cow<'a, Vec<Vec<Bytes32>>>> {
+    pub fn to_owned(self) -> CleanMerkle<Vec<Vec<Bytes32>>> {
+        CleanMerkle {
+            ty: self.ty,
+            layers: self.layers.into_owned(),
+        }
+    }
+}
+
+impl DirtyMerkle {
+    /// Creates a new Merkle tree with the given type and leaf hashes.
+    /// The tree is built up to the minimum depth necessary to hold all the
+    /// leaves.
+    pub fn new(ty: MerkleType, hashes: Vec<Bytes32>) -> DirtyMerkle {
+        Self::new_advanced(ty, hashes, 0)
+    }
+
+    /// Creates a new Merkle tree with the given type, leaf hashes, a hash to
+    /// use for representing empty leaves, and a minimum depth.
+    pub fn new_advanced(ty: MerkleType, hashes: Vec<Bytes32>, min_depth: usize) -> DirtyMerkle {
+        #[cfg(feature = "counters")]
+        NEW_COUNTERS[&ty].fetch_add(1, Ordering::Relaxed);
+        let clean = CleanMerkle::new_advanced(ty, hashes, min_depth);
+        let dirty_layers = clean
+            .layers
+            .iter()
+            .map(|layer| HashSet::with_capacity(layer.len()))
+            .collect();
+        DirtyMerkle {
             ty,
-            layers: Arc::new(Mutex::new(layers)),
             min_depth,
-            dirty_layers,
+            data: UnsafeCell::new(DirtyMerkleData {
+                layers: clean.layers,
+                dirty_layers,
+            }),
+            clean: done_once(),
         }
     }
 
     fn rehash(&self) {
-        let dirty_layers = &mut self.dirty_layers.lock().unwrap();
-        if dirty_layers.is_empty() || dirty_layers[0].is_empty() {
-            return;
+        self.clean.call_once(|| {
+            // SAFETY: We have an immutable reference and are in a Once, so nothing else can mutate this
+            let data = unsafe { &mut *self.data.get() };
+            data.rehash(self.ty);
+        })
+    }
+
+    pub fn clean(&self) -> CleanMerkle<&'_ Vec<Vec<Bytes32>>> {
+        self.rehash();
+        // SAFETY: It's safe to read data with an immutable reference after a rehash
+        let data = unsafe { &*self.data.get() };
+        CleanMerkle {
+            ty: self.ty,
+            layers: data.layers.borrow(),
         }
-        let layers = &mut self.layers.lock().unwrap();
-        for layer_i in 1..layers.len() {
-            let dirty_i = layer_i - 1;
-            let dirt = dirty_layers[dirty_i].clone();
-            for idx in dirt.iter().sorted() {
-                let left_child_idx = idx << 1;
-                let right_child_idx = left_child_idx + 1;
-                let left = layers[layer_i - 1][left_child_idx];
-                let right = layers[layer_i - 1]
-                    .get(right_child_idx)
-                    .unwrap_or(empty_hash_at(self.ty, layer_i - 1));
-                let new_hash = hash_node(self.ty, left, right);
-                if *idx < layers[layer_i].len() {
-                    layers[layer_i][*idx] = new_hash;
-                } else {
-                    layers[layer_i].push(new_hash);
-                }
-                if layer_i < layers.len() - 1 {
-                    dirty_layers[dirty_i + 1].insert(idx >> 1);
-                }
-            }
-            dirty_layers[dirty_i].clear();
+    }
+
+    pub fn into_clean(self) -> CleanMerkle {
+        self.rehash();
+        CleanMerkle {
+            ty: self.ty,
+            layers: self.data.into_inner().layers,
         }
     }
 
     pub fn root(&self) -> Bytes32 {
         #[cfg(feature = "counters")]
         ROOT_COUNTERS[&self.ty].fetch_add(1, Ordering::Relaxed);
-        self.rehash();
-        if let Some(layer) = self.layers.lock().unwrap().last() {
+        self.clean().root()
+    }
+
+    // Returns the total number of leaves the tree can hold.
+    #[inline]
+    fn capacity(&self) -> usize {
+        let clean = self.clean();
+        if clean.layers.is_empty() {
+            return 0;
+        }
+        let base: usize = 2;
+        base.pow((clean.layers.len() - 1).try_into().unwrap())
+    }
+
+    // Returns the number of leaves in the tree.
+    pub fn len(&self) -> usize {
+        let clean = self.clean();
+        clean.layers[0].len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        let clean = self.clean();
+        clean.layers.is_empty() || clean.layers[0].is_empty()
+    }
+
+    #[must_use]
+    pub fn prove(&mut self, idx: usize) -> Option<Vec<u8>> {
+        self.clean().prove(idx)
+    }
+
+    /// creates a merkle proof regardless of if the leaf has content
+    #[must_use]
+    pub fn prove_any(&mut self, idx: usize) -> Vec<u8> {
+        self.clean().prove_any(idx)
+    }
+
+    /// Adds a new leaf to the merkle
+    /// Currently O(n) in the number of leaves (could be log(n))
+    pub fn push_leaf(&mut self, leaf: Bytes32) {
+        let mut leaves = self.data.get_mut().layers.swap_remove(0);
+        leaves.push(leaf);
+        *self = Self::new_advanced(self.ty, leaves, self.min_depth);
+    }
+
+    /// Removes the rightmost leaf from the merkle
+    /// Currently O(n) in the number of leaves (could be log(n))
+    pub fn pop_leaf(&mut self) {
+        let mut leaves = self.data.get_mut().layers.swap_remove(0);
+        leaves.pop();
+        *self = Self::new_advanced(self.ty, leaves, self.min_depth);
+    }
+
+    // Sets the leaf at the given index to the given hash.
+    // Panics if the index is out of bounds (since the structure doesn't grow).
+    pub fn set(&mut self, idx: usize, hash: Bytes32) {
+        #[cfg(feature = "counters")]
+        SET_COUNTERS[&self.ty].fetch_add(1, Ordering::Relaxed);
+        // This dirties the merkle tree
+        self.clean = Once::new();
+        let data = self.data.get_mut();
+        if data.layers[0][idx] == hash {
+            return;
+        }
+        data.layers[0][idx] = hash;
+        data.dirty_layers[0].insert(idx >> 1);
+    }
+
+    /// Resizes the number of leaves the tree can hold.
+    ///
+    /// The extra space is filled with empty hashes.
+    pub fn resize(&mut self, new_len: usize) -> Result<usize, String> {
+        if new_len > self.capacity() {
+            return Err(
+                "Cannot resize to a length greater than the capacity of the tree.".to_owned(),
+            );
+        }
+        let mut layer_size = new_len;
+        // This dirties the merkle tree
+        self.clean = Once::new();
+        let data = self.data.get_mut();
+        for (layer_i, layer) in data.layers.iter_mut().enumerate() {
+            layer.resize(layer_size, *empty_hash_at(self.ty, layer_i));
+            layer_size = max(layer_size >> 1, 1);
+        }
+        let start = data.layers[0].len();
+        for i in start..new_len {
+            data.dirty_layers[0].insert(i);
+        }
+        Ok(data.layers[0].len())
+    }
+}
+
+impl<L: Borrow<Vec<Vec<Bytes32>>>> CleanMerkle<L> {
+    pub fn root(&self) -> Bytes32 {
+        let layers = self.layers.borrow();
+        if let Some(layer) = layers.last() {
             assert_eq!(layer.len(), 1);
             layer[0]
         } else {
@@ -298,40 +497,8 @@ impl Merkle {
         }
     }
 
-    // Returns the total number of leaves the tree can hold.
-    #[inline]
-    fn capacity(&self) -> usize {
-        let layers = self.layers.lock().unwrap();
-        if layers.is_empty() {
-            return 0;
-        }
-        let base: usize = 2;
-        base.pow((layers.len() - 1).try_into().unwrap())
-    }
-
-    // Returns the number of leaves in the tree.
-    pub fn len(&self) -> usize {
-        self.layers.lock().unwrap()[0].len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        let layers = self.layers.lock().unwrap();
-        layers.is_empty() || layers[0].is_empty()
-    }
-
-    #[must_use]
-    pub fn prove(&self, idx: usize) -> Option<Vec<u8>> {
-        if self.layers.lock().unwrap().is_empty() || idx >= self.layers.lock().unwrap()[0].len() {
-            return None;
-        }
-        Some(self.prove_any(idx))
-    }
-
-    /// creates a merkle proof regardless of if the leaf has content
-    #[must_use]
     pub fn prove_any(&self, mut idx: usize) -> Vec<u8> {
-        self.rehash();
-        let layers = self.layers.lock().unwrap();
+        let layers = self.layers.borrow();
         let mut proof = vec![u8::try_from(layers.len() - 1).unwrap()];
         for (layer_i, layer) in layers.iter().enumerate() {
             if layer_i == layers.len() - 1 {
@@ -349,69 +516,26 @@ impl Merkle {
         proof
     }
 
-    /// Adds a new leaf to the merkle
-    /// Currently O(n) in the number of leaves (could be log(n))
-    pub fn push_leaf(&mut self, leaf: Bytes32) {
-        let mut leaves = self.layers.lock().unwrap().swap_remove(0);
-        leaves.push(leaf);
-        *self = Self::new_advanced(self.ty, leaves, self.min_depth);
-    }
-
-    /// Removes the rightmost leaf from the merkle
-    /// Currently O(n) in the number of leaves (could be log(n))
-    pub fn pop_leaf(&mut self) {
-        let mut leaves = self.layers.lock().unwrap().swap_remove(0);
-        leaves.pop();
-        *self = Self::new_advanced(self.ty, leaves, self.min_depth);
-    }
-
-    // Sets the leaf at the given index to the given hash.
-    // Panics if the index is out of bounds (since the structure doesn't grow).
-    pub fn set(&self, idx: usize, hash: Bytes32) {
-        #[cfg(feature = "counters")]
-        SET_COUNTERS[&self.ty].fetch_add(1, Ordering::Relaxed);
-        let mut layers = self.layers.lock().unwrap();
-        if layers[0][idx] == hash {
-            return;
+    pub fn prove(&self, idx: usize) -> Option<Vec<u8>> {
+        let layers = self.layers.borrow();
+        if layers.is_empty() || idx >= layers[0].len() {
+            return None;
         }
-        layers[0][idx] = hash;
-        self.dirty_layers.lock().unwrap()[0].insert(idx >> 1);
-    }
-
-    /// Resizes the number of leaves the tree can hold.
-    ///
-    /// The extra space is filled with empty hashes.
-    pub fn resize(&self, new_len: usize) -> Result<usize, String> {
-        if new_len > self.capacity() {
-            return Err(
-                "Cannot resize to a length greater than the capacity of the tree.".to_owned(),
-            );
-        }
-        let mut layers = self.layers.lock().unwrap();
-        let mut layer_size = new_len;
-        for (layer_i, layer) in layers.iter_mut().enumerate() {
-            layer.resize(layer_size, *empty_hash_at(self.ty, layer_i));
-            layer_size = max(layer_size >> 1, 1);
-        }
-        let start = layers[0].len();
-        for i in start..new_len {
-            self.dirty_layers.lock().unwrap()[0].insert(i);
-        }
-        Ok(layers[0].len())
+        Some(self.prove_any(idx))
     }
 }
 
-impl PartialEq for Merkle {
+impl<L: Borrow<Vec<Vec<Bytes32>>>> PartialEq for CleanMerkle<L> {
     fn eq(&self, other: &Self) -> bool {
         self.root() == other.root()
     }
 }
 
-impl Eq for Merkle {}
+impl<L: Borrow<Vec<Vec<Bytes32>>>> Eq for CleanMerkle<L> {}
 
-pub mod arc_mutex_sedre {
+pub mod mutex_sedre {
     pub fn serialize<S, T>(
-        data: &std::sync::Arc<std::sync::Mutex<T>>,
+        data: &std::sync::Mutex<T>,
         serializer: S,
     ) -> Result<S::Ok, S::Error>
     where
@@ -423,14 +547,14 @@ pub mod arc_mutex_sedre {
 
     pub fn deserialize<'de, D, T>(
         deserializer: D,
-    ) -> Result<std::sync::Arc<std::sync::Mutex<T>>, D::Error>
+    ) -> Result<std::sync::Mutex<T>, D::Error>
     where
         D: serde::Deserializer<'de>,
         T: serde::Deserialize<'de>,
     {
-        Ok(std::sync::Arc::new(std::sync::Mutex::new(T::deserialize(
+        Ok(std::sync::Mutex::new(T::deserialize(
             deserializer,
-        )?)))
+        )?))
     }
 }
 
@@ -472,7 +596,7 @@ fn resize_works() {
             ),
         ),
     );
-    let merkle = Merkle::new(MerkleType::Value, hashes.clone());
+    let mut merkle = DirtyMerkle::new(MerkleType::Value, hashes.clone());
     assert_eq!(merkle.capacity(), 8);
     assert_eq!(merkle.root(), expected);
 
@@ -516,9 +640,9 @@ fn resize_works() {
 
 #[test]
 fn correct_capacity() {
-    let merkle = Merkle::new(MerkleType::Value, vec![Bytes32::from([1; 32])]);
+    let merkle = DirtyMerkle::new(MerkleType::Value, vec![Bytes32::from([1; 32])]);
     assert_eq!(merkle.capacity(), 1);
-    let merkle = Merkle::new_advanced(MerkleType::Memory, vec![Bytes32::from([1; 32])], 11);
+    let merkle = DirtyMerkle::new_advanced(MerkleType::Memory, vec![Bytes32::from([1; 32])], 11);
     assert_eq!(merkle.capacity(), 1024);
 }
 
@@ -546,18 +670,16 @@ fn emit_memory_zerohashes() {
 
 #[test]
 fn serialization_roundtrip() {
-    let merkle = Merkle::new_advanced(MerkleType::Value, vec![Bytes32::from([1; 32])], 4);
-    merkle.resize(4).expect("resize failed");
-    merkle.set(3, Bytes32::from([2; 32]));
+    let mut merkle = CleanMerkle::new_advanced(MerkleType::Value, vec![Bytes32::from([1; 32])], 4);
     let serialized = bincode::serialize(&merkle).unwrap();
-    let deserialized: Merkle = bincode::deserialize(&serialized).unwrap();
+    let mut deserialized: CleanMerkle = bincode::deserialize(&serialized).unwrap();
     assert_eq!(merkle, deserialized);
 }
 
 #[test]
 #[should_panic(expected = "index out of bounds")]
 fn set_with_bad_index_panics() {
-    let merkle = Merkle::new(
+    let mut merkle = DirtyMerkle::new(
         MerkleType::Value,
         vec![Bytes32::default(), Bytes32::default()],
     );


### PR DESCRIPTION
This needs comments and is completely untested, it's just a first draft, but hopefully it's a good starting point. I think this should both make the implementation faster and remove the risk of deadlocks, at the risk of a safety issue, though I think the safety of this is pretty easy to reason about. The DirtyMerkleData can only be mutated with a mutable reference to a DirtyMerkle or inside the clean's Once, and those can only happen once at a time and are mutually exclusive.