### PR TITLE
Remove a warning from the linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,12 @@
 # golangci-lint configuration
 
 run:
-  skip-dirs:
-    - go-ethereum
-    - fastcache
-
   timeout: 10m
 
 issues:
+  exclude-dirs:
+    - go-ethereum
+    - fastcache
   exclude-rules:
     - path: _test\.go
       linters:


### PR DESCRIPTION
The `run.skip-dirs` option has been deprecated in favor of `issues.exclude-dirs`.