### PR TITLE
[NIT-2668] init: fix loading db with custom ancient path

### DIFF
--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -408,7 +408,7 @@ func isLeveldbNotExistError(err error) bool {
 
 func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeConfig, chainId *big.Int, cacheConfig *core.CacheConfig, persistentConfig *conf.PersistentConfig, l1Client arbutil.L1Interface, rollupAddrs chaininfo.RollupAddresses) (ethdb.Database, *core.BlockChain, error) {
 	if !config.Init.Force {
-		if readOnlyDb, err := stack.OpenDatabaseWithFreezerWithExtraOptions("l2chaindata", 0, 0, "", "l2chaindata/", true, persistentConfig.Pebble.ExtraOptions("l2chaindata")); err == nil {
+		if readOnlyDb, err := stack.OpenDatabaseWithFreezerWithExtraOptions("l2chaindata", 0, 0, config.Persistent.Ancient, "l2chaindata/", true, persistentConfig.Pebble.ExtraOptions("l2chaindata")); err == nil {
 			if chainConfig := gethexec.TryReadStoredChainConfig(readOnlyDb); chainConfig != nil {
 				readOnlyDb.Close()
 				if !arbmath.BigEquals(chainConfig.ChainID, chainId) {


### PR DESCRIPTION
In a previous commit, we added a check to verify whether the database directory was empty before initializing it. This check highlighted a bug where an existing database wasn’t being loaded properly when the persistent.ancient flag was set. Before the empty check, the code worked because the database was reinitialized instead of just being loaded.