### PR TITLE
Don't close the sigint channel

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -679,8 +679,6 @@ func mainImpl() int {
 			exitCode = 1
 		}
 		if nodeConfig.Init.ThenQuit {
-			close(sigint)
-
 			return exitCode
 		}
 	}
@@ -693,9 +691,6 @@ func mainImpl() int {
 	case <-sigint:
 		log.Info("shutting down because of sigint")
 	}
-
-	// cause future ctrl+c's to panic
-	close(sigint)
 
 	return exitCode
 }


### PR DESCRIPTION
Right now, if a fatal error happens at the same time as a sigint, the node will crash. In general, we should let sigints be sigints, and if the user wants to hard kill the process they can use sigkill.