### PR TITLE
Rename consensus-v30-rc.2 to consensus-v30 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -204,7 +204,7 @@ COPY ./scripts/download-machine.sh .
 #RUN ./download-machine.sh consensus-v11 0xf4389b835497a910d7ba3ebfb77aa93da985634f3c052de1290360635be40c4a
 #RUN ./download-machine.sh consensus-v11.1 0x68e4fe5023f792d4ef584796c84d710303a5e12ea02d6e37e2b5e9c4332507c4
 #RUN ./download-machine.sh consensus-v20 0x8b104a2e80ac6165dc58b9048de12f301d70b02a0ab51396c22b4b4b802a16a4
-RUN ./download-machine.sh consensus-v30-rc.2 0xb0de9cb89e4d944ae6023a3b62276e54804c242fd8c4c2d8e6cc4450f5fa8b1b
+RUN ./download-machine.sh consensus-v30 0xb0de9cb89e4d944ae6023a3b62276e54804c242fd8c4c2d8e6cc4450f5fa8b1b
 
 FROM golang:1.21.10-bookworm as node-builder
 WORKDIR /workspace


### PR DESCRIPTION
These tags and releases are identical. Release notes: https://github.com/OffchainLabs/nitro/releases/tag/consensus-v30