### PR TITLE
Move validateMessageNumber method to arbdebug ns

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -779,7 +779,7 @@ func CreateNode(
 	}
 	if currentNode.StatelessBlockValidator != nil {
 		apis = append(apis, rpc.API{
-			Namespace: "arbvalidator",
+			Namespace: "arbdebug",
 			Version:   "1.0",
 			Service: &BlockValidatorDebugAPI{
 				val: currentNode.StatelessBlockValidator,


### PR DESCRIPTION
This is a debugging related call, changed namespace to make it clear.

Fixes NIT-2682