### PR TITLE
Fix off-by-one in data poster nonce check

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -857,24 +857,23 @@ func (p *DataPoster) sendTx(ctx context.Context, prevTx *storage.QueuedTransacti
 			return fmt.Errorf("couldn't get preceding tx in DataPoster to check if should send tx with nonce %d: %w", newTx.FullTx.Nonce(), err)
 		}
 		if precedingTx != nil { // precedingTx == nil -> the actual preceding tx was already confirmed
-			var latestBlockNumber, prevBlockNumber, reorgResistantNonce uint64
 			if precedingTx.FullTx.Type() != newTx.FullTx.Type() || !precedingTx.Sent {
-				latestBlockNumber, err = p.client.BlockNumber(ctx)
+				latestBlockNumber, err := p.client.BlockNumber(ctx)
 				if err != nil {
 					return fmt.Errorf("couldn't get block number in DataPoster to check if should send tx with nonce %d: %w", newTx.FullTx.Nonce(), err)
 				}
-				prevBlockNumber = arbmath.SaturatingUSub(latestBlockNumber, 1)
-				reorgResistantNonce, err = p.client.NonceAt(ctx, p.Sender(), new(big.Int).SetUint64(prevBlockNumber))
+				prevBlockNumber := arbmath.SaturatingUSub(latestBlockNumber, 1)
+				reorgResistantTxCount, err := p.client.NonceAt(ctx, p.Sender(), new(big.Int).SetUint64(prevBlockNumber))
 				if err != nil {
 					return fmt.Errorf("couldn't determine reorg resistant nonce in DataPoster to check if should send tx with nonce %d: %w", newTx.FullTx.Nonce(), err)
 				}
 
-				if precedingTx.FullTx.Nonce() > reorgResistantNonce {
-					log.Info("DataPoster is avoiding creating a mempool nonce gap (the tx remains queued and will be retried)", "nonce", newTx.FullTx.Nonce(), "prevType", precedingTx.FullTx.Type(), "type", newTx.FullTx.Type(), "prevSent", precedingTx.Sent)
+				if newTx.FullTx.Nonce() > reorgResistantTxCount {
+					log.Info("DataPoster is avoiding creating a mempool nonce gap (the tx remains queued and will be retried)", "nonce", newTx.FullTx.Nonce(), "prevType", precedingTx.FullTx.Type(), "type", newTx.FullTx.Type(), "prevSent", precedingTx.Sent, "latestBlockNumber", latestBlockNumber, "prevBlockNumber", prevBlockNumber, "reorgResistantTxCount", reorgResistantTxCount)
 					return nil
 				}
 			} else {
-				log.Info("DataPoster will send previously unsent batch tx", "nonce", newTx.FullTx.Nonce(), "prevType", precedingTx.FullTx.Type(), "type", newTx.FullTx.Type(), "prevSent", precedingTx.Sent, "latestBlockNumber", latestBlockNumber, "prevBlockNumber", prevBlockNumber, "reorgResistantNonce", reorgResistantNonce)
+				log.Info("DataPoster will send previously unsent batch tx", "nonce", newTx.FullTx.Nonce(), "prevType", precedingTx.FullTx.Type(), "type", newTx.FullTx.Type(), "prevSent", precedingTx.Sent)
 			}
 		}
 	}

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -851,7 +851,8 @@ func (p *DataPoster) sendTx(ctx context.Context, prevTx *storage.QueuedTransacti
 	// different type with a lower nonce.
 	// If we decide not to send this tx yet, just leave it queued and with Sent set to false.
 	// The resending/repricing loop in DataPoster.Start will keep trying.
-	if !newTx.Sent && newTx.FullTx.Nonce() > 0 {
+	previouslySent := newTx.Sent || (prevTx != nil && prevTx.Sent) // if we've previously sent this nonce
+	if !previouslySent && newTx.FullTx.Nonce() > 0 {
 		precedingTx, err := p.queue.Get(ctx, arbmath.SaturatingUSub(newTx.FullTx.Nonce(), 1))
 		if err != nil {
 			return fmt.Errorf("couldn't get preceding tx in DataPoster to check if should send tx with nonce %d: %w", newTx.FullTx.Nonce(), err)


### PR DESCRIPTION
The "reorg resistant nonce" is really a reorg resistant tx count, which is one higher than the tx nonce that won't be reorged. In other words, if the previous tx is equal to the reorg resistant tx count, then the previous tx can still be reorged (only the one before it is safe). This PR fixes that by comparing it to the new tx nonce. If the new tx nonce is greater than the reorg resistant tx count, then that means that there's a gap between the last safe tx and the new tx we're posting. This would be equivalent to changing the `>` to a `>=`, but I thought this way was clearer. I also cleaned up some logging which was logging the variables in the wrong place (they aren't populated in the second log statement).