### PR TITLE
Adds apt-get update to wasm-libs-builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN apt-get update && apt-get install -y curl build-essential=12.9
 
 FROM wasm-base as wasm-libs-builder
 	# clang / lld used by soft-float wasm
-RUN apt-get install -y clang=1:14.0-55.7~deb12u1 lld=1:14.0-55.7~deb12u1 wabt
+RUN apt-get update && \
+    apt-get install -y clang=1:14.0-55.7~deb12u1 lld=1:14.0-55.7~deb12u1 wabt
     # pinned rust 1.75.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.75.0 --target x86_64-unknown-linux-gnu wasm32-unknown-unknown wasm32-wasi
 COPY ./Makefile ./


### PR DESCRIPTION
Adds apt-get update to wasm-libs-builder.

Avoids issues like:
```
29.34 E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/g/glibc/libc6-i386_2.36-9%2bdeb12u6_amd64.deb  404  Not Found [IP: 151.101.94.132 80]
```