### PR TITLE
santize device names for iostat metrics

### DIFF
--- a/util/iostat/iostat.go
+++ b/util/iostat/iostat.go
@@ -30,6 +30,7 @@ func RegisterAndPopulateMetrics(ctx context.Context, spawnInterval, maxDeviceCou
 		if _, ok := deviceMetrics[stat.DeviceName]; !ok {
 			// Register metrics for a maximum of maxDeviceCount (fail safe incase iostat command returns incorrect names indefinitely)
 			if len(deviceMetrics) < maxDeviceCount {
+				// Replace hyphens with underscores to avoid metric name issues
 				sanitizedDeviceName := strings.Replace(stat.DeviceName, "-", "_", -1)
 				baseMetricName := fmt.Sprintf("isotat/%s/", sanitizedDeviceName)
 				deviceMetrics[stat.DeviceName] = make(map[string]metrics.GaugeFloat64)

--- a/util/iostat/iostat.go
+++ b/util/iostat/iostat.go
@@ -30,7 +30,8 @@ func RegisterAndPopulateMetrics(ctx context.Context, spawnInterval, maxDeviceCou
 		if _, ok := deviceMetrics[stat.DeviceName]; !ok {
 			// Register metrics for a maximum of maxDeviceCount (fail safe incase iostat command returns incorrect names indefinitely)
 			if len(deviceMetrics) < maxDeviceCount {
-				baseMetricName := fmt.Sprintf("isotat/%s/", stat.DeviceName)
+				sanitizedDeviceName := strings.Replace(stat.DeviceName, "-", "_", -1)
+				baseMetricName := fmt.Sprintf("isotat/%s/", sanitizedDeviceName)
 				deviceMetrics[stat.DeviceName] = make(map[string]metrics.GaugeFloat64)
 				deviceMetrics[stat.DeviceName]["readspersecond"] = metrics.NewRegisteredGaugeFloat64(baseMetricName+"readspersecond", nil)
 				deviceMetrics[stat.DeviceName]["writespersecond"] = metrics.NewRegisteredGaugeFloat64(baseMetricName+"writespersecond", nil)

--- a/util/iostat/iostat.go
+++ b/util/iostat/iostat.go
@@ -31,7 +31,7 @@ func RegisterAndPopulateMetrics(ctx context.Context, spawnInterval, maxDeviceCou
 			// Register metrics for a maximum of maxDeviceCount (fail safe incase iostat command returns incorrect names indefinitely)
 			if len(deviceMetrics) < maxDeviceCount {
 				// Replace hyphens with underscores to avoid metric name issues
-				sanitizedDeviceName := strings.Replace(stat.DeviceName, "-", "_", -1)
+				sanitizedDeviceName := strings.ReplaceAll(stat.DeviceName, "-", "_")
 				baseMetricName := fmt.Sprintf("iostat/%s/", sanitizedDeviceName)
 				deviceMetrics[stat.DeviceName] = make(map[string]metrics.GaugeFloat64)
 				deviceMetrics[stat.DeviceName]["readspersecond"] = metrics.NewRegisteredGaugeFloat64(baseMetricName+"readspersecond", nil)

--- a/util/iostat/iostat.go
+++ b/util/iostat/iostat.go
@@ -32,7 +32,7 @@ func RegisterAndPopulateMetrics(ctx context.Context, spawnInterval, maxDeviceCou
 			if len(deviceMetrics) < maxDeviceCount {
 				// Replace hyphens with underscores to avoid metric name issues
 				sanitizedDeviceName := strings.Replace(stat.DeviceName, "-", "_", -1)
-				baseMetricName := fmt.Sprintf("isotat/%s/", sanitizedDeviceName)
+				baseMetricName := fmt.Sprintf("iostat/%s/", sanitizedDeviceName)
 				deviceMetrics[stat.DeviceName] = make(map[string]metrics.GaugeFloat64)
 				deviceMetrics[stat.DeviceName]["readspersecond"] = metrics.NewRegisteredGaugeFloat64(baseMetricName+"readspersecond", nil)
 				deviceMetrics[stat.DeviceName]["writespersecond"] = metrics.NewRegisteredGaugeFloat64(baseMetricName+"writespersecond", nil)


### PR DESCRIPTION
iostat devices can have dashes which creates an invalid prometheus metric. Also renames metric to fix a presumed typo