### PR TITLE
Switch merge checks action to pull_request_target event

### DIFF
--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -1,7 +1,7 @@
 name: Merge Checks
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ master ]
     types: [synchronize, opened, reopened, labeled, unlabeled]
 


### PR DESCRIPTION
This should allow the check to run on 3rd party PRs from forks