### PR TITLE
Consensus/Execution split: simplifies ConsensusSequencer and ExecutionEngine interfaces

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -792,17 +792,6 @@ func CreateNode(
 	return currentNode, nil
 }
 
-func (n *Node) CacheL1PriceDataOfMsg(pos arbutil.MessageIndex, callDataUnits uint64, l1GasCharged uint64) {
-	n.TxStreamer.CacheL1PriceDataOfMsg(pos, callDataUnits, l1GasCharged)
-}
-
-func (n *Node) BacklogL1GasCharged() uint64 {
-	return n.TxStreamer.BacklogL1GasCharged()
-}
-func (n *Node) BacklogCallDataUnits() uint64 {
-	return n.TxStreamer.BacklogCallDataUnits()
-}
-
 func (n *Node) Start(ctx context.Context) error {
 	execClient, ok := n.Execution.(*gethexec.ExecutionNode)
 	if !ok {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -133,10 +133,6 @@ const (
 	BlockHashMismatchLogMsg = "BlockHash from feed doesn't match locally computed hash. Check feed source."
 )
 
-func (s *TransactionStreamer) CurrentEstimateOfL1GasPrice() uint64 {
-	return s.exec.GetL1GasPriceEstimate()
-}
-
 // Encodes a uint64 as bytes in a lexically sortable manner for database iteration.
 // Generally this is only used for database keys, which need sorted.
 // A shorter RLP encoding is usually used for database values.

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -69,9 +69,6 @@ type TransactionStreamer struct {
 	broadcastServer *broadcaster.Broadcaster
 	inboxReader     *InboxReader
 	delayedBridge   *DelayedBridge
-
-	cachedL1PriceDataMutex sync.RWMutex
-	cachedL1PriceData      *L1PriceData
 }
 
 type TransactionStreamerConfig struct {
@@ -118,29 +115,12 @@ func NewTransactionStreamer(
 		fatalErrChan:       fatalErrChan,
 		config:             config,
 		snapSyncConfig:     snapSyncConfig,
-		cachedL1PriceData: &L1PriceData{
-			msgToL1PriceData: []L1PriceDataOfMsg{},
-		},
 	}
 	err := streamer.cleanupInconsistentState()
 	if err != nil {
 		return nil, err
 	}
 	return streamer, nil
-}
-
-type L1PriceDataOfMsg struct {
-	callDataUnits            uint64
-	cummulativeCallDataUnits uint64
-	l1GasCharged             uint64
-	cummulativeL1GasCharged  uint64
-}
-
-type L1PriceData struct {
-	startOfL1PriceDataCache     arbutil.MessageIndex
-	endOfL1PriceDataCache       arbutil.MessageIndex
-	msgToL1PriceData            []L1PriceDataOfMsg
-	currentEstimateOfL1GasPrice uint64
 }
 
 // Represents a block's hash in the database.
@@ -154,103 +134,7 @@ const (
 )
 
 func (s *TransactionStreamer) CurrentEstimateOfL1GasPrice() uint64 {
-	s.cachedL1PriceDataMutex.Lock()
-	defer s.cachedL1PriceDataMutex.Unlock()
-
-	currentEstimate, err := s.exec.GetL1GasPriceEstimate()
-	if err != nil {
-		log.Error("error fetching current L2 estimate of L1 gas price hence reusing cached estimate", "err", err)
-	} else {
-		s.cachedL1PriceData.currentEstimateOfL1GasPrice = currentEstimate
-	}
-	return s.cachedL1PriceData.currentEstimateOfL1GasPrice
-}
-
-func (s *TransactionStreamer) BacklogCallDataUnits() uint64 {
-	s.cachedL1PriceDataMutex.RLock()
-	defer s.cachedL1PriceDataMutex.RUnlock()
-
-	size := len(s.cachedL1PriceData.msgToL1PriceData)
-	if size == 0 {
-		return 0
-	}
-	return (s.cachedL1PriceData.msgToL1PriceData[size-1].cummulativeCallDataUnits -
-		s.cachedL1PriceData.msgToL1PriceData[0].cummulativeCallDataUnits +
-		s.cachedL1PriceData.msgToL1PriceData[0].callDataUnits)
-}
-
-func (s *TransactionStreamer) BacklogL1GasCharged() uint64 {
-	s.cachedL1PriceDataMutex.RLock()
-	defer s.cachedL1PriceDataMutex.RUnlock()
-
-	size := len(s.cachedL1PriceData.msgToL1PriceData)
-	if size == 0 {
-		return 0
-	}
-	return (s.cachedL1PriceData.msgToL1PriceData[size-1].cummulativeL1GasCharged -
-		s.cachedL1PriceData.msgToL1PriceData[0].cummulativeL1GasCharged +
-		s.cachedL1PriceData.msgToL1PriceData[0].l1GasCharged)
-}
-
-func (s *TransactionStreamer) TrimCache(to arbutil.MessageIndex) {
-	s.cachedL1PriceDataMutex.Lock()
-	defer s.cachedL1PriceDataMutex.Unlock()
-
-	if to < s.cachedL1PriceData.startOfL1PriceDataCache {
-		log.Info("trying to trim older cache which doesnt exist anymore")
-	} else if to >= s.cachedL1PriceData.endOfL1PriceDataCache {
-		s.cachedL1PriceData.startOfL1PriceDataCache = 0
-		s.cachedL1PriceData.endOfL1PriceDataCache = 0
-		s.cachedL1PriceData.msgToL1PriceData = []L1PriceDataOfMsg{}
-	} else {
-		newStart := to - s.cachedL1PriceData.startOfL1PriceDataCache + 1
-		s.cachedL1PriceData.msgToL1PriceData = s.cachedL1PriceData.msgToL1PriceData[newStart:]
-		s.cachedL1PriceData.startOfL1PriceDataCache = to + 1
-	}
-}
-
-func (s *TransactionStreamer) CacheL1PriceDataOfMsg(seqNum arbutil.MessageIndex, callDataUnits uint64, l1GasCharged uint64) {
-	s.cachedL1PriceDataMutex.Lock()
-	defer s.cachedL1PriceDataMutex.Unlock()
-
-	resetCache := func() {
-		s.cachedL1PriceData.startOfL1PriceDataCache = seqNum
-		s.cachedL1PriceData.endOfL1PriceDataCache = seqNum
-		s.cachedL1PriceData.msgToL1PriceData = []L1PriceDataOfMsg{{
-			callDataUnits:            callDataUnits,
-			cummulativeCallDataUnits: callDataUnits,
-			l1GasCharged:             l1GasCharged,
-			cummulativeL1GasCharged:  l1GasCharged,
-		}}
-	}
-	size := len(s.cachedL1PriceData.msgToL1PriceData)
-	if size == 0 ||
-		s.cachedL1PriceData.startOfL1PriceDataCache == 0 ||
-		s.cachedL1PriceData.endOfL1PriceDataCache == 0 ||
-		arbutil.MessageIndex(size) != s.cachedL1PriceData.endOfL1PriceDataCache-s.cachedL1PriceData.startOfL1PriceDataCache+1 {
-		resetCache()
-		return
-	}
-	if seqNum != s.cachedL1PriceData.endOfL1PriceDataCache+1 {
-		if seqNum > s.cachedL1PriceData.endOfL1PriceDataCache+1 {
-			log.Info("message position higher then current end of l1 price data cache, resetting cache to this message")
-			resetCache()
-		} else if seqNum < s.cachedL1PriceData.startOfL1PriceDataCache {
-			log.Info("message position lower than start of l1 price data cache, ignoring")
-		} else {
-			log.Info("message position already seen in l1 price data cache, ignoring")
-		}
-	} else {
-		cummulativeCallDataUnits := s.cachedL1PriceData.msgToL1PriceData[size-1].cummulativeCallDataUnits
-		cummulativeL1GasCharged := s.cachedL1PriceData.msgToL1PriceData[size-1].cummulativeL1GasCharged
-		s.cachedL1PriceData.msgToL1PriceData = append(s.cachedL1PriceData.msgToL1PriceData, L1PriceDataOfMsg{
-			callDataUnits:            callDataUnits,
-			cummulativeCallDataUnits: cummulativeCallDataUnits + callDataUnits,
-			l1GasCharged:             l1GasCharged,
-			cummulativeL1GasCharged:  cummulativeL1GasCharged + l1GasCharged,
-		})
-		s.cachedL1PriceData.endOfL1PriceDataCache = seqNum
-	}
+	return s.exec.GetL1GasPriceEstimate()
 }
 
 // Encodes a uint64 as bytes in a lexically sortable manner for database iteration.
@@ -773,7 +657,7 @@ func (s *TransactionStreamer) AddMessagesAndEndBatch(pos arbutil.MessageIndex, m
 
 	if messagesAreConfirmed {
 		// Trim confirmed messages from l1pricedataCache
-		s.TrimCache(pos + arbutil.MessageIndex(len(messages)))
+		s.exec.TrimCache(pos + arbutil.MessageIndex(len(messages)))
 		s.reorgMutex.RLock()
 		dups, _, _, err := s.countDuplicateMessages(pos, messagesWithBlockHash, nil)
 		s.reorgMutex.RUnlock()

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -681,7 +681,7 @@ func (s *ExecutionEngine) ResultAtPos(pos arbutil.MessageIndex) (*execution.Mess
 	return s.resultFromHeader(s.bc.GetHeaderByNumber(s.MessageIndexToBlockNumber(pos)))
 }
 
-func (s *ExecutionEngine) GetL1GasPriceEstimate() uint64 {
+func (s *ExecutionEngine) getL1GasPriceEstimate() uint64 {
 	bc := s.bc
 	latestHeader := bc.CurrentBlock()
 	latestState, err := bc.StateAt(latestHeader.Root)

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -277,10 +277,6 @@ func CreateExecutionNode(
 
 }
 
-func (n *ExecutionNode) GetL1GasPriceEstimate() uint64 {
-	return n.ExecEngine.GetL1GasPriceEstimate()
-}
-
 func (n *ExecutionNode) TrimCache(to arbutil.MessageIndex) {
 	n.ExecEngine.TrimCache(to)
 }

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -277,8 +277,12 @@ func CreateExecutionNode(
 
 }
 
-func (n *ExecutionNode) GetL1GasPriceEstimate() (uint64, error) {
+func (n *ExecutionNode) GetL1GasPriceEstimate() uint64 {
 	return n.ExecEngine.GetL1GasPriceEstimate()
+}
+
+func (n *ExecutionNode) TrimCache(to arbutil.MessageIndex) {
+	n.ExecEngine.TrimCache(to)
 }
 
 func (n *ExecutionNode) Initialize(ctx context.Context) error {

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -54,6 +54,7 @@ var (
 	successfulBlocksCounter                 = metrics.NewRegisteredCounter("arb/sequencer/block/successful", nil)
 	conditionalTxRejectedBySequencerCounter = metrics.NewRegisteredCounter("arb/sequencer/condtionaltx/rejected", nil)
 	conditionalTxAcceptedBySequencerCounter = metrics.NewRegisteredCounter("arb/sequencer/condtionaltx/accepted", nil)
+	l1GasPriceEstimateGauge                 = metrics.NewRegisteredGauge("arb/sequencer/l1gasprice/estimate", nil)
 	l1GasPriceGauge                         = metrics.NewRegisteredGauge("arb/sequencer/l1gasprice", nil)
 	callDataUnitsBacklogGauge               = metrics.NewRegisteredGauge("arb/sequencer/calldataunitsbacklog", nil)
 	unusedL1GasChargeGauge                  = metrics.NewRegisteredGauge("arb/sequencer/unusedl1gascharge", nil)
@@ -1061,8 +1062,10 @@ func (s *Sequencer) updateExpectedSurplus(ctx context.Context) (int64, error) {
 	backlogL1GasCharged := int64(s.execEngine.backlogL1GasCharged())
 	backlogCallDataUnits := int64(s.execEngine.backlogCallDataUnits())
 	expectedSurplus := int64(surplus) + backlogL1GasCharged - backlogCallDataUnits*int64(l1GasPrice)
+	l1GasPriceEstimate := int64(s.execEngine.getL1GasPriceEstimate())
 	// update metrics
 	l1GasPriceGauge.Update(int64(l1GasPrice))
+	l1GasPriceEstimateGauge.Update(l1GasPriceEstimate)
 	callDataUnitsBacklogGauge.Update(backlogCallDataUnits)
 	unusedL1GasChargeGauge.Update(backlogL1GasCharged)
 	currentSurplusGauge.Update(surplus)

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -1058,8 +1058,8 @@ func (s *Sequencer) updateExpectedSurplus(ctx context.Context) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("error encountered getting l1 pricing surplus while updating expectedSurplus: %w", err)
 	}
-	backlogL1GasCharged := int64(s.execEngine.consensus.BacklogL1GasCharged())
-	backlogCallDataUnits := int64(s.execEngine.consensus.BacklogCallDataUnits())
+	backlogL1GasCharged := int64(s.execEngine.backlogL1GasCharged())
+	backlogCallDataUnits := int64(s.execEngine.backlogCallDataUnits())
 	expectedSurplus := int64(surplus) + backlogL1GasCharged - backlogCallDataUnits*int64(l1GasPrice)
 	// update metrics
 	l1GasPriceGauge.Update(int64(l1GasPrice))

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -56,7 +56,8 @@ type ExecutionSequencer interface {
 	ForwardTo(url string) error
 	SequenceDelayedMessage(message *arbostypes.L1IncomingMessage, delayedSeqNum uint64) error
 	NextDelayedMessageNumber() (uint64, error)
-	GetL1GasPriceEstimate() (uint64, error)
+	GetL1GasPriceEstimate() uint64
+	TrimCache(to arbutil.MessageIndex)
 }
 
 type FullExecutionClient interface {
@@ -94,9 +95,6 @@ type ConsensusInfo interface {
 type ConsensusSequencer interface {
 	WriteMessageFromSequencer(pos arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult MessageResult) error
 	ExpectChosenSequencer() error
-	CacheL1PriceDataOfMsg(pos arbutil.MessageIndex, callDataUnits uint64, l1GasCharged uint64)
-	BacklogL1GasCharged() uint64
-	BacklogCallDataUnits() uint64
 }
 
 type FullConsensusClient interface {

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -56,7 +56,6 @@ type ExecutionSequencer interface {
 	ForwardTo(url string) error
 	SequenceDelayedMessage(message *arbostypes.L1IncomingMessage, delayedSeqNum uint64) error
 	NextDelayedMessageNumber() (uint64, error)
-	GetL1GasPriceEstimate() uint64
 	TrimCache(to arbutil.MessageIndex)
 }
 


### PR DESCRIPTION
This PR is part of the Consensus/Execution split effort.

It aims to simplify ConsensusSequencer interface by removing the need of ExecutionEngine calling ConsensusSequencer.CacheL1PriceDataOfMsg, ConsensusSequencer.BacklogL1GasCharged, ConsensusSequencer.BacklogCallDataUnits.
And also removing the need of Consensus calling ExecutionEngine.GetL1GasPriceEstimate.

To achieve that this PR moves l1GasPriceEstimateGauge metric from BatchPoster to the Sequencer.
It also removes latestBatchSurplusGauge from BatchPoster, which can be computed by the server pulling the metrics using l1GasPriceGauge, l1GasPriceEstimateGauge, and messageLengthGauge (metric created in this PR).