### PR TITLE
Make sure fee > tip in validator wallet estimateGas

### DIFF
--- a/staker/validatorwallet/contract.go
+++ b/staker/validatorwallet/contract.go
@@ -307,6 +307,7 @@ func (v *Contract) estimateGas(ctx context.Context, value *big.Int, data []byte)
 	if err != nil {
 		return 0, fmt.Errorf("getting suggested gas tip cap: %w", err)
 	}
+	gasFeeCap.Add(gasFeeCap, gasTipCap)
 	g, err := v.l1Reader.Client().EstimateGas(
 		ctx,
 		ethereum.CallMsg{


### PR DESCRIPTION
The tip is charged as part of the gasFeeCap, so we should add it on to our expected basefee