### PR TITLE
Write validation inputs to json file in working directory

### DIFF
--- a/validator/client/validation_client.go
+++ b/validator/client/validation_client.go
@@ -158,7 +158,11 @@ func (c *ExecutionClient) LatestWasmModuleRoot() containers.PromiseInterface[com
 
 func (c *ExecutionClient) WriteToFile(input *validator.ValidationInput, expOut validator.GoGlobalState, moduleRoot common.Hash) containers.PromiseInterface[struct{}] {
 	jsonInput := server_api.ValidationInputToJson(input)
-	jsonInput.WriteToFile()
+	if err := jsonInput.WriteToFile(); err != nil {
+		return stopwaiter.LaunchPromiseThread[struct{}](c, func(ctx context.Context) (struct{}, error) {
+			return struct{}{}, err
+		})
+	}
 	return stopwaiter.LaunchPromiseThread[struct{}](c, func(ctx context.Context) (struct{}, error) {
 		err := c.client.CallContext(ctx, nil, server_api.Namespace+"_writeToFile", jsonInput, expOut, moduleRoot)
 		return struct{}{}, err

--- a/validator/client/validation_client.go
+++ b/validator/client/validation_client.go
@@ -158,6 +158,7 @@ func (c *ExecutionClient) LatestWasmModuleRoot() containers.PromiseInterface[com
 
 func (c *ExecutionClient) WriteToFile(input *validator.ValidationInput, expOut validator.GoGlobalState, moduleRoot common.Hash) containers.PromiseInterface[struct{}] {
 	jsonInput := server_api.ValidationInputToJson(input)
+	jsonInput.WriteToFile()
 	return stopwaiter.LaunchPromiseThread[struct{}](c, func(ctx context.Context) (struct{}, error) {
 		err := c.client.CallContext(ctx, nil, server_api.Namespace+"_writeToFile", jsonInput, expOut, moduleRoot)
 		return struct{}{}, err

--- a/validator/server_api/json.go
+++ b/validator/server_api/json.go
@@ -71,7 +71,7 @@ func (i *InputJSON) WriteToFile() error {
 	if err != nil {
 		return err
 	}
-	if err = os.WriteFile(fmt.Sprintf("block_inputs_%d.json", i.Id), contents, 0644); err != nil {
+	if err = os.WriteFile(fmt.Sprintf("block_inputs_%d.json", i.Id), contents, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/validator/server_api/json.go
+++ b/validator/server_api/json.go
@@ -5,7 +5,9 @@ package server_api
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -62,6 +64,17 @@ type InputJSON struct {
 	StartState    validator.GoGlobalState
 	UserWasms     map[common.Hash]UserWasmJson
 	DebugChain    bool
+}
+
+func (i *InputJSON) WriteToFile() error {
+	contents, err := json.MarshalIndent(i, "", "    ")
+	if err != nil {
+		return err
+	}
+	if err = os.WriteFile(fmt.Sprintf("block_inputs_%d.json", i.Id), contents, 0644); err != nil {
+		return err
+	}
+	return nil
 }
 
 type UserWasmJson struct {


### PR DESCRIPTION
Adds a simple method for dumping validation inputs to file on disk in json format.

This file can be useful as input to a run of the arbitrator prover to validate block hashes at various states in the state transition function.