### PR TITLE
Try to fix docker artifact name in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,12 +64,12 @@ jobs:
         run: |
           cd nitro-testnode
           ./test-node.bash --init --dev &
-      
+
       - name: Wait for rpc to come up
         shell: bash
         run: |
           ${{ github.workspace }}/.github/workflows/waitForNitro.sh
-  
+
       - name: Print WAVM module root
         id: module-root
         run: |
@@ -77,7 +77,7 @@ jobs:
           # We work around this by piping a tarball through stdout
           docker run --rm --entrypoint tar localhost:5000/nitro-node-dev:latest -cf - target/machines/latest | tar xf -
           module_root="$(cat "target/machines/latest/module-root.txt")"
-          echo "name=module-root=$module_root" >> $GITHUB_STATE
+          echo "module-root=$module_root" >> "$GITHUB_OUTPUT"
           echo -e "\x1b[1;34mWAVM module root:\x1b[0m $module_root"
 
       - name: Upload WAVM machine as artifact


### PR DESCRIPTION
The docker artifact is currently named `wavm-machine-.zip` and is missing the module root. This used to work. This PR tries to use GITHUB_OUTPUT instead to fix it.