### PR TITLE
remove errcheck lint from syscal.Sync

### DIFF
--- a/das/local_file_storage_service.go
+++ b/das/local_file_storage_service.go
@@ -737,6 +737,8 @@ func (l *trieLayout) commitMigration() error {
 		return err
 	}
 
+	// in OSX - syscall.Sync() returns an error, but in linux it does not.
+	// nolint:errcheck
 	syscall.Sync()
 
 	// Done migrating


### PR DESCRIPTION
syscall.Sync returns an error on OSx, so in this OS - lint step fails without an error check.

However, on Linux syscall.Sync does not return an error so an error check will not compile, see #2527 

Solution: don't check the error, don't lint this line.
