### PR TITLE
Make 3 troublesome tests not run in parallel with others.

### DIFF
--- a/system_tests/full_challenge_mock_test.go
+++ b/system_tests/full_challenge_mock_test.go
@@ -7,7 +7,6 @@ package arbtest
 import "testing"
 
 func TestMockChallengeManagerAsserterIncorrect(t *testing.T) {
-	t.Parallel()
 	defaultWasmRootDir := ""
 	for i := int64(1); i <= makeBatch_MsgsPerBatch*3; i++ {
 		RunChallengeTest(t, false, true, i, defaultWasmRootDir)
@@ -15,7 +14,6 @@ func TestMockChallengeManagerAsserterIncorrect(t *testing.T) {
 }
 
 func TestMockChallengeManagerAsserterCorrect(t *testing.T) {
-	t.Parallel()
 	defaultWasmRootDir := ""
 	for i := int64(1); i <= makeBatch_MsgsPerBatch*3; i++ {
 		RunChallengeTest(t, true, true, i, defaultWasmRootDir)

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -397,7 +397,6 @@ func storageTest(t *testing.T, jit bool) {
 }
 
 func TestProgramTransientStorage(t *testing.T) {
-	t.Parallel()
 	transientStorageTest(t, true)
 }
 


### PR DESCRIPTION
These tests sometimes fail when they are run in parallel with others on a Mac.

With this change a `make clean && make all && make test-go` actually works on my Mac.

Related to NIT-2696