### PR TITLE
Fix lazy asm recreation

### DIFF
--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -153,7 +153,8 @@ func (p Programs) ActivateProgram(evm *vm.EVM, address common.Address, runMode c
 	}
 	// replace the cached asm
 	if cached {
-		cacheProgram(statedb, info.moduleHash, programData, params, debugMode, time, runMode)
+		code := statedb.GetCode(address)
+		cacheProgram(statedb, info.moduleHash, programData, code, codeHash, params, debugMode, time, runMode)
 	}
 
 	return stylusVersion, codeHash, info.moduleHash, dataFee, false, p.setProgram(codeHash, programData)
@@ -210,7 +211,7 @@ func (p Programs) CallProgram(
 	statedb.AddStylusPages(program.footprint)
 	defer statedb.SetStylusPagesOpen(open)
 
-	localAsm, err := getLocalAsm(statedb, moduleHash, contract.Address(), params.PageLimit, evm.Context.Time, debugMode, program)
+	localAsm, err := getLocalAsm(statedb, moduleHash, contract.Address(), contract.Code, contract.CodeHash, params.PageLimit, evm.Context.Time, debugMode, program)
 	if err != nil {
 		log.Crit("failed to get local wasm for activated program", "program", contract.Address())
 		return nil, err
@@ -399,7 +400,11 @@ func (p Programs) SetProgramCached(
 		return err
 	}
 	if cache {
-		cacheProgram(db, moduleHash, program, params, debug, time, runMode)
+		code, err := db.GetCodeFromHash(codeHash)
+		if err != nil {
+			return err
+		}
+		cacheProgram(db, moduleHash, program, code, codeHash, params, debug, time, runMode)
 	} else {
 		evictProgram(db, moduleHash, program.version, debug, runMode, expired)
 	}

--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -400,7 +400,8 @@ func (p Programs) SetProgramCached(
 		return err
 	}
 	if cache {
-		code, err := db.GetCodeFromHash(codeHash)
+		// Not passing in an address is supported pre-Verkle, as in Blockchain's ContractCodeWithPrefix method.
+		code, err := db.Database().ContractCode(common.Address{}, codeHash)
 		if err != nil {
 			return err
 		}

--- a/arbos/programs/wasm.go
+++ b/arbos/programs/wasm.go
@@ -95,7 +95,7 @@ func activateProgram(
 }
 
 // stub any non-consensus, Rust-side caching updates
-func cacheProgram(db vm.StateDB, module common.Hash, program Program, params *StylusParams, debug bool, time uint64, runMode core.MessageRunMode) {
+func cacheProgram(db vm.StateDB, module common.Hash, program Program, code []byte, codeHash common.Hash, params *StylusParams, debug bool, time uint64, runMode core.MessageRunMode) {
 }
 func evictProgram(db vm.StateDB, module common.Hash, version uint16, debug bool, mode core.MessageRunMode, forever bool) {
 }
@@ -128,7 +128,7 @@ func startProgram(module uint32) uint32
 //go:wasmimport programs send_response
 func sendResponse(req_id uint32) uint32
 
-func getLocalAsm(statedb vm.StateDB, moduleHash common.Hash, address common.Address, pagelimit uint16, time uint64, debugMode bool, program Program) ([]byte, error) {
+func getLocalAsm(statedb vm.StateDB, moduleHash common.Hash, addressForLogging common.Address, code []byte, codeHash common.Hash, pagelimit uint16, time uint64, debugMode bool, program Program) ([]byte, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This PR adds the code (and code hash to avoid rehashing) as arguments to getLocalAsm instead of trying to get it from the address, which may not even be passed in.