### PR TITLE
Fix disabling P2P

### DIFF
--- a/cmd/nitro-val/nitro_val.go
+++ b/cmd/nitro-val/nitro_val.go
@@ -70,6 +70,9 @@ func mainImpl() int {
 	nodeConfig.WS.Apply(&stackConf)
 	nodeConfig.Auth.Apply(&stackConf)
 	nodeConfig.IPC.Apply(&stackConf)
+	stackConf.P2P.ListenAddr = ""
+	stackConf.P2P.NoDial = true
+	stackConf.P2P.NoDiscovery = true
 	vcsRevision, strippedRevision, vcsTime := confighelpers.GetVersion()
 	stackConf.Version = strippedRevision
 

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -183,6 +183,9 @@ func mainImpl() int {
 	if nodeConfig.WS.ExposeAll {
 		stackConf.WSModules = append(stackConf.WSModules, "personal")
 	}
+	stackConf.P2P.ListenAddr = ""
+	stackConf.P2P.NoDial = true
+	stackConf.P2P.NoDiscovery = true
 	vcsRevision, strippedRevision, vcsTime := confighelpers.GetVersion()
 	stackConf.Version = strippedRevision
 


### PR DESCRIPTION
When removing the P2P options in https://github.com/OffchainLabs/nitro/pull/2462 I assumed it'd not listen to P2P, but I didn't realize the default was to listen on port 30303. This PR restores the code to disable P2P from before https://github.com/OffchainLabs/nitro/pull/2124