### PR TITLE
ci: test one package at a time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,13 +145,23 @@ jobs:
         if: matrix.test-mode == 'defaults'
         run: |
           packages=`go list ./...`
-          stdbuf -oL gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 --no-color=false -- ./... -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -timeout 20m -parallel=8 -tags=cionly > >(stdbuf -oL tee full.log | grep -vE "INFO|seal")
+          for package in $packages; do
+            echo running tests for $package
+            if ! stdbuf -oL gotestsum --format short-verbose --packages="$package" --rerun-fails=1 --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -timeout 20m -tags=cionly > >(stdbuf -oL tee -a full.log | grep -vE "INFO|seal"); then
+              exit 1
+            fi
+          done
 
       - name: run tests with race detection
         if: matrix.test-mode == 'race'
         run: |
           packages=`go list ./...`
-          stdbuf -oL gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 --no-color=false -- ./... -race -timeout 30m -parallel=8 > >(stdbuf -oL tee full.log | grep -vE "INFO|seal")
+          for package in $packages; do
+            echo running tests for $package
+            if ! stdbuf -oL gotestsum --format short-verbose --packages="$package" --rerun-fails=1 --no-color=false -- -race -timeout 30m > >(stdbuf -oL tee -a full.log | grep -vE "INFO|seal"); then
+              exit 1
+            fi
+          done
 
       - name: run redis tests
         if: matrix.test-mode == 'defaults'
@@ -161,19 +171,34 @@ jobs:
         if: matrix.test-mode == 'challenge'
         run: |
           packages=`go list ./...`
-          stdbuf -oL gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 --no-color=false -- ./... -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=8 -tags=challengetest -run=TestChallenge > >(stdbuf -oL tee full.log | grep -vE "INFO|seal")
+          for package in $packages; do
+            echo running tests for $package
+            if ! stdbuf -oL gotestsum --format short-verbose --packages="$package" --rerun-fails=1 --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -tags=challengetest -run=TestChallenge > >(stdbuf -oL tee -a full.log | grep -vE "INFO|seal"); then
+              exit 1
+            fi
+          done
 
       - name: run stylus tests
         if: matrix.test-mode == 'stylus'
         run: |
           packages=`go list ./...`
-          stdbuf -oL gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 --no-color=false -- ./... -timeout 60m -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=8 -tags=stylustest -run="TestProgramArbitrator" > >(stdbuf -oL tee full.log | grep -vE "INFO|seal")
+          for package in $packages; do
+            echo running tests for $package
+            if ! stdbuf -oL gotestsum --format short-verbose --packages="$package" --rerun-fails=1 --no-color=false -- -timeout 60m -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -tags=stylustest -run="TestProgramArbitrator" > >(stdbuf -oL tee -a full.log | grep -vE "INFO|seal"); then
+              exit 1
+            fi
+          done
 
       - name: run long stylus tests
         if: matrix.test-mode == 'long'
         run: |
           packages=`go list ./...`
-          stdbuf -oL gotestsum --format short-verbose --packages="$packages" --rerun-fails=1 --no-color=false -- ./... -timeout 60m -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -parallel=8 -tags=stylustest -run="TestProgramLong" > >(stdbuf -oL tee full.log | grep -vE "INFO|seal")
+          for package in $packages; do
+            echo running tests for $package
+            if ! stdbuf -oL gotestsum --format short-verbose --packages="$package" --rerun-fails=1 --no-color=false -- -timeout 60m -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/... -tags=stylustest -run="TestProgramLong" > >(stdbuf -oL tee -a full.log | grep -vE "INFO|seal"); then
+              exit 1
+            fi
+          done
 
       - name: Archive detailed run log
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This averts a bug where gotesum seems to succeed if there were failures in multiple packages, some packages were o.k. after rerunning failures and some were not.

not sure if this is the best way - but it seems to work.

Here is an example of the problem: see how Go Test(default) step passes CI, and it's "run tests without race detection" step appears as passing even though it did record errors:
https://github.com/OffchainLabs/nitro/actions/runs/10015286108/job/27686456877

Here is execution for the same ci with said fix - notice that both (defaults) and (race) fail - correctly, when executed 3 times:
https://github.com/OffchainLabs/nitro/actions/runs/10014238547?pr=2504