### PR TITLE
Minor fixes to "separate cached from call cost"

### DIFF
--- a/arbitrator/prover/src/binary.rs
+++ b/arbitrator/prover/src/binary.rs
@@ -618,7 +618,7 @@ impl<'a> WasmBinary<'a> {
 
         let mut init: u64 = 0;
         if compile.version == 1 {
-            init = cached_init; // in version 1 cached cost is part of call cost
+            init = cached_init; // in version 1 cached cost is part of init cost
         }
         init = init.saturating_add(funcs.saturating_mul(8252) / 1000);
         init = init.saturating_add(type_len.saturating_mul(1059) / 1000);

--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -197,7 +197,7 @@ func (p Programs) CallProgram(
 
 	// pay for program init
 	cached := program.cached || statedb.GetRecentWasms().Insert(codeHash, params.BlockCacheSize)
-	if cached || params.Version > 1 { // in version 1 cached cost is part of called cost
+	if cached || program.version > 1 { // in version 1 cached cost is part of init cost
 		callCost = am.SaturatingUAdd(callCost, program.cachedGas(params))
 	}
 	if !cached {


### PR DESCRIPTION
This PR updates https://github.com/OffchainLabs/nitro/pull/2426 to update the comment as recommended by Ganesh, and also use `program.version` instead of `params.Version` even though they're currently required to be the same.