### PR TITLE
[NIT-2640] Add EVM tracing for Stylus programs

### DIFF
--- a/arbitrator/wasm-libraries/user-host-trait/src/lib.rs
+++ b/arbitrator/wasm-libraries/user-host-trait/src/lib.rs
@@ -534,7 +534,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
     fn return_data_size(&mut self) -> Result<u32, Self::Err> {
         self.buy_ink(HOSTIO_INK)?;
         let len = *self.evm_return_data_len();
-        trace!("return_data_size", self, be!(len), &[], len)
+        trace!("return_data_size", self, &[], be!(len), len)
     }
 
     /// Emits an EVM log with the given number of topics and data, the first bytes of which should
@@ -629,7 +629,8 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
         self.buy_gas(gas_cost)?;
 
         let code = code.slice();
-        trace!("account_code_size", self, address, &[], code.len() as u32)
+        let len = code.len() as u32;
+        trace!("account_code_size", self, address, be!(len), len)
     }
 
     /// Gets the code hash of the account at the given address. The semantics are equivalent
@@ -735,7 +736,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
     fn evm_gas_left(&mut self) -> Result<u64, Self::Err> {
         self.buy_ink(HOSTIO_INK)?;
         let gas = self.gas_left()?;
-        trace!("evm_gas_left", self, be!(gas), &[], gas)
+        trace!("evm_gas_left", self, &[], be!(gas), gas)
     }
 
     /// Gets the amount of ink remaining after paying for the cost of this hostio. The semantics
@@ -747,7 +748,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
     fn evm_ink_left(&mut self) -> Result<u64, Self::Err> {
         self.buy_ink(HOSTIO_INK)?;
         let ink = self.ink_ready()?;
-        trace!("evm_ink_left", self, be!(ink), &[], ink)
+        trace!("evm_ink_left", self, &[], be!(ink), ink)
     }
 
     /// Computes `value ÷ exponent` using 256-bit math, writing the result to the first.

--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -206,6 +206,9 @@ func callProgram(
 	if status == userFailure && debug {
 		log.Warn("program failure", "err", err, "msg", msg, "program", address, "depth", depth)
 	}
+	if tracingInfo != nil {
+		tracingInfo.CaptureStylusExit(uint8(status), data, err, scope.Contract.Gas)
+	}
 	return data, err
 }
 

--- a/arbos/util/storage_cache.go
+++ b/arbos/util/storage_cache.go
@@ -1,0 +1,76 @@
+// Copyright 2024, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package util
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type storageCacheEntry struct {
+	Value common.Hash
+	Known *common.Hash
+}
+
+func (e storageCacheEntry) dirty() bool {
+	return e.Known == nil || e.Value != *e.Known
+}
+
+type storageCacheStores struct {
+	Key   common.Hash
+	Value common.Hash
+}
+
+// storageCache mirrors the stylus storage cache on arbos when tracing a call.
+// This is useful for correctly reporting the SLOAD and SSTORE opcodes.
+type storageCache struct {
+	cache map[common.Hash]storageCacheEntry
+}
+
+func newStorageCache() *storageCache {
+	return &storageCache{
+		cache: make(map[common.Hash]storageCacheEntry),
+	}
+}
+
+// Load adds a value to the cache and returns true if the logger should emit a load opcode.
+func (s *storageCache) Load(key, value common.Hash) bool {
+	_, ok := s.cache[key]
+	if !ok {
+		// The value was not in cache, so it came from EVM
+		s.cache[key] = storageCacheEntry{
+			Value: value,
+			Known: &value,
+		}
+	}
+	return !ok
+}
+
+// Store updates the value on the cache.
+func (s *storageCache) Store(key, value common.Hash) {
+	entry := s.cache[key]
+	entry.Value = value // Do not change known value
+	s.cache[key] = entry
+}
+
+// Flush returns the store operations that should be logged.
+func (s *storageCache) Flush() []storageCacheStores {
+	stores := []storageCacheStores{}
+	for key, entry := range s.cache {
+		if entry.dirty() {
+			v := entry.Value // Create new var to avoid alliasing
+			entry.Known = &v
+			s.cache[key] = entry
+			stores = append(stores, storageCacheStores{
+				Key:   key,
+				Value: entry.Value,
+			})
+		}
+	}
+	return stores
+}
+
+// Clear clears the cache.
+func (s *storageCache) Clear() {
+	s.cache = make(map[common.Hash]storageCacheEntry)
+}

--- a/arbos/util/storage_cache_test.go
+++ b/arbos/util/storage_cache_test.go
@@ -1,0 +1,110 @@
+// Copyright 2024, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package util
+
+import (
+	"bytes"
+	"slices"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/go-cmp/cmp"
+	"github.com/offchainlabs/nitro/util/testhelpers"
+)
+
+func TestStorageCache(t *testing.T) {
+	keys := make([]common.Hash, 3)
+	values := make([]common.Hash, len(keys))
+	for i := range keys {
+		keys[i] = testhelpers.RandomHash()
+		values[i] = testhelpers.RandomHash()
+	}
+
+	cache := newStorageCache()
+
+	t.Run("load then load", func(t *testing.T) {
+		emitLog := cache.Load(keys[0], values[0])
+		if !emitLog {
+			t.Fatal("unexpected value in cache")
+		}
+		emitLog = cache.Load(keys[0], values[0])
+		if emitLog {
+			t.Fatal("expected value in cache")
+		}
+	})
+
+	t.Run("load another value", func(t *testing.T) {
+		emitLog := cache.Load(keys[1], values[1])
+		if !emitLog {
+			t.Fatal("unexpected value in cache")
+		}
+	})
+
+	t.Run("load then store", func(t *testing.T) {
+		_ = cache.Load(keys[2], values[0])
+		cache.Store(keys[2], values[2])
+		if !cache.cache[keys[2]].dirty() {
+			t.Fatal("expected value to be dirty")
+		}
+		if cache.cache[keys[2]].Value != values[2] {
+			t.Fatal("wrong value in cache")
+		}
+	})
+
+	t.Run("clear", func(t *testing.T) {
+		cache.Clear()
+		if len(cache.cache) != 0 {
+			t.Fatal("expected to be empty")
+		}
+	})
+
+	t.Run("store then load", func(t *testing.T) {
+		cache.Store(keys[0], values[0])
+		emitLog := cache.Load(keys[0], values[0])
+		if emitLog {
+			t.Fatal("expected value in cache")
+		}
+	})
+
+	t.Run("flush only stored", func(t *testing.T) {
+		_ = cache.Load(keys[1], values[1])
+		cache.Store(keys[2], values[2])
+		stores := cache.Flush()
+		expected := []storageCacheStores{
+			{Key: keys[0], Value: values[0]},
+			{Key: keys[2], Value: values[2]},
+		}
+		sortFunc := func(a, b storageCacheStores) int {
+			return bytes.Compare(a.Key.Bytes(), b.Key.Bytes())
+		}
+		slices.SortFunc(stores, sortFunc)
+		slices.SortFunc(expected, sortFunc)
+		if diff := cmp.Diff(stores, expected); diff != "" {
+			t.Fatalf("wrong flush: %s", diff)
+		}
+		// everything should still be in cache
+		for i := range keys {
+			entry, ok := cache.cache[keys[i]]
+			if !ok {
+				t.Fatal("entry missing from cache")
+			}
+			if entry.dirty() {
+				t.Fatal("dirty entry after flush")
+			}
+			if entry.Value != values[i] {
+				t.Fatal("wrong value in entry")
+			}
+		}
+	})
+
+	t.Run("do not flush known values", func(t *testing.T) {
+		cache.Clear()
+		_ = cache.Load(keys[0], values[0])
+		cache.Store(keys[0], values[0])
+		stores := cache.Flush()
+		if len(stores) != 0 {
+			t.Fatal("unexpected store")
+		}
+	})
+}

--- a/arbos/util/tracing.go
+++ b/arbos/util/tracing.go
@@ -4,11 +4,12 @@
 package util
 
 import (
-	"fmt"
+	"encoding/binary"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/holiman/uint256"
 )
 
@@ -46,23 +47,6 @@ func NewTracingInfo(evm *vm.EVM, from, to common.Address, scenario TracingScenar
 		Contract: vm.NewContract(addressHolder{to}, addressHolder{from}, uint256.NewInt(0), 0),
 		Depth:    evm.Depth(),
 	}
-}
-
-func (info *TracingInfo) RecordEmitLog(topics []common.Hash, data []byte) {
-	size := uint64(len(data))
-	var args []uint256.Int
-	args = append(args, *uint256.NewInt(0))    // offset: byte offset in the memory in bytes
-	args = append(args, *uint256.NewInt(size)) // size: byte size to copy (length of data)
-	for _, topic := range topics {
-		args = append(args, HashToUint256(topic)) // topic: 32-byte value. Max topics count is 4
-	}
-	scope := &vm.ScopeContext{
-		Memory:   TracingMemoryFromBytes(data),
-		Stack:    TracingStackFromArgs(args...),
-		Contract: info.Contract,
-	}
-	logType := fmt.Sprintf("LOG%d", len(topics))
-	info.Tracer.CaptureState(0, vm.StringToOp(logType), 0, 0, scope, []byte{}, info.Depth, nil)
 }
 
 func (info *TracingInfo) RecordStorageGet(key common.Hash) {
@@ -134,6 +118,424 @@ func (info *TracingInfo) MockCall(input []byte, gas uint64, from, to common.Addr
 		Contract: contract,
 	}
 	tracer.CaptureState(0, vm.POP, 0, 0, popScope, []byte{}, depth, nil)
+}
+
+func (info *TracingInfo) CaptureEVMTraceForHostio(name string, args, outs []byte, startInk, endInk uint64, scope *vm.ScopeContext, depth int) {
+	intToBytes := func(v int) []byte {
+		return binary.BigEndian.AppendUint64(nil, uint64(v))
+	}
+
+	checkArgs := func(want int) bool {
+		if len(args) < want {
+			log.Warn("tracing: missing arguments bytes for hostio", "name", name, "want", want, "got", len(args))
+			return false
+		}
+		return true
+	}
+
+	checkOuts := func(want int) bool {
+		if len(outs) < want {
+			log.Warn("tracing: missing outputs bytes for hostio", "name", name, "want", want, "got", len(args))
+			return false
+		}
+		return true
+	}
+
+	firstOpcode := true
+	capture := func(op vm.OpCode, memory []byte, stackValues ...[]byte) {
+		const inkToGas = 10000
+		var gas, cost uint64
+		if firstOpcode {
+			gas = startInk / inkToGas
+			cost = (startInk - endInk) / inkToGas
+			firstOpcode = false
+		} else {
+			// When capturing multiple opcodes, usually the first one is the relevant
+			// action and the following ones just pop the result values from the stack.
+			gas = endInk / inkToGas
+			cost = 0
+		}
+
+		stack := []uint256.Int{}
+		for _, value := range stackValues {
+			stack = append(stack, *uint256.NewInt(0).SetBytes(value))
+		}
+		scope := &vm.ScopeContext{
+			Memory:   TracingMemoryFromBytes(memory),
+			Stack:    TracingStackFromArgs(stack...),
+			Contract: scope.Contract,
+		}
+
+		info.Tracer.CaptureState(0, op, gas, cost, scope, []byte{}, depth, nil)
+	}
+
+	switch name {
+	case "read_args":
+		destOffset := []byte(nil)
+		offset := []byte(nil)
+		size := intToBytes(len(outs))
+		capture(vm.CALLDATACOPY, outs, destOffset, offset, size)
+
+	case "exit_early":
+		if !checkArgs(4) {
+			return
+		}
+		status := binary.BigEndian.Uint32(args[:4])
+		var opcode vm.OpCode
+		if status == 0 {
+			opcode = vm.RETURN
+		} else {
+			opcode = vm.REVERT
+		}
+		offset := []byte(nil)
+		size := []byte(nil)
+		capture(opcode, nil, offset, size)
+
+	case "storage_load_bytes32":
+		if !checkArgs(32) || !checkOuts(32) {
+			return
+		}
+		key := args[:32]
+		value := outs[:32]
+		capture(vm.SLOAD, nil, key)
+		capture(vm.POP, nil, value)
+
+	case "storage_cache_bytes32":
+		if !checkArgs(32 + 32) {
+			return
+		}
+		key := args[:32]
+		value := args[32:64]
+		capture(vm.SSTORE, nil, key, value)
+
+	case "storage_flush_cache":
+		// SSTORE is handled above by storage_cache_bytes32
+
+	case "transient_load_bytes32":
+		if !checkArgs(32) || !checkOuts(32) {
+			return
+		}
+		key := args[:32]
+		value := outs[:32]
+		capture(vm.TLOAD, nil, key)
+		capture(vm.POP, nil, value)
+
+	case "transient_store_bytes32":
+		if !checkArgs(32 + 32) {
+			return
+		}
+		key := args[:32]
+		value := args[32:64]
+		capture(vm.TSTORE, nil, key, value)
+
+	case "call_contract":
+		if !checkArgs(20+8+32) || !checkOuts(4+1) {
+			return
+		}
+		address := args[:20]
+		gas := args[20:28]
+		value := args[28:60]
+		callArgs := args[60:]
+		argsOffset := []byte(nil)
+		argsSize := intToBytes(len(callArgs))
+		retOffset := []byte(nil)
+		retSize := []byte(nil)
+		status := outs[4:5]
+		capture(vm.CALL, callArgs, gas, address, value, argsOffset, argsSize, retOffset, retSize)
+		capture(vm.POP, callArgs, status)
+
+	case "delegate_call_contract", "static_call_contract":
+		if !checkArgs(20+8) || !checkOuts(4+1) {
+			return
+		}
+		address := args[:20]
+		gas := args[20:28]
+		callArgs := args[28:]
+		argsOffset := []byte(nil)
+		argsSize := intToBytes(len(callArgs))
+		retOffset := []byte(nil)
+		retSize := []byte(nil)
+		status := outs[4:5]
+		var opcode vm.OpCode
+		if name == "delegate_call_contract" {
+			opcode = vm.DELEGATECALL
+		} else {
+			opcode = vm.STATICCALL
+		}
+		capture(opcode, callArgs, gas, address, argsOffset, argsSize, retOffset, retSize)
+		capture(vm.POP, callArgs, status)
+
+	case "create1":
+		if !checkArgs(32) || !checkOuts(20) {
+			return
+		}
+		value := args[:32]
+		code := args[32:]
+		offset := []byte(nil)
+		size := intToBytes(len(code))
+		address := outs[:20]
+		capture(vm.CREATE, code, value, offset, size)
+		capture(vm.POP, code, address)
+
+	case "create2":
+		if !checkArgs(32+32) || !checkOuts(20) {
+			return
+		}
+		value := args[:32]
+		salt := args[32:64]
+		code := args[64:]
+		offset := []byte(nil)
+		size := intToBytes(len(code))
+		address := outs[:20]
+		capture(vm.CREATE2, code, value, offset, size, salt)
+		capture(vm.POP, code, address)
+
+	case "read_return_data":
+		if !checkArgs(8) {
+			return
+		}
+		destOffset := []byte(nil)
+		offset := args[:4]
+		size := args[4:8]
+		capture(vm.RETURNDATACOPY, outs, destOffset, offset, size)
+
+	case "return_data_size":
+		if !checkOuts(4) {
+			return
+		}
+		size := outs[:4]
+		capture(vm.RETURNDATASIZE, nil)
+		capture(vm.POP, nil, size)
+
+	case "emit_log":
+		if !checkArgs(4) {
+			return
+		}
+		numTopics := int(binary.BigEndian.Uint32(args[:4]))
+		dataOffset := 4 + 32*numTopics
+		if !checkArgs(dataOffset) {
+			return
+		}
+		data := args[dataOffset:]
+		offset := []byte(nil)
+		size := intToBytes(len(data))
+		opcode := vm.LOG0 + vm.OpCode(numTopics)
+		stack := [][]byte{offset, size}
+		for i := 0; i < numTopics; i++ {
+			topic := args[4+32*i : 4+32*(i+1)]
+			stack = append(stack, topic)
+		}
+		capture(opcode, data, stack...)
+
+	case "account_balance":
+		if !checkArgs(20) || !checkOuts(32) {
+			return
+		}
+		address := args[:20]
+		balance := outs[:32]
+		capture(vm.BALANCE, nil, address)
+		capture(vm.POP, nil, balance)
+
+	case "account_code":
+		if !checkArgs(20 + 4 + 4) {
+			return
+		}
+		address := args[:20]
+		destOffset := []byte(nil)
+		offset := args[20:24]
+		size := args[24:28]
+		capture(vm.EXTCODECOPY, nil, address, destOffset, offset, size)
+
+	case "account_code_size":
+		if !checkArgs(20) || !checkOuts(4) {
+			return
+		}
+		address := args[:20]
+		size := outs[:4]
+		capture(vm.EXTCODESIZE, nil, address)
+		capture(vm.POP, nil, size)
+
+	case "account_codehash":
+		if !checkArgs(20) || !checkOuts(32) {
+			return
+		}
+		address := args[:20]
+		hash := outs[:32]
+		capture(vm.EXTCODEHASH, nil, address)
+		capture(vm.POP, nil, hash)
+
+	case "block_basefee":
+		if !checkOuts(32) {
+			return
+		}
+		baseFee := outs[:32]
+		capture(vm.BASEFEE, nil)
+		capture(vm.POP, nil, baseFee)
+
+	case "block_coinbase":
+		if !checkOuts(20) {
+			return
+		}
+		address := outs[:20]
+		capture(vm.COINBASE, nil)
+		capture(vm.POP, nil, address)
+
+	case "block_gas_limit":
+		if !checkOuts(8) {
+			return
+		}
+		gasLimit := outs[:8]
+		capture(vm.GASLIMIT, nil)
+		capture(vm.POP, nil, gasLimit)
+
+	case "block_number":
+		if !checkOuts(8) {
+			return
+		}
+		blockNumber := outs[:8]
+		capture(vm.NUMBER, nil)
+		capture(vm.POP, nil, blockNumber)
+
+	case "block_timestamp":
+		if !checkOuts(8) {
+			return
+		}
+		timestamp := outs[:8]
+		capture(vm.TIMESTAMP, nil)
+		capture(vm.POP, nil, timestamp)
+
+	case "chainid":
+		if !checkOuts(8) {
+			return
+		}
+		chainId := outs[:8]
+		capture(vm.CHAINID, nil)
+		capture(vm.POP, nil, chainId)
+
+	case "contract_address":
+		if !checkOuts(20) {
+			return
+		}
+		address := outs[:20]
+		capture(vm.ADDRESS, nil)
+		capture(vm.POP, nil, address)
+
+	case "evm_gas_left", "evm_ink_left":
+		if !checkOuts(8) {
+			return
+		}
+		gas := outs[:8]
+		capture(vm.GAS, nil)
+		capture(vm.POP, nil, gas)
+
+	case "math_div":
+		if !checkArgs(32+32) || !checkOuts(32) {
+			return
+		}
+		a := args[:32]
+		b := args[32:64]
+		result := outs[:32]
+		capture(vm.DIV, nil, a, b)
+		capture(vm.POP, nil, result)
+
+	case "math_mod":
+		if !checkArgs(32+32) || !checkOuts(32) {
+			return
+		}
+		a := args[:32]
+		b := args[32:64]
+		result := outs[:32]
+		capture(vm.MOD, nil, a, b)
+		capture(vm.POP, nil, result)
+
+	case "math_pow":
+		if !checkArgs(32+32) || !checkOuts(32) {
+			return
+		}
+		a := args[:32]
+		b := args[32:64]
+		result := outs[:32]
+		capture(vm.EXP, nil, a, b)
+		capture(vm.POP, nil, result)
+
+	case "math_add_mod":
+		if !checkArgs(32+32+32) || !checkOuts(32) {
+			return
+		}
+		a := args[:32]
+		b := args[32:64]
+		c := args[64:96]
+		result := outs[:32]
+		capture(vm.ADDMOD, nil, a, b, c)
+		capture(vm.POP, nil, result)
+
+	case "math_mul_mod":
+		if !checkArgs(32+32+32) || !checkOuts(32) {
+			return
+		}
+		a := args[:32]
+		b := args[32:64]
+		c := args[64:96]
+		result := outs[:32]
+		capture(vm.MULMOD, nil, a, b, c)
+		capture(vm.POP, nil, result)
+
+	case "msg_sender":
+		if !checkOuts(20) {
+			return
+		}
+		address := outs[:20]
+		capture(vm.CALLER, nil)
+		capture(vm.POP, nil, address)
+
+	case "msg_value":
+		if !checkOuts(32) {
+			return
+		}
+		value := outs[:32]
+		capture(vm.CALLVALUE, nil)
+		capture(vm.POP, nil, value)
+
+	case "native_keccak256":
+		if !checkOuts(32) {
+			return
+		}
+		offset := []byte(nil)
+		size := intToBytes(len(args))
+		hash := outs[:32]
+		capture(vm.KECCAK256, args, offset, size)
+		capture(vm.POP, args, hash)
+
+	case "tx_gas_price":
+		if !checkOuts(32) {
+			return
+		}
+		price := outs[:32]
+		capture(vm.GASPRICE, nil)
+		capture(vm.POP, nil, price)
+
+	case "tx_ink_price":
+		if !checkOuts(4) {
+			return
+		}
+		price := outs[:4]
+		capture(vm.GASPRICE, nil)
+		capture(vm.POP, nil, price)
+
+	case "tx_origin":
+		if !checkOuts(20) {
+			return
+		}
+		address := outs[:20]
+		capture(vm.ORIGIN, nil)
+		capture(vm.POP, nil, address)
+
+	case "user_entrypoint", "user_returned", "msg_reentrant", "write_result", "pay_for_memory_grow", "console_log_test", "console_log":
+		// No EVM counterpart
+
+	default:
+		log.Warn("unhandled hostio trace", "name", name)
+	}
 }
 
 func HashToUint256(hash common.Hash) uint256.Int {

--- a/arbos/util/tracing.go
+++ b/arbos/util/tracing.go
@@ -142,15 +142,14 @@ func (info *TracingInfo) CaptureEVMTraceForHostio(name string, args, outs []byte
 	firstOpcode := true
 	capture := func(op vm.OpCode, memory []byte, stackValues ...[]byte) {
 		const inkToGas = 10000
-		var gas, cost uint64
+		gas := endInk / inkToGas
+		var cost uint64
 		if firstOpcode {
-			gas = startInk / inkToGas
 			cost = (startInk - endInk) / inkToGas
 			firstOpcode = false
 		} else {
 			// When capturing multiple opcodes, usually the first one is the relevant
 			// action and the following ones just pop the result values from the stack.
-			gas = endInk / inkToGas
 			cost = 0
 		}
 		info.captureState(op, gas, cost, memory, stackValues...)

--- a/arbos/util/tracing.go
+++ b/arbos/util/tracing.go
@@ -482,7 +482,7 @@ func (info *TracingInfo) CaptureEVMTraceForHostio(name string, args, outs []byte
 	case "write_result", "exit_early":
 		// These calls are handled on CaptureStylusExit to also cover the normal exit case.
 
-	case "user_entrypoint", "user_returned", "msg_reentrant", "pay_for_memory_grow", "console_log_test", "console_log":
+	case "user_entrypoint", "user_returned", "msg_reentrant", "pay_for_memory_grow", "console_log_text", "console_log":
 		// No EVM counterpart
 
 	default:

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -1063,6 +1064,12 @@ func Require(t *testing.T, err error, text ...interface{}) {
 func Fatal(t *testing.T, printables ...interface{}) {
 	t.Helper()
 	testhelpers.FailImpl(t, printables...)
+}
+
+func CheckEqual[T any](t *testing.T, want T, got T) {
+	if !reflect.DeepEqual(want, got) {
+		Fatal(t, "wrong result, want ", want, ", got ", got)
+	}
 }
 
 func Create2ndNodeWithConfig(

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -1118,9 +1118,10 @@ func Fatal(t *testing.T, printables ...interface{}) {
 	testhelpers.FailImpl(t, printables...)
 }
 
-func CheckEqual[T any](t *testing.T, want T, got T) {
+func CheckEqual[T any](t *testing.T, want T, got T, printables ...interface{}) {
+	t.Helper()
 	if !reflect.DeepEqual(want, got) {
-		Fatal(t, "wrong result, want ", want, ", got ", got)
+		testhelpers.FailImpl(t, "wrong result, want ", want, ", got ", got, printables)
 	}
 }
 

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -1617,6 +1617,35 @@ func multicallAppend(calls []byte, opcode vm.OpCode, address common.Address, inn
 	return calls
 }
 
+func multicallEmptyArgs() []byte {
+	return []byte{0} // number of actions
+}
+
+func multicallAppendStore(args []byte, key, value common.Hash, emitLog bool) []byte {
+	var action byte = 0x10
+	if emitLog {
+		action |= 0x08
+	}
+	args[0] += 1
+	args = binary.BigEndian.AppendUint32(args, 1+64) // length
+	args = append(args, action)
+	args = append(args, key.Bytes()...)
+	args = append(args, value.Bytes()...)
+	return args
+}
+
+func multicallAppendLoad(args []byte, key common.Hash, emitLog bool) []byte {
+	var action byte = 0x11
+	if emitLog {
+		action |= 0x08
+	}
+	args[0] += 1
+	args = binary.BigEndian.AppendUint32(args, 1+32) // length
+	args = append(args, action)
+	args = append(args, key.Bytes()...)
+	return args
+}
+
 func assertStorageAt(
 	t *testing.T, ctx context.Context, l2client *ethclient.Client, contract common.Address, key, value common.Hash,
 ) {

--- a/system_tests/stylus_trace_test.go
+++ b/system_tests/stylus_trace_test.go
@@ -1,0 +1,406 @@
+// Copyright 2022-2024, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
+
+package arbtest
+
+import (
+	"encoding/binary"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/tracers/logger"
+	"github.com/holiman/uint256"
+	"github.com/offchainlabs/nitro/arbos/util"
+	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
+	"github.com/offchainlabs/nitro/util/testhelpers"
+)
+
+func sendAndTraceTransaction(
+	t *testing.T,
+	builder *NodeBuilder,
+	program common.Address,
+	value *big.Int,
+	data []byte,
+) logger.ExecutionResult {
+	ctx := builder.ctx
+	l2client := builder.L2.Client
+	l2info := builder.L2Info
+	rpcClient := builder.L2.ConsensusNode.Stack.Attach()
+
+	tx := l2info.PrepareTxTo("Owner", &program, l2info.TransferGas, value, data)
+	err := l2client.SendTransaction(ctx, tx)
+	Require(t, err)
+	_, err = EnsureTxSucceeded(ctx, l2client, tx)
+	Require(t, err)
+
+	var result logger.ExecutionResult
+	err = rpcClient.CallContext(ctx, &result, "debug_traceTransaction", tx.Hash(), nil)
+	Require(t, err, "failed to trace call")
+
+	for i, log := range result.StructLogs {
+		if log.Stack == nil {
+			stack := []string{}
+			log.Stack = &stack
+		}
+		t.Log("Trace call: i =", i, "| OpCode =", log.Op, "| Stack =", *log.Stack)
+	}
+
+	return result
+}
+
+func checkOpcode(t *testing.T, result logger.ExecutionResult, index int, wantOp vm.OpCode, wantStackSize int) {
+	CheckEqual(t, wantOp.String(), result.StructLogs[index].Op)
+	CheckEqual(t, wantStackSize, len(*result.StructLogs[index].Stack))
+}
+
+func checkOpcodeStack(t *testing.T, result logger.ExecutionResult, index int, wantOp vm.OpCode, wantStack ...[]byte) {
+	checkOpcode(t, result, index, wantOp, len(wantStack))
+
+	// reverse stack to canonical order
+	for i, j := 0, len(wantStack)-1; i < j; i, j = i+1, j-1 {
+		wantStack[i], wantStack[j] = wantStack[j], wantStack[i]
+
+	}
+
+	for i, wantBytes := range wantStack {
+		wantVal := uint256.NewInt(0).SetBytes(wantBytes).Hex()
+		CheckEqual(t, wantVal, (*result.StructLogs[index].Stack)[i])
+	}
+}
+
+func intToBytes(v int) []byte {
+	return binary.BigEndian.AppendUint64(nil, uint64(v))
+}
+
+func TestStylusTraceStorage(t *testing.T) {
+	const jit = false
+	builder, auth, cleanup := setupProgramTest(t, jit)
+	ctx := builder.ctx
+	l2client := builder.L2.Client
+	defer cleanup()
+
+	program := deployWasm(t, ctx, auth, l2client, rustFile("storage"))
+
+	key := testhelpers.RandomHash()
+	value := testhelpers.RandomHash()
+
+	trans := func(data []byte) []byte {
+		data[0] += 2
+		return data
+	}
+
+	// storage_cache_bytes32
+	result := sendAndTraceTransaction(t, builder, program, nil, argsForStorageWrite(key, value))
+	checkOpcodeStack(t, result, 3, vm.SSTORE, key[:], value[:])
+
+	// storage_load_bytes32
+	result = sendAndTraceTransaction(t, builder, program, nil, argsForStorageRead(key))
+	checkOpcodeStack(t, result, 3, vm.SLOAD, key[:])
+	checkOpcodeStack(t, result, 4, vm.POP, value[:])
+
+	// transient_store_bytes32
+	result = sendAndTraceTransaction(t, builder, program, nil, trans(argsForStorageWrite(key, value)))
+	checkOpcodeStack(t, result, 3, vm.TSTORE, key[:], value[:])
+
+	// transient_load_bytes32
+	result = sendAndTraceTransaction(t, builder, program, nil, trans(argsForStorageRead(key)))
+	checkOpcodeStack(t, result, 3, vm.TLOAD, key[:])
+	checkOpcodeStack(t, result, 4, vm.POP, nil)
+}
+
+func TestStylusTraceNativeKeccak(t *testing.T) {
+	const jit = false
+	builder, auth, cleanup := setupProgramTest(t, jit)
+	ctx := builder.ctx
+	l2client := builder.L2.Client
+	defer cleanup()
+
+	program := deployWasm(t, ctx, auth, l2client, watFile("timings/keccak"))
+
+	args := binary.LittleEndian.AppendUint32(nil, 1) // rounds
+	args = append(args, testhelpers.RandomSlice(123)...)
+	hash := crypto.Keccak256Hash(args) // the keccak.wat program computes the hash of the whole args
+
+	// native_keccak256
+	result := sendAndTraceTransaction(t, builder, program, nil, args)
+	checkOpcodeStack(t, result, 3, vm.KECCAK256, nil, intToBytes(len(args)))
+	checkOpcodeStack(t, result, 4, vm.POP, hash[:])
+}
+
+func TestStylusTraceMath(t *testing.T) {
+	const jit = false
+	builder, auth, cleanup := setupProgramTest(t, jit)
+	ctx := builder.ctx
+	l2client := builder.L2.Client
+	defer cleanup()
+
+	program := deployWasm(t, ctx, auth, l2client, rustFile("math"))
+	result := sendAndTraceTransaction(t, builder, program, nil, nil)
+
+	value := common.Hex2Bytes("eddecf107b5740cef7f5a01e3ea7e287665c4e75a8eb6afae2fda2e3d4367786")
+	unknown := common.Hex2Bytes("c6178c2de1078cd36c3bd302cde755340d7f17fcb3fcc0b9c333ba03b217029f")
+	ed25519 := common.Hex2Bytes("fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f")
+	results := [][]byte{
+		common.Hex2Bytes("b28a98598473836430b84078e55690d279cca19b9922f248c6a6ad6588d12494"),
+		common.Hex2Bytes("265b7ffdc26469bd58409a734987e66a5ece71a2312970d5403f395d24a31b85"),
+		common.Hex2Bytes("00000000000000002947e87fd2cf7e1eacd01ef1286c0d795168d90db4fc5bb3"),
+		common.Hex2Bytes("c4b1cfcc1423392b29d826de0b3779a096d543ad2b71f34aa4596bd97f493fbb"),
+		common.Hex2Bytes("00000000000000000000000000000000000000000000000015d41b922f2eafc5"),
+	}
+
+	// math_mul_mod
+	checkOpcodeStack(t, result, 3, vm.MULMOD, value, unknown, ed25519)
+	checkOpcodeStack(t, result, 4, vm.POP, results[0])
+
+	// math_add_mod
+	checkOpcodeStack(t, result, 5, vm.ADDMOD, results[0], ed25519, unknown)
+	checkOpcodeStack(t, result, 6, vm.POP, results[1])
+
+	// math_div
+	checkOpcodeStack(t, result, 7, vm.DIV, results[1], value[:8])
+	checkOpcodeStack(t, result, 8, vm.POP, results[2])
+
+	// math_pow
+	checkOpcodeStack(t, result, 9, vm.EXP, results[2], ed25519[24:32])
+	checkOpcodeStack(t, result, 10, vm.POP, results[3])
+
+	// math_mod
+	checkOpcodeStack(t, result, 11, vm.MOD, results[3], unknown[:8])
+	checkOpcodeStack(t, result, 12, vm.POP, results[4])
+}
+
+func TestStylusTraceExitEarly(t *testing.T) {
+	const jit = false
+	builder, auth, cleanup := setupProgramTest(t, jit)
+	ctx := builder.ctx
+	l2client := builder.L2.Client
+	defer cleanup()
+
+	program := deployWasm(t, ctx, auth, l2client, watFile("exit-early/exit-early"))
+	result := sendAndTraceTransaction(t, builder, program, nil, nil)
+
+	// exit_early
+	checkOpcodeStack(t, result, 3, vm.RETURN, nil, nil)
+}
+
+func TestStylusTraceEvmData(t *testing.T) {
+	const jit = false
+	builder, auth, cleanup := setupProgramTest(t, jit)
+	ctx := builder.ctx
+	l2info := builder.L2Info
+	l2client := builder.L2.Client
+	defer cleanup()
+
+	program := deployWasm(t, ctx, auth, l2client, rustFile("evm-data"))
+
+	fundedAddr := l2info.GetAddress("Faucet")
+	ethPrecompile := common.BigToAddress(big.NewInt(1))
+	arbTestAddress := types.ArbosTestAddress
+	burnArbGas, _ := util.NewCallParser(precompilesgen.ArbosTestABI, "burnArbGas")
+	gasToBurn := uint64(1000000)
+	callBurnData, err := burnArbGas(new(big.Int).SetUint64(gasToBurn))
+	Require(t, err)
+
+	data := []byte{}
+	data = append(data, fundedAddr.Bytes()...)
+	data = append(data, ethPrecompile.Bytes()...)
+	data = append(data, arbTestAddress.Bytes()...)
+	data = append(data, program.Bytes()...)
+	data = append(data, callBurnData...)
+	result := sendAndTraceTransaction(t, builder, program, nil, data)
+
+	fundedBalance, err := l2client.BalanceAt(ctx, fundedAddr, nil)
+	Require(t, err)
+	programCode, err := l2client.CodeAt(ctx, program, nil)
+	Require(t, err)
+	programCodehash := crypto.Keccak256(programCode)
+	owner := l2info.GetAddress("Owner")
+
+	// read_args
+	checkOpcodeStack(t, result, 2, vm.CALLDATACOPY, nil, nil, intToBytes(len(data)))
+
+	// account_balance
+	checkOpcodeStack(t, result, 3, vm.BALANCE, fundedAddr[:])
+	checkOpcodeStack(t, result, 4, vm.POP, fundedBalance.Bytes())
+
+	// account_codehash
+	checkOpcodeStack(t, result, 9, vm.EXTCODEHASH, program[:])
+	checkOpcodeStack(t, result, 10, vm.POP, programCodehash)
+
+	// account_code_size
+	checkOpcodeStack(t, result, 11, vm.EXTCODESIZE, program[:])
+	checkOpcodeStack(t, result, 12, vm.POP, intToBytes(len(programCode)))
+
+	// account_code
+	checkOpcodeStack(t, result, 13, vm.EXTCODECOPY, program[:], nil, nil, intToBytes(len(programCode)))
+
+	// block_basefee
+	checkOpcodeStack(t, result, 26, vm.BASEFEE)
+	checkOpcode(t, result, 27, vm.POP, 1)
+
+	// chainid
+	checkOpcodeStack(t, result, 28, vm.CHAINID)
+	checkOpcodeStack(t, result, 29, vm.POP, intToBytes(412346))
+
+	// block_coinbase
+	checkOpcodeStack(t, result, 30, vm.COINBASE)
+	checkOpcode(t, result, 31, vm.POP, 1)
+
+	// block_gas_limit
+	checkOpcodeStack(t, result, 32, vm.GASLIMIT)
+	checkOpcode(t, result, 33, vm.POP, 1)
+
+	// block_timestamp
+	checkOpcodeStack(t, result, 34, vm.TIMESTAMP)
+	checkOpcode(t, result, 35, vm.POP, 1)
+
+	// contract_address
+	checkOpcodeStack(t, result, 36, vm.ADDRESS)
+	checkOpcodeStack(t, result, 37, vm.POP, program[:])
+
+	// msg_sender
+	checkOpcodeStack(t, result, 38, vm.CALLER)
+	checkOpcodeStack(t, result, 39, vm.POP, owner[:])
+
+	// msg_value
+	checkOpcodeStack(t, result, 40, vm.CALLVALUE)
+	checkOpcodeStack(t, result, 41, vm.POP, nil)
+
+	// tx_origin
+	checkOpcodeStack(t, result, 42, vm.ORIGIN)
+	checkOpcodeStack(t, result, 43, vm.POP, owner[:])
+
+	// tx_gas_price
+	checkOpcodeStack(t, result, 44, vm.GASPRICE)
+	checkOpcode(t, result, 45, vm.POP, 1)
+
+	// tx_ink_price
+	checkOpcodeStack(t, result, 46, vm.GASPRICE)
+	checkOpcode(t, result, 47, vm.POP, 1)
+
+	// block_number
+	checkOpcodeStack(t, result, 48, vm.NUMBER)
+	checkOpcode(t, result, 49, vm.POP, 1)
+
+	// evm_gas_left
+	checkOpcodeStack(t, result, 50, vm.GAS)
+	checkOpcode(t, result, 51, vm.POP, 1)
+
+	// evm_ink_left
+	checkOpcodeStack(t, result, 52, vm.GAS)
+	checkOpcode(t, result, 53, vm.POP, 1)
+}
+
+func TestStylusTraceLog(t *testing.T) {
+	const jit = false
+	builder, auth, cleanup := setupProgramTest(t, jit)
+	ctx := builder.ctx
+	l2client := builder.L2.Client
+	defer cleanup()
+
+	program := deployWasm(t, ctx, auth, l2client, rustFile("log"))
+
+	const numTopics = 4
+	const logSize = 123
+	expectedStack := [][]byte{nil, intToBytes(logSize)}
+	args := []byte{numTopics}
+	for i := 0; i < numTopics; i++ {
+		topic := testhelpers.RandomSlice(32)
+		expectedStack = append(expectedStack, topic)
+		args = append(args, topic...) // topic
+	}
+	args = append(args, testhelpers.RandomSlice(logSize)...) // log
+
+	result := sendAndTraceTransaction(t, builder, program, nil, args)
+
+	// emit_log
+	checkOpcodeStack(t, result, 3, vm.LOG4, expectedStack...)
+}
+
+func TestStylusTraceReturnDataSize(t *testing.T) {
+	const jit = false
+	builder, auth, cleanup := setupProgramTest(t, jit)
+	ctx := builder.ctx
+	l2client := builder.L2.Client
+	defer cleanup()
+
+	program := deployWasm(t, ctx, auth, l2client, watFile("timings/return_data_size"))
+	args := binary.LittleEndian.AppendUint32(nil, 1) // rounds
+	result := sendAndTraceTransaction(t, builder, program, nil, args)
+
+	// return_data_size
+	checkOpcodeStack(t, result, 3, vm.RETURNDATASIZE)
+	checkOpcodeStack(t, result, 4, vm.POP, nil)
+}
+
+func TestStylusTraceCall(t *testing.T) {
+	const jit = false
+	builder, auth, cleanup := setupProgramTest(t, jit)
+	ctx := builder.ctx
+	l2client := builder.L2.Client
+	defer cleanup()
+
+	storage := deployWasm(t, ctx, auth, l2client, rustFile("storage"))
+	multicall := deployWasm(t, ctx, auth, l2client, rustFile("multicall"))
+	key := testhelpers.RandomHash()
+	innerArgs := argsForStorageRead(key)
+	gas := common.Hex2Bytes("ffffffffffffffff")
+	argsLen := intToBytes(len(innerArgs))
+	returnLen := intToBytes(32)
+
+	args := argsForMulticall(vm.CALL, storage, nil, innerArgs)
+	args = multicallAppend(args, vm.DELEGATECALL, storage, innerArgs)
+	args = multicallAppend(args, vm.STATICCALL, storage, innerArgs)
+	result := sendAndTraceTransaction(t, builder, multicall, nil, args)
+
+	// call_contract
+	checkOpcodeStack(t, result, 6, vm.CALL, gas, storage[:], nil, nil, argsLen, nil, nil)
+	checkOpcodeStack(t, result, 7, vm.POP, nil)
+
+	// read_return_data
+	checkOpcodeStack(t, result, 8, vm.RETURNDATACOPY, nil, nil, returnLen)
+
+	// delegate_call_contract
+	checkOpcodeStack(t, result, 12, vm.DELEGATECALL, gas, storage[:], nil, argsLen, nil, nil)
+
+	// static_call_contract
+	checkOpcodeStack(t, result, 18, vm.STATICCALL, gas, storage[:], nil, argsLen, nil, nil)
+}
+
+func TestStylusTraceCreate(t *testing.T) {
+	const jit = false
+	builder, auth, cleanup := setupProgramTest(t, jit)
+	ctx := builder.ctx
+	l2client := builder.L2.Client
+	defer cleanup()
+
+	program := deployWasm(t, ctx, auth, l2client, rustFile("create"))
+
+	deployWasm, _ := readWasmFile(t, rustFile("storage"))
+	deployCode := deployContractInitCode(deployWasm, false)
+	startValue := testhelpers.RandomCallValue(1e5)
+	salt := testhelpers.RandomHash()
+	create1Addr := crypto.CreateAddress(program, 1)
+	create2Addr := crypto.CreateAddress2(program, salt, crypto.Keccak256(deployCode))
+
+	// create1
+	create1Args := []byte{0x01}
+	create1Args = append(create1Args, common.BigToHash(startValue).Bytes()...)
+	create1Args = append(create1Args, deployCode...)
+	result := sendAndTraceTransaction(t, builder, program, startValue, create1Args)
+	checkOpcodeStack(t, result, 10, vm.CREATE, startValue.Bytes(), nil, intToBytes(len(deployCode)))
+	checkOpcodeStack(t, result, 11, vm.POP, create1Addr[:])
+
+	// create2
+	create2Args := []byte{0x02}
+	create2Args = append(create2Args, common.BigToHash(startValue).Bytes()...)
+	create2Args = append(create2Args, salt[:]...)
+	create2Args = append(create2Args, deployCode...)
+	result = sendAndTraceTransaction(t, builder, program, startValue, create2Args)
+	checkOpcodeStack(t, result, 10, vm.CREATE2, startValue.Bytes(), nil, intToBytes(len(deployCode)), salt[:])
+	checkOpcodeStack(t, result, 11, vm.POP, create2Addr[:])
+}

--- a/system_tests/stylus_trace_test.go
+++ b/system_tests/stylus_trace_test.go
@@ -480,4 +480,13 @@ func TestStylusOpcodeTraceEquivalence(t *testing.T) {
 
 	checkOpcode(t, wasmResult, 8, vm.SSTORE, key[:], value[:])
 	checkOpcode(t, evmResult, 4723, vm.SSTORE, key[:], value[:])
+
+	// inner return
+	returnLen := intToBytes(0x20)
+	checkOpcode(t, wasmResult, 10, vm.RETURN, offset, returnLen)
+	checkOpcode(t, evmResult, 4828, vm.RETURN, offset, returnLen)
+
+	// outer return
+	checkOpcode(t, wasmResult, 12, vm.RETURN, offset, returnLen)
+	checkOpcode(t, evmResult, 5078, vm.RETURN, offset, returnLen)
 }


### PR DESCRIPTION
Stylus programs perform HostIO calls when they need to interact with the EVM state, for instance, when loading a value from storage. When performing these calls, we want to capture EVM traces as if they were being executed on the EVM. So, when a stylus program loads a value from storage, we want to emit a trace for the SLOAD opcode.

We should set up a fake EVM stack for each opcode as if it were being executed in the EVM. We should also emit a POP opcode after emitting a trace for an opcode that leaves a value on the stack. 

When a Stylus program performs a HostIO (mostly in `arbitrator/wasm-libraries/user-host-trait/src/lib.rs`), the host-calling library also calls a special `CaptureHostIO` HostIO, passing the call's name, arguments, and outputs.

On the host side, Nitro now handles this call on `arbos/programs/api.go`. The API now calls the `TracingInfo.CaptureEVMTraceForHostio` method to generate the EVM traces for all HostIOs based on their names.

This PR centralizes all the EVM traces in the `CaptureEVMTraceForHostio` method and removes redundant tracing code on the programs' API. It also adds tests specifically for the EVM traces on Stylus.

**Example**

Here is an example trace for a transaction that performs a write and then a read to the [storage contract](https://github.com/OffchainLabs/nitro/blob/3fc95e6a1152ff8841a9ab40e43432dca48ec883/arbitrator/stylus/tests/storage/src/main.rs) using the [multi-call contract](https://github.com/OffchainLabs/nitro/blob/3fc95e6a1152ff8841a9ab40e43432dca48ec883/arbitrator/stylus/tests/multicall/src/main.rs).

```
{
  "gas": 249657,
  "failed": false,
  "returnValue": "117094d34db10679fa57f2146afe957557635232129eef332049aeed23a53c98",
  "structLogs": [
    {
      "pc": 0,
      "op": "SLOAD",
      "gas": 0,
      "gasCost": 0,
      "depth": 1,
      "stack": [
        "0x0"
      ],
      "storage": {
        "0000000000000000000000000000000000000000000000000000000000000000": "0000000000000000000000000000000000000000000000000000000000000000"
      }
    },
    {
      "pc": 0,
      "op": "SLOAD",
      "gas": 0,
      "gasCost": 0,
      "depth": 1,
      "stack": [
        "0x3c79da47f96b0f39664f73c0a1f350580be90742947dddfa21ba64d578dfe600"
      ],
      "storage": {
        "0000000000000000000000000000000000000000000000000000000000000000": "0000000000000000000000000000000000000000000000000000000000000000",
        "3c79da47f96b0f39664f73c0a1f350580be90742947dddfa21ba64d578dfe600": "0000000000000000000000000000000000000000000000000000000000000000"
      }
    },
    {
      "pc": 0,
      "op": "CALLDATACOPY",
      "gas": 8798120,
      "gasCost": 1,
      "depth": 1,
      "stack": [
        "0xd5",
        "0x0",
        "0x0"
      ]
    },
    {
      "pc": 0,
      "op": "CALL",
      "gas": 7712916,
      "gasCost": 7715516,
      "depth": 1,
      "stack": [
        "0x0",
        "0x0",
        "0x41",
        "0x0",
        "0x0",
        "0x457b1ba688e9854bdbed2f473f7510c476a3da09",
        "0x75b094"
      ]
    },
    {
      "pc": 0,
      "op": "CALLDATACOPY",
      "gas": 8643741,
      "gasCost": 1,
      "depth": 2,
      "stack": [
        "0x41",
        "0x0",
        "0x0"
      ]
    },
    {
      "pc": 0,
      "op": "SSTORE",
      "gas": 8643732,
      "gasCost": 1,
      "depth": 2,
      "stack": [
        "0x117094d34db10679fa57f2146afe957557635232129eef332049aeed23a53c98",
        "0x6102537d4b5c24fa4582f62653740c8e110e5b5d3b037f7f5dba539ed460550d"
      ],
      "storage": {
        "6102537d4b5c24fa4582f62653740c8e110e5b5d3b037f7f5dba539ed460550d": "117094d34db10679fa57f2146afe957557635232129eef332049aeed23a53c98"
      }
    },
    {
      "pc": 0,
      "op": "STOP",
      "gas": 7700411,
      "gasCost": 0,
      "depth": 2,
      "stack": []
    },
    {
      "pc": 0,
      "op": "CALL",
      "gas": 7700481,
      "gasCost": 7700581,
      "depth": 1,
      "stack": [
        "0x0",
        "0x0",
        "0x21",
        "0x0",
        "0x0",
        "0x457b1ba688e9854bdbed2f473f7510c476a3da09",
        "0x758001"
      ]
    },
    {
      "pc": 0,
      "op": "CALLDATACOPY",
      "gas": 8629783,
      "gasCost": 1,
      "depth": 2,
      "stack": [
        "0x21",
        "0x0",
        "0x0"
      ]
    },
    {
      "pc": 0,
      "op": "SLOAD",
      "gas": 8629774,
      "gasCost": 67097,
      "depth": 2,
      "stack": [
        "0x6102537d4b5c24fa4582f62653740c8e110e5b5d3b037f7f5dba539ed460550d"
      ],
      "storage": {
        "6102537d4b5c24fa4582f62653740c8e110e5b5d3b037f7f5dba539ed460550d": "0000000000000000000000000000000000000000000000000000000000000000"
      }
    },
    {
      "pc": 0,
      "op": "POP",
      "gas": 8562677,
      "gasCost": 0,
      "depth": 2,
      "stack": [
        "0x117094d34db10679fa57f2146afe957557635232129eef332049aeed23a53c98"
      ]
    },
    {
      "pc": 0,
      "op": "RETURN",
      "gas": 7628190,
      "gasCost": 0,
      "depth": 2,
      "stack": [
        "0x20",
        "0x0"
      ]
    },
    {
      "pc": 0,
      "op": "RETURNDATACOPY",
      "gas": 8699820,
      "gasCost": 7,
      "depth": 1,
      "stack": [
        "0x20",
        "0x0",
        "0x0"
      ]
    },
    {
      "pc": 0,
      "op": "RETURN",
      "gas": 7750343,
      "gasCost": 0,
      "depth": 1,
      "stack": [
        "0x20",
        "0x0"
      ]
    }
  ]
}
```