### PR TITLE
Check all "not found" errors

### DIFF
--- a/arbnode/dataposter/dbstorage/storage.go
+++ b/arbnode/dataposter/dbstorage/storage.go
@@ -7,14 +7,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/offchainlabs/nitro/arbnode/dataposter/storage"
 	"github.com/offchainlabs/nitro/util/dbutil"
-	"github.com/syndtr/goleveldb/leveldb"
 )
 
 // Storage implements db based storage for batch poster.
@@ -61,7 +59,7 @@ func (s *Storage) Get(_ context.Context, index uint64) (*storage.QueuedTransacti
 	key := idxToKey(index)
 	value, err := s.db.Get(key)
 	if err != nil {
-		if isErrNotFound(err) {
+		if dbutil.IsErrNotFound(err) {
 			return nil, nil
 		}
 		return nil, err

--- a/arbnode/dataposter/dbstorage/storage.go
+++ b/arbnode/dataposter/dbstorage/storage.go
@@ -61,7 +61,7 @@ func (s *Storage) Get(_ context.Context, index uint64) (*storage.QueuedTransacti
 	key := idxToKey(index)
 	value, err := s.db.Get(key)
 	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) {
+		if isErrNotFound(err) {
 			return nil, nil
 		}
 		return nil, err


### PR DESCRIPTION
Currently only the leveldb not found errors are handled. If a pebble not found error is returned by the backend it is propagated, causing the batchposter to fail to send transactions.

```
ERROR[07-30|07:16:29.468] failed to re-send transaction            err="couldn't get preceding tx in DataPoster to check if should send tx with nonce 142: pebble: not found" nonce=142 feeCap=32,434,520,350 tipCap=56,469,658 blobFeeCap=<nil> gas=1,586,650
...
ERROR[07-30|07:14:20.688] error posting batch                      err="pebble: not found"
```

We saw this error only appear recently and I believe it's because the default was changed from `leveldb` to `pebble` here

https://github.com/OffchainLabs/nitro/pull/2447/files

With this change all DB not found errors are handled the same way.

(cherry picked from commit 85068866fb3f409cebfc0a5c446bdab05e655d03)