### PR TITLE
Use default rpcclient config when unmarshalling JSON

### DIFF
--- a/util/rpcclient/rpcclient.go
+++ b/util/rpcclient/rpcclient.go
@@ -44,6 +44,13 @@ func (c *ClientConfig) Validate() error {
 	return err
 }
 
+func (c *ClientConfig) UnmarshalJSON(data []byte) error {
+	// Use DefaultClientConfig for default values when unmarshalling JSON
+	*c = DefaultClientConfig
+	type clientConfigWithoutCustomUnmarshal ClientConfig
+	return json.Unmarshal(data, (*clientConfigWithoutCustomUnmarshal)(c))
+}
+
 type ClientConfigFetcher func() *ClientConfig
 
 var TestClientConfig = ClientConfig{


### PR DESCRIPTION
Fixes NIT-2691

JSON unmarshalling an array of ClientConfigs is used in `stateless_block_validator.go`. With this PR, it'll now respect the default rpcclient config options, such as the max log line length.