### PR TITLE
separate cached from call cost

### DIFF
--- a/arbitrator/prover/src/binary.rs
+++ b/arbitrator/prover/src/binary.rs
@@ -616,7 +616,10 @@ impl<'a> WasmBinary<'a> {
         cached_init = cached_init.saturating_add(data_len.saturating_mul(75244) / 100_000);
         cached_init = cached_init.saturating_add(footprint as u64 * 5);
 
-        let mut init = cached_init;
+        let mut init: u64 = 0;
+        if compile.version == 1 {
+            init = cached_init; // in version 1 cached cost is part of call cost
+        }
         init = init.saturating_add(funcs.saturating_mul(8252) / 1000);
         init = init.saturating_add(type_len.saturating_mul(1059) / 1000);
         init = init.saturating_add(wasm_len.saturating_mul(1286) / 10_000);

--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -200,9 +200,10 @@ func (p Programs) CallProgram(
 
 	// pay for program init
 	cached := program.cached || statedb.GetRecentWasms().Insert(codeHash, params.BlockCacheSize)
-	if cached {
+	if cached || params.Version > 1 { // in version 1 cached cost is part of called cost
 		callCost = am.SaturatingUAdd(callCost, program.cachedGas(params))
-	} else {
+	}
+	if !cached {
 		callCost = am.SaturatingUAdd(callCost, program.initGas(params))
 	}
 	if err := contract.BurnGas(callCost); err != nil {


### PR DESCRIPTION
This will allow us to play with cached init vs uncached init gas cost params separately