### PR TITLE
Stylus cache tag

### DIFF
--- a/arbitrator/stylus/src/cache.rs
+++ b/arbitrator/stylus/src/cache.rs
@@ -72,7 +72,9 @@ impl InitCache {
     }
 
     pub fn set_lru_size(size: u32) {
-        cache!().lru.resize(NonZeroUsize::new(size.try_into().unwrap()).unwrap())
+        cache!()
+            .lru
+            .resize(NonZeroUsize::new(size.try_into().unwrap()).unwrap())
     }
 
     /// Retrieves a cached value, updating items as necessary.
@@ -106,7 +108,7 @@ impl InitCache {
         // if in LRU, add to ArbOS
         let mut cache = cache!();
         if let Some(item) = cache.long_term.get(&key) {
-            return Ok(item.data())
+            return Ok(item.data());
         }
         if let Some(item) = cache.lru.peek(&key).cloned() {
             if long_term_tag == Self::ARBOS_TAG {
@@ -135,7 +137,7 @@ impl InitCache {
     /// Evicts an item in the long-term cache.
     pub fn evict(module_hash: Bytes32, version: u16, long_term_tag: u32, debug: bool) {
         if long_term_tag != Self::ARBOS_TAG {
-            return
+            return;
         }
         let key = CacheKey::new(module_hash, version, debug);
         let mut cache = cache!();
@@ -146,8 +148,8 @@ impl InitCache {
 
     pub fn clear_long_term(long_term_tag: u32) {
         if long_term_tag != Self::ARBOS_TAG {
-            return
-        }        
+            return;
+        }
         let mut cache = cache!();
         let cache = &mut *cache;
         for (key, item) in cache.long_term.drain() {

--- a/arbitrator/stylus/src/cache.rs
+++ b/arbitrator/stylus/src/cache.rs
@@ -66,6 +66,10 @@ impl InitCache {
         }
     }
 
+    pub fn set_lru_size(size: u32) {
+        cache!().lru.resize(NonZeroUsize::new(size.try_into().unwrap()).unwrap())
+    }
+
     /// Retrieves a cached value, updating items as necessary.
     pub fn get(module_hash: Bytes32, version: u16, debug: bool) -> Option<(Module, Store)> {
         let mut cache = cache!();

--- a/arbitrator/stylus/src/lib.rs
+++ b/arbitrator/stylus/src/lib.rs
@@ -194,7 +194,14 @@ pub unsafe extern "C" fn stylus_call(
 
     // Safety: module came from compile_user_wasm and we've paid for memory expansion
     let instance = unsafe {
-        NativeInstance::deserialize_cached(module, config.version, evm_api, evm_data, long_term_tag, debug_chain)
+        NativeInstance::deserialize_cached(
+            module,
+            config.version,
+            evm_api,
+            evm_data,
+            long_term_tag,
+            debug_chain,
+        )
     };
     let mut instance = match instance {
         Ok(instance) => instance,
@@ -241,7 +248,12 @@ pub unsafe extern "C" fn stylus_cache_module(
 
 /// Evicts an activated user program from the init cache.
 #[no_mangle]
-pub extern "C" fn stylus_evict_module(module_hash: Bytes32, version: u16, arbos_tag: u32, debug: bool) {
+pub extern "C" fn stylus_evict_module(
+    module_hash: Bytes32,
+    version: u16,
+    arbos_tag: u32,
+    debug: bool,
+) {
     InitCache::evict(module_hash, version, arbos_tag, debug);
 }
 

--- a/arbitrator/stylus/src/lib.rs
+++ b/arbitrator/stylus/src/lib.rs
@@ -183,6 +183,7 @@ pub unsafe extern "C" fn stylus_call(
     debug_chain: bool,
     output: *mut RustBytes,
     gas: *mut u64,
+    long_term_tag: u32,
 ) -> UserOutcomeKind {
     let module = module.slice();
     let calldata = calldata.slice().to_vec();
@@ -193,7 +194,7 @@ pub unsafe extern "C" fn stylus_call(
 
     // Safety: module came from compile_user_wasm and we've paid for memory expansion
     let instance = unsafe {
-        NativeInstance::deserialize_cached(module, config.version, evm_api, evm_data, debug_chain)
+        NativeInstance::deserialize_cached(module, config.version, evm_api, evm_data, long_term_tag, debug_chain)
     };
     let mut instance = match instance {
         Ok(instance) => instance,
@@ -223,28 +224,31 @@ pub extern "C" fn stylus_cache_lru_resize(size: u32) {
 /// # Safety
 ///
 /// `module` must represent a valid module produced from `stylus_activate`.
+/// arbos_tag: a tag for arbos cache. 0 won't affect real caching
+/// currently only if tag==1 caching will be affected
 #[no_mangle]
 pub unsafe extern "C" fn stylus_cache_module(
     module: GoSliceData,
     module_hash: Bytes32,
     version: u16,
+    arbos_tag: u32,
     debug: bool,
 ) {
-    if let Err(error) = InitCache::insert(module_hash, module.slice(), version, debug) {
+    if let Err(error) = InitCache::insert(module_hash, module.slice(), version, arbos_tag, debug) {
         panic!("tried to cache invalid asm!: {error}");
     }
 }
 
 /// Evicts an activated user program from the init cache.
 #[no_mangle]
-pub extern "C" fn stylus_evict_module(module_hash: Bytes32, version: u16, debug: bool) {
-    InitCache::evict(module_hash, version, debug);
+pub extern "C" fn stylus_evict_module(module_hash: Bytes32, version: u16, arbos_tag: u32, debug: bool) {
+    InitCache::evict(module_hash, version, arbos_tag, debug);
 }
 
 /// Reorgs the init cache. This will likely never happen.
 #[no_mangle]
-pub extern "C" fn stylus_reorg_vm(block: u64) {
-    InitCache::reorg(block);
+pub extern "C" fn stylus_reorg_vm(_block: u64, arbos_tag: u32) {
+    InitCache::clear_long_term(arbos_tag);
 }
 
 /// Frees the vector. Does nothing when the vector is null.

--- a/arbitrator/stylus/src/lib.rs
+++ b/arbitrator/stylus/src/lib.rs
@@ -212,6 +212,12 @@ pub unsafe extern "C" fn stylus_call(
     status
 }
 
+/// resize lru
+#[no_mangle]
+pub extern "C" fn stylus_cache_lru_resize(size: u32) {
+    InitCache::set_lru_size(size);
+}
+
 /// Caches an activated user program.
 ///
 /// # Safety

--- a/arbitrator/stylus/src/native.rs
+++ b/arbitrator/stylus/src/native.rs
@@ -113,6 +113,7 @@ impl<D: DataReader, E: EvmApi<D>> NativeInstance<D, E> {
         version: u16,
         evm: E,
         evm_data: EvmData,
+        mut long_term_tag: u32,
         debug: bool,
     ) -> Result<Self> {
         let compile = CompileConfig::version(version, debug);
@@ -122,10 +123,10 @@ impl<D: DataReader, E: EvmApi<D>> NativeInstance<D, E> {
         if let Some((module, store)) = InitCache::get(module_hash, version, debug) {
             return Self::from_module(module, store, env);
         }
-        let (module, store) = match env.evm_data.cached {
-            true => InitCache::insert(module_hash, module, version, debug)?,
-            false => InitCache::insert_lru(module_hash, module, version, debug)?,
-        };
+        if !env.evm_data.cached {
+            long_term_tag = 0;
+        }
+        let (module, store) = InitCache::insert(module_hash, module, version, long_term_tag, debug)?;
         Self::from_module(module, store, env)
     }
 

--- a/arbitrator/stylus/src/native.rs
+++ b/arbitrator/stylus/src/native.rs
@@ -126,7 +126,8 @@ impl<D: DataReader, E: EvmApi<D>> NativeInstance<D, E> {
         if !env.evm_data.cached {
             long_term_tag = 0;
         }
-        let (module, store) = InitCache::insert(module_hash, module, version, long_term_tag, debug)?;
+        let (module, store) =
+            InitCache::insert(module_hash, module, version, long_term_tag, debug)?;
         Self::from_module(module, store, env)
     }
 

--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -65,6 +65,7 @@ func NewTransactionStreamerForTest(t *testing.T, ownerAddress common.Address) (*
 	if err != nil {
 		Fail(t, err)
 	}
+	execEngine.Initialize(gethexec.DefaultCachingConfig.StylusLRUCache)
 	execSeq := &execClientWrapper{execEngine, t}
 	inbox, err := NewTransactionStreamer(arbDb, bc.Config(), execSeq, nil, make(chan error, 1), transactionStreamerConfigFetcher)
 	if err != nil {

--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -253,6 +253,10 @@ func init() {
 	}
 }
 
+func ResizeWasmLruCache(size uint32) {
+	C.stylus_cache_lru_resize(u32(size))
+}
+
 func (value bytes32) toHash() common.Hash {
 	hash := common.Hash{}
 	for index, b := range value.bytes {

--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -166,6 +166,7 @@ func (p Programs) CallProgram(
 	tracingInfo *util.TracingInfo,
 	calldata []byte,
 	reentrant bool,
+	runmode core.MessageRunMode,
 ) ([]byte, error) {
 	evm := interpreter.Evm()
 	contract := scope.Contract
@@ -237,7 +238,11 @@ func (p Programs) CallProgram(
 	if contract.CodeAddr != nil {
 		address = *contract.CodeAddr
 	}
-	return callProgram(address, moduleHash, localAsm, scope, interpreter, tracingInfo, calldata, evmData, goParams, model)
+	var arbos_tag uint32
+	if runmode == core.MessageCommitMode {
+		arbos_tag = statedb.Database().WasmCacheTag()
+	}
+	return callProgram(address, moduleHash, localAsm, scope, interpreter, tracingInfo, calldata, evmData, goParams, model, arbos_tag)
 }
 
 func getWasm(statedb vm.StateDB, program common.Address) ([]byte, error) {

--- a/arbos/programs/wasm.go
+++ b/arbos/programs/wasm.go
@@ -143,6 +143,7 @@ func callProgram(
 	evmData *EvmData,
 	params *ProgParams,
 	memoryModel *MemoryModel,
+	_arbos_tag uint32,
 ) ([]byte, error) {
 	reqHandler := newApiClosures(interpreter, tracingInfo, scope, memoryModel)
 	gasLeft, retData, err := CallProgramLoop(moduleHash, calldata, scope.Contract.Gas, evmData, params, reqHandler)

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -127,6 +127,7 @@ func (p *TxProcessor) ExecuteWASM(scope *vm.ScopeContext, input []byte, interpre
 		tracingInfo,
 		input,
 		reentrant,
+		p.RunMode(),
 	)
 }
 

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -186,7 +186,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 				if err != nil {
 					return nil, nil, err
 				}
-				chainDb := rawdb.WrapDatabaseWithWasm(chainData, wasmDb)
+				chainDb := rawdb.WrapDatabaseWithWasm(chainData, wasmDb, 1)
 				err = pruning.PruneChainDb(ctx, chainDb, stack, &config.Init, cacheConfig, l1Client, rollupAddrs, config.Node.ValidatorRequired())
 				if err != nil {
 					return chainDb, nil, fmt.Errorf("error pruning: %w", err)
@@ -243,7 +243,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 	if err != nil {
 		return nil, nil, err
 	}
-	chainDb := rawdb.WrapDatabaseWithWasm(chainData, wasmDb)
+	chainDb := rawdb.WrapDatabaseWithWasm(chainData, wasmDb, 1)
 
 	if config.Init.ImportFile != "" {
 		initDataReader, err = statetransfer.NewJsonInitDataReader(config.Init.ImportFile)

--- a/execution/gethexec/blockchain.go
+++ b/execution/gethexec/blockchain.go
@@ -37,6 +37,7 @@ type CachingConfig struct {
 	SnapshotRestoreGasLimit            uint64        `koanf:"snapshot-restore-gas-limit"`
 	MaxNumberOfBlocksToSkipStateSaving uint32        `koanf:"max-number-of-blocks-to-skip-state-saving"`
 	MaxAmountOfGasToSkipStateSaving    uint64        `koanf:"max-amount-of-gas-to-skip-state-saving"`
+	StylusLRUCache                     uint32        `koanf:"stylus-lru-cache"`
 }
 
 func CachingConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -51,6 +52,7 @@ func CachingConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Uint64(prefix+".snapshot-restore-gas-limit", DefaultCachingConfig.SnapshotRestoreGasLimit, "maximum gas rolled back to recover snapshot")
 	f.Uint32(prefix+".max-number-of-blocks-to-skip-state-saving", DefaultCachingConfig.MaxNumberOfBlocksToSkipStateSaving, "maximum number of blocks to skip state saving to persistent storage (archive node only) -- warning: this option seems to cause issues")
 	f.Uint64(prefix+".max-amount-of-gas-to-skip-state-saving", DefaultCachingConfig.MaxAmountOfGasToSkipStateSaving, "maximum amount of gas in blocks to skip saving state to Persistent storage (archive node only) -- warning: this option seems to cause issues")
+	f.Uint32(prefix+".stylus-lru-cache", DefaultCachingConfig.StylusLRUCache, "initialized stylus programs to keep in LRU cache")
 }
 
 var DefaultCachingConfig = CachingConfig{
@@ -65,6 +67,22 @@ var DefaultCachingConfig = CachingConfig{
 	SnapshotRestoreGasLimit:            300_000_000_000,
 	MaxNumberOfBlocksToSkipStateSaving: 0,
 	MaxAmountOfGasToSkipStateSaving:    0,
+	StylusLRUCache:                     256,
+}
+
+var TestCachingConfig = CachingConfig{
+	Archive:                            false,
+	BlockCount:                         128,
+	BlockAge:                           30 * time.Minute,
+	TrieTimeLimit:                      time.Hour,
+	TrieDirtyCache:                     1024,
+	TrieCleanCache:                     600,
+	SnapshotCache:                      400,
+	DatabaseCache:                      2048,
+	SnapshotRestoreGasLimit:            300_000_000_000,
+	MaxNumberOfBlocksToSkipStateSaving: 0,
+	MaxAmountOfGasToSkipStateSaving:    0,
+	StylusLRUCache:                     0,
 }
 
 // TODO remove stack from parameters as it is no longer needed here

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -147,8 +147,9 @@ func (s *ExecutionEngine) Reorg(count arbutil.MessageIndex, newMessages []arbost
 		return nil, nil
 	}
 
+	tag := s.bc.StateCache().WasmCacheTag()
 	// reorg Rust-side VM state
-	C.stylus_reorg_vm(C.uint64_t(blockNum))
+	C.stylus_reorg_vm(C.uint64_t(blockNum), C.uint32_t(tag))
 
 	err := s.bc.ReorgToOldBlock(targetBlock)
 	if err != nil {

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -1,6 +1,9 @@
 // Copyright 2022-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
+//go:build !wasm
+// +build !wasm
+
 package gethexec
 
 /*
@@ -28,6 +31,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbos/l1pricing"
+	"github.com/offchainlabs/nitro/arbos/programs"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/util/arbmath"
@@ -70,6 +74,12 @@ func NewExecutionEngine(bc *core.BlockChain) (*ExecutionEngine, error) {
 		resequenceChan:   make(chan []*arbostypes.MessageWithMetadata),
 		newBlockNotifier: make(chan struct{}, 1),
 	}, nil
+}
+
+func (n *ExecutionEngine) Initialize(rustCacheSize uint32) {
+	if rustCacheSize != 0 {
+		programs.ResizeWasmLruCache(rustCacheSize)
+	}
 }
 
 func (s *ExecutionEngine) SetRecorder(recorder *BlockRecorder) {

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -107,6 +107,7 @@ var ConfigDefault = Config{
 
 func ConfigDefaultNonSequencerTest() *Config {
 	config := ConfigDefault
+	config.Caching = TestCachingConfig
 	config.ParentChainReader = headerreader.TestConfig
 	config.Sequencer.Enable = false
 	config.Forwarder = DefaultTestForwarderConfig
@@ -119,6 +120,7 @@ func ConfigDefaultNonSequencerTest() *Config {
 
 func ConfigDefaultTest() *Config {
 	config := ConfigDefault
+	config.Caching = TestCachingConfig
 	config.Sequencer = TestSequencerConfig
 	config.ParentChainReader = headerreader.TestConfig
 	config.ForwardingTarget = "null"
@@ -280,6 +282,7 @@ func (n *ExecutionNode) GetL1GasPriceEstimate() (uint64, error) {
 }
 
 func (n *ExecutionNode) Initialize(ctx context.Context) error {
+	n.ExecEngine.Initialize(n.ConfigFetcher().Caching.StylusLRUCache)
 	n.ArbInterface.Initialize(n)
 	err := n.Backend.Start()
 	if err != nil {

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -777,7 +777,7 @@ func createL2BlockChainWithStackConfig(
 	Require(t, err)
 	wasmData, err := stack.OpenDatabase("wasm", 0, 0, "wasm/", false)
 	Require(t, err)
-	chainDb := rawdb.WrapDatabaseWithWasm(chainData, wasmData)
+	chainDb := rawdb.WrapDatabaseWithWasm(chainData, wasmData, 0)
 	arbDb, err := stack.OpenDatabase("arbitrumdata", 0, 0, "arbitrumdata/", false)
 	Require(t, err)
 
@@ -984,7 +984,7 @@ func Create2ndNodeWithConfig(
 	Require(t, err)
 	wasmData, err := l2stack.OpenDatabase("wasm", 0, 0, "wasm/", false)
 	Require(t, err)
-	l2chainDb := rawdb.WrapDatabaseWithWasm(l2chainData, wasmData)
+	l2chainDb := rawdb.WrapDatabaseWithWasm(l2chainData, wasmData, 0)
 
 	l2arbDb, err := l2stack.OpenDatabase("arbitrumdata", 0, 0, "arbitrumdata/", false)
 	Require(t, err)

--- a/system_tests/recreatestate_rpc_test.go
+++ b/system_tests/recreatestate_rpc_test.go
@@ -449,7 +449,7 @@ func testSkippingSavingStateAndRecreatingAfterRestart(t *testing.T, cacheConfig 
 }
 
 func TestSkippingSavingStateAndRecreatingAfterRestart(t *testing.T) {
-	cacheConfig := gethexec.DefaultCachingConfig
+	cacheConfig := gethexec.TestCachingConfig
 	cacheConfig.Archive = true
 	cacheConfig.SnapshotCache = 0 // disable snapshots
 	cacheConfig.BlockAge = 0      // use only Caching.BlockCount to keep only last N blocks in dirties cache, no matter how new they are

--- a/system_tests/staterecovery_test.go
+++ b/system_tests/staterecovery_test.go
@@ -52,7 +52,7 @@ func TestRectreateMissingStates(t *testing.T) {
 		chainDb, err := stack.OpenDatabase("l2chaindata", 0, 0, "l2chaindata/", false)
 		Require(t, err)
 		defer chainDb.Close()
-		cacheConfig := gethexec.DefaultCacheConfigFor(stack, &gethexec.DefaultCachingConfig)
+		cacheConfig := gethexec.DefaultCacheConfigFor(stack, &gethexec.TestCachingConfig)
 		bc, err := gethexec.GetBlockChain(chainDb, cacheConfig, builder.chainConfig, builder.execConfig.TxLookupLimit)
 		Require(t, err)
 		err = staterecovery.RecreateMissingStates(chainDb, bc, cacheConfig, 1)


### PR DESCRIPTION
Pulls in https://github.com/OffchainLabs/go-ethereum/pull/319

Stylus-cache tag is added to ethdb and state.Database. Currently tag==1 means local compiled wasm will be cached with wasm-cache, and any other tag means it won't be (tag==0 will always mean using LRU cache only)

This:
* allows running tests in parallel without interefering with one another
* allows recording-db not to interfere with normal arbos
* by checking runmode in CallProgram: makes sure eth_calls etc will not affect arbos cache

In addition, a config option to change LRU-cache size is added