### PR TITLE
Work around duplicate response from CL

### DIFF
--- a/util/headerreader/blob_client.go
+++ b/util/headerreader/blob_client.go
@@ -229,10 +229,11 @@ func (b *BlobClient) blobSidecars(ctx context.Context, slot uint64, versionedHas
 		var found bool
 		for outputIdx = range versionedHashes {
 			if versionedHashes[outputIdx] == versionedHash {
-				found = true
 				if outputsFound[outputIdx] {
-					return nil, fmt.Errorf("found blob with versioned hash %v twice", versionedHash)
+					// Duplicate, skip this one
+					break
 				}
+				found = true
 				outputsFound[outputIdx] = true
 				break
 			}


### PR DESCRIPTION
Some CLs seem to hit this twice, we can just ignore the second instance.