### PR TITLE
[NIT-2494] Ensure system tests are using the node builder

### DIFF
--- a/system_tests/blocks_reexecutor_test.go
+++ b/system_tests/blocks_reexecutor_test.go
@@ -2,39 +2,29 @@ package arbtest
 
 import (
 	"context"
-	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/offchainlabs/nitro/arbnode"
 	blocksreexecutor "github.com/offchainlabs/nitro/blocks_reexecutor"
-	"github.com/offchainlabs/nitro/execution/gethexec"
 )
 
 func TestBlocksReExecutorModes(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	execConfig := gethexec.ConfigDefaultTest()
-	Require(t, execConfig.Validate())
-	l2info, stack, chainDb, arbDb, blockchain := createL2BlockChain(t, nil, t.TempDir(), params.ArbitrumDevTestChainConfig(), &execConfig.Caching)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
+	cleanup := builder.Build(t)
+	defer cleanup()
 
-	execConfigFetcher := func() *gethexec.Config { return execConfig }
-	execNode, err := gethexec.CreateExecutionNode(ctx, stack, chainDb, blockchain, nil, execConfigFetcher)
-	Require(t, err)
-
-	parentChainID := big.NewInt(1234)
+	l2info := builder.L2Info
+	client := builder.L2.Client
+	blockchain := builder.L2.ExecNode.Backend.ArbInterface().BlockChain()
 	feedErrChan := make(chan error, 10)
-	node, err := arbnode.CreateNode(ctx, stack, execNode, arbDb, NewFetcherFromConfig(arbnode.ConfigDefaultL2Test()), blockchain.Config(), nil, nil, nil, nil, nil, feedErrChan, parentChainID, nil)
-	Require(t, err)
-	err = node.TxStreamer.AddFakeInitMessage()
-	Require(t, err)
-	Require(t, node.Start(ctx))
-	client := ClientForStack(t, stack)
 
 	l2info.GenerateAccount("User2")
-	for i := 0; i < 100; i++ {
+	genesis, err := client.BlockNumber(ctx)
+	Require(t, err)
+	for i := genesis; i < genesis+100; i++ {
 		tx := l2info.PrepareTx("Owner", "User2", l2info.TransferGas, common.Big1, nil)
 		err := client.SendTransaction(ctx, tx)
 		Require(t, err)
@@ -49,14 +39,9 @@ func TestBlocksReExecutorModes(t *testing.T) {
 	success := make(chan struct{})
 	executorFull := blocksreexecutor.New(&blocksreexecutor.TestConfig, blockchain, feedErrChan)
 	executorFull.Start(ctx, success)
-
 	select {
 	case err := <-feedErrChan:
-		t.Errorf("error occurred: %v", err)
-		if node != nil {
-			node.StopAndWait()
-		}
-		t.FailNow()
+		t.Fatalf("error occurred: %v", err)
 	case <-success:
 	}
 
@@ -66,14 +51,9 @@ func TestBlocksReExecutorModes(t *testing.T) {
 	c.Mode = "random"
 	executorRandom := blocksreexecutor.New(c, blockchain, feedErrChan)
 	executorRandom.Start(ctx, success)
-
 	select {
 	case err := <-feedErrChan:
-		t.Errorf("error occurred: %v", err)
-		if node != nil {
-			node.StopAndWait()
-		}
-		t.FailNow()
+		t.Fatalf("error occurred: %v", err)
 	case <-success:
 	}
 }

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -259,7 +259,7 @@ func (b *NodeBuilder) BuildL1(t *testing.T) {
 
 func (b *NodeBuilder) BuildL2OnL1(t *testing.T) func() {
 	if b.L1 == nil {
-		panic("must build L1 before building L2")
+		t.Fatal("must build L1 before building L2")
 	}
 	b.L2 = NewTestClient(b.ctx)
 

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -424,6 +424,9 @@ func (b *NodeBuilder) Build2ndNode(t *testing.T, params *SecondNodeParams) (*Tes
 			params.execConfig.RPC.MaxRecreateStateDepth = arbitrum.DefaultNonArchiveNodeMaxRecreateStateDepth
 		}
 	}
+	if b.nodeConfig.BatchPoster.Enable && params.nodeConfig.BatchPoster.Enable && params.nodeConfig.BatchPoster.RedisUrl == "" {
+		t.Fatal("The batch poster must use Redis when enabled for multiple nodes")
+	}
 
 	l2 := NewTestClient(b.ctx)
 	l2.Client, l2.ConsensusNode =

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -218,7 +218,7 @@ func (b *NodeBuilder) Build(t *testing.T) func() {
 	b.CheckConfig(t)
 	if b.withL1 {
 		b.BuildL1(t)
-		return b.BuildL2WithL1(t)
+		return b.BuildL2OnL1(t)
 	}
 	return b.BuildL2(t)
 }
@@ -257,7 +257,7 @@ func (b *NodeBuilder) BuildL1(t *testing.T) {
 	b.L1.cleanup = func() { requireClose(t, b.L1.Stack) }
 }
 
-func (b *NodeBuilder) BuildL2WithL1(t *testing.T) func() {
+func (b *NodeBuilder) BuildL2OnL1(t *testing.T) func() {
 	if b.L1 == nil {
 		panic("must build L1 before building L2")
 	}

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -122,7 +122,7 @@ func TestDASRekey(t *testing.T) {
 
 		// Setup L2 chain
 		builder.L2Info.GenerateAccount("User2")
-		builder.BuildL2WithL1(t)
+		builder.BuildL2OnL1(t)
 
 		// Setup second node
 		l1NodeConfigB.BlockValidator.Enable = false
@@ -154,7 +154,7 @@ func TestDASRekey(t *testing.T) {
 	// Restart the node on the new keyset against the new DAS server running on the same disk as the first with new keys
 	builder.nodeConfig.DataAvailability.RPCAggregator = aggConfigForBackend(t, backendConfigB)
 	builder.l2StackConfig = createStackConfigForTest(builder.dataDir)
-	cleanup := builder.BuildL2WithL1(t)
+	cleanup := builder.BuildL2OnL1(t)
 	defer cleanup()
 
 	nodeBParams := SecondNodeParams{
@@ -276,7 +276,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 	// Setup L2 chain
 	builder.L2Info = NewArbTestInfo(t, builder.chainConfig.ChainID)
 	builder.L2Info.GenerateAccount("User2")
-	cleanup := builder.BuildL2WithL1(t)
+	cleanup := builder.BuildL2OnL1(t)
 	defer cleanup()
 
 	// Create node to sync from chain

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -20,20 +20,16 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/blsSignatures"
-	"github.com/offchainlabs/nitro/cmd/conf"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/das"
-	"github.com/offchainlabs/nitro/execution/gethexec"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/util/headerreader"
-	"github.com/offchainlabs/nitro/util/signature"
 	"golang.org/x/exp/slog"
 )
 
@@ -110,96 +106,68 @@ func TestDASRekey(t *testing.T) {
 	defer cancel()
 
 	// Setup L1 chain and contracts
-	chainConfig := params.ArbitrumDevTestDASChainConfig()
-	l1info, l1client, _, l1stack := createTestL1BlockChain(t, nil)
-	defer requireClose(t, l1stack)
-	feedErrChan := make(chan error, 10)
-	addresses, initMessage := DeployOnTestL1(t, ctx, l1info, l1client, chainConfig)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder.BuildL1(t)
 
 	// Setup DAS servers
 	dasDataDir := t.TempDir()
-	nodeDir := t.TempDir()
-	dasRpcServerA, pubkeyA, backendConfigA, _, restServerUrlA := startLocalDASServer(t, ctx, dasDataDir, l1client, addresses.SequencerInbox)
-	l2info := NewArbTestInfo(t, chainConfig.ChainID)
-	l1NodeConfigA := arbnode.ConfigDefaultL1Test()
+	dasRpcServerA, pubkeyA, backendConfigA, _, restServerUrlA := startLocalDASServer(t, ctx, dasDataDir, builder.L1.Client, builder.addresses.SequencerInbox)
 	l1NodeConfigB := arbnode.ConfigDefaultL1NonSequencerTest()
-	sequencerTxOpts := l1info.GetDefaultTransactOpts("Sequencer", ctx)
-	sequencerTxOptsPtr := &sequencerTxOpts
-	parentChainID := big.NewInt(1337)
 	{
-		authorizeDASKeyset(t, ctx, pubkeyA, l1info, l1client)
-
-		// Setup L2 chain
-		_, l2stackA, l2chainDb, l2arbDb, l2blockchain := createL2BlockChainWithStackConfig(t, l2info, nodeDir, chainConfig, initMessage, nil, nil)
-		l2info.GenerateAccount("User2")
+		authorizeDASKeyset(t, ctx, pubkeyA, builder.L1Info, builder.L1.Client)
 
 		// Setup DAS config
+		builder.nodeConfig.DataAvailability.Enable = true
+		builder.nodeConfig.DataAvailability.RPCAggregator = aggConfigForBackend(t, backendConfigA)
+		builder.nodeConfig.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
+		builder.nodeConfig.DataAvailability.RestAggregator.Enable = true
+		builder.nodeConfig.DataAvailability.RestAggregator.Urls = []string{restServerUrlA}
+		builder.nodeConfig.DataAvailability.ParentChainNodeURL = "none"
 
-		l1NodeConfigA.DataAvailability.Enable = true
-		l1NodeConfigA.DataAvailability.RPCAggregator = aggConfigForBackend(t, backendConfigA)
-		l1NodeConfigA.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
-		l1NodeConfigA.DataAvailability.RestAggregator.Enable = true
-		l1NodeConfigA.DataAvailability.RestAggregator.Urls = []string{restServerUrlA}
-		l1NodeConfigA.DataAvailability.ParentChainNodeURL = "none"
-		execA, err := gethexec.CreateExecutionNode(ctx, l2stackA, l2chainDb, l2blockchain, l1client, gethexec.ConfigDefaultTest)
-		Require(t, err)
-		nodeA, err := arbnode.CreateNode(ctx, l2stackA, execA, l2arbDb, NewFetcherFromConfig(l1NodeConfigA), l2blockchain.Config(), l1client, addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, nil, feedErrChan, parentChainID, nil)
-		Require(t, err)
-		Require(t, nodeA.Start(ctx))
-		l2clientA := ClientForStack(t, l2stackA)
+		// Setup L2 chain
+		builder.L2Info.GenerateAccount("User2")
+		builder.BuildL2WithL1(t)
 
+		// Setup second node
 		l1NodeConfigB.BlockValidator.Enable = false
 		l1NodeConfigB.DataAvailability.Enable = true
 		l1NodeConfigB.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
 		l1NodeConfigB.DataAvailability.RestAggregator.Enable = true
 		l1NodeConfigB.DataAvailability.RestAggregator.Urls = []string{restServerUrlA}
-
 		l1NodeConfigB.DataAvailability.ParentChainNodeURL = "none"
+		nodeBParams := SecondNodeParams{
+			nodeConfig: l1NodeConfigB,
+			initData:   &builder.L2Info.ArbInitData,
+		}
+		l2B, cleanupB := builder.Build2ndNode(t, &nodeBParams)
+		checkBatchPosting(t, ctx, builder.L1.Client, builder.L2.Client, builder.L1Info, builder.L2Info, big.NewInt(1e12), l2B.Client)
 
-		l2clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, l1info, &l2info.ArbInitData, l1NodeConfigB, nil, nil)
-		checkBatchPosting(t, ctx, l1client, l2clientA, l1info, l2info, big.NewInt(1e12), l2clientB)
-		nodeA.StopAndWait()
-		nodeB.StopAndWait()
+		builder.L2.cleanup()
+		cleanupB()
 	}
 
 	err := dasRpcServerA.Shutdown(ctx)
 	Require(t, err)
-	dasRpcServerB, pubkeyB, backendConfigB, _, _ := startLocalDASServer(t, ctx, dasDataDir, l1client, addresses.SequencerInbox)
+	dasRpcServerB, pubkeyB, backendConfigB, _, _ := startLocalDASServer(t, ctx, dasDataDir, builder.L1.Client, builder.addresses.SequencerInbox)
 	defer func() {
 		err = dasRpcServerB.Shutdown(ctx)
 		Require(t, err)
 	}()
-	authorizeDASKeyset(t, ctx, pubkeyB, l1info, l1client)
+	authorizeDASKeyset(t, ctx, pubkeyB, builder.L1Info, builder.L1.Client)
 
 	// Restart the node on the new keyset against the new DAS server running on the same disk as the first with new keys
+	builder.nodeConfig.DataAvailability.RPCAggregator = aggConfigForBackend(t, backendConfigB)
+	builder.l2StackConfig = createStackConfigForTest(builder.dataDir)
+	cleanup := builder.BuildL2WithL1(t)
+	defer cleanup()
 
-	stackConfig := createStackConfigForTest(nodeDir)
-	l2stackA, err := node.New(stackConfig)
-	Require(t, err)
-
-	l2chainDb, err := l2stackA.OpenDatabaseWithExtraOptions("l2chaindata", 0, 0, "l2chaindata/", false, conf.PersistentConfigDefault.Pebble.ExtraOptions("l2chaindata"))
-	Require(t, err)
-
-	l2arbDb, err := l2stackA.OpenDatabaseWithExtraOptions("arbitrumdata", 0, 0, "arbitrumdata/", false, conf.PersistentConfigDefault.Pebble.ExtraOptions("arbitrumdata"))
-	Require(t, err)
-
-	l2blockchain, err := gethexec.GetBlockChain(l2chainDb, nil, chainConfig, gethexec.ConfigDefaultTest().TxLookupLimit)
-	Require(t, err)
-
-	execA, err := gethexec.CreateExecutionNode(ctx, l2stackA, l2chainDb, l2blockchain, l1client, gethexec.ConfigDefaultTest)
-	Require(t, err)
-
-	l1NodeConfigA.DataAvailability.RPCAggregator = aggConfigForBackend(t, backendConfigB)
-	nodeA, err := arbnode.CreateNode(ctx, l2stackA, execA, l2arbDb, NewFetcherFromConfig(l1NodeConfigA), l2blockchain.Config(), l1client, addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, nil, feedErrChan, parentChainID, nil)
-	Require(t, err)
-	Require(t, nodeA.Start(ctx))
-	l2clientA := ClientForStack(t, l2stackA)
-
-	l2clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, l1info, &l2info.ArbInitData, l1NodeConfigB, nil, nil)
-	checkBatchPosting(t, ctx, l1client, l2clientA, l1info, l2info, big.NewInt(2e12), l2clientB)
-
-	nodeA.StopAndWait()
-	nodeB.StopAndWait()
+	nodeBParams := SecondNodeParams{
+		nodeConfig: l1NodeConfigB,
+		initData:   &builder.L2Info.ArbInitData,
+	}
+	l2B, cleanup := builder.Build2ndNode(t, &nodeBParams)
+	defer cleanup()
+	checkBatchPosting(t, ctx, builder.L1.Client, builder.L2.Client, builder.L1Info, builder.L2Info, big.NewInt(2e12), l2B.Client)
 }
 
 func checkBatchPosting(t *testing.T, ctx context.Context, l1client, l2clientA *ethclient.Client, l1info, l2info info, expectedBalance *big.Int, l2ClientsToCheck ...*ethclient.Client) {
@@ -240,16 +208,15 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 	defer cancel()
 
 	// Setup L1 chain and contracts
-	chainConfig := params.ArbitrumDevTestDASChainConfig()
-	l1info, l1client, _, l1stack := createTestL1BlockChain(t, nil)
-	defer requireClose(t, l1stack)
-	arbSys, _ := precompilesgen.NewArbSys(types.ArbSysAddress, l1client)
-	l1Reader, err := headerreader.New(ctx, l1client, func() *headerreader.Config { return &headerreader.TestConfig }, arbSys)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder.chainConfig = params.ArbitrumDevTestDASChainConfig()
+	builder.BuildL1(t)
+
+	arbSys, _ := precompilesgen.NewArbSys(types.ArbSysAddress, builder.L1.Client)
+	l1Reader, err := headerreader.New(ctx, builder.L1.Client, func() *headerreader.Config { return &headerreader.TestConfig }, arbSys)
 	Require(t, err)
 	l1Reader.Start(ctx)
 	defer l1Reader.StopAndWait()
-	feedErrChan := make(chan error, 10)
-	addresses, initMessage := DeployOnTestL1(t, ctx, l1info, l1client, chainConfig)
 
 	keyDir, fileDataDir, dbDataDir := t.TempDir(), t.TempDir(), t.TempDir()
 	pubkey, _, err := das.GenerateAndStoreKeys(keyDir)
@@ -278,7 +245,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 		// L1NodeURL: normally we would have to set this but we are passing in the already constructed client and addresses to the factory
 	}
 
-	daReader, daWriter, signatureVerifier, daHealthChecker, lifecycleManager, err := das.CreateDAComponentsForDaserver(ctx, &serverConfig, l1Reader, &addresses.SequencerInbox)
+	daReader, daWriter, signatureVerifier, daHealthChecker, lifecycleManager, err := das.CreateDAComponentsForDaserver(ctx, &serverConfig, l1Reader, &builder.addresses.SequencerInbox)
 	Require(t, err)
 	defer lifecycleManager.StopAndWaitUntil(time.Second)
 	rpcLis, err := net.Listen("tcp", "localhost:0")
@@ -288,13 +255,13 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 	restLis, err := net.Listen("tcp", "localhost:0")
 	Require(t, err)
 	restServer, err := das.NewRestfulDasServerOnListener(restLis, genericconf.HTTPServerTimeoutConfigDefault, daReader, daHealthChecker)
+	Require(t, err)
 
 	pubkeyA := pubkey
-	authorizeDASKeyset(t, ctx, pubkeyA, l1info, l1client)
+	authorizeDASKeyset(t, ctx, pubkeyA, builder.L1Info, builder.L1.Client)
 
 	//
-	l1NodeConfigA := arbnode.ConfigDefaultL1Test()
-	l1NodeConfigA.DataAvailability = das.DataAvailabilityConfig{
+	builder.nodeConfig.DataAvailability = das.DataAvailabilityConfig{
 		Enable: true,
 
 		// AggregatorConfig set up below
@@ -305,29 +272,17 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 		PubKeyBase64Encoded: blsPubToBase64(pubkey),
 		SignerMask:          1,
 	}
-	l1NodeConfigA.DataAvailability.RPCAggregator = aggConfigForBackend(t, beConfigA)
-	l1NodeConfigA.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
-	l1NodeConfigA.DataAvailability.RestAggregator.Enable = true
-	l1NodeConfigA.DataAvailability.RestAggregator.Urls = []string{"http://" + restLis.Addr().String()}
-	l1NodeConfigA.DataAvailability.ParentChainNodeURL = "none"
-
-	dataSigner := signature.DataSignerFromPrivateKey(l1info.Accounts["Sequencer"].PrivateKey)
-
-	Require(t, err)
+	builder.nodeConfig.DataAvailability.RPCAggregator = aggConfigForBackend(t, beConfigA)
+	builder.nodeConfig.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
+	builder.nodeConfig.DataAvailability.RestAggregator.Enable = true
+	builder.nodeConfig.DataAvailability.RestAggregator.Urls = []string{"http://" + restLis.Addr().String()}
+	builder.nodeConfig.DataAvailability.ParentChainNodeURL = "none"
 
 	// Setup L2 chain
-	l2info, l2stackA, l2chainDb, l2arbDb, l2blockchain := createL2BlockChainWithStackConfig(t, nil, "", chainConfig, initMessage, nil, nil)
-	l2info.GenerateAccount("User2")
-
-	execA, err := gethexec.CreateExecutionNode(ctx, l2stackA, l2chainDb, l2blockchain, l1client, gethexec.ConfigDefaultTest)
-	Require(t, err)
-
-	sequencerTxOpts := l1info.GetDefaultTransactOpts("Sequencer", ctx)
-	sequencerTxOptsPtr := &sequencerTxOpts
-	nodeA, err := arbnode.CreateNode(ctx, l2stackA, execA, l2arbDb, NewFetcherFromConfig(l1NodeConfigA), l2blockchain.Config(), l1client, addresses, sequencerTxOptsPtr, sequencerTxOptsPtr, dataSigner, feedErrChan, big.NewInt(1337), nil)
-	Require(t, err)
-	Require(t, nodeA.Start(ctx))
-	l2clientA := ClientForStack(t, l2stackA)
+	builder.L2Info = NewArbTestInfo(t, builder.chainConfig.ChainID)
+	builder.L2Info.GenerateAccount("User2")
+	cleanup := builder.BuildL2WithL1(t)
+	defer cleanup()
 
 	// Create node to sync from chain
 	l1NodeConfigB := arbnode.ConfigDefaultL1NonSequencerTest()
@@ -346,12 +301,14 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 	l1NodeConfigB.DataAvailability.RestAggregator.Enable = true
 	l1NodeConfigB.DataAvailability.RestAggregator.Urls = []string{"http://" + restLis.Addr().String()}
 	l1NodeConfigB.DataAvailability.ParentChainNodeURL = "none"
-	l2clientB, nodeB := Create2ndNodeWithConfig(t, ctx, nodeA, l1stack, l1info, &l2info.ArbInitData, l1NodeConfigB, nil, nil)
+	nodeBParams := SecondNodeParams{
+		nodeConfig: l1NodeConfigB,
+		initData:   &builder.L2Info.ArbInitData,
+	}
+	l2B, cleanupB := builder.Build2ndNode(t, &nodeBParams)
+	defer cleanupB()
 
-	checkBatchPosting(t, ctx, l1client, l2clientA, l1info, l2info, big.NewInt(1e12), l2clientB)
-
-	nodeA.StopAndWait()
-	nodeB.StopAndWait()
+	checkBatchPosting(t, ctx, builder.L1.Client, builder.L2.Client, builder.L1Info, builder.L2Info, big.NewInt(1e12), l2B.Client)
 
 	err = restServer.Shutdown()
 	Require(t, err)

--- a/system_tests/full_challenge_impl_test.go
+++ b/system_tests/full_challenge_impl_test.go
@@ -25,17 +25,13 @@ import (
 	"github.com/offchainlabs/nitro/arbcompress"
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbos"
-	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/cmd/chaininfo"
-	"github.com/offchainlabs/nitro/execution/gethexec"
 	"github.com/offchainlabs/nitro/solgen/go/challengegen"
 	"github.com/offchainlabs/nitro/solgen/go/mocksgen"
 	"github.com/offchainlabs/nitro/solgen/go/ospgen"
 	"github.com/offchainlabs/nitro/solgen/go/yulgen"
 	"github.com/offchainlabs/nitro/staker"
-	"github.com/offchainlabs/nitro/util/signature"
 	"github.com/offchainlabs/nitro/validator"
 	"github.com/offchainlabs/nitro/validator/server_common"
 	"github.com/offchainlabs/nitro/validator/valnode"
@@ -238,16 +234,6 @@ func setupSequencerInboxStub(ctx context.Context, t *testing.T, l1Info *Blockcha
 	return bridgeAddr, seqInbox, seqInboxAddr
 }
 
-func createL2Nodes(t *testing.T, ctx context.Context, conf *arbnode.Config, chainConfig *params.ChainConfig, l1Client arbutil.L1Interface, l2info *BlockchainTestInfo, rollupAddresses *chaininfo.RollupAddresses, initMsg *arbostypes.ParsedInitMessage, txOpts *bind.TransactOpts, signer signature.DataSignerFunc, fatalErrChan chan error) (*arbnode.Node, *gethexec.ExecutionNode) {
-	_, stack, l2ChainDb, l2ArbDb, l2Blockchain := createL2BlockChainWithStackConfig(t, l2info, "", chainConfig, initMsg, nil, nil)
-	execNode, err := gethexec.CreateExecutionNode(ctx, stack, l2ChainDb, l2Blockchain, l1Client, gethexec.ConfigDefaultTest)
-	Require(t, err)
-	consensusNode, err := arbnode.CreateNode(ctx, stack, execNode, l2ArbDb, NewFetcherFromConfig(conf), chainConfig, l1Client, rollupAddresses, txOpts, txOpts, signer, fatalErrChan, big.NewInt(1337), nil)
-	Require(t, err)
-
-	return consensusNode, execNode
-}
-
 func RunChallengeTest(t *testing.T, asserterIsCorrect bool, useStubs bool, challengeMsgIdx int64) {
 	glogger := log.NewGlogHandler(
 		log.NewTerminalHandler(io.Writer(os.Stderr), false))
@@ -257,16 +243,16 @@ func RunChallengeTest(t *testing.T, asserterIsCorrect bool, useStubs bool, chall
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
 	initialBalance := new(big.Int).Lsh(big.NewInt(1), 200)
-	l1Info := NewL1TestInfo(t)
+	l1Info := builder.L1Info
 	l1Info.GenerateGenesisAccount("deployer", initialBalance)
 	l1Info.GenerateGenesisAccount("asserter", initialBalance)
 	l1Info.GenerateGenesisAccount("challenger", initialBalance)
 	l1Info.GenerateGenesisAccount("sequencer", initialBalance)
 
-	chainConfig := params.ArbitrumDevTestChainConfig()
-	l1Info, l1Backend, _, _ := createTestL1BlockChain(t, l1Info)
-	conf := arbnode.ConfigDefaultL1Test()
+	chainConfig := builder.chainConfig
+	conf := builder.nodeConfig
 	conf.BlockValidator.Enable = false
 	conf.BatchPoster.Enable = false
 	conf.InboxReader.CheckDelay = time.Second
@@ -280,8 +266,8 @@ func RunChallengeTest(t *testing.T, asserterIsCorrect bool, useStubs bool, chall
 	}
 	configByValidationNode(conf, valStack)
 
-	fatalErrChan := make(chan error, 10)
-	asserterRollupAddresses, initMessage := DeployOnTestL1(t, ctx, l1Info, l1Backend, chainConfig)
+	builder.BuildL1(t)
+	l1Backend := builder.L1.Client
 
 	deployerTxOpts := l1Info.GetDefaultTransactOpts("deployer", ctx)
 	sequencerTxOpts := l1Info.GetDefaultTransactOpts("sequencer", ctx)
@@ -291,20 +277,28 @@ func RunChallengeTest(t *testing.T, asserterIsCorrect bool, useStubs bool, chall
 	asserterBridgeAddr, asserterSeqInbox, asserterSeqInboxAddr := setupSequencerInboxStub(ctx, t, l1Info, l1Backend, chainConfig)
 	challengerBridgeAddr, challengerSeqInbox, challengerSeqInboxAddr := setupSequencerInboxStub(ctx, t, l1Info, l1Backend, chainConfig)
 
+	asserterRollupAddresses := builder.addresses
 	asserterRollupAddresses.Bridge = asserterBridgeAddr
 	asserterRollupAddresses.SequencerInbox = asserterSeqInboxAddr
-	asserterL2Info := NewArbTestInfo(t, chainConfig.ChainID)
-	asserterL2, asserterExec := createL2Nodes(t, ctx, conf, chainConfig, l1Backend, asserterL2Info, asserterRollupAddresses, initMessage, nil, nil, fatalErrChan)
-	err := asserterL2.Start(ctx)
-	Require(t, err)
 
-	challengerRollupAddresses := *asserterRollupAddresses
+	cleanup := builder.BuildL2WithL1(t)
+	defer cleanup()
+	asserterL2 := builder.L2.ConsensusNode
+	asserterL2Info := builder.L2Info
+	asserterExec := builder.L2.ExecNode
+
+	challengerRollupAddresses := *builder.addresses
 	challengerRollupAddresses.Bridge = challengerBridgeAddr
 	challengerRollupAddresses.SequencerInbox = challengerSeqInboxAddr
 	challengerL2Info := NewArbTestInfo(t, chainConfig.ChainID)
-	challengerL2, challengerExec := createL2Nodes(t, ctx, conf, chainConfig, l1Backend, challengerL2Info, &challengerRollupAddresses, initMessage, nil, nil, fatalErrChan)
-	err = challengerL2.Start(ctx)
-	Require(t, err)
+	challengerParams := SecondNodeParams{
+		addresses: &challengerRollupAddresses,
+		initData:  &challengerL2Info.ArbInitData,
+	}
+	challenger, challengerCleanup := builder.Build2ndNode(t, &challengerParams)
+	defer challengerCleanup()
+	challengerL2 := challenger.ConsensusNode
+	challengerExec := challenger.ExecNode
 
 	asserterL2Info.GenerateAccount("Destination")
 	challengerL2Info.SetFullAccountInfo("Destination", asserterL2Info.GetInfoWithPrivKey("Destination"))

--- a/system_tests/full_challenge_impl_test.go
+++ b/system_tests/full_challenge_impl_test.go
@@ -281,7 +281,7 @@ func RunChallengeTest(t *testing.T, asserterIsCorrect bool, useStubs bool, chall
 	asserterRollupAddresses.Bridge = asserterBridgeAddr
 	asserterRollupAddresses.SequencerInbox = asserterSeqInboxAddr
 
-	cleanup := builder.BuildL2WithL1(t)
+	cleanup := builder.BuildL2OnL1(t)
 	defer cleanup()
 	asserterL2 := builder.L2.ConsensusNode
 	asserterL2Info := builder.L2Info

--- a/system_tests/nodeinterface_test.go
+++ b/system_tests/nodeinterface_test.go
@@ -41,7 +41,7 @@ func TestFindBatch(t *testing.T) {
 	builder.addresses.Bridge = bridgeAddr
 	builder.addresses.SequencerInbox = seqInboxAddr
 
-	cleanup := builder.BuildL2WithL1(t)
+	cleanup := builder.BuildL2OnL1(t)
 	defer cleanup()
 
 	nodeInterface, err := node_interfacegen.NewNodeInterface(types.NodeInterfaceAddress, builder.L2.Client)

--- a/system_tests/nodeinterface_test.go
+++ b/system_tests/nodeinterface_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbos/util"
 	"github.com/offchainlabs/nitro/solgen/go/node_interfacegen"
 )
@@ -25,44 +23,39 @@ func TestFindBatch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	l1Info := NewL1TestInfo(t)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	l1Info := builder.L1Info
 	initialBalance := new(big.Int).Lsh(big.NewInt(1), 200)
 	l1Info.GenerateGenesisAccount("deployer", initialBalance)
 	l1Info.GenerateGenesisAccount("asserter", initialBalance)
 	l1Info.GenerateGenesisAccount("challenger", initialBalance)
 	l1Info.GenerateGenesisAccount("sequencer", initialBalance)
 
-	l1Info, l1Backend, _, _ := createTestL1BlockChain(t, l1Info)
-	conf := arbnode.ConfigDefaultL1Test()
+	conf := builder.nodeConfig
 	conf.BlockValidator.Enable = false
 	conf.BatchPoster.Enable = false
 
-	chainConfig := params.ArbitrumDevTestChainConfig()
-	fatalErrChan := make(chan error, 10)
-	rollupAddresses, initMsg := DeployOnTestL1(t, ctx, l1Info, l1Backend, chainConfig)
+	builder.BuildL1(t)
 
-	bridgeAddr, seqInbox, seqInboxAddr := setupSequencerInboxStub(ctx, t, l1Info, l1Backend, chainConfig)
+	bridgeAddr, seqInbox, seqInboxAddr := setupSequencerInboxStub(ctx, t, builder.L1Info, builder.L1.Client, builder.chainConfig)
+	builder.addresses.Bridge = bridgeAddr
+	builder.addresses.SequencerInbox = seqInboxAddr
 
-	callOpts := bind.CallOpts{Context: ctx}
+	cleanup := builder.BuildL2WithL1(t)
+	defer cleanup()
 
-	rollupAddresses.Bridge = bridgeAddr
-	rollupAddresses.SequencerInbox = seqInboxAddr
-	l2Info := NewArbTestInfo(t, chainConfig.ChainID)
-	consensus, _ := createL2Nodes(t, ctx, conf, chainConfig, l1Backend, l2Info, rollupAddresses, initMsg, nil, nil, fatalErrChan)
-	err := consensus.Start(ctx)
+	nodeInterface, err := node_interfacegen.NewNodeInterface(types.NodeInterfaceAddress, builder.L2.Client)
 	Require(t, err)
+	sequencerTxOpts := builder.L1Info.GetDefaultTransactOpts("sequencer", ctx)
 
-	l2Client := ClientForStack(t, consensus.Stack)
-	nodeInterface, err := node_interfacegen.NewNodeInterface(types.NodeInterfaceAddress, l2Client)
-	Require(t, err)
-	sequencerTxOpts := l1Info.GetDefaultTransactOpts("sequencer", ctx)
-
-	l2Info.GenerateAccount("Destination")
-	makeBatch(t, consensus, l2Info, l1Backend, &sequencerTxOpts, seqInbox, seqInboxAddr, -1)
-	makeBatch(t, consensus, l2Info, l1Backend, &sequencerTxOpts, seqInbox, seqInboxAddr, -1)
-	makeBatch(t, consensus, l2Info, l1Backend, &sequencerTxOpts, seqInbox, seqInboxAddr, -1)
+	builder.L2Info.GenerateAccount("Destination")
+	const numBatches = 3
+	for i := 0; i < numBatches; i++ {
+		makeBatch(t, builder.L2.ConsensusNode, builder.L2Info, builder.L1.Client, &sequencerTxOpts, seqInbox, seqInboxAddr, -1)
+	}
 
 	for blockNum := uint64(0); blockNum < uint64(makeBatch_MsgsPerBatch)*3; blockNum++ {
+		callOpts := bind.CallOpts{Context: ctx}
 		gotBatchNum, err := nodeInterface.FindBatchContainingBlock(&callOpts, blockNum)
 		Require(t, err)
 		expBatchNum := uint64(0)
@@ -72,17 +65,17 @@ func TestFindBatch(t *testing.T) {
 		if expBatchNum != gotBatchNum {
 			Fatal(t, "wrong result from findBatchContainingBlock. blocknum ", blockNum, " expected ", expBatchNum, " got ", gotBatchNum)
 		}
-		batchL1Block, err := consensus.InboxTracker.GetBatchParentChainBlock(gotBatchNum)
+		batchL1Block, err := builder.L2.ConsensusNode.InboxTracker.GetBatchParentChainBlock(gotBatchNum)
 		Require(t, err)
-		blockHeader, err := l2Client.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNum))
+		blockHeader, err := builder.L2.Client.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNum))
 		Require(t, err)
 		blockHash := blockHeader.Hash()
 
-		minCurrentL1Block, err := l1Backend.BlockNumber(ctx)
+		minCurrentL1Block, err := builder.L1.Client.BlockNumber(ctx)
 		Require(t, err)
 		gotConfirmations, err := nodeInterface.GetL1Confirmations(&callOpts, blockHash)
 		Require(t, err)
-		maxCurrentL1Block, err := l1Backend.BlockNumber(ctx)
+		maxCurrentL1Block, err := builder.L1.Client.BlockNumber(ctx)
 		Require(t, err)
 
 		if gotConfirmations > (maxCurrentL1Block-batchL1Block) || gotConfirmations < (minCurrentL1Block-batchL1Block) {

--- a/system_tests/seq_coordinator_test.go
+++ b/system_tests/seq_coordinator_test.go
@@ -67,6 +67,7 @@ func TestRedisSeqCoordinatorPriorities(t *testing.T) {
 	createStartNode := func(nodeNum int) {
 		builder.nodeConfig.SeqCoordinator.MyUrl = nodeNames[nodeNum]
 		builder.L2Info = l2Info
+		builder.dataDir = t.TempDir() // set new data dir for each node
 		builder.Build(t)
 		testNodes[nodeNum] = builder.L2
 	}

--- a/system_tests/snap_sync_test.go
+++ b/system_tests/snap_sync_test.go
@@ -39,7 +39,13 @@ func TestSnapSync(t *testing.T) {
 	// This node will be stopped in middle and arbitrumdata will be deleted.
 	testDir := t.TempDir()
 	nodeBStack := createStackConfigForTest(testDir)
-	nodeB, cleanupB := builder.Build2ndNode(t, &SecondNodeParams{stackConfig: nodeBStack})
+	nodeBConfig := builder.nodeConfig
+	nodeBConfig.BatchPoster.Enable = false
+	nodeBParams := &SecondNodeParams{
+		stackConfig: nodeBStack,
+		nodeConfig:  nodeBConfig,
+	}
+	nodeB, cleanupB := builder.Build2ndNode(t, nodeBParams)
 
 	builder.BridgeBalance(t, "Faucet", big.NewInt(1).Mul(big.NewInt(params.Ether), big.NewInt(10000)))
 

--- a/util/testhelpers/testhelpers.go
+++ b/util/testhelpers/testhelpers.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"os"
 	"regexp"
+	"runtime/debug"
 	"sync"
 	"testing"
 
@@ -24,6 +25,7 @@ import (
 func RequireImpl(t *testing.T, err error, printables ...interface{}) {
 	t.Helper()
 	if err != nil {
+		t.Log(string(debug.Stack()))
 		t.Fatal(colors.Red, printables, err, colors.Clear)
 	}
 }


### PR DESCRIPTION
This PR modifies the following system tests to use the node builder instead of using the createNode functions directly.
- Block Reexecutor
- DAS
- Challenge
- Node interface
- Recreate state

To archive that, this PR modifies the NodeBuilder.Build function so it can be called directly or in two steps, first creating the L1 and then creating the L2. It also adds a new function to the builder to restart the L2 node, used in the recreate state test.