### PR TITLE
Separate DAS keyset and batch fetching logic, fixes: NIT-2486

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -523,14 +523,15 @@ func createNodeImpl(
 	var daWriter das.DataAvailabilityServiceWriter
 	var daReader das.DataAvailabilityServiceReader
 	var dasLifecycleManager *das.LifecycleManager
+	var dasKeysetFetcher *das.KeysetFetcher
 	if config.DataAvailability.Enable {
 		if config.BatchPoster.Enable {
-			daWriter, daReader, dasLifecycleManager, err = das.CreateBatchPosterDAS(ctx, &config.DataAvailability, dataSigner, l1client, deployInfo.SequencerInbox)
+			daWriter, daReader, dasKeysetFetcher, dasLifecycleManager, err = das.CreateBatchPosterDAS(ctx, &config.DataAvailability, dataSigner, l1client, deployInfo.SequencerInbox)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			daReader, dasLifecycleManager, err = das.CreateDAReaderForNode(ctx, &config.DataAvailability, l1Reader, &deployInfo.SequencerInbox)
+			daReader, dasKeysetFetcher, dasLifecycleManager, err = das.CreateDAReaderForNode(ctx, &config.DataAvailability, l1Reader, &deployInfo.SequencerInbox)
 			if err != nil {
 				return nil, err
 			}
@@ -554,7 +555,7 @@ func createNodeImpl(
 	}
 	var dapReaders []daprovider.Reader
 	if daReader != nil {
-		dapReaders = append(dapReaders, daprovider.NewReaderForDAS(daReader))
+		dapReaders = append(dapReaders, daprovider.NewReaderForDAS(daReader, dasKeysetFetcher))
 	}
 	if blobReader != nil {
 		dapReaders = append(dapReaders, daprovider.NewReaderForBlobReader(blobReader))

--- a/arbstate/daprovider/reader.go
+++ b/arbstate/daprovider/reader.go
@@ -30,12 +30,16 @@ type Reader interface {
 
 // NewReaderForDAS is generally meant to be only used by nitro.
 // DA Providers should implement methods in the Reader interface independently
-func NewReaderForDAS(dasReader DASReader) *readerForDAS {
-	return &readerForDAS{dasReader: dasReader}
+func NewReaderForDAS(dasReader DASReader, keysetFetcher DASKeysetFetcher) *readerForDAS {
+	return &readerForDAS{
+		dasReader:     dasReader,
+		keysetFetcher: keysetFetcher,
+	}
 }
 
 type readerForDAS struct {
-	dasReader DASReader
+	dasReader     DASReader
+	keysetFetcher DASKeysetFetcher
 }
 
 func (d *readerForDAS) IsValidHeaderByte(headerByte byte) bool {
@@ -50,7 +54,7 @@ func (d *readerForDAS) RecoverPayloadFromBatch(
 	preimageRecorder PreimageRecorder,
 	validateSeqMsg bool,
 ) ([]byte, error) {
-	return RecoverPayloadFromDasBatch(ctx, batchNum, sequencerMsg, d.dasReader, preimageRecorder, validateSeqMsg)
+	return RecoverPayloadFromDasBatch(ctx, batchNum, sequencerMsg, d.dasReader, d.keysetFetcher, preimageRecorder, validateSeqMsg)
 }
 
 // NewReaderForBlobReader is generally meant to be only used by nitro.

--- a/arbstate/daprovider/util.go
+++ b/arbstate/daprovider/util.go
@@ -35,7 +35,7 @@ type DASWriter interface {
 }
 
 type DASKeysetFetcher interface {
-	GetByHash(context.Context, common.Hash) ([]byte, error)
+	GetKeysetByHash(context.Context, common.Hash) ([]byte, error)
 }
 
 type BlobReader interface {
@@ -186,7 +186,7 @@ func RecoverPayloadFromDasBatch(
 		return preimage, nil
 	}
 
-	keysetPreimage, err := keysetFetcher.GetByHash(ctx, cert.KeysetHash)
+	keysetPreimage, err := keysetFetcher.GetKeysetByHash(ctx, cert.KeysetHash)
 	if err != nil {
 		log.Error("Couldn't get keyset", "err", err)
 		return nil, err

--- a/arbstate/daprovider/util.go
+++ b/arbstate/daprovider/util.go
@@ -35,7 +35,7 @@ type DASWriter interface {
 }
 
 type DASKeysetFetcher interface {
-	GetKeyset(context.Context, common.Hash) ([]byte, error)
+	GetByHash(context.Context, common.Hash) ([]byte, error)
 }
 
 type BlobReader interface {
@@ -186,7 +186,7 @@ func RecoverPayloadFromDasBatch(
 		return preimage, nil
 	}
 
-	keysetPreimage, err := keysetFetcher.GetKeyset(ctx, cert.KeysetHash)
+	keysetPreimage, err := keysetFetcher.GetByHash(ctx, cert.KeysetHash)
 	if err != nil {
 		log.Error("Couldn't get keyset", "err", err)
 		return nil, err

--- a/arbstate/daprovider/util.go
+++ b/arbstate/daprovider/util.go
@@ -34,6 +34,10 @@ type DASWriter interface {
 	fmt.Stringer
 }
 
+type DASKeysetFetcher interface {
+	GetKeyset(context.Context, common.Hash) ([]byte, error)
+}
+
 type BlobReader interface {
 	GetBlobs(
 		ctx context.Context,
@@ -138,6 +142,7 @@ func RecoverPayloadFromDasBatch(
 	batchNum uint64,
 	sequencerMsg []byte,
 	dasReader DASReader,
+	keysetFetcher DASKeysetFetcher,
 	preimageRecorder PreimageRecorder,
 	validateSeqMsg bool,
 ) ([]byte, error) {
@@ -181,7 +186,7 @@ func RecoverPayloadFromDasBatch(
 		return preimage, nil
 	}
 
-	keysetPreimage, err := getByHash(ctx, cert.KeysetHash)
+	keysetPreimage, err := keysetFetcher.GetKeyset(ctx, cert.KeysetHash)
 	if err != nil {
 		log.Error("Couldn't get keyset", "err", err)
 		return nil, err

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -215,7 +215,7 @@ func main() {
 		}
 		var dapReaders []daprovider.Reader
 		if dasReader != nil {
-			dapReaders = append(dapReaders, daprovider.NewReaderForDAS(dasReader))
+			dapReaders = append(dapReaders, daprovider.NewReaderForDAS(dasReader, dasReader))
 		}
 		dapReaders = append(dapReaders, daprovider.NewReaderForBlobReader(&BlobPreimageReader{}))
 		inboxMultiplexer := arbstate.NewInboxMultiplexer(backend, delayedMessagesRead, dapReaders, keysetValidationMode)

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -113,6 +113,10 @@ func (dasReader *PreimageDASReader) GetByHash(ctx context.Context, hash common.H
 	return dastree.Content(hash, oracle)
 }
 
+func (dasReader *PreimageDASReader) GetKeysetByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
+	return dasReader.GetByHash(ctx, hash)
+}
+
 func (dasReader *PreimageDASReader) HealthCheck(ctx context.Context) error {
 	return nil
 }
@@ -205,8 +209,11 @@ func main() {
 			delayedMessagesRead = lastBlockHeader.Nonce.Uint64()
 		}
 		var dasReader daprovider.DASReader
+		var dasKeysetFetcher daprovider.DASKeysetFetcher
 		if dasEnabled {
+			// DAS batch and keysets are all together in the same preimage binary.
 			dasReader = &PreimageDASReader{}
+			dasKeysetFetcher = &PreimageDASReader{}
 		}
 		backend := WavmInbox{}
 		var keysetValidationMode = daprovider.KeysetPanicIfInvalid
@@ -215,7 +222,7 @@ func main() {
 		}
 		var dapReaders []daprovider.Reader
 		if dasReader != nil {
-			dapReaders = append(dapReaders, daprovider.NewReaderForDAS(dasReader, dasReader))
+			dapReaders = append(dapReaders, daprovider.NewReaderForDAS(dasReader, dasKeysetFetcher))
 		}
 		dapReaders = append(dapReaders, daprovider.NewReaderForBlobReader(&BlobPreimageReader{}))
 		inboxMultiplexer := arbstate.NewInboxMultiplexer(backend, delayedMessagesRead, dapReaders, keysetValidationMode)

--- a/das/chain_fetch_das.go
+++ b/das/chain_fetch_das.go
@@ -59,8 +59,8 @@ func NewKeysetFetcherWithSeqInbox(seqInbox *bridgegen.SequencerInbox) (*KeysetFe
 	}, nil
 }
 
-func (c *KeysetFetcher) GetByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
-	log.Trace("das.KeysetFetcher.GetByHash", "hash", pretty.PrettyHash(hash))
+func (c *KeysetFetcher) GetKeysetByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
+	log.Trace("das.KeysetFetcher.GetKeysetByHash", "hash", pretty.PrettyHash(hash))
 	cache := &c.keysetCache
 	seqInboxCaller := c.seqInboxCaller
 	seqInboxFilterer := c.seqInboxFilterer

--- a/das/chain_fetch_das.go
+++ b/das/chain_fetch_das.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/offchainlabs/nitro/arbstate/daprovider"
 	"github.com/offchainlabs/nitro/util/pretty"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -37,57 +36,39 @@ func (c *syncedKeysetCache) put(key [32]byte, value []byte) {
 	c.cache[key] = value
 }
 
-type ChainFetchReader struct {
-	daprovider.DASReader
+type KeysetFetcher struct {
 	seqInboxCaller   *bridgegen.SequencerInboxCaller
 	seqInboxFilterer *bridgegen.SequencerInboxFilterer
 	keysetCache      syncedKeysetCache
 }
 
-func NewChainFetchReader(inner daprovider.DASReader, l1client arbutil.L1Interface, seqInboxAddr common.Address) (*ChainFetchReader, error) {
+func NewKeysetFetcher(l1client arbutil.L1Interface, seqInboxAddr common.Address) (*KeysetFetcher, error) {
 	seqInbox, err := bridgegen.NewSequencerInbox(seqInboxAddr, l1client)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewChainFetchReaderWithSeqInbox(inner, seqInbox)
+	return NewKeysetFetcherWithSeqInbox(seqInbox)
 }
 
-func NewChainFetchReaderWithSeqInbox(inner daprovider.DASReader, seqInbox *bridgegen.SequencerInbox) (*ChainFetchReader, error) {
-	return &ChainFetchReader{
-		DASReader:        inner,
+func NewKeysetFetcherWithSeqInbox(seqInbox *bridgegen.SequencerInbox) (*KeysetFetcher, error) {
+	return &KeysetFetcher{
 		seqInboxCaller:   &seqInbox.SequencerInboxCaller,
 		seqInboxFilterer: &seqInbox.SequencerInboxFilterer,
 		keysetCache:      syncedKeysetCache{cache: make(map[[32]byte][]byte)},
 	}, nil
 }
 
-func (c *ChainFetchReader) GetByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
-	log.Trace("das.ChainFetchReader.GetByHash", "hash", pretty.PrettyHash(hash))
-	return chainFetchGetByHash(ctx, c.DASReader, &c.keysetCache, c.seqInboxCaller, c.seqInboxFilterer, hash)
-}
-func (c *ChainFetchReader) String() string {
-	return "ChainFetchReader"
-}
+func (c *KeysetFetcher) GetKeyset(ctx context.Context, hash common.Hash) ([]byte, error) {
+	log.Trace("das.KeysetFetcher.GetByHash", "hash", pretty.PrettyHash(hash))
+	cache := &c.keysetCache
+	seqInboxCaller := c.seqInboxCaller
+	seqInboxFilterer := c.seqInboxFilterer
 
-func chainFetchGetByHash(
-	ctx context.Context,
-	daReader daprovider.DASReader,
-	cache *syncedKeysetCache,
-	seqInboxCaller *bridgegen.SequencerInboxCaller,
-	seqInboxFilterer *bridgegen.SequencerInboxFilterer,
-	hash common.Hash,
-) ([]byte, error) {
 	// try to fetch from the cache
 	res, ok := cache.get(hash)
 	if ok {
 		return res, nil
-	}
-
-	// try to fetch from the inner DAS
-	innerRes, err := daReader.GetByHash(ctx, hash)
-	if err == nil && dastree.ValidHash(hash, innerRes) {
-		return innerRes, nil
 	}
 
 	// try to fetch from the L1 chain

--- a/das/chain_fetch_das.go
+++ b/das/chain_fetch_das.go
@@ -59,7 +59,7 @@ func NewKeysetFetcherWithSeqInbox(seqInbox *bridgegen.SequencerInbox) (*KeysetFe
 	}, nil
 }
 
-func (c *KeysetFetcher) GetKeyset(ctx context.Context, hash common.Hash) ([]byte, error) {
+func (c *KeysetFetcher) GetByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
 	log.Trace("das.KeysetFetcher.GetByHash", "hash", pretty.PrettyHash(hash))
 	cache := &c.keysetCache
 	seqInboxCaller := c.seqInboxCaller


### PR DESCRIPTION
The logic for fetching keysets and batches was originally all done using GetByHash on the the DASReader interface. Nitro nodes, batch posters, and daservers would all include the ChainFetchReader at the beginning of their chain of DASReaders in order to intercept GetByHash calls and do the lookup of the keyset on L1. It was confusing, however, because it also forwarded GetByHash requests to an inner DASReader, since it had no way of telling if the GetByHash requests were for keysets or batch data.

This commit renames the ChainFetchReader to KeysetFetcher and removes the inner DASReader and chaining logic so that it only tries to fetch keysets from L1 or its own internal cache. The orchestration of normal nodes and batch posters is changed to set up the KeysetFetcher separately rather than part of the chain of DASReaders.