### PR TITLE
[NIT-2568] Stores message result at consensus side

### DIFF
--- a/arbnode/message_pruner.go
+++ b/arbnode/message_pruner.go
@@ -30,6 +30,7 @@ type MessagePruner struct {
 	lastPruneDone                    time.Time
 	cachedPrunedMessages             uint64
 	cachedPrunedBlockHashesInputFeed uint64
+	cachedPrunedMessageResult        uint64
 	cachedPrunedDelayedMessages      uint64
 }
 
@@ -116,7 +117,15 @@ func (m *MessagePruner) prune(ctx context.Context, count arbutil.MessageIndex, g
 }
 
 func (m *MessagePruner) deleteOldMessagesFromDB(ctx context.Context, messageCount arbutil.MessageIndex, delayedMessageCount uint64) error {
-	prunedKeysRange, err := deleteFromLastPrunedUptoEndKey(ctx, m.transactionStreamer.db, blockHashInputFeedPrefix, &m.cachedPrunedBlockHashesInputFeed, uint64(messageCount))
+	prunedKeysRange, err := deleteFromLastPrunedUptoEndKey(ctx, m.transactionStreamer.db, messageResultPrefix, &m.cachedPrunedMessageResult, uint64(messageCount))
+	if err != nil {
+		return fmt.Errorf("error deleting message results: %w", err)
+	}
+	if len(prunedKeysRange) > 0 {
+		log.Info("Pruned message results:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
+	}
+
+	prunedKeysRange, err = deleteFromLastPrunedUptoEndKey(ctx, m.transactionStreamer.db, blockHashInputFeedPrefix, &m.cachedPrunedBlockHashesInputFeed, uint64(messageCount))
 	if err != nil {
 		return fmt.Errorf("error deleting expected block hashes: %w", err)
 	}

--- a/arbnode/message_pruner_test.go
+++ b/arbnode/message_pruner_test.go
@@ -23,6 +23,7 @@ func TestMessagePrunerWithPruningEligibleMessagePresent(t *testing.T) {
 
 	checkDbKeys(t, messagesCount, transactionStreamerDb, messagePrefix)
 	checkDbKeys(t, messagesCount, transactionStreamerDb, blockHashInputFeedPrefix)
+	checkDbKeys(t, messagesCount, transactionStreamerDb, messageResultPrefix)
 	checkDbKeys(t, messagesCount, inboxTrackerDb, rlpDelayedMessagePrefix)
 }
 
@@ -72,8 +73,8 @@ func TestMessagePrunerWithNoPruningEligibleMessagePresent(t *testing.T) {
 
 	checkDbKeys(t, uint64(messagesCount), transactionStreamerDb, messagePrefix)
 	checkDbKeys(t, uint64(messagesCount), transactionStreamerDb, blockHashInputFeedPrefix)
+	checkDbKeys(t, uint64(messagesCount), transactionStreamerDb, messageResultPrefix)
 	checkDbKeys(t, messagesCount, inboxTrackerDb, rlpDelayedMessagePrefix)
-
 }
 
 func setupDatabase(t *testing.T, messageCount, delayedMessageCount uint64) (ethdb.Database, ethdb.Database, *MessagePruner) {
@@ -82,6 +83,8 @@ func setupDatabase(t *testing.T, messageCount, delayedMessageCount uint64) (ethd
 		err := transactionStreamerDb.Put(dbKey(messagePrefix, i), []byte{})
 		Require(t, err)
 		err = transactionStreamerDb.Put(dbKey(blockHashInputFeedPrefix, i), []byte{})
+		Require(t, err)
+		err = transactionStreamerDb.Put(dbKey(messageResultPrefix, i), []byte{})
 		Require(t, err)
 	}
 

--- a/arbnode/schema.go
+++ b/arbnode/schema.go
@@ -6,6 +6,7 @@ package arbnode
 var (
 	messagePrefix                []byte = []byte("m") // maps a message sequence number to a message
 	blockHashInputFeedPrefix     []byte = []byte("b") // maps a message sequence number to a block hash received through the input feed
+	messageResultPrefix          []byte = []byte("r") // maps a message sequence number to a message result
 	legacyDelayedMessagePrefix   []byte = []byte("d") // maps a delayed sequence number to an accumulator and a message as serialized on L1
 	rlpDelayedMessagePrefix      []byte = []byte("e") // maps a delayed sequence number to an accumulator and an RLP encoded message
 	parentChainBlockNumberPrefix []byte = []byte("p") // maps a delayed sequence number to a parent chain block number

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1072,7 +1072,7 @@ func (s *TransactionStreamer) ResultAtCount(count arbutil.MessageIndex) (*execut
 		return nil, err
 	}
 
-	log.Warn(FailedToGetMsgResultFromDB, "count", count, "err", err)
+	log.Info(FailedToGetMsgResultFromDB, "count", count, "err", err)
 	return s.exec.ResultAtPos(pos)
 }
 

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -374,8 +374,7 @@ func (s *TransactionStreamer) reorg(batch ethdb.Batch, count arbutil.MessageInde
 		}
 	}
 
-	pos := uint64(count) - 1
-	err = deleteStartingAt(s.db, batch, messageResultPrefix, uint64ToKey(pos))
+	err = deleteStartingAt(s.db, batch, messageResultPrefix, uint64ToKey(uint64(count)))
 	if err != nil {
 		return err
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -130,7 +130,7 @@ type blockHashDBValue struct {
 
 const (
 	BlockHashMismatchLogMsg    = "BlockHash from feed doesn't match locally computed hash. Check feed source."
-	FailedToGetMsgResultFromDB = "Streamer: failed getting message result from db"
+	FailedToGetMsgResultFromDB = "Reading message result remotely."
 )
 
 // Encodes a uint64 as bytes in a lexically sortable manner for database iteration.
@@ -1071,7 +1071,7 @@ func (s *TransactionStreamer) ResultAtCount(count arbutil.MessageIndex) (*execut
 	} else if !dbutil.IsErrNotFound(err) {
 		return nil, err
 	}
-	log.Info(FailedToGetMsgResultFromDB, "count", count, "err", err)
+	log.Info(FailedToGetMsgResultFromDB, "count", count)
 
 	msgResult, err := s.exec.ResultAtPos(pos)
 	if err != nil {

--- a/system_tests/meaningless_reorg_test.go
+++ b/system_tests/meaningless_reorg_test.go
@@ -62,6 +62,8 @@ func TestMeaninglessBatchReorg(t *testing.T) {
 		builder.L1.TransferBalance(t, "Faucet", "Faucet", common.Big1, builder.L1Info)
 	}
 
+	compareAllMsgResultsFromConsensusAndExecution(t, builder.L2, "before reorg")
+
 	parentBlock := builder.L1.L1Backend.BlockChain().GetBlockByNumber(batchReceipt.BlockNumber.Uint64() - 1)
 	err = builder.L1.L1Backend.BlockChain().ReorgToOldBlock(parentBlock)
 	Require(t, err)
@@ -104,4 +106,6 @@ func TestMeaninglessBatchReorg(t *testing.T) {
 	if l2Header.Hash() != l2Receipt.BlockHash {
 		Fatal(t, "L2 block hash changed")
 	}
+
+	compareAllMsgResultsFromConsensusAndExecution(t, builder.L2, "after reorg")
 }

--- a/system_tests/reorg_resequencing_test.go
+++ b/system_tests/reorg_resequencing_test.go
@@ -59,7 +59,7 @@ func TestReorgResequencing(t *testing.T) {
 
 	// Reorg of old messages is done in the background.
 	// As a strategy to avoid test flakiness, this sleep tries to ensure that the reorg is done before we continue.
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	verifyBalances("after empty reorg")
 	compareAllMsgResultsFromConsensusAndExecution(t, builder.L2, "after empty reorg")
@@ -89,7 +89,7 @@ func TestReorgResequencing(t *testing.T) {
 
 	accountsWithBalance = append(accountsWithBalance, "User4")
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 	verifyBalances("after reorg with new deposit")
 	compareAllMsgResultsFromConsensusAndExecution(t, builder.L2, "after reorg with new deposit")
 
@@ -99,7 +99,7 @@ func TestReorgResequencing(t *testing.T) {
 	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageNumberSync(t)
 	Require(t, err)
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 	verifyBalances("after second empty reorg")
 	compareAllMsgResultsFromConsensusAndExecution(t, builder.L2, "after second empty reorg")
 }

--- a/system_tests/reorg_resequencing_test.go
+++ b/system_tests/reorg_resequencing_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
@@ -56,7 +57,12 @@ func TestReorgResequencing(t *testing.T) {
 	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageNumberSync(t)
 	Require(t, err)
 
+	// Reorg of old messages is done in the background.
+	// As a strategy to avoid test flakiness, this sleep tries to ensure that the reorg is done before we continue.
+	time.Sleep(2 * time.Second)
+
 	verifyBalances("after empty reorg")
+	compareAllMsgResultsFromConsensusAndExecution(t, builder.L2, "after empty reorg")
 
 	prevMessage, err := builder.L2.ConsensusNode.TxStreamer.GetMessage(startMsgCount - 1)
 	Require(t, err)
@@ -82,7 +88,10 @@ func TestReorgResequencing(t *testing.T) {
 	Require(t, err)
 
 	accountsWithBalance = append(accountsWithBalance, "User4")
+
+	time.Sleep(2 * time.Second)
 	verifyBalances("after reorg with new deposit")
+	compareAllMsgResultsFromConsensusAndExecution(t, builder.L2, "after reorg with new deposit")
 
 	err = builder.L2.ConsensusNode.TxStreamer.ReorgTo(startMsgCount)
 	Require(t, err)
@@ -90,5 +99,7 @@ func TestReorgResequencing(t *testing.T) {
 	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageNumberSync(t)
 	Require(t, err)
 
+	time.Sleep(2 * time.Second)
 	verifyBalances("after second empty reorg")
+	compareAllMsgResultsFromConsensusAndExecution(t, builder.L2, "after second empty reorg")
 }

--- a/system_tests/reorg_resequencing_test.go
+++ b/system_tests/reorg_resequencing_test.go
@@ -21,7 +21,7 @@ import (
 // which then adds old messages to a channel, so they can be resequenced asynchronously by ExecutionEngine.
 // After that, and before releasing the lock, TransactionStreamer does more computations.
 // - Asynchronously, ExecutionEngine reads from this channel and calls TransactionStreamer,
-// which expects that insertionMutex is free in order to succeed. Which cause then this error:
+// which expects that insertionMutex is free in order to succeed. When that happens this error generated:
 // 'failed to re-sequence old user message removed by reorg err="insert lock taken"'
 func TestReorgResequencing(t *testing.T) {
 	t.Parallel()

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -301,12 +301,6 @@ func testLyingSequencer(t *testing.T, dasModeStr string) {
 		t.Fatal("Unexpected balance of real account:", l2balanceRealAcct)
 	}
 
-	// Consensus should update message result stored in its database after a reorg
-	realResult := compareAllMsgResultsFromConsensusAndExecution(t, testClientB, "real")
-	// Checks that results changed
-	if reflect.DeepEqual(fraudResult, realResult) {
-		t.Fatal("realResult and fraudResult are equal")
-	}
 	// Since NodeB is not a sequencer, it will produce blocks through Consensus.
 	// So it is expected that Consensus.ResultAtCount will not rely on Execution to retrieve results.
 	// However, since count 1 is related to genesis, and Execution is initialized through InitializeArbosInDatabase and not through Consensus,
@@ -323,6 +317,12 @@ func testLyingSequencer(t *testing.T, dasModeStr string) {
 	Require(t, err)
 	if logHandler.WasLogged(arbnode.FailedToGetMsgResultFromDB) {
 		t.Fatal("Consensus relied on execution database to return the result")
+	}
+	// Consensus should update message result stored in its database after a reorg
+	realResult := compareAllMsgResultsFromConsensusAndExecution(t, testClientB, "real")
+	// Checks that results changed
+	if reflect.DeepEqual(fraudResult, realResult) {
+		t.Fatal("realResult and fraudResult are equal")
 	}
 }
 

--- a/util/dbutil/dbutil.go
+++ b/util/dbutil/dbutil.go
@@ -1,0 +1,16 @@
+// Copyright 2021-2024, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package dbutil
+
+import (
+	"errors"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+func IsErrNotFound(err error) bool {
+	return errors.Is(err, leveldb.ErrNotFound) || errors.Is(err, pebble.ErrNotFound) || errors.Is(err, memorydb.ErrMemorydbNotFound)
+}


### PR DESCRIPTION
Stores message result at consensus side, which can decrease communication between consensus and execution.
Part of the consensus/execution split effort. 

Linear task suggests to reuse blockHashInputFeedPrefix entries to store MessageResult, or at least, MessageResult.BlockHash. 
However this strategy can increase code complexity without a relevant amount of disk being saved.