### PR TITLE
Update scopeContext's stack to have correct contract address while tracing for contract calls

### DIFF
--- a/arbos/util/tracing.go
+++ b/arbos/util/tracing.go
@@ -56,11 +56,8 @@ func (info *TracingInfo) RecordEmitLog(topics []common.Hash, data []byte) {
 	for _, topic := range topics {
 		args = append(args, HashToUint256(topic)) // topic: 32-byte value. Max topics count is 4
 	}
-	memory := vm.NewMemory()
-	memory.Resize(size)
-	memory.Set(0, size, data)
 	scope := &vm.ScopeContext{
-		Memory:   memory,
+		Memory:   TracingMemoryFromBytes(data),
 		Stack:    TracingStackFromArgs(args...),
 		Contract: info.Contract,
 	}


### PR DESCRIPTION
If a Stylus contract invoked another contract, scopeContext used in tracing of such calls didn't have the correct contract address in its stack, resulting in situations like- null dereference in prestateTracers. 

This PR fixes such cases by calling CaptureState with the new contract's address included in the scopeContext's stack.