### PR TITLE
enhance: break down query logs

### DIFF
--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -381,7 +381,7 @@ func (v *L1Validator) generateNodeAction(
 		return nil, false, nil
 	}
 
-	successorNodes, err := v.rollup.LookupNodeChildren(ctx, stakerInfo.LatestStakedNode, stakerConfig.LogQueryRange, stakerInfo.LatestStakedNodeHash)
+	successorNodes, err := v.rollup.LookupNodeChildren(ctx, stakerInfo.LatestStakedNode, stakerConfig.LogQueryBatchSize, stakerInfo.LatestStakedNodeHash)
 	if err != nil {
 		return nil, false, fmt.Errorf("error looking up node %v (hash %v) children: %w", stakerInfo.LatestStakedNode, stakerInfo.LatestStakedNodeHash, err)
 	}

--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -381,7 +381,7 @@ func (v *L1Validator) generateNodeAction(
 		return nil, false, nil
 	}
 
-	successorNodes, err := v.rollup.LookupNodeChildren(ctx, stakerInfo.LatestStakedNode, stakerInfo.LatestStakedNodeHash)
+	successorNodes, err := v.rollup.LookupNodeChildren(ctx, stakerInfo.LatestStakedNode, stakerConfig.LogQueryRange, stakerInfo.LatestStakedNodeHash)
 	if err != nil {
 		return nil, false, fmt.Errorf("error looking up node %v (hash %v) children: %w", stakerInfo.LatestStakedNode, stakerInfo.LatestStakedNodeHash, err)
 	}

--- a/staker/rollup_watcher.go
+++ b/staker/rollup_watcher.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 var rollupInitializedID common.Hash
@@ -165,7 +166,7 @@ func (r *RollupWatcher) LookupNode(ctx context.Context, number uint64) (*NodeInf
 	}, nil
 }
 
-func (r *RollupWatcher) LookupNodeChildren(ctx context.Context, nodeNum uint64, nodeHash common.Hash) ([]*NodeInfo, error) {
+func (r *RollupWatcher) LookupNodeChildren(ctx context.Context, nodeNum uint64, logQueryRange uint64, nodeHash common.Hash) ([]*NodeInfo, error) {
 	node, err := r.RollupUserLogic.GetNode(r.getCallOpts(ctx), nodeNum)
 	if err != nil {
 		return nil, err
@@ -180,17 +181,28 @@ func (r *RollupWatcher) LookupNodeChildren(ctx context.Context, nodeNum uint64, 
 		Addresses: []common.Address{r.address},
 		Topics:    [][]common.Hash{{nodeCreatedID}, nil, {nodeHash}},
 	}
-	query.FromBlock, err = r.getNodeCreationBlock(ctx, nodeNum)
+	fromBlock, err := r.getNodeCreationBlock(ctx, nodeNum)
 	if err != nil {
 		return nil, err
 	}
-	query.ToBlock, err = r.getNodeCreationBlock(ctx, node.LatestChildNumber)
+	toBlock, err := r.getNodeCreationBlock(ctx, node.LatestChildNumber)
 	if err != nil {
 		return nil, err
 	}
-	logs, err := r.client.FilterLogs(ctx, query)
-	if err != nil {
-		return nil, err
+	var logs []types.Log
+	// break down the query to avoid eth_getLogs query limit
+	for toBlock.Cmp(fromBlock) > 0 {
+		query.FromBlock = fromBlock
+		query.ToBlock = new(big.Int).Add(fromBlock, big.NewInt(logQueryRange))
+		if query.ToBlock.Cmp(toBlock) > 0 {
+			query.ToBlock = toBlock
+		}
+		segment, err := r.client.FilterLogs(ctx, query)
+		if err != nil {
+			return nil, err
+		}
+		logs = append(logs, segment)
+		fromBlock = new(big.Int).Add(query.ToBlock, big.NewInt(1))
 	}
 	infos := make([]*NodeInfo, 0, len(logs))
 	lastHash := nodeHash

--- a/staker/rollup_watcher.go
+++ b/staker/rollup_watcher.go
@@ -201,7 +201,7 @@ func (r *RollupWatcher) LookupNodeChildren(ctx context.Context, nodeNum uint64, 
 		if err != nil {
 			return nil, err
 		}
-		logs = append(logs, segment)
+		logs = append(logs, segment...)
 		fromBlock = new(big.Int).Add(query.ToBlock, big.NewInt(1))
 	}
 	infos := make([]*NodeInfo, 0, len(logs))

--- a/staker/rollup_watcher.go
+++ b/staker/rollup_watcher.go
@@ -193,7 +193,7 @@ func (r *RollupWatcher) LookupNodeChildren(ctx context.Context, nodeNum uint64, 
 	// break down the query to avoid eth_getLogs query limit
 	for toBlock.Cmp(fromBlock) > 0 {
 		query.FromBlock = fromBlock
-		query.ToBlock = new(big.Int).Add(fromBlock, big.NewInt(logQueryRange))
+		query.ToBlock = new(big.Int).Add(fromBlock, big.NewInt(int64(logQueryRange)))
 		if query.ToBlock.Cmp(toBlock) > 0 {
 			query.ToBlock = toBlock
 		}

--- a/staker/rollup_watcher.go
+++ b/staker/rollup_watcher.go
@@ -166,7 +166,7 @@ func (r *RollupWatcher) LookupNode(ctx context.Context, number uint64) (*NodeInf
 	}, nil
 }
 
-func (r *RollupWatcher) LookupNodeChildren(ctx context.Context, nodeNum uint64, logQueryRange uint64, nodeHash common.Hash) ([]*NodeInfo, error) {
+func (r *RollupWatcher) LookupNodeChildren(ctx context.Context, nodeNum uint64, logQueryRangeSize uint64, nodeHash common.Hash) ([]*NodeInfo, error) {
 	node, err := r.RollupUserLogic.GetNode(r.getCallOpts(ctx), nodeNum)
 	if err != nil {
 		return nil, err
@@ -193,7 +193,7 @@ func (r *RollupWatcher) LookupNodeChildren(ctx context.Context, nodeNum uint64, 
 	// break down the query to avoid eth_getLogs query limit
 	for toBlock.Cmp(fromBlock) > 0 {
 		query.FromBlock = fromBlock
-		query.ToBlock = new(big.Int).Add(fromBlock, big.NewInt(int64(logQueryRange)))
+		query.ToBlock = new(big.Int).Add(fromBlock, big.NewInt(int64(logQueryRangeSize)))
 		if query.ToBlock.Cmp(toBlock) > 0 {
 			query.ToBlock = toBlock
 		}

--- a/staker/rollup_watcher.go
+++ b/staker/rollup_watcher.go
@@ -193,7 +193,11 @@ func (r *RollupWatcher) LookupNodeChildren(ctx context.Context, nodeNum uint64, 
 	// break down the query to avoid eth_getLogs query limit
 	for toBlock.Cmp(fromBlock) > 0 {
 		query.FromBlock = fromBlock
-		query.ToBlock = new(big.Int).Add(fromBlock, big.NewInt(int64(logQueryRangeSize)))
+		if logQueryRangeSize == 0 {
+			query.ToBlock = toBlock
+		} else {
+			query.ToBlock = new(big.Int).Add(fromBlock, big.NewInt(int64(logQueryRangeSize)))
+		}
 		if query.ToBlock.Cmp(toBlock) > 0 {
 			query.ToBlock = toBlock
 		}

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -178,7 +178,7 @@ var TestL1ValidatorConfig = L1ValidatorConfig{
 	ExtraGas:                  50000,
 	Dangerous:                 DefaultDangerousConfig,
 	ParentChainWallet:         DefaultValidatorL1WalletConfig,
-	LogQueryBatchSize:         999,
+	LogQueryBatchSize:         0,
 }
 
 var DefaultValidatorL1WalletConfig = genericconf.WalletConfig{

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -204,7 +204,7 @@ func L1ValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".gas-refunder-address", DefaultL1ValidatorConfig.GasRefunderAddress, "The gas refunder contract address (optional)")
 	f.String(prefix+".redis-url", DefaultL1ValidatorConfig.RedisUrl, "redis url for L1 validator")
 	f.Uint64(prefix+".extra-gas", DefaultL1ValidatorConfig.ExtraGas, "use this much more gas than estimation says is necessary to post transactions")
-	f.Uint64(prefix+".log-query-range", DefaultL1ValidatorConfig.LogQueryBatchSize, "range ro query from eth_getLogs")
+	f.Uint64(prefix+".log-query-range-size", DefaultL1ValidatorConfig.LogQueryBatchSize, "range ro query from eth_getLogs")
 	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f, dataposter.DefaultDataPosterConfigForValidator)
 	DangerousConfigAddOptions(prefix+".dangerous", f)
 	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultL1ValidatorConfig.ParentChainWallet.Pathname)

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -204,7 +204,7 @@ func L1ValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".gas-refunder-address", DefaultL1ValidatorConfig.GasRefunderAddress, "The gas refunder contract address (optional)")
 	f.String(prefix+".redis-url", DefaultL1ValidatorConfig.RedisUrl, "redis url for L1 validator")
 	f.Uint64(prefix+".extra-gas", DefaultL1ValidatorConfig.ExtraGas, "use this much more gas than estimation says is necessary to post transactions")
-	f.Uint64(prefix+".log-query-range-size", DefaultL1ValidatorConfig.LogQueryBatchSize, "range ro query from eth_getLogs")
+	f.Uint64(prefix+".log-query-batch-size", DefaultL1ValidatorConfig.LogQueryBatchSize, "range ro query from eth_getLogs")
 	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f, dataposter.DefaultDataPosterConfigForValidator)
 	DangerousConfigAddOptions(prefix+".dangerous", f)
 	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultL1ValidatorConfig.ParentChainWallet.Pathname)

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -90,6 +90,7 @@ type L1ValidatorConfig struct {
 	ExtraGas                  uint64                      `koanf:"extra-gas" reload:"hot"`
 	Dangerous                 DangerousConfig             `koanf:"dangerous"`
 	ParentChainWallet         genericconf.WalletConfig    `koanf:"parent-chain-wallet"`
+	LogQueryRange             uint64                      `koanf:"log-query-range" reload:"hot"`
 
 	strategy    StakerStrategy
 	gasRefunder common.Address
@@ -156,6 +157,7 @@ var DefaultL1ValidatorConfig = L1ValidatorConfig{
 	ExtraGas:                  50000,
 	Dangerous:                 DefaultDangerousConfig,
 	ParentChainWallet:         DefaultValidatorL1WalletConfig,
+	LogQueryRange:             999,
 }
 
 var TestL1ValidatorConfig = L1ValidatorConfig{
@@ -176,6 +178,7 @@ var TestL1ValidatorConfig = L1ValidatorConfig{
 	ExtraGas:                  50000,
 	Dangerous:                 DefaultDangerousConfig,
 	ParentChainWallet:         DefaultValidatorL1WalletConfig,
+	LogQueryRange:             999,
 }
 
 var DefaultValidatorL1WalletConfig = genericconf.WalletConfig{
@@ -201,6 +204,7 @@ func L1ValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".gas-refunder-address", DefaultL1ValidatorConfig.GasRefunderAddress, "The gas refunder contract address (optional)")
 	f.String(prefix+".redis-url", DefaultL1ValidatorConfig.RedisUrl, "redis url for L1 validator")
 	f.Uint64(prefix+".extra-gas", DefaultL1ValidatorConfig.ExtraGas, "use this much more gas than estimation says is necessary to post transactions")
+	f.Uint64(prefix+".log-query-range", DefaultL1ValidatorConfig.LogQueryRange, "range ro query from eth_getLogs")
 	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f, dataposter.DefaultDataPosterConfigForValidator)
 	DangerousConfigAddOptions(prefix+".dangerous", f)
 	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultL1ValidatorConfig.ParentChainWallet.Pathname)

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -90,7 +90,7 @@ type L1ValidatorConfig struct {
 	ExtraGas                  uint64                      `koanf:"extra-gas" reload:"hot"`
 	Dangerous                 DangerousConfig             `koanf:"dangerous"`
 	ParentChainWallet         genericconf.WalletConfig    `koanf:"parent-chain-wallet"`
-	LogQueryRange             uint64                      `koanf:"log-query-range" reload:"hot"`
+	LogQueryBatchSize         uint64                      `koanf:"log-query-batch-size" reload:"hot"`
 
 	strategy    StakerStrategy
 	gasRefunder common.Address
@@ -157,7 +157,7 @@ var DefaultL1ValidatorConfig = L1ValidatorConfig{
 	ExtraGas:                  50000,
 	Dangerous:                 DefaultDangerousConfig,
 	ParentChainWallet:         DefaultValidatorL1WalletConfig,
-	LogQueryRange:             999,
+	LogQueryBatchSize:         0,
 }
 
 var TestL1ValidatorConfig = L1ValidatorConfig{
@@ -178,7 +178,7 @@ var TestL1ValidatorConfig = L1ValidatorConfig{
 	ExtraGas:                  50000,
 	Dangerous:                 DefaultDangerousConfig,
 	ParentChainWallet:         DefaultValidatorL1WalletConfig,
-	LogQueryRange:             999,
+	LogQueryBatchSize:         999,
 }
 
 var DefaultValidatorL1WalletConfig = genericconf.WalletConfig{
@@ -204,7 +204,7 @@ func L1ValidatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".gas-refunder-address", DefaultL1ValidatorConfig.GasRefunderAddress, "The gas refunder contract address (optional)")
 	f.String(prefix+".redis-url", DefaultL1ValidatorConfig.RedisUrl, "redis url for L1 validator")
 	f.Uint64(prefix+".extra-gas", DefaultL1ValidatorConfig.ExtraGas, "use this much more gas than estimation says is necessary to post transactions")
-	f.Uint64(prefix+".log-query-range", DefaultL1ValidatorConfig.LogQueryRange, "range ro query from eth_getLogs")
+	f.Uint64(prefix+".log-query-range", DefaultL1ValidatorConfig.LogQueryBatchSize, "range ro query from eth_getLogs")
 	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f, dataposter.DefaultDataPosterConfigForValidator)
 	DangerousConfigAddOptions(prefix+".dangerous", f)
 	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultL1ValidatorConfig.ParentChainWallet.Pathname)


### PR DESCRIPTION
In practice, while using some rpc provider we might easily reach the query limit and get following error which prevent sequencer from advancing the rollup blocks (nodes):

```
INFO [06-28|06:34:11.221] rpc response                             method=eth_getLogs logId=33993 err="413 Request Entity Too Large: {\"jsonrpc\":\"2.0\",\"id\":33993,\"error\":{\"code\":-32614,\"message\":\"eth_getLogs is limited to a 10,000 range\"}}" result=null attempt=0 args="[{\"address\":[\"0x2eb0e377acc5ec7fd8587dc4511021c708047466\"],\"fromBlock\":\"0x385caa6\",\"toBlock\":\"0x385fb75\",\"topics\":[[\"0x4f4caa9e67fb994e349dd35d1ad0ce23053d4323f83ce11dc817b5435031d096\"],null,[\"0x76f1d4183bf7e09c7b7f73c97bc48d9fcff35932149007eebfd12ec56a66eb96\"]]}]"
```

so it might be good to introduce a query range parameter and breakdown the query according to it.