### PR TITLE
MessageFromTxes: check l2message length

### DIFF
--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -234,6 +234,9 @@ func MessageFromTxes(header *arbostypes.L1IncomingMessageHeader, txes types.Tran
 			l2Message = append(l2Message, txBytes...)
 		}
 	}
+	if len(l2Message) > arbostypes.MaxL2MessageSize {
+		return nil, errors.New("l2message too long")
+	}
 	return &arbostypes.L1IncomingMessage{
 		Header: header,
 		L2msg:  l2Message,


### PR DESCRIPTION
We should never hit this, but since this is a static rule we should check it in encoding and not just decoding.