### PR TITLE
Add workflow_dispatch to gh actions merge-checks.yml

### DIFF
--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -1,6 +1,7 @@
 name: Merge Checks
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ master ]
     types: [synchronize, opened, reopened, labeled, unlabeled]


### PR DESCRIPTION
This doesn't do anything on its own, but it's necessary to merge this before https://github.com/OffchainLabs/nitro/pull/2468 can be fully tested.

Source: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

> **Note:** This event will only trigger a workflow run if the workflow file is on the default branch.