### PR TITLE
Only run "design approved" check when necessary [NIT-2667]

### DIFF
--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -1,21 +1,41 @@
 name: Merge Checks
 
 on:
-  workflow_dispatch:
   pull_request:
     branches: [ master ]
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
+permissions:
+  statuses: write
+
 jobs:
-  design-approved-check:
-    if: ${{ !contains(github.event.*.labels.*.name, 'design-approved') }}
-    name: Design Approved Check
+  check-design-approved:
+    name: Check if Design Approved
     runs-on: ubuntu-latest
     steps:
-      - name: Check for design-approved label
+      - name: Check if design approved and update status
         run: |
-          echo "Pull request is missing the 'design-approved' label"
-          echo "This workflow fails so that the pull request cannot be merged"
-          exit 1
-
-
+          set -x pipefail
+          status_state="pending"
+          if ${{ contains(github.event.*.labels.*.name, 'design-approved') }}; then
+            status_state="success"
+          else
+            resp="$(curl -sSL --fail-with-body \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/$GITHUB_REPOSITORY/commits/${{ github.event.pull_request.head.sha }}/statuses")"
+            if ! jq -e '.[] | select(.context == "Design Approved Check")' > /dev/null <<< "$resp"; then
+              # Design not approved yet and no status exists
+              # Keep it without a status to keep the green checkmark appearing
+              # Merging will still be blocked until the required status appears
+              exit 0
+            fi
+          fi
+          curl -sSL --fail-with-body \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{ github.event.pull_request.head.sha }}" \
+            -d '{"context":"Design Approved Check","state":"'"$status_state"'"}'

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -28,6 +28,7 @@ jobs:
             if ! jq -e '.[] | select(.context == "Design Approved Check")' > /dev/null <<< "$resp"; then
               # Design not approved yet and no status exists
               # Keep it without a status to keep the green checkmark appearing
+              # Otherwise, the commit and PR's CI will appear to be indefinitely pending
               # Merging will still be blocked until the required status appears
               exit 0
             fi


### PR DESCRIPTION
This PR will prevent PRs from appearing as failing CI when in reality they just haven't been design approved yet.