### PR TITLE
[NIT-2652] init: allow classic node exported data in db dir

### DIFF
--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -327,6 +327,30 @@ func dirExists(path string) bool {
 	return info.IsDir()
 }
 
+func checkEmptyDatabaseDir(dir string, force bool) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("failed to open database dir %s: %w", dir, err)
+	}
+	unexpectedFiles := []string{}
+	allowedFiles := map[string]bool{
+		"LOCK": true, "classic-msg": true, "l2chaindata": true,
+	}
+	for _, entry := range entries {
+		if !allowedFiles[entry.Name()] {
+			unexpectedFiles = append(unexpectedFiles, entry.Name())
+		}
+	}
+	if len(unexpectedFiles) > 0 {
+		if force {
+			return fmt.Errorf("trying to overwrite old database directory '%s' (delete the database directory and try again)", dir)
+		}
+		firstThreeFilenames := strings.Join(unexpectedFiles[:min(len(unexpectedFiles), 3)], ", ")
+		return fmt.Errorf("found %d unexpected files in database directory, including: %s", len(unexpectedFiles), firstThreeFilenames)
+	}
+	return nil
+}
+
 var pebbleNotExistErrorRegex = regexp.MustCompile("pebble: database .* does not exist")
 
 func isPebbleNotExistError(err error) bool {
@@ -424,23 +448,8 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 		return nil, nil, fmt.Errorf(errorFmt, stack.InstanceDir(), grandParentDir)
 	}
 
-	// Check if database directory is empty
-	entries, err := os.ReadDir(stack.InstanceDir())
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open database dir %s: %w", stack.InstanceDir(), err)
-	}
-	unexpectedFiles := []string{}
-	for _, entry := range entries {
-		if entry.Name() != "LOCK" {
-			unexpectedFiles = append(unexpectedFiles, entry.Name())
-		}
-	}
-	if len(unexpectedFiles) > 0 {
-		if config.Init.Force {
-			return nil, nil, fmt.Errorf("trying to overwrite old database directory '%s' (delete the database directory and try again)", stack.InstanceDir())
-		}
-		firstThreeFilenames := strings.Join(unexpectedFiles[:min(len(unexpectedFiles), 3)], ", ")
-		return nil, nil, fmt.Errorf("found %d unexpected files in database directory, including: %s", len(unexpectedFiles), firstThreeFilenames)
+	if err := checkEmptyDatabaseDir(stack.InstanceDir(), config.Init.Force); err != nil {
+		return nil, nil, err
 	}
 
 	if err := setLatestSnapshotUrl(ctx, &config.Init, config.Chain.Name); err != nil {

--- a/cmd/nitro/init_test.go
+++ b/cmd/nitro/init_test.go
@@ -13,7 +13,9 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -209,4 +211,54 @@ func TestIsNotExistError(t *testing.T) {
 	t.Run("TestIsLeveldbNotExistError", func(t *testing.T) {
 		testIsNotExistError(t, "leveldb", isLeveldbNotExistError)
 	})
+}
+
+func TestEmptyDatabaseDir(t *testing.T) {
+	testCases := []struct {
+		name    string
+		files   []string
+		force   bool
+		wantErr string
+	}{
+		{
+			name: "succeed with empty dir",
+		},
+		{
+			name:  "succeed with expected files",
+			files: []string{"LOCK", "classic-msg", "l2chaindata"},
+		},
+		{
+			name:    "fail with unexpected files",
+			files:   []string{"LOCK", "a", "b", "c", "d"},
+			wantErr: "found 4 unexpected files in database directory, including: a, b, c",
+		},
+		{
+			name:    "fail with unexpected files when forcing",
+			files:   []string{"LOCK", "a", "b", "c", "d"},
+			force:   true,
+			wantErr: "trying to overwrite old database directory",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, file := range tc.files {
+				const filePerm = 0600
+				err := os.WriteFile(path.Join(dir, file), []byte{1, 2, 3}, filePerm)
+				Require(t, err)
+			}
+			err := checkEmptyDatabaseDir(dir, tc.force)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected nil error, got %q", err)
+				}
+			} else {
+				if err == nil {
+					t.Error("expected error, got nil")
+				} else if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("expected %q, got %q", tc.wantErr, err)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR adds more files to the allowed list of files that can be present when initializing the database. I also moved this code to a separate function to add a unit test.