### PR TITLE
Allow 0x prefix for allowed-wasm-module-roots flag

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -453,7 +453,7 @@ func mainImpl() int {
 		if len(allowedWasmModuleRoots) > 0 {
 			moduleRootMatched := false
 			for _, root := range allowedWasmModuleRoots {
-				bytes, err := hex.DecodeString(root)
+				bytes, err := hex.DecodeString(strings.TrimPrefix(root, "0x"))
 				if err == nil {
 					if common.HexToHash(root) == common.BytesToHash(bytes) {
 						moduleRootMatched = true


### PR DESCRIPTION
`strings.TrimPrefix` documentation:

> TrimPrefix returns s without the provided leading prefix string. If s doesn't start with prefix, s is returned unchanged.
