### PR TITLE
Add submodule pin check to CI

### DIFF
--- a/.github/workflows/submodule-pin-check.sh
+++ b/.github/workflows/submodule-pin-check.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+declare -Ar exceptions=(
+	[contracts]=origin/develop
+	[nitro-testnode]=origin/master
+)
+
+divergent=0
+for mod in `git submodule --quiet foreach 'echo $name'`; do
+	branch=origin/HEAD
+	if [[ -v exceptions[$mod] ]]; then
+		branch=${exceptions[$mod]}
+	fi
+
+	if ! git -C $mod merge-base --is-ancestor HEAD $branch; then
+		echo $mod diverges from $branch
+		divergent=1
+	fi
+done
+
+exit $divergent
+

--- a/.github/workflows/submodule-pin-check.sh
+++ b/.github/workflows/submodule-pin-check.sh
@@ -3,6 +3,10 @@
 declare -Ar exceptions=(
 	[contracts]=origin/develop
 	[nitro-testnode]=origin/master
+
+	#TODO Rachel to check these are the intended branches.
+	[arbitrator/langs/c]=origin/vm-storage-cache
+	[arbitrator/tools/wasmer]=origin/adopt-v4.2.8
 )
 
 divergent=0

--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -1,4 +1,4 @@
-name: Merge Checks
+name: Submodule Pin Check
 
 on:
   pull_request:

--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -1,0 +1,15 @@
+name: Merge Checks
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  submodule-pin-check:
+    name: Submodule Pin Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all submodules are under origin/HEAD
+        run: git submodule foreach git merge-base --is-ancestor HEAD origin/HEAD
+

--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -13,8 +13,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           submodules: recursive
 
-      - name: Check all submodules are under origin/HEAD
+      - name: Check all submodules are ancestors of origin/HEAD or configured branch
         run: ${{ github.workspace }}/.github/workflows/submodule-pin-check.sh
 

--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -10,6 +10,9 @@ jobs:
     name: Submodule Pin Check
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Check all submodules are under origin/HEAD
         run: git submodule foreach git merge-base --is-ancestor HEAD origin/HEAD
 

--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -16,5 +16,5 @@ jobs:
           submodules: recursive
 
       - name: Check all submodules are under origin/HEAD
-        run: git submodule foreach git merge-base --is-ancestor HEAD origin/HEAD
+        run: ${{ github.workspace }}/.github/workflows/submodule-pin-check.sh
 

--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Check all submodules are under origin/HEAD
         run: git submodule foreach git merge-base --is-ancestor HEAD origin/HEAD

--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -3,7 +3,7 @@ name: Submodule Pin Check
 on:
   pull_request:
     branches: [ master ]
-    types: [synchronize, opened, reopened, labeled, unlabeled]
+    types: [synchronize, opened, reopened]
 
 jobs:
   submodule-pin-check:


### PR DESCRIPTION
This checks that submodules are ancestors of origin/HEAD or a configurable expected branch so that non-merged branches aren't accidentally checked in.

Fixes NIT-2604

Initially this will likely FAIL because we have some submodules that are not under origin/HEAD.

# Testing done
This screenshot shows an example of what you see when it fails:
![Screenshot from 2024-07-09 12-36-22](https://github.com/OffchainLabs/nitro/assets/87238672/e0df3594-6d2d-4448-bfc0-fd67518042b2)

