### PR TITLE
[NIT-2642] Support latest snapshot with tar.gz extension

### DIFF
--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -258,13 +259,18 @@ func setLatestSnapshotUrl(ctx context.Context, initConfig *conf.InitConfig, chai
 	if err != nil {
 		return fmt.Errorf("failed to parse latest mirror \"%s\": %w", initConfig.LatestBase, err)
 	}
-	latestDateUrl := baseUrl.JoinPath(chain, "latest-"+initConfig.Latest+".txt").String()
-	latestDateBytes, err := httpGet(ctx, latestDateUrl)
+	latestFileUrl := baseUrl.JoinPath(chain, "latest-"+initConfig.Latest+".txt").String()
+	latestFileBytes, err := httpGet(ctx, latestFileUrl)
 	if err != nil {
-		return fmt.Errorf("failed to get latest snapshot at \"%s\": %w", latestDateUrl, err)
+		return fmt.Errorf("failed to get latest file at \"%s\": %w", latestFileUrl, err)
 	}
-	latestDate := strings.TrimSpace(string(latestDateBytes))
-	initConfig.Url = baseUrl.JoinPath(chain, latestDate, initConfig.Latest+".tar").String()
+	latestFile := strings.TrimSpace(string(latestFileBytes))
+	containsScheme := regexp.MustCompile("https?://")
+	if containsScheme.MatchString(latestFile) {
+		initConfig.Url = latestFile
+	} else {
+		initConfig.Url = baseUrl.JoinPath(latestFile).String()
+	}
 	log.Info("Set latest snapshot url", "url", initConfig.Url)
 	return nil
 }


### PR DESCRIPTION
There is a small issue with the nitro code that finds the latest snapshot URL: it has the file extension hardcoded to .tar. So, if the DevOps team wants to use .tar.gz instead, the code won't work. Nitro can already handle unarchiving zipped files, so it is just a matter of fixing the latest URL generation.

To recap, we generate the URL by looking up a date in the latest file. For instance, for the sepolia-rollup archive, the server should have a file <base-url>/sepolia-rollup/archive-latest.txt containing the year and week (e.g., 2024/20). The resulting latest URL will be <base-url>/sepolia-rollup/2024/20/archive.tar.

The proposed solution is:
Change the latest URL file to contain the file's path or full URL of the file instead of just the year and week. In the example above, the latest file contents would be <base-url>/sepolia-rollup/2024/20/archive.tar.gz.