### PR TITLE
Split envvars with commas in them into a slice

### DIFF
--- a/cmd/util/confighelpers/configuration.go
+++ b/cmd/util/confighelpers/configuration.go
@@ -93,19 +93,28 @@ func applyOverrideOverrides(f *flag.FlagSet, k *koanf.Koanf) error {
 }
 
 var envvarsToSplitOnComma map[string]any = map[string]any{
-	"allowed-wasm-module-roots":   struct{}{},
-	"module-roots":                struct{}{},
-	"url":                         struct{}{},
-	"secondary-url":               struct{}{},
-	"file":                        struct{}{},
-	"api":                         struct{}{},
-	"corsdomain":                  struct{}{},
-	"vhosts":                      struct{}{},
-	"origins":                     struct{}{},
-	"bootnodes":                   struct{}{},
-	"bootnodes-v5":                struct{}{},
-	"secondary-forwarding-target": struct{}{},
-	"allowed-addresses":           struct{}{},
+	"auth.api":                              struct{}{},
+	"auth.origins":                          struct{}{},
+	"chain.info-files":                      struct{}{},
+	"conf.file":                             struct{}{},
+	"execution.secondary-forwarding-target": struct{}{},
+	"graphql.corsdomain":                    struct{}{},
+	"graphql.vhosts":                        struct{}{},
+	"http.api":                              struct{}{},
+	"http.corsdomain":                       struct{}{},
+	"http.vhosts":                           struct{}{},
+	"node.data-availability.rest-aggregator.urls":                       struct{}{},
+	"node.feed.input.secondary-url":                                     struct{}{},
+	"node.feed.input.url":                                               struct{}{},
+	"node.feed.input.verify.allowed-addresses":                          struct{}{},
+	"node.seq-coordinator.signer.ecdsa.allowed-addresses":               struct{}{},
+	"p2p.bootnodes":                                                     struct{}{},
+	"p2p.bootnodes-v5":                                                  struct{}{},
+	"validation.api-auth":                                               struct{}{},
+	"validation.arbitrator.redis-validation-server-config.module-roots": struct{}{},
+	"validation.wasm.allowed-wasm-module-roots":                         struct{}{},
+	"ws.api":     struct{}{},
+	"ws.origins": struct{}{},
 }
 
 func loadEnvironmentVariables(k *koanf.Koanf) error {
@@ -117,16 +126,12 @@ func loadEnvironmentVariables(k *koanf.Koanf) error {
 				strings.TrimPrefix(key, envPrefix+"_")), "__", "-")
 			key = strings.ReplaceAll(key, "_", ".")
 
-			keyParts := strings.Split(key, ".")
-			if len(keyParts) > 0 {
-				if _, found := envvarsToSplitOnComma[keyParts[len(keyParts)-1]]; found {
-					// If there are commas in the value, split the value into a slice.
-					if strings.Contains(v, ",") {
-						return key, strings.Split(v, ",")
+			if _, found := envvarsToSplitOnComma[key]; found {
+				// If there are commas in the value, split the value into a slice.
+				if strings.Contains(v, ",") {
+					return key, strings.Split(v, ",")
 
-					}
 				}
-
 			}
 
 			return key, v

--- a/cmd/util/confighelpers/configuration.go
+++ b/cmd/util/confighelpers/configuration.go
@@ -92,6 +92,22 @@ func applyOverrideOverrides(f *flag.FlagSet, k *koanf.Koanf) error {
 	return nil
 }
 
+var envvarsToSplitOnComma map[string]any = map[string]any{
+	"allowed-wasm-module-roots":   struct{}{},
+	"module-roots":                struct{}{},
+	"url":                         struct{}{},
+	"secondary-url":               struct{}{},
+	"file":                        struct{}{},
+	"api":                         struct{}{},
+	"corsdomain":                  struct{}{},
+	"vhosts":                      struct{}{},
+	"origins":                     struct{}{},
+	"bootnodes":                   struct{}{},
+	"bootnodes-v5":                struct{}{},
+	"secondary-forwarding-target": struct{}{},
+	"allowed-addresses":           struct{}{},
+}
+
 func loadEnvironmentVariables(k *koanf.Koanf) error {
 	envPrefix := k.String("conf.env-prefix")
 	if len(envPrefix) != 0 {
@@ -101,9 +117,16 @@ func loadEnvironmentVariables(k *koanf.Koanf) error {
 				strings.TrimPrefix(key, envPrefix+"_")), "__", "-")
 			key = strings.ReplaceAll(key, "_", ".")
 
-			// If there is a space in the value, split the value into a slice by the space.
-			if strings.Contains(v, ",") {
-				return key, strings.Split(v, ",")
+			keyParts := strings.Split(key, ".")
+			if len(keyParts) > 0 {
+				if _, found := envvarsToSplitOnComma[keyParts[len(keyParts)-1]]; found {
+					// If there are commas in the value, split the value into a slice.
+					if strings.Contains(v, ",") {
+						return key, strings.Split(v, ",")
+
+					}
+				}
+
 			}
 
 			return key, v


### PR DESCRIPTION
This makes command line options that accept multiple string values separated by commas also work correctly when used as an environment variable. eg
ARB_NODE_VALIDATION_WASM_ALLOWED__WASM__MODULE__ROOTS=/a,/b now works as expected, with separate entries "/a" and "/b"

# Testing done
As a CLI opt for comparison:
``` 
$ ./target/bin/cfgtest --validation.wasm.allowed-wasm-module-roots "/a,/b" 
        root: /a
        root: /b
```

As an env var:
```
$ ARB_NODE_VALIDATION_WASM_ALLOWED__WASM__MODULE__ROOTS=/a,/b ./target/bin/cfgtest --conf.env-prefix ARB_NODE
        root: /a
        root: /b
```

Single env var still works
```
$ ARB_NODE_VALIDATION_WASM_ALLOWED__WASM__MODULE__ROOTS=/a ./target/bin/cfgtest --conf.env-prefix ARB_NODE                 
        root: /a    
```

Related to: https://linear.app/offchain-labs/issue/NIT-2612/support-comma-separated-environment-variables-for-multi-string