### PR TITLE
Halve EIP-4844 batch size to only fill 3 batches

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -216,8 +216,9 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	Enable:                             false,
 	DisableDapFallbackStoreDataOnChain: false,
 	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go
-	MaxSize:                        100000,
-	Max4844BatchSize:               blobs.BlobEncodableData*(params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob) - 2000,
+	MaxSize: 100000,
+	// Try to fill 3 blobs per batch
+	Max4844BatchSize:               blobs.BlobEncodableData*(params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob)/2 - 2000,
 	PollInterval:                   time.Second * 10,
 	ErrorDelay:                     time.Second * 10,
 	MaxDelay:                       time.Hour,


### PR DESCRIPTION
Unfortunately, this seems like the only good way to handle EIP-4844, given that there might be e.g. consistently 1 other blob tx per block with a high tip, which wouldn't cause the blobfee to escalate and thus creates a pre-EIP-1559-like tip market against a blob tx that takes up all 6 blob slots. The block producer's local incentive is to include the tx with 1 blob and a high tip instead of the tx with 6 blobs and a low tip. Using only 3 blobs per tx fixes this by ensuring that if the blobspace of a block is filled up with other txs, it must have at least 4 blobs, which means the blobfee will escalate and we'll have a EIP-1559-like market as intended.