### PR TITLE
[config change] Deprecate local-db-storage, add migration opt, fixes: NIT-2539

### DIFF
--- a/das/das.go
+++ b/das/das.go
@@ -45,6 +45,8 @@ type DataAvailabilityConfig struct {
 	LocalFileStorage LocalFileStorageConfig `koanf:"local-file-storage"`
 	S3Storage        S3StorageServiceConfig `koanf:"s3-storage"`
 
+	MigrateLocalDBToFileStorage bool `koanf:"migrate-local-db-to-file-storage"`
+
 	Key KeyConfig `koanf:"key"`
 
 	RPCAggregator  AggregatorConfig              `koanf:"rpc-aggregator"`
@@ -112,6 +114,7 @@ func dataAvailabilityConfigAddOptions(prefix string, f *flag.FlagSet, r role) {
 		LocalDBStorageConfigAddOptions(prefix+".local-db-storage", f)
 		LocalFileStorageConfigAddOptions(prefix+".local-file-storage", f)
 		S3ConfigAddOptions(prefix+".s3-storage", f)
+		f.Bool(prefix+".migrate-local-db-to-file-storage", DefaultDataAvailabilityConfig.MigrateLocalDBToFileStorage, "daserver will migrate all data on startup from local-db-storage to local-file-storage, then mark local-db-storage as unusable")
 
 		// Key config for storage
 		KeyConfigAddOptions(prefix+".key", f)

--- a/das/factory.go
+++ b/das/factory.go
@@ -25,26 +25,36 @@ func CreatePersistentStorageService(
 ) (StorageService, *LifecycleManager, error) {
 	storageServices := make([]StorageService, 0, 10)
 	var lifecycleManager LifecycleManager
-	if config.LocalDBStorage.Enable {
-		s, err := NewDBStorageService(ctx, &config.LocalDBStorage)
+	var err error
+
+	var fs *LocalFileStorageService
+	if config.LocalFileStorage.Enable {
+		fs, err = NewLocalFileStorageService(config.LocalFileStorage)
 		if err != nil {
 			return nil, nil, err
 		}
-		lifecycleManager.Register(s)
-		storageServices = append(storageServices, s)
+		err = fs.start(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		lifecycleManager.Register(fs)
+		storageServices = append(storageServices, fs)
 	}
 
-	if config.LocalFileStorage.Enable {
-		s, err := NewLocalFileStorageService(config.LocalFileStorage)
+	if config.LocalDBStorage.Enable {
+		var s *DBStorageService
+		if config.MigrateLocalDBToFileStorage {
+			s, err = NewDBStorageService(ctx, &config.LocalDBStorage, fs)
+		} else {
+			s, err = NewDBStorageService(ctx, &config.LocalDBStorage, nil)
+		}
 		if err != nil {
 			return nil, nil, err
 		}
-		err = s.start(ctx)
-		if err != nil {
-			return nil, nil, err
+		if s != nil {
+			lifecycleManager.Register(s)
+			storageServices = append(storageServices, s)
 		}
-		lifecycleManager.Register(s)
-		storageServices = append(storageServices, s)
 	}
 
 	if config.S3Storage.Enable {
@@ -67,6 +77,10 @@ func CreatePersistentStorageService(
 	if len(storageServices) == 1 {
 		return storageServices[0], &lifecycleManager, nil
 	}
+	if len(storageServices) == 0 {
+		return nil, nil, errors.New("No data-availability storage backend has been configured")
+	}
+
 	return nil, &lifecycleManager, nil
 }
 


### PR DESCRIPTION
The local DB storage backend, based on badgerdb, is being deprecated due
to its unfavorable memory performance when compacting.
local-file-storage is now the recommended local storage instead.
To migrate to it, use --data-availability.migrate-local-db-to-file-storage
and enable the local-file-storage service.

Migration must be enabled manually using this flag since the
operator may need to set up a new storage directory and backing volume.

In-process migration is only provided from local-db-storage to
local-file-storage since it is the only other local storage backend
we current provide. To migrate to other backends, start a new daserver
instance and use the rest-aggregator.sync-to-storage options.
In the case where both S3 and DB backends were being used, it is recommended
to migrate to the file backend and retain S3 instead of just dropping the DB
backend configuration, otherwise there would no longer be a local store.

ERROR and WARN messages on startup will inform operators that they
should migrate (but can continue anyway), if migration failed, or if
migration had previously succeeded and config/storage cleanup is
recommended. These messages will be made fatal in the future before the
local-db-storage backend code is removed entirely for the full
deprecation.


# Test
Manually the main migration scenario and various errors.

`$ ../../nitro/target/bin/daserver --conf.file test-migrate.cfg`
Relevant part of test-migrate.cfg
```
{
  "data-availability": {
    "enable": true,
    "local-db-storage": {
      "data-dir": "/home/tristan/offchain/datestconf/test-badgerdb-deprecation/badgerdata",
      "enable": true,
      "discard-after-timeout": true
    },
	"local-file-storage": {
      "data-dir": "/home/tristan/offchain/datestconf/test-badgerdb-deprecation/data",
      "enable": true,
      "enable-expiry": true,
      "max-retention": "98h0m"
    },
	"migrate-local-db-to-file-storage": true,

```


Log of error informing operator to migrate if `migrate-local-db-to-file-storage` is not specified.
```
ERROR[06-17|18:53:16.399] local-db-storage is DEPRECATED, please use use the local-file-storage and migrate-local-db-to-file-storage options. This error will be made fatal in future, continuing for now...
<startup continues>
```

Log of migration.
```
INFO [06-17|18:54:32.911] Migrating from DBStorageService          target=LocalFileStorageService(/home/tristan/offchain/datestconf/test-badgerdb-deprecation/data)
INFO [06-17|18:54:32.913] Migration in progress                    migrated=0
INFO [06-17|18:54:32.956] Migration from DBStorageService complete target=LocalFileStorageService(/home/tristan/offchain/datestconf/test-badgerdb-deprecation/data) migrated=301 duration=44.891557ms
<startup continues>
```

After migration, the MIGRATED marker file is created, final cleanup is left to the operator for safety.
```
$ ll badgerdata
total 5676
-rw-r--r--. 1 tristan tristan    2980575 Jun 17 17:33 000001.sst
-rw-r--r--. 1 tristan tristan     590479 Jun 17 17:33 000002.sst
-rw-r--r--. 1 tristan tristan    2204064 Jun 17 18:54 000003.sst
-rw-r--r--. 1 tristan tristan         20 Jun 17 18:54 000007.vlog
-rw-r--r--. 1 tristan tristan 2147483646 Jun 17 18:54 000008.vlog
-rw-r--r--. 1 tristan tristan  134217728 Jun 17 18:54 00001.mem
-rw-r--r--. 1 tristan tristan    1048576 Jun 17 17:28 DISCARD
-rw-------. 1 tristan tristan         28 Jun 17 17:28 KEYREGISTRY
-rw-r--r--. 1 tristan tristan          7 Jun 17 18:54 LOCK
-rw-------. 1 tristan tristan         58 Jun 17 18:54 MANIFEST
-rw-------. 1 tristan tristan          0 Jun 17 18:54 MIGRATED
```

Warning informing operator on startup that the migration is already complete.
```
WARN [06-17|19:04:04.197] local-db-storage already migrated, please remove it from the daserver configuration and restart                
```

Fatal error informing operator if migration already performed and no other storage backend is configured.
```
ERROR[06-17|19:01:02.762] local-db-storage already migrated, please remove it from the daserver configuration and restart
ERROR[06-17|19:01:02.762] Error running DAServer                   err="No data-availability storage backend has been configured"
```

Fatal error informing operator on startup of migration of incompatible database types.
```
ERROR[06-17|19:11:26.804] Error running DAServer                   err="error migrating local-db-storage to LocalFileSto
rageService(/home/tristan/offchain/datestconf/test-badgerdb-deprecation/data-noexpiry): can't migrate from DBStorageServ
ice to target, incompatible expiration policies - can't migrate from non-expiring to expiring since non-expiring DB lack
s expiry time metadata"
```

Logs for migration without expiry on source or target backends.
```
INFO [06-17|19:13:12.607] Migrating from DBStorageService          target=LocalFileStorageService(/home/tristan/offchain/datestconf/test-badgerdb-deprecation/data-noexpiry)
INFO [06-17|19:13:12.608] Migration in progress                    migrated=0
INFO [06-17|19:13:12.613] Migration from DBStorageService complete target=LocalFileStorageService(/home/tristan/offchain/datestconf/test-badgerdb-deprecation/data-noexpiry) migrated=57 duration=6.076443ms
```
