### PR TITLE
block_validator: fail but dont segfault if no validator

### DIFF
--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -791,8 +791,9 @@ validationsLoop:
 		}
 		for _, moduleRoot := range wasmRoots {
 			if v.chosenValidator[moduleRoot] == nil {
-				v.possiblyFatal(fmt.Errorf("did not find spawner for moduleRoot :%v", moduleRoot))
-				continue
+				notFoundErr := fmt.Errorf("did not find spawner for moduleRoot :%v", moduleRoot)
+				v.possiblyFatal(notFoundErr)
+				return nil, notFoundErr
 			}
 			if v.chosenValidator[moduleRoot].Room() == 0 {
 				log.Trace("advanceValidations: no more room", "moduleRoot", moduleRoot)
@@ -1107,7 +1108,7 @@ func (v *BlockValidator) Initialize(ctx context.Context) error {
 				}
 			}
 			if v.chosenValidator[root] == nil {
-				log.Error("validator not found", "WasmModuleRoot", root)
+				return fmt.Errorf("cannot validate WasmModuleRoot %v", root)
 			}
 		}
 	}


### PR DESCRIPTION
fixes a bug where not finding a validator will cause crash with segfault

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x12b76d8]

goroutine 534 [running]:
github.com/offchainlabs/nitro/staker.(*BlockValidator).advanceValidations(0xc000350f00, {0x30df2a8, 0xc0469d43c0})
	/workspace/staker/block_validator.go:820 +0xf18
```