### PR TITLE
Handle error in syscall.Sync

### DIFF
--- a/das/local_file_storage_service.go
+++ b/das/local_file_storage_service.go
@@ -737,7 +737,9 @@ func (l *trieLayout) commitMigration() error {
 		return err
 	}
 
-	syscall.Sync()
+	if err := syscall.Sync(); err != nil {
+		return err
+	}
 
 	// Done migrating
 	l.migrating = false


### PR DESCRIPTION
This makes the linter pass that runs as part of `make`.