### PR TITLE
[DAS] Always make expiry index

### DIFF
--- a/das/local_file_storage_service_test.go
+++ b/das/local_file_storage_service_test.go
@@ -98,10 +98,9 @@ func TestMigrationNoExpiry(t *testing.T) {
 	countEntries(t, &s.layout, 4)
 	getByHashAndCheck(t, s, "a", "b", "c", "d")
 
-	_, err = s.layout.iterateBatchesByTimestamp(time.Unix(int64(now+10), 0))
-	if err == nil {
-		Fail(t, "can't iterate by timestamp when expiry is disabled")
-	}
+	// Can still iterate by timestamp even if expiry disabled
+	countTimestampEntries(t, &s.layout, time.Unix(int64(now+11), 0), 4)
+
 }
 
 func TestMigrationExpiry(t *testing.T) {


### PR DESCRIPTION
This PR makes the das filestore always create the by-expiry-timestamp directory so that expiry can be enabled at a later time if the operator desires, without needing any additional migration.

Original PR: https://github.com/OffchainLabs/nitro/pull/2385

Under the top level directory of `<datadir>/by-expiry-timestamp` a new directory will be created every ~2.7 hours, which, for a non-expiring DAS, gives about 3244 directories per year, giving about 20 years til we hit the 65K we are trying to avoid.

Example path: `<datadir>/by-expiry-timestamp/171702/5712/1b7a84fcdb5f467ec4889e99dba58b2e6d56e0154538ee2a3083aa1582ab833e`

# Testing done
Re-tested migrating the old style format with the configuration used in https://github.com/OffchainLabs/nitro/pull/2385 but with `data-availability.local-file-storage.enable-expiry` set to false, and spot checked that the `by-expiry-timestamp` directory was populated correctly. Stopped the daserver and checked that setting  `data-availability.local-file-storage.enable-expiry` to true then pruned the data as expected. 