### PR TITLE
Fix solgen paths with new foundry versions

### DIFF
--- a/solgen/gen.go
+++ b/solgen/gen.go
@@ -68,7 +68,7 @@ func main() {
 	}
 	root := filepath.Dir(filename)
 	parent := filepath.Dir(root)
-	filePaths, err := filepath.Glob(filepath.Join(parent, "contracts", "build", "contracts", "src", "*", "*", "*.json"))
+	filePaths, err := filepath.Glob(filepath.Join(parent, "contracts", "build", "contracts", "src", "*", "*.sol", "*.json"))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func main() {
 		modInfo.addArtifact(artifact)
 	}
 
-	yulFilePaths, err := filepath.Glob(filepath.Join(parent, "contracts", "out", "yul", "*", "*.json"))
+	yulFilePaths, err := filepath.Glob(filepath.Join(parent, "contracts", "out", "*", "*.yul", "*.json"))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
As seen in e.g. https://github.com/OffchainLabs/nitro/pull/2386, CI is now failing because new foundry versions are producing a build-info folder that's confusing solgen. This PR updates solgen to look for `*.sol` and `*.yul` directories specifically, which excludes the build-info directory which does not contain ABI JSONs.