### PR TITLE
chore(all): use `errors.New` to replace `fmt.Errorf` with no parameters

### DIFF
--- a/arbcompress/wasm.go
+++ b/arbcompress/wasm.go
@@ -7,7 +7,7 @@
 package arbcompress
 
 import (
-	"fmt"
+	"errors"
 	"unsafe"
 
 	"github.com/offchainlabs/nitro/arbutil"
@@ -38,7 +38,7 @@ func Compress(input []byte, level uint32, dictionary Dictionary) ([]byte, error)
 		dictionary,
 	)
 	if status != brotliSuccess {
-		return nil, fmt.Errorf("failed compression")
+		return nil, errors.New("failed compression")
 	}
 	return outBuf[:outLen], nil
 }
@@ -58,7 +58,7 @@ func DecompressWithDictionary(input []byte, maxSize int, dictionary Dictionary) 
 		dictionary,
 	)
 	if status != brotliSuccess {
-		return nil, fmt.Errorf("failed decompression")
+		return nil, errors.New("failed decompression")
 	}
 	return outBuf[:outLen], nil
 }

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1052,7 +1052,7 @@ var errAttemptLockFailed = errors.New("failed to acquire lock; either another ba
 
 func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error) {
 	if b.batchReverted.Load() {
-		return false, fmt.Errorf("batch was reverted, not posting any more batches")
+		return false, errors.New("batch was reverted, not posting any more batches")
 	}
 	nonce, batchPositionBytes, err := b.dataPoster.GetNextNonceAndMeta(ctx)
 	if err != nil {

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -737,7 +737,7 @@ func (p *DataPoster) PostTransaction(ctx context.Context, dataCreatedAt time.Tim
 	defer p.mutex.Unlock()
 
 	if p.config().DisableNewTx {
-		return nil, fmt.Errorf("posting new transaction is disabled")
+		return nil, errors.New("posting new transaction is disabled")
 	}
 
 	var weight uint64 = 1

--- a/arbnode/dataposter/externalsignertest/externalsignertest.go
+++ b/arbnode/dataposter/externalsignertest/externalsignertest.go
@@ -47,7 +47,7 @@ type SignerServer struct {
 func basePath() (string, error) {
 	_, file, _, ok := runtime.Caller(1)
 	if !ok {
-		return "", fmt.Errorf("error getting caller")
+		return "", errors.New("error getting caller")
 	}
 	idx := strings.Index(file, selfPath)
 	if idx == -1 {
@@ -181,7 +181,7 @@ type SignerAPI struct {
 
 func (a *SignerAPI) SignTransaction(ctx context.Context, req *apitypes.SendTxArgs) (hexutil.Bytes, error) {
 	if req == nil {
-		return nil, fmt.Errorf("nil request")
+		return nil, errors.New("nil request")
 	}
 	tx, err := req.ToTransaction()
 	if err != nil {

--- a/arbos/programs/params.go
+++ b/arbos/programs/params.go
@@ -5,7 +5,6 @@ package programs
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -142,10 +141,10 @@ func (p *StylusParams) Save() error {
 
 func (p *StylusParams) UpgradeToVersion(version uint16) error {
 	if version != 2 {
-		return fmt.Errorf("dest version not supported for upgrade")
+		return errors.New("dest version not supported for upgrade")
 	}
 	if p.Version != 1 {
-		return fmt.Errorf("existing version not supported for upgrade")
+		return errors.New("existing version not supported for upgrade")
 	}
 	p.Version = 2
 	p.MinInitGas = v2MinInitGas

--- a/cmd/daserver/daserver.go
+++ b/cmd/daserver/daserver.go
@@ -159,7 +159,7 @@ func startMetrics(cfg *DAServerConfig) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
 	if cfg.Metrics && !metrics.Enabled {
-		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+		return errors.New("metrics must be enabled via command line by adding --metrics, json config has no effect")
 	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)

--- a/cmd/nitro-val/nitro_val.go
+++ b/cmd/nitro-val/nitro_val.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	_ "net/http/pprof" // #nosec G108
 	"os"
@@ -39,7 +40,7 @@ func startMetrics(cfg *ValidationNodeConfig) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
 	if cfg.Metrics && !metrics.Enabled {
-		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+		return errors.New("metrics must be enabled via command line by adding --metrics, json config has no effect")
 	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -93,7 +93,7 @@ func downloadInit(ctx context.Context, initConfig *conf.InitConfig) (string, err
 	}
 	file, err := downloadFile(ctx, initConfig, initConfig.Url, checksum)
 	if err != nil && errors.Is(err, notFoundError) {
-		return "", fmt.Errorf("file not found but checksum exists")
+		return "", errors.New("file not found but checksum exists")
 	}
 	return file, err
 }
@@ -195,7 +195,7 @@ func fetchChecksum(ctx context.Context, url string) ([]byte, error) {
 		return nil, fmt.Errorf("error decoding checksum: %w", err)
 	}
 	if len(checksum) != sha256.Size {
-		return nil, fmt.Errorf("invalid checksum length")
+		return nil, errors.New("invalid checksum length")
 	}
 	return checksum, nil
 }
@@ -222,7 +222,7 @@ func downloadInitInParts(ctx context.Context, initConfig *conf.InitConfig) (stri
 	for _, line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) != 2 {
-			return "", fmt.Errorf("manifest file in wrong format")
+			return "", errors.New("manifest file in wrong format")
 		}
 		checksum, err := hex.DecodeString(fields[0])
 		if err != nil {
@@ -264,7 +264,7 @@ func downloadInitInParts(ctx context.Context, initConfig *conf.InitConfig) (stri
 // joinArchive joins the archive parts into a single file and return its path.
 func joinArchive(parts []string, archivePath string) (string, error) {
 	if len(parts) == 0 {
-		return "", fmt.Errorf("no database parts found")
+		return "", errors.New("no database parts found")
 	}
 	archive, err := os.Create(archivePath)
 	if err != nil {
@@ -293,7 +293,7 @@ func setLatestSnapshotUrl(ctx context.Context, initConfig *conf.InitConfig, chai
 		return nil
 	}
 	if initConfig.Url != "" {
-		return fmt.Errorf("cannot set latest url if url is already set")
+		return errors.New("cannot set latest url if url is already set")
 	}
 	baseUrl, err := url.Parse(initConfig.LatestBase)
 	if err != nil {
@@ -644,7 +644,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 				}
 			}
 			if initMessage == nil {
-				return chainDb, nil, fmt.Errorf("failed to get init message while attempting to get serialized chain config")
+				return chainDb, nil, errors.New("failed to get init message while attempting to get serialized chain config")
 			}
 			parsedInitMessage, err = initMessage.ParseInitMessage()
 			if err != nil {

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -146,7 +146,7 @@ func startMetrics(cfg *NodeConfig) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
 	if cfg.Metrics && !metrics.Enabled {
-		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+		return errors.New("metrics must be enabled via command line by adding --metrics, json config has no effect")
 	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -40,7 +41,7 @@ func startMetrics(cfg *relay.Config) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
 	if cfg.Metrics && !metrics.Enabled {
-		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+		return errors.New("metrics must be enabled via command line by adding --metrics, json config has no effect")
 	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)

--- a/cmd/staterecovery/staterecovery.go
+++ b/cmd/staterecovery/staterecovery.go
@@ -1,6 +1,7 @@
 package staterecovery
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -17,7 +18,7 @@ func RecreateMissingStates(chainDb ethdb.Database, bc *core.BlockChain, cacheCon
 	start := time.Now()
 	currentHeader := bc.CurrentBlock()
 	if currentHeader == nil {
-		return fmt.Errorf("current header is nil")
+		return errors.New("current header is nil")
 	}
 	target := currentHeader.Number.Uint64()
 	current := startBlock

--- a/cmd/util/confighelpers/configuration.go
+++ b/cmd/util/confighelpers/configuration.go
@@ -260,5 +260,5 @@ func DumpConfig(k *koanf.Koanf, extraOverrideFields map[string]interface{}) erro
 
 	fmt.Println(string(c))
 	os.Exit(0)
-	return fmt.Errorf("Unreachable")
+	return errors.New("Unreachable")
 }

--- a/das/dasRpcServer.go
+++ b/das/dasRpcServer.go
@@ -189,7 +189,7 @@ func (b *batchBuilder) assign(nChunks, timeout, chunkSize, totalSize uint64) (ui
 	id := rand.Uint64()
 	_, ok := b.batches[id]
 	if ok {
-		return 0, fmt.Errorf("can't start new batch, try again")
+		return 0, errors.New("can't start new batch, try again")
 	}
 
 	b.batches[id] = &batch{

--- a/das/dastree/dastree.go
+++ b/das/dastree/dastree.go
@@ -5,6 +5,7 @@ package dastree
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -222,7 +223,7 @@ func Content(root bytes32, oracle func(bytes32) ([]byte, error)) ([]byte, error)
 
 	// Check the hash matches. Given the size data this should never fail but we'll check anyway
 	if Hash(preimage) != root {
-		return nil, fmt.Errorf("preimage not canonically hashed")
+		return nil, errors.New("preimage not canonically hashed")
 	}
 	return preimage, nil
 }

--- a/das/factory.go
+++ b/das/factory.go
@@ -6,7 +6,6 @@ package das
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -270,7 +269,7 @@ func CreateDAReaderForNode(
 	}
 
 	if !config.RestAggregator.Enable {
-		return nil, nil, nil, fmt.Errorf("--node.data-availability.enable was set but not --node.data-availability.rest-aggregator. When running a Nitro Anytrust node in non-Batch Poster mode, some way to get the batch data is required.")
+		return nil, nil, nil, errors.New("--node.data-availability.enable was set but not --node.data-availability.rest-aggregator. When running a Nitro Anytrust node in non-Batch Poster mode, some way to get the batch data is required.")
 	}
 	// Done checking config requirements
 

--- a/das/syncing_fallback_storage.go
+++ b/das/syncing_fallback_storage.go
@@ -6,6 +6,7 @@ package das
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -136,7 +137,7 @@ func readSyncStateOrDefault(syncDir string, dflt uint64) uint64 {
 
 func writeSyncState(syncDir string, blockNr uint64) error {
 	if syncDir == "" {
-		return fmt.Errorf("No sync-to-storage.state-dir has been configured")
+		return errors.New("No sync-to-storage.state-dir has been configured")
 	}
 
 	path := syncDir + "/" + nextBlockNoFilename

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -673,7 +673,7 @@ func (s *ExecutionEngine) appendBlock(block *types.Block, statedb *state.StateDB
 
 func (s *ExecutionEngine) resultFromHeader(header *types.Header) (*execution.MessageResult, error) {
 	if header == nil {
-		return nil, fmt.Errorf("result not found")
+		return nil, errors.New("result not found")
 	}
 	info := types.DeserializeHeaderExtraInformation(header)
 	return &execution.MessageResult{

--- a/pubsub/consumer.go
+++ b/pubsub/consumer.go
@@ -55,7 +55,7 @@ type Message[Request any] struct {
 
 func NewConsumer[Request any, Response any](client redis.UniversalClient, streamName string, cfg *ConsumerConfig) (*Consumer[Request, Response], error) {
 	if streamName == "" {
-		return nil, fmt.Errorf("redis stream name cannot be empty")
+		return nil, errors.New("redis stream name cannot be empty")
 	}
 	return &Consumer[Request, Response]{
 		id:          uuid.NewString(),

--- a/pubsub/producer.go
+++ b/pubsub/producer.go
@@ -84,10 +84,10 @@ func ProducerAddConfigAddOptions(prefix string, f *pflag.FlagSet) {
 
 func NewProducer[Request any, Response any](client redis.UniversalClient, streamName string, cfg *ProducerConfig) (*Producer[Request, Response], error) {
 	if client == nil {
-		return nil, fmt.Errorf("redis client cannot be nil")
+		return nil, errors.New("redis client cannot be nil")
 	}
 	if streamName == "" {
-		return nil, fmt.Errorf("stream name cannot be empty")
+		return nil, errors.New("stream name cannot be empty")
 	}
 	return &Producer[Request, Response]{
 		id:          uuid.NewString(),
@@ -104,7 +104,7 @@ func (p *Producer[Request, Response]) errorPromisesFor(msgs []*Message[Request])
 	defer p.promisesLock.Unlock()
 	for _, msg := range msgs {
 		if promise, found := p.promises[msg.ID]; found {
-			promise.ProduceError(fmt.Errorf("internal error, consumer died while serving the request"))
+			promise.ProduceError(errors.New("internal error, consumer died while serving the request"))
 			delete(p.promises, msg.ID)
 		}
 	}
@@ -197,7 +197,7 @@ func (p *Producer[Request, Response]) reproduce(ctx context.Context, value Reque
 	if oldKey != "" && promise == nil {
 		// This will happen if the old consumer became inactive but then ack_d
 		// the message afterwards.
-		return nil, fmt.Errorf("error reproducing the message, could not find existing one")
+		return nil, errors.New("error reproducing the message, could not find existing one")
 	}
 	if oldKey == "" || promise == nil {
 		pr := containers.NewPromise[Response](nil)

--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -274,7 +274,7 @@ func NewBlockValidator(
 			if config().MemoryFreeLimit == "default" {
 				log.Warn("Cgroups V1 or V2 is unsupported, memory-free-limit feature inside block-validator is disabled")
 			} else {
-				return nil, fmt.Errorf("failed to create MemoryFreeLimitChecker, Cgroups V1 or V2 is unsupported")
+				return nil, errors.New("failed to create MemoryFreeLimitChecker, Cgroups V1 or V2 is unsupported")
 			}
 		} else {
 			ret.MemoryFreeLimitChecker = limtchecker
@@ -901,7 +901,7 @@ func (v *BlockValidator) validGSIsNew(globalState validator.GoGlobalState) bool 
 // this accepts globalstate even if not caught up
 func (v *BlockValidator) InitAssumeValid(globalState validator.GoGlobalState) error {
 	if v.Started() {
-		return fmt.Errorf("cannot handle InitAssumeValid while running")
+		return errors.New("cannot handle InitAssumeValid while running")
 	}
 
 	// don't do anything if we already validated past that
@@ -1155,7 +1155,7 @@ func (v *BlockValidator) checkLegacyValid() error {
 	}
 	if result.BlockHash != v.legacyValidInfo.BlockHash {
 		log.Error("legacy validated blockHash does not fit chain", "info.BlockHash", v.legacyValidInfo.BlockHash, "chain", result.BlockHash, "count", msgCount)
-		return fmt.Errorf("legacy validated blockHash does not fit chain")
+		return errors.New("legacy validated blockHash does not fit chain")
 	}
 	validGS := validator.GoGlobalState{
 		BlockHash:  result.BlockHash,

--- a/staker/challenge-cache/cache.go
+++ b/staker/challenge-cache/cache.go
@@ -142,7 +142,7 @@ func (c *Cache) Put(lookup *Key, hashes []common.Hash) error {
 		return ErrNoHashes
 	}
 	if c.tempWritesDir == "" {
-		return fmt.Errorf("cache not initialized by calling .Init(ctx)")
+		return errors.New("cache not initialized by calling .Init(ctx)")
 	}
 	fName, err := determineFilePath(c.baseDir, lookup)
 	if err != nil {

--- a/staker/challenge_manager.go
+++ b/staker/challenge_manager.go
@@ -489,7 +489,7 @@ func (m *ChallengeManager) createExecutionBackend(ctx context.Context, step uint
 		}
 	}
 	if execRun == nil {
-		return fmt.Errorf("did not find valid execution backend")
+		return errors.New("did not find valid execution backend")
 	}
 	backend, err := NewExecutionChallengeBackend(execRun)
 	if err != nil {

--- a/staker/l1_validator.go
+++ b/staker/l1_validator.go
@@ -317,7 +317,7 @@ func (v *L1Validator) generateNodeAction(
 		if !wasmRootValid {
 			if !stakerConfig.Dangerous.IgnoreRollupWasmModuleRoot {
 				if len(valInfo.WasmRoots) == 0 {
-					return nil, false, fmt.Errorf("block validation is still pending")
+					return nil, false, errors.New("block validation is still pending")
 				}
 				return nil, false, fmt.Errorf(
 					"wasmroot doesn't match rollup : %v, valid: %v",

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -5,6 +5,7 @@ package arbtest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -160,16 +161,16 @@ func testNodes(t *testing.T, n int) []string {
 // Errors out after timeout.
 func waitForSequencerLockout(ctx context.Context, node *arbnode.Node, duration time.Duration) error {
 	if node == nil {
-		return fmt.Errorf("node is nil")
+		return errors.New("node is nil")
 	}
 	if node.SeqCoordinator == nil {
-		return fmt.Errorf("sequence coordinator in the node is nil")
+		return errors.New("sequence coordinator in the node is nil")
 	}
 	// TODO: implement exponential backoff retry mechanism and use it instead.
 	for {
 		select {
 		case <-time.After(duration):
-			return fmt.Errorf("no sequencer was chosen")
+			return errors.New("no sequencer was chosen")
 		default:
 			if c, err := node.SeqCoordinator.CurrentChosenSequencer(ctx); err == nil && c != "" {
 				return nil
@@ -204,7 +205,7 @@ func tryWithTimeout(ctx context.Context, f func() error, duration time.Duration)
 	for {
 		select {
 		case <-time.After(duration):
-			return fmt.Errorf("timeout expired")
+			return errors.New("timeout expired")
 		default:
 			if err := f(); err == nil {
 				return nil

--- a/util/headerreader/blob_client.go
+++ b/util/headerreader/blob_client.go
@@ -272,15 +272,15 @@ func saveBlobDataToDisk(rawData json.RawMessage, slot uint64, blobDirectory stri
 	filePath := path.Join(blobDirectory, fmt.Sprint(slot))
 	file, err := os.Create(filePath)
 	if err != nil {
-		return fmt.Errorf("could not create file to store fetched blobs")
+		return errors.New("could not create file to store fetched blobs")
 	}
 	full := fullResult[json.RawMessage]{Data: rawData}
 	fullbytes, err := json.Marshal(full)
 	if err != nil {
-		return fmt.Errorf("unable to marshal data into bytes while attempting to store fetched blobs")
+		return errors.New("unable to marshal data into bytes while attempting to store fetched blobs")
 	}
 	if _, err := file.Write(fullbytes); err != nil {
-		return fmt.Errorf("failed to write blob data to disk")
+		return errors.New("failed to write blob data to disk")
 	}
 	file.Close()
 	return nil

--- a/util/testhelpers/github/releases.go
+++ b/util/testhelpers/github/releases.go
@@ -2,7 +2,7 @@ package github
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/url"
 	"regexp"
 	"strings"
@@ -44,7 +44,7 @@ func LatestConsensusRelease(ctx context.Context) (*ConsensusRelease, error) {
 		}
 	}
 	if found == nil {
-		return nil, fmt.Errorf("no consensus release found")
+		return nil, errors.New("no consensus release found")
 	}
 	return found, nil
 }
@@ -54,7 +54,7 @@ func fromRelease(release *github.RepositoryRelease) (*ConsensusRelease, error) {
 	// This is currently brittle because it relies on the release body format.
 	matches := wasmRootExp.FindStringSubmatch(release.GetBody())
 	if len(matches) != 2 {
-		return nil, fmt.Errorf("no WAVM module root found in release body")
+		return nil, errors.New("no WAVM module root found in release body")
 	}
 	wavmModuleRoot := matches[1]
 	var machineWavmURL url.URL

--- a/validator/client/redis/producer.go
+++ b/validator/client/redis/producer.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 
@@ -69,7 +70,7 @@ type ValidationClient struct {
 
 func NewValidationClient(cfg *ValidationClientConfig) (*ValidationClient, error) {
 	if cfg.RedisURL == "" {
-		return nil, fmt.Errorf("redis url cannot be empty")
+		return nil, errors.New("redis url cannot be empty")
 	}
 	redisClient, err := redisutil.RedisClientFromURL(cfg.RedisURL)
 	if err != nil {

--- a/validator/client/validation_client.go
+++ b/validator/client/validation_client.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -69,7 +68,7 @@ func (c *ValidationClient) Start(ctx_in context.Context) error {
 		return err
 	}
 	if len(moduleRoots) == 0 {
-		return fmt.Errorf("server reported no wasmModuleRoots")
+		return errors.New("server reported no wasmModuleRoots")
 	}
 	var room int
 	if err := c.client.CallContext(c.GetContext(), &room, server_api.Namespace+"_room"); err != nil {

--- a/validator/server_arb/execution_run.go
+++ b/validator/server_arb/execution_run.go
@@ -5,6 +5,7 @@ package server_arb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -96,10 +97,10 @@ func (e *executionRun) machineHashesWithStepSize(
 	maxIterations uint64,
 ) ([]common.Hash, error) {
 	if stepSize == 0 {
-		return nil, fmt.Errorf("step size cannot be 0")
+		return nil, errors.New("step size cannot be 0")
 	}
 	if maxIterations == 0 {
-		return nil, fmt.Errorf("max number of iterations cannot be 0")
+		return nil, errors.New("max number of iterations cannot be 0")
 	}
 	machine, err := e.cache.GetMachineAt(ctx, machineStartIndex)
 	if err != nil {

--- a/validator/valnode/redis/consumer.go
+++ b/validator/valnode/redis/consumer.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -28,7 +29,7 @@ type ValidationServer struct {
 
 func NewValidationServer(cfg *ValidationServerConfig, spawner validator.ValidationSpawner) (*ValidationServer, error) {
 	if cfg.RedisURL == "" {
-		return nil, fmt.Errorf("redis url cannot be empty")
+		return nil, errors.New("redis url cannot be empty")
 	}
 	redisClient, err := redisutil.RedisClientFromURL(cfg.RedisURL)
 	if err != nil {


### PR DESCRIPTION
This PR replaces all `fmt.Errorf` without parameters with `errors.New`