### PR TITLE
Message index/count refactor - Part 1

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1259,7 +1259,7 @@ func (b *BatchPoster) MaybePostSequencerBatch(ctx context.Context) (bool, error)
 		var use4844 bool
 		config := b.config()
 		if config.Post4844Blobs && b.dapWriter == nil && latestHeader.ExcessBlobGas != nil && latestHeader.BlobGasUsed != nil {
-			arbOSVersion, err := b.arbOSVersionGetter.ArbOSVersionForMessageNumber(arbutil.MessageIndex(arbmath.SaturatingUSub(uint64(batchPosition.MessageCount), 1)))
+			arbOSVersion, err := b.arbOSVersionGetter.ArbOSVersionForMessageIndex(arbutil.MessageIndex(arbmath.SaturatingUSub(uint64(batchPosition.MessageCount), 1)))
 			if err != nil {
 				return false, err
 			}

--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -81,12 +81,12 @@ func (w *execClientWrapper) Reorg(count arbutil.MessageIndex, newMessages []arbo
 	return containers.NewReadyPromise(w.ExecutionEngine.Reorg(count, newMessages, oldMessages))
 }
 
-func (w *execClientWrapper) HeadMessageNumber() containers.PromiseInterface[arbutil.MessageIndex] {
-	return containers.NewReadyPromise(w.ExecutionEngine.HeadMessageNumber())
+func (w *execClientWrapper) HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex] {
+	return containers.NewReadyPromise(w.ExecutionEngine.HeadMessageIndex())
 }
 
-func (w *execClientWrapper) ResultAtPos(pos arbutil.MessageIndex) containers.PromiseInterface[*execution.MessageResult] {
-	return containers.NewReadyPromise(w.ExecutionEngine.ResultAtPos(pos))
+func (w *execClientWrapper) ResultAtMessageIndex(pos arbutil.MessageIndex) containers.PromiseInterface[*execution.MessageResult] {
+	return containers.NewReadyPromise(w.ExecutionEngine.ResultAtMessageIndex(pos))
 }
 
 func (w *execClientWrapper) Start(ctx context.Context) containers.PromiseInterface[struct{}] {

--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -192,7 +192,7 @@ func TestTransactionStreamer(t *testing.T) {
 			if blockStates[reorgTo].numMessages == 0 {
 				Fail(t, "invalid reorg target")
 			}
-			err := inbox.ReorgTo(blockStates[reorgTo].numMessages - 1)
+			err := inbox.ReorgAt(blockStates[reorgTo].numMessages)
 			if err != nil {
 				Fail(t, err)
 			}

--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -189,7 +189,10 @@ func TestTransactionStreamer(t *testing.T) {
 	for i := 1; i < 100; i++ {
 		if i%10 == 0 {
 			reorgTo := rand.Int() % len(blockStates)
-			err := inbox.ReorgTo(blockStates[reorgTo].numMessages)
+			if blockStates[reorgTo].numMessages == 0 {
+				Fail(t, "invalid reorg target")
+			}
+			err := inbox.ReorgTo(blockStates[reorgTo].numMessages - 1)
 			if err != nil {
 				Fail(t, err)
 			}

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -303,7 +303,7 @@ func (t *InboxTracker) PopulateFeedBacklog(broadcastServer *broadcaster.Broadcas
 			return fmt.Errorf("error getting message %v: %w", seqNum, err)
 		}
 
-		msgResult, err := t.txStreamer.ResultAtCount(seqNum + 1)
+		msgResult, err := t.txStreamer.ResultAtMessageIndex(seqNum)
 		var blockHash *common.Hash
 		if err == nil {
 			blockHash = &msgResult.BlockHash

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -307,7 +307,7 @@ func (t *InboxTracker) PopulateFeedBacklog(broadcastServer *broadcaster.Broadcas
 			blockHash = &msgResult.BlockHash
 		}
 
-		blockMetadata, err := t.txStreamer.BlockMetadataAtCount(seqNum + 1)
+		blockMetadata, err := t.txStreamer.BlockMetadataAtMessageIndex(seqNum)
 		if err != nil {
 			log.Warn("Error getting blockMetadata byte array from tx streamer", "err", err)
 		}

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -32,8 +32,6 @@ import (
 var (
 	inboxLatestBatchGauge        = metrics.NewRegisteredGauge("arb/inbox/latest/batch", nil)
 	inboxLatestBatchMessageGauge = metrics.NewRegisteredGauge("arb/inbox/latest/batch/message", nil)
-
-	invalidReorgMsgIndex = errors.New("invalid reorg message index")
 )
 
 type InboxTracker struct {
@@ -616,11 +614,7 @@ func (t *InboxTracker) setDelayedCountReorgAndWriteBatch(batch ethdb.Batch, firs
 		}
 	}
 	// Writes batch
-	if prevMessageCount == 0 {
-		return invalidReorgMsgIndex
-	}
-	prevHeadMsgIdx := prevMessageCount - 1
-	return t.txStreamer.ReorgToAndEndBatch(batch, prevHeadMsgIdx)
+	return t.txStreamer.ReorgAtAndEndBatch(batch, prevMessageCount)
 }
 
 type multiplexerBackend struct {
@@ -942,9 +936,5 @@ func (t *InboxTracker) ReorgBatchesTo(count uint64) error {
 		return err
 	}
 	log.Info("InboxTracker", "SequencerBatchCount", count)
-	if prevBatchMeta.MessageCount == 0 {
-		return invalidReorgMsgIndex
-	}
-	prevBatchHeadMsgIdx := prevBatchMeta.MessageCount - 1
-	return t.txStreamer.ReorgToAndEndBatch(dbBatch, prevBatchHeadMsgIdx)
+	return t.txStreamer.ReorgAtAndEndBatch(dbBatch, prevBatchMeta.MessageCount)
 }

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1526,6 +1526,6 @@ func (n *Node) ExpectChosenSequencer() error {
 	return n.TxStreamer.ExpectChosenSequencer()
 }
 
-func (n *Node) BlockMetadataAtCount(count arbutil.MessageIndex) (common.BlockMetadata, error) {
-	return n.TxStreamer.BlockMetadataAtCount(count)
+func (n *Node) BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) (common.BlockMetadata, error) {
+	return n.TxStreamer.BlockMetadataAtMessageIndex(msgIdx)
 }

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -540,7 +540,7 @@ func (s *TransactionStreamer) GetProcessedMessageCount() (arbutil.MessageIndex, 
 	if err != nil {
 		return 0, err
 	}
-	digestedHead, err := s.exec.HeadMessageNumber().Await(s.GetContext())
+	digestedHead, err := s.exec.HeadMessageIndex().Await(s.GetContext())
 	if err != nil {
 		return 0, err
 	}
@@ -1281,7 +1281,7 @@ func (s *TransactionStreamer) ExecuteNextMsg(ctx context.Context) bool {
 		return false
 	}
 	s.execLastMsgCount = msgCount
-	pos, err := s.exec.HeadMessageNumber().Await(ctx)
+	pos, err := s.exec.HeadMessageIndex().Await(ctx)
 	if err != nil {
 		log.Error("feedOneMsg failed to get exec engine message count", "err", err)
 		return false

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -768,7 +768,7 @@ func (s *TransactionStreamer) getPrevPrevDelayedRead(pos arbutil.MessageIndex) (
 }
 
 func (s *TransactionStreamer) countDuplicateMessages(
-	pos arbutil.MessageIndex,
+	msgIdx arbutil.MessageIndex,
 	messages []arbostypes.MessageWithMetadataAndBlockInfo,
 	batch *ethdb.Batch,
 ) (uint64, bool, *arbostypes.MessageWithMetadata, error) {
@@ -777,7 +777,7 @@ func (s *TransactionStreamer) countDuplicateMessages(
 		if uint64(len(messages)) == curMsg {
 			break
 		}
-		key := dbKey(messagePrefix, uint64(pos))
+		key := dbKey(messagePrefix, uint64(msgIdx))
 		hasMessage, err := s.db.Has(key)
 		if err != nil {
 			return 0, false, nil, err
@@ -800,7 +800,7 @@ func (s *TransactionStreamer) countDuplicateMessages(
 
 			if err := rlp.DecodeBytes(haveMessage, &dbMessageParsed); err != nil {
 				log.Warn("TransactionStreamer: Reorg detected! (failed parsing db message)",
-					"pos", pos,
+					"msgIdx", msgIdx,
 					"err", err,
 				)
 				return curMsg, true, nil, nil
@@ -823,7 +823,7 @@ func (s *TransactionStreamer) countDuplicateMessages(
 							if *batch == nil {
 								*batch = s.db.NewBatch()
 							}
-							if err := s.writeMessage(pos, nextMessage, *batch); err != nil {
+							if err := s.writeMessage(msgIdx, nextMessage, *batch); err != nil {
 								return 0, false, nil, err
 							}
 						}
@@ -838,7 +838,7 @@ func (s *TransactionStreamer) countDuplicateMessages(
 		}
 
 		curMsg++
-		pos++
+		msgIdx++
 	}
 
 	return curMsg, false, nil, nil

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1117,13 +1117,13 @@ func (s *TransactionStreamer) writeMessage(msgIdx arbutil.MessageIndex, msg arbo
 
 func (s *TransactionStreamer) broadcastMessages(
 	msgs []arbostypes.MessageWithMetadataAndBlockInfo,
-	pos arbutil.MessageIndex,
+	firstMsgIdx arbutil.MessageIndex,
 ) {
 	if s.broadcastServer == nil {
 		return
 	}
-	if err := s.broadcastServer.BroadcastMessages(msgs, pos); err != nil {
-		log.Error("failed broadcasting messages", "pos", pos, "err", err)
+	if err := s.broadcastServer.BroadcastMessages(msgs, firstMsgIdx); err != nil {
+		log.Error("failed broadcasting messages", "firstMsgIdx", firstMsgIdx, "err", err)
 	}
 }
 

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -371,7 +371,7 @@ func (s *TransactionStreamer) reorg(batch ethdb.Batch, count arbutil.MessageInde
 	s.reorgMutex.Lock()
 	defer s.reorgMutex.Unlock()
 
-	messagesResults, err := s.exec.Reorg(count, newMessages, oldMessages).Await(s.GetContext())
+	messagesResults, err := s.exec.Reorg(count-1, newMessages, oldMessages).Await(s.GetContext())
 	if err != nil {
 		return err
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -217,7 +217,7 @@ func (s *TransactionStreamer) ReorgTo(newHeadMsgIdx arbutil.MessageIndex) error 
 func (s *TransactionStreamer) ReorgToAndEndBatch(batch ethdb.Batch, newHeadMsgIdx arbutil.MessageIndex) error {
 	s.insertionMutex.Lock()
 	defer s.insertionMutex.Unlock()
-	err := s.reorg(batch, newHeadMsgIdx, nil)
+	err := s.addMessagesAndReorg(batch, newHeadMsgIdx, nil)
 	if err != nil {
 		return err
 	}
@@ -281,7 +281,7 @@ func deleteFromRange(ctx context.Context, db ethdb.Database, prefix []byte, star
 
 // The insertion mutex must be held. This acquires the reorg mutex.
 // Note: oldMessages will be empty if reorgHook is nil
-func (s *TransactionStreamer) reorg(batch ethdb.Batch, lastMsgIdxToKeep arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo) error {
+func (s *TransactionStreamer) addMessagesAndReorg(batch ethdb.Batch, lastMsgIdxToKeep arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo) error {
 	lastDelayedMsgIdx, err := s.getPrevPrevDelayedRead(lastMsgIdxToKeep + 1)
 	if err != nil {
 		return err
@@ -963,7 +963,7 @@ func (s *TransactionStreamer) addMessagesAndEndBatchImpl(firstMsgIdx arbutil.Mes
 			return invalidReorgMsgIndex
 		}
 		reorgBatch := s.db.NewBatch()
-		err := s.reorg(reorgBatch, firstMsgIdx-1, messages)
+		err := s.addMessagesAndReorg(reorgBatch, firstMsgIdx-1, messages)
 		if err != nil {
 			return err
 		}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -299,6 +299,7 @@ func (s *TransactionStreamer) addMessagesAndReorg(batch ethdb.Batch, msgIdxOfFir
 	config := s.config()
 
 	numberOfOldMsgsAfterLastMsgToKeep := currentHeadMsgIdx - msgIdxOfFirstMsgToAdd + 1
+	// #nosec G115
 	numberOfOldMsgsToResequence := min(
 		arbutil.MessageIndex(config.MaxReorgResequenceDepth),
 		numberOfOldMsgsAfterLastMsgToKeep,

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1218,7 +1218,7 @@ func (s *TransactionStreamer) ResultAtMessageIndex(msgIdx arbutil.MessageIndex) 
 	return msgResult, nil
 }
 
-func (s *TransactionStreamer) checkResult(pos arbutil.MessageIndex, msgResult *execution.MessageResult, msgAndBlockInfo *arbostypes.MessageWithMetadataAndBlockInfo) {
+func (s *TransactionStreamer) checkResult(msgIdx arbutil.MessageIndex, msgResult *execution.MessageResult, msgAndBlockInfo *arbostypes.MessageWithMetadataAndBlockInfo) {
 	if msgAndBlockInfo.BlockHash == nil {
 		return
 	}
@@ -1230,18 +1230,18 @@ func (s *TransactionStreamer) checkResult(pos arbutil.MessageIndex, msgResult *e
 		)
 		// Try deleting the existing blockMetadata for this block in arbDB and set it as missing
 		if msgAndBlockInfo.BlockMetadata != nil &&
-			s.trackBlockMetadataFrom != 0 && pos >= s.trackBlockMetadataFrom {
+			s.trackBlockMetadataFrom != 0 && msgIdx >= s.trackBlockMetadataFrom {
 			batch := s.db.NewBatch()
-			if err := batch.Delete(dbKey(blockMetadataInputFeedPrefix, uint64(pos))); err != nil {
-				log.Error("error deleting blockMetadata of block whose BlockHash from feed doesn't match locally computed hash", "msgSeqNum", pos, "err", err)
+			if err := batch.Delete(dbKey(blockMetadataInputFeedPrefix, uint64(msgIdx))); err != nil {
+				log.Error("error deleting blockMetadata of block whose BlockHash from feed doesn't match locally computed hash", "msgIdx", msgIdx, "err", err)
 				return
 			}
-			if err := batch.Put(dbKey(missingBlockMetadataInputFeedPrefix, uint64(pos)), nil); err != nil {
-				log.Error("error marking deleted blockMetadata as missing in arbDB for a block whose BlockHash from feed doesn't match locally computed hash", "msgSeqNum", pos, "err", err)
+			if err := batch.Put(dbKey(missingBlockMetadataInputFeedPrefix, uint64(msgIdx)), nil); err != nil {
+				log.Error("error marking deleted blockMetadata as missing in arbDB for a block whose BlockHash from feed doesn't match locally computed hash", "msgIdx", msgIdx, "err", err)
 				return
 			}
 			if err := batch.Write(); err != nil {
-				log.Error("error writing batch that deletes blockMetadata of the block whose BlockHash from feed doesn't match locally computed hash", "msgSeqNum", pos, "err", err)
+				log.Error("error writing batch that deletes blockMetadata of the block whose BlockHash from feed doesn't match locally computed hash", "msgIdx", msgIdx, "err", err)
 			}
 		}
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -749,15 +749,15 @@ func (s *TransactionStreamer) AddMessagesAndEndBatch(firstMsgIdx arbutil.Message
 	return s.addMessagesAndEndBatchImpl(firstMsgIdx, messagesAreConfirmed, messagesWithBlockInfo, batch)
 }
 
-func (s *TransactionStreamer) getPrevPrevDelayedRead(pos arbutil.MessageIndex) (uint64, error) {
-	if s.snapSyncConfig.Enabled && uint64(pos) == s.snapSyncConfig.PrevBatchMessageCount {
+func (s *TransactionStreamer) getPrevPrevDelayedRead(msgIdx arbutil.MessageIndex) (uint64, error) {
+	if s.snapSyncConfig.Enabled && uint64(msgIdx) == s.snapSyncConfig.PrevBatchMessageCount {
 		return s.snapSyncConfig.PrevDelayedRead, nil
 	}
 	var prevDelayedRead uint64
-	if pos > 0 {
-		prevMsg, err := s.GetMessage(pos - 1)
+	if msgIdx > 0 {
+		prevMsg, err := s.GetMessage(msgIdx - 1)
 		if err != nil {
-			return 0, fmt.Errorf("failed to get previous message for pos %d: %w", pos, err)
+			return 0, fmt.Errorf("failed to get previous message for msgIdx %d: %w", msgIdx, err)
 		}
 		prevDelayedRead = prevMsg.DelayedMessagesRead
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -926,7 +926,7 @@ func (s *TransactionStreamer) addMessagesAndEndBatchImpl(firstMsgIdx arbutil.Mes
 			return err
 		}
 		if numberOfDuplicates > 0 {
-			lastDelayedRead = messages[numberOfDuplicates].MessageWithMeta.DelayedMessagesRead
+			lastDelayedRead = messages[numberOfDuplicates-1].MessageWithMeta.DelayedMessagesRead
 			messages = messages[numberOfDuplicates:]
 			firstMsgIdx += arbutil.MessageIndex(numberOfDuplicates)
 		}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -842,7 +842,7 @@ func (s *TransactionStreamer) countDuplicateMessages(
 	return curMsg, false, nil, nil
 }
 
-func (s *TransactionStreamer) logReorg(pos arbutil.MessageIndex, dbMsg *arbostypes.MessageWithMetadata, newMsg *arbostypes.MessageWithMetadata, confirmed bool) {
+func (s *TransactionStreamer) logReorg(msgIdx arbutil.MessageIndex, dbMsg *arbostypes.MessageWithMetadata, newMsg *arbostypes.MessageWithMetadata, confirmed bool) {
 	sendLog := confirmed
 	if time.Now().After(s.nextAllowedFeedReorgLog) {
 		sendLog = true
@@ -851,7 +851,7 @@ func (s *TransactionStreamer) logReorg(pos arbutil.MessageIndex, dbMsg *arbostyp
 		s.nextAllowedFeedReorgLog = time.Now().Add(time.Minute)
 		log.Warn("TransactionStreamer: Reorg detected!",
 			"confirmed", confirmed,
-			"pos", pos,
+			"msgIdx", msgIdx,
 			"got-delayed", newMsg.DelayedMessagesRead,
 			"got-header", newMsg.Message.Header,
 			"db-delayed", dbMsg.DelayedMessagesRead,

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1202,7 +1202,7 @@ func (s *TransactionStreamer) ResultAtCount(count arbutil.MessageIndex) (*execut
 	if s.Started() {
 		ctx = s.GetContext()
 	}
-	msgResult, err := s.exec.ResultAtPos(pos).Await(ctx)
+	msgResult, err := s.exec.ResultAtMessageIndex(pos).Await(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -447,8 +447,8 @@ func dbKey(prefix []byte, pos uint64) []byte {
 }
 
 // Note: if changed to acquire the mutex, some internal users may need to be updated to a non-locking version.
-func (s *TransactionStreamer) GetMessage(seqNum arbutil.MessageIndex) (*arbostypes.MessageWithMetadata, error) {
-	key := dbKey(messagePrefix, uint64(seqNum))
+func (s *TransactionStreamer) GetMessage(msgIdx arbutil.MessageIndex) (*arbostypes.MessageWithMetadata, error) {
+	key := dbKey(messagePrefix, uint64(msgIdx))
 	data, err := s.db.Get(key)
 	if err != nil {
 		return nil, err

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1129,19 +1129,19 @@ func (s *TransactionStreamer) broadcastMessages(
 
 // The mutex must be held, and pos must be the latest message count.
 // `batch` may be nil, which initializes a new batch. The batch is closed out in this function.
-func (s *TransactionStreamer) writeMessages(pos arbutil.MessageIndex, messages []arbostypes.MessageWithMetadataAndBlockInfo, batch ethdb.Batch) error {
+func (s *TransactionStreamer) writeMessages(firstMsgIdx arbutil.MessageIndex, messages []arbostypes.MessageWithMetadataAndBlockInfo, batch ethdb.Batch) error {
 	if batch == nil {
 		batch = s.db.NewBatch()
 	}
 	for i, msg := range messages {
 		// #nosec G115
-		err := s.writeMessage(pos+arbutil.MessageIndex(i), msg, batch)
+		err := s.writeMessage(firstMsgIdx+arbutil.MessageIndex(i), msg, batch)
 		if err != nil {
 			return err
 		}
 	}
 
-	err := setMessageCount(batch, pos+arbutil.MessageIndex(len(messages)))
+	err := setMessageCount(batch, firstMsgIdx+arbutil.MessageIndex(len(messages)))
 	if err != nil {
 		return err
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -508,16 +508,16 @@ func (s *TransactionStreamer) getMessageWithMetadataAndBlockInfo(seqNum arbutil.
 
 // Note: if changed to acquire the mutex, some internal users may need to be updated to a non-locking version.
 func (s *TransactionStreamer) GetMessageCount() (arbutil.MessageIndex, error) {
-	posBytes, err := s.db.Get(messageCountKey)
+	countBytes, err := s.db.Get(messageCountKey)
 	if err != nil {
 		return 0, err
 	}
-	var pos uint64
-	err = rlp.DecodeBytes(posBytes, &pos)
+	var count uint64
+	err = rlp.DecodeBytes(countBytes, &count)
 	if err != nil {
 		return 0, err
 	}
-	return arbutil.MessageIndex(pos), nil
+	return arbutil.MessageIndex(count), nil
 }
 
 func (s *TransactionStreamer) GetProcessedMessageCount() (arbutil.MessageIndex, error) {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -210,14 +210,14 @@ func (s *TransactionStreamer) cleanupInconsistentState() error {
 	return nil
 }
 
-func (s *TransactionStreamer) ReorgTo(newHeadMsgIdx arbutil.MessageIndex) error {
-	return s.ReorgToAndEndBatch(s.db.NewBatch(), newHeadMsgIdx)
+func (s *TransactionStreamer) ReorgAt(firstMsgIdxToReorg arbutil.MessageIndex) error {
+	return s.ReorgAtAndEndBatch(s.db.NewBatch(), firstMsgIdxToReorg)
 }
 
-func (s *TransactionStreamer) ReorgToAndEndBatch(batch ethdb.Batch, newHeadMsgIdx arbutil.MessageIndex) error {
+func (s *TransactionStreamer) ReorgAtAndEndBatch(batch ethdb.Batch, firstMsgIdxToReorg arbutil.MessageIndex) error {
 	s.insertionMutex.Lock()
 	defer s.insertionMutex.Unlock()
-	err := s.addMessagesAndReorg(batch, newHeadMsgIdx+1, nil)
+	err := s.addMessagesAndReorg(batch, firstMsgIdxToReorg, nil)
 	if err != nil {
 		return err
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -210,14 +210,14 @@ func (s *TransactionStreamer) cleanupInconsistentState() error {
 	return nil
 }
 
-func (s *TransactionStreamer) ReorgAt(firstMsgIdxReorg arbutil.MessageIndex) error {
-	return s.ReorgAtAndEndBatch(s.db.NewBatch(), firstMsgIdxReorg)
+func (s *TransactionStreamer) ReorgAt(firstMsgIdxReorged arbutil.MessageIndex) error {
+	return s.ReorgAtAndEndBatch(s.db.NewBatch(), firstMsgIdxReorged)
 }
 
-func (s *TransactionStreamer) ReorgAtAndEndBatch(batch ethdb.Batch, firstMsgIdxReorg arbutil.MessageIndex) error {
+func (s *TransactionStreamer) ReorgAtAndEndBatch(batch ethdb.Batch, firstMsgIdxReorged arbutil.MessageIndex) error {
 	s.insertionMutex.Lock()
 	defer s.insertionMutex.Unlock()
-	err := s.addMessagesAndReorg(batch, firstMsgIdxReorg, nil)
+	err := s.addMessagesAndReorg(batch, firstMsgIdxReorged, nil)
 	if err != nil {
 		return err
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1128,7 +1128,7 @@ func (s *TransactionStreamer) broadcastMessages(
 	}
 }
 
-// The mutex must be held, and pos must be the latest message count.
+// The mutex must be held, and firstMsgIdx must be the latest message count.
 // `batch` may be nil, which initializes a new batch. The batch is closed out in this function.
 func (s *TransactionStreamer) writeMessages(firstMsgIdx arbutil.MessageIndex, messages []arbostypes.MessageWithMetadataAndBlockInfo, batch ethdb.Batch) error {
 	if batch == nil {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -474,8 +474,8 @@ func (s *TransactionStreamer) GetMessage(msgIdx arbutil.MessageIndex) (*arbostyp
 	return &message, nil
 }
 
-func (s *TransactionStreamer) getMessageWithMetadataAndBlockInfo(seqNum arbutil.MessageIndex) (*arbostypes.MessageWithMetadataAndBlockInfo, error) {
-	msg, err := s.GetMessage(seqNum)
+func (s *TransactionStreamer) getMessageWithMetadataAndBlockInfo(msgIdx arbutil.MessageIndex) (*arbostypes.MessageWithMetadataAndBlockInfo, error) {
+	msg, err := s.GetMessage(msgIdx)
 	if err != nil {
 		return nil, err
 	}
@@ -483,7 +483,7 @@ func (s *TransactionStreamer) getMessageWithMetadataAndBlockInfo(seqNum arbutil.
 	// Get block hash.
 	// To keep it backwards compatible, since it is possible that a message related
 	// to a sequence number exists in the database, but the block hash doesn't.
-	key := dbKey(blockHashInputFeedPrefix, uint64(seqNum))
+	key := dbKey(blockHashInputFeedPrefix, uint64(msgIdx))
 	var blockHash *common.Hash
 	data, err := s.db.Get(key)
 	if err == nil {
@@ -497,7 +497,7 @@ func (s *TransactionStreamer) getMessageWithMetadataAndBlockInfo(seqNum arbutil.
 		return nil, err
 	}
 
-	blockMetadata, err := s.BlockMetadataAtCount(seqNum + 1)
+	blockMetadata, err := s.BlockMetadataAtCount(msgIdx + 1)
 	if err != nil {
 		return nil, err
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1018,15 +1018,15 @@ func (s *TransactionStreamer) WriteMessageFromSequencer(
 	defer s.insertionMutex.Unlock()
 
 	headMsgIdx, err := s.GetHeadMessageIndex()
-	nextHeadMsgIdx := headMsgIdx + 1
+	expectedMsgIdx := headMsgIdx + 1
 	if errors.Is(err, ErrNoMessages) {
-		nextHeadMsgIdx = 0
+		expectedMsgIdx = 0
 	} else if err != nil {
 		return err
 	}
 
-	if msgIdx != nextHeadMsgIdx {
-		return fmt.Errorf("wrong msgIdx got %d expected %d", msgIdx, nextHeadMsgIdx)
+	if msgIdx != expectedMsgIdx {
+		return fmt.Errorf("wrong msgIdx got %d expected %d", msgIdx, expectedMsgIdx)
 	}
 
 	if s.coordinator != nil {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1247,7 +1247,7 @@ func (s *TransactionStreamer) checkResult(pos arbutil.MessageIndex, msgResult *e
 }
 
 func (s *TransactionStreamer) storeResult(
-	pos arbutil.MessageIndex,
+	msgIdx arbutil.MessageIndex,
 	msgResult execution.MessageResult,
 	batch ethdb.Batch,
 ) error {
@@ -1255,7 +1255,7 @@ func (s *TransactionStreamer) storeResult(
 	if err != nil {
 		return err
 	}
-	key := dbKey(messageResultPrefix, uint64(pos))
+	key := dbKey(messageResultPrefix, uint64(msgIdx))
 	return batch.Put(key, msgResultBytes)
 }
 

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -210,14 +210,14 @@ func (s *TransactionStreamer) cleanupInconsistentState() error {
 	return nil
 }
 
-func (s *TransactionStreamer) ReorgAt(firstMsgIdxToReorg arbutil.MessageIndex) error {
-	return s.ReorgAtAndEndBatch(s.db.NewBatch(), firstMsgIdxToReorg)
+func (s *TransactionStreamer) ReorgAt(firstMsgIdxReorg arbutil.MessageIndex) error {
+	return s.ReorgAtAndEndBatch(s.db.NewBatch(), firstMsgIdxReorg)
 }
 
-func (s *TransactionStreamer) ReorgAtAndEndBatch(batch ethdb.Batch, firstMsgIdxToReorg arbutil.MessageIndex) error {
+func (s *TransactionStreamer) ReorgAtAndEndBatch(batch ethdb.Batch, firstMsgIdxReorg arbutil.MessageIndex) error {
 	s.insertionMutex.Lock()
 	defer s.insertionMutex.Unlock()
-	err := s.addMessagesAndReorg(batch, firstMsgIdxToReorg, nil)
+	err := s.addMessagesAndReorg(batch, firstMsgIdxReorg, nil)
 	if err != nil {
 		return err
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -553,18 +553,18 @@ func (s *TransactionStreamer) AddMessages(firstMsgIdx arbutil.MessageIndex, mess
 }
 
 func (s *TransactionStreamer) FeedPendingMessageCount() arbutil.MessageIndex {
-	pos := s.broadcasterQueuedMessagesFirstMsgIdx.Load()
-	if pos == 0 {
+	firstMsgIdx := s.broadcasterQueuedMessagesFirstMsgIdx.Load()
+	if firstMsgIdx == 0 {
 		return 0
 	}
 
 	s.insertionMutex.Lock()
 	defer s.insertionMutex.Unlock()
-	pos = s.broadcasterQueuedMessagesFirstMsgIdx.Load()
-	if pos == 0 {
+	firstMsgIdx = s.broadcasterQueuedMessagesFirstMsgIdx.Load()
+	if firstMsgIdx == 0 {
 		return 0
 	}
-	return arbutil.MessageIndex(pos + uint64(len(s.broadcasterQueuedMessages)))
+	return arbutil.MessageIndex(firstMsgIdx + uint64(len(s.broadcasterQueuedMessages)))
 }
 
 func (s *TransactionStreamer) AddBroadcastMessages(feedMessages []*m.BroadcastFeedMessage) error {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -372,7 +372,7 @@ func (s *TransactionStreamer) addMessagesAndReorg(batch ethdb.Batch, lastMsgIdxT
 	s.reorgMutex.Lock()
 	defer s.reorgMutex.Unlock()
 
-	messagesResults, err := s.exec.Reorg(lastMsgIdxToKeep, newMessages, oldMessages).Await(s.GetContext())
+	messagesResults, err := s.exec.Reorg(lastMsgIdxToKeep+1, newMessages, oldMessages).Await(s.GetContext())
 	if err != nil {
 		return err
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -729,12 +729,12 @@ func (s *TransactionStreamer) AddMessagesAndEndBatch(firstMsgIdx arbutil.Message
 			log.Warn("TransactionStreamer: failed to mark feed start", "firstMsgIdx", firstMsgIdx, "err", err)
 		}
 		s.reorgMutex.RLock()
-		dups, _, _, err := s.countDuplicateMessages(firstMsgIdx, messagesWithBlockInfo, nil)
+		numberOfDuplicates, _, _, err := s.countDuplicateMessages(firstMsgIdx, messagesWithBlockInfo, nil)
 		s.reorgMutex.RUnlock()
 		if err != nil {
 			return err
 		}
-		if dups == uint64(len(messages)) {
+		if numberOfDuplicates == uint64(len(messages)) {
 			return endBatch(batch)
 		}
 		// cant keep reorg lock when catching insertionMutex.

--- a/arbutil/block_message_relation.go
+++ b/arbutil/block_message_relation.go
@@ -6,14 +6,11 @@ package arbutil
 // messages are 0-indexed
 type MessageIndex uint64
 
-// represents the number of messages
-type MessageCount uint64
-
-func BlockNumberToMessageCount(blockNumber uint64, genesisBlockNumber uint64) MessageCount {
-	return MessageCount(blockNumber + 1 - genesisBlockNumber)
+func BlockNumberToMessageCount(blockNumber uint64, genesisBlockNumber uint64) MessageIndex {
+	return MessageIndex(blockNumber + 1 - genesisBlockNumber)
 }
 
-func MessageCountToBlockNumber(messageCount MessageCount, genesisBlockNumber uint64) int64 {
+func MessageCountToBlockNumber(messageCount MessageIndex, genesisBlockNumber uint64) int64 {
 	// #nosec G115
 	return int64(uint64(messageCount)+genesisBlockNumber) - 1
 }

--- a/arbutil/block_message_relation.go
+++ b/arbutil/block_message_relation.go
@@ -3,19 +3,23 @@
 
 package arbutil
 
+// messages are 0-indexed
 type MessageIndex uint64
 
-func BlockNumberToMessageCount(blockNumber uint64, genesisBlockNumber uint64) MessageIndex {
-	return MessageIndex(blockNumber + 1 - genesisBlockNumber)
+// represents the number of messages
+type MessageCount uint64
+
+func BlockNumberToMessageCount(blockNumber uint64, genesisBlockNumber uint64) MessageCount {
+	return MessageCount(blockNumber + 1 - genesisBlockNumber)
 }
 
 // Block number must correspond to a message count, meaning it may not be less than -1
-func SignedBlockNumberToMessageCount(blockNumber int64, genesisBlockNumber uint64) MessageIndex {
+func SignedBlockNumberToMessageCount(blockNumber int64, genesisBlockNumber uint64) MessageCount {
 	// #nosec G115
-	return MessageIndex(uint64(blockNumber+1) - genesisBlockNumber)
+	return MessageCount(uint64(blockNumber+1) - genesisBlockNumber)
 }
 
-func MessageCountToBlockNumber(messageCount MessageIndex, genesisBlockNumber uint64) int64 {
+func MessageCountToBlockNumber(messageCount MessageCount, genesisBlockNumber uint64) int64 {
 	// #nosec G115
 	return int64(uint64(messageCount)+genesisBlockNumber) - 1
 }

--- a/arbutil/block_message_relation.go
+++ b/arbutil/block_message_relation.go
@@ -13,12 +13,6 @@ func BlockNumberToMessageCount(blockNumber uint64, genesisBlockNumber uint64) Me
 	return MessageCount(blockNumber + 1 - genesisBlockNumber)
 }
 
-// Block number must correspond to a message count, meaning it may not be less than -1
-func SignedBlockNumberToMessageCount(blockNumber int64, genesisBlockNumber uint64) MessageCount {
-	// #nosec G115
-	return MessageCount(uint64(blockNumber+1) - genesisBlockNumber)
-}
-
 func MessageCountToBlockNumber(messageCount MessageCount, genesisBlockNumber uint64) int64 {
 	// #nosec G115
 	return int64(uint64(messageCount)+genesisBlockNumber) - 1

--- a/broadcaster/broadcaster.go
+++ b/broadcaster/broadcaster.go
@@ -68,7 +68,7 @@ func (b *Broadcaster) NewBroadcastFeedMessage(
 
 func (b *Broadcaster) BroadcastSingle(
 	msg arbostypes.MessageWithMetadata,
-	seq arbutil.MessageIndex,
+	msgIdx arbutil.MessageIndex,
 	blockHash *common.Hash,
 	blockMetadata common.BlockMetadata,
 ) (err error) {
@@ -78,7 +78,7 @@ func (b *Broadcaster) BroadcastSingle(
 			err = errors.New("panic in BroadcastSingle")
 		}
 	}()
-	bfm, err := b.NewBroadcastFeedMessage(msg, seq, blockHash, blockMetadata)
+	bfm, err := b.NewBroadcastFeedMessage(msg, msgIdx, blockHash, blockMetadata)
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func (b *Broadcaster) BroadcastSingleFeedMessage(bfm *m.BroadcastFeedMessage) {
 
 func (b *Broadcaster) BroadcastMessages(
 	messagesWithBlockInfo []arbostypes.MessageWithMetadataAndBlockInfo,
-	seq arbutil.MessageIndex,
+	firstMsgIdx arbutil.MessageIndex,
 ) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -108,7 +108,7 @@ func (b *Broadcaster) BroadcastMessages(
 	var feedMessages []*m.BroadcastFeedMessage
 	for i, msg := range messagesWithBlockInfo {
 		// #nosec G115
-		bfm, err := b.NewBroadcastFeedMessage(msg.MessageWithMeta, seq+arbutil.MessageIndex(i), msg.BlockHash, msg.BlockMetadata)
+		bfm, err := b.NewBroadcastFeedMessage(msg.MessageWithMeta, firstMsgIdx+arbutil.MessageIndex(i), msg.BlockHash, msg.BlockMetadata)
 		if err != nil {
 			return err
 		}
@@ -121,21 +121,19 @@ func (b *Broadcaster) BroadcastMessages(
 }
 
 func (b *Broadcaster) BroadcastFeedMessages(messages []*m.BroadcastFeedMessage) {
-
 	bm := &m.BroadcastMessage{
 		Version:  1,
 		Messages: messages,
 	}
-
 	b.server.Broadcast(bm)
 }
 
-func (b *Broadcaster) Confirm(seq arbutil.MessageIndex) {
-	log.Debug("confirming sequence number", "sequenceNumber", seq)
+func (b *Broadcaster) Confirm(msgIdx arbutil.MessageIndex) {
+	log.Debug("confirming msgIdx", "msgIdx", msgIdx)
 	b.server.Broadcast(&m.BroadcastMessage{
 		Version: 1,
 		ConfirmedSequenceNumberMessage: &m.ConfirmedSequenceNumberMessage{
-			SequenceNumber: seq,
+			SequenceNumber: msgIdx,
 		},
 	})
 }

--- a/cmd/pruning/pruning.go
+++ b/cmd/pruning/pruning.go
@@ -213,7 +213,7 @@ func findImportantRoots(ctx context.Context, chainDb ethdb.Database, stack *node
 				return nil, err
 			}
 			if meta.ParentChainBlock <= l1BlockNum {
-				signedBlockNum := arbutil.MessageCountToBlockNumber(arbutil.MessageCount(meta.MessageCount), genesisNum)
+				signedBlockNum := arbutil.MessageCountToBlockNumber(meta.MessageCount, genesisNum)
 				// #nosec G115
 				blockNum := uint64(signedBlockNum)
 				l2Hash := rawdb.ReadCanonicalHash(chainDb, blockNum)

--- a/cmd/pruning/pruning.go
+++ b/cmd/pruning/pruning.go
@@ -213,7 +213,7 @@ func findImportantRoots(ctx context.Context, chainDb ethdb.Database, stack *node
 				return nil, err
 			}
 			if meta.ParentChainBlock <= l1BlockNum {
-				signedBlockNum := arbutil.MessageCountToBlockNumber(meta.MessageCount, genesisNum)
+				signedBlockNum := arbutil.MessageCountToBlockNumber(arbutil.MessageCount(meta.MessageCount), genesisNum)
 				// #nosec G115
 				blockNum := uint64(signedBlockNum)
 				l2Hash := rawdb.ReadCanonicalHash(chainDb, blockNum)

--- a/execution/gethexec/blockmetadata.go
+++ b/execution/gethexec/blockmetadata.go
@@ -18,7 +18,7 @@ import (
 var ErrBlockMetadataApiBlocksLimitExceeded = errors.New("number of blocks requested for blockMetadata exceeded")
 
 type BlockMetadataFetcher interface {
-	BlockMetadataAtCount(count arbutil.MessageIndex) (common.BlockMetadata, error)
+	BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) (common.BlockMetadata, error)
 	BlockNumberToMessageIndex(blockNum uint64) (arbutil.MessageIndex, error)
 	MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) uint64
 	SetReorgEventsNotifier(reorgEventsNotifier chan struct{})
@@ -81,7 +81,7 @@ func (b *BulkBlockMetadataFetcher) Fetch(fromBlock, toBlock rpc.BlockNumber) ([]
 			data, found = b.cache.Get(i)
 		}
 		if !found {
-			data, err = b.fetcher.BlockMetadataAtCount(i + 1)
+			data, err = b.fetcher.BlockMetadataAtMessageIndex(i)
 			if err != nil {
 				return nil, err
 			}

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -1011,10 +1011,10 @@ func (s *ExecutionEngine) digestMessageWithBlockMutex(num arbutil.MessageIndex, 
 	return msgResult, nil
 }
 
-func (s *ExecutionEngine) ArbOSVersionForMessageNumber(messageNum arbutil.MessageIndex) (uint64, error) {
-	block := s.bc.GetBlockByNumber(s.MessageIndexToBlockNumber(messageNum))
+func (s *ExecutionEngine) ArbOSVersionForMessageIndex(msgIdx arbutil.MessageIndex) (uint64, error) {
+	block := s.bc.GetBlockByNumber(s.MessageIndexToBlockNumber(msgIdx))
 	if block == nil {
-		return 0, fmt.Errorf("couldn't find block for message number %d", messageNum)
+		return 0, fmt.Errorf("couldn't find block for message index %d", msgIdx)
 	}
 	extra := types.DeserializeHeaderExtraInformation(block.Header())
 	return extra.ArbOSFormatVersion, nil

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -846,7 +846,7 @@ func (s *ExecutionEngine) getL1PricingSurplus() (int64, error) {
 	return surplus.Int64(), nil
 }
 
-func (s *ExecutionEngine) cacheL1PriceDataOfMsg(seqNum arbutil.MessageIndex, receipts types.Receipts, block *types.Block, blockBuiltUsingDelayedMessage bool) {
+func (s *ExecutionEngine) cacheL1PriceDataOfMsg(msgIdx arbutil.MessageIndex, receipts types.Receipts, block *types.Block, blockBuiltUsingDelayedMessage bool) {
 	var gasUsedForL1 uint64
 	var callDataUnits uint64
 	if !blockBuiltUsingDelayedMessage {
@@ -869,8 +869,8 @@ func (s *ExecutionEngine) cacheL1PriceDataOfMsg(seqNum arbutil.MessageIndex, rec
 	defer s.cachedL1PriceData.mutex.Unlock()
 
 	resetCache := func() {
-		s.cachedL1PriceData.startOfL1PriceDataCache = seqNum
-		s.cachedL1PriceData.endOfL1PriceDataCache = seqNum
+		s.cachedL1PriceData.startOfL1PriceDataCache = msgIdx
+		s.cachedL1PriceData.endOfL1PriceDataCache = msgIdx
 		s.cachedL1PriceData.msgToL1PriceData = []L1PriceDataOfMsg{{
 			callDataUnits:            callDataUnits,
 			cummulativeCallDataUnits: callDataUnits,
@@ -886,11 +886,11 @@ func (s *ExecutionEngine) cacheL1PriceDataOfMsg(seqNum arbutil.MessageIndex, rec
 		resetCache()
 		return
 	}
-	if seqNum != s.cachedL1PriceData.endOfL1PriceDataCache+1 {
-		if seqNum > s.cachedL1PriceData.endOfL1PriceDataCache+1 {
+	if msgIdx != s.cachedL1PriceData.endOfL1PriceDataCache+1 {
+		if msgIdx > s.cachedL1PriceData.endOfL1PriceDataCache+1 {
 			log.Info("message position higher then current end of l1 price data cache, resetting cache to this message")
 			resetCache()
-		} else if seqNum < s.cachedL1PriceData.startOfL1PriceDataCache {
+		} else if msgIdx < s.cachedL1PriceData.startOfL1PriceDataCache {
 			log.Info("message position lower than start of l1 price data cache, ignoring")
 		} else {
 			log.Info("message position already seen in l1 price data cache, ignoring")
@@ -904,7 +904,7 @@ func (s *ExecutionEngine) cacheL1PriceDataOfMsg(seqNum arbutil.MessageIndex, rec
 			l1GasCharged:             l1GasCharged,
 			cummulativeL1GasCharged:  cummulativeL1GasCharged + l1GasCharged,
 		})
-		s.cachedL1PriceData.endOfL1PriceDataCache = seqNum
+		s.cachedL1PriceData.endOfL1PriceDataCache = msgIdx
 	}
 }
 

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -262,9 +262,9 @@ func (s *ExecutionEngine) SetConsensus(consensus execution.FullConsensusClient) 
 	s.consensus = consensus
 }
 
-func (s *ExecutionEngine) BlockMetadataAtCount(count arbutil.MessageIndex) (common.BlockMetadata, error) {
+func (s *ExecutionEngine) BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) (common.BlockMetadata, error) {
 	if s.consensus != nil {
-		return s.consensus.BlockMetadataAtCount(count)
+		return s.consensus.BlockMetadataAtMessageIndex(msgIdx)
 	}
 	return nil, errors.New("FullConsensusClient is not accessible to execution")
 }

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -591,7 +591,7 @@ func (s *ExecutionEngine) sequenceTransactionsWithBlockMutex(header *arbostypes.
 		return nil, err
 	}
 
-	pos, err := s.BlockNumberToMessageIndex(lastBlockHeader.Number.Uint64() + 1)
+	msgIdx, err := s.BlockNumberToMessageIndex(lastBlockHeader.Number.Uint64() + 1)
 	if err != nil {
 		return nil, err
 	}
@@ -606,7 +606,7 @@ func (s *ExecutionEngine) sequenceTransactionsWithBlockMutex(header *arbostypes.
 	}
 
 	blockMetadata := s.blockMetadataFromBlock(block, timeboostedTxs)
-	err = s.consensus.WriteMessageFromSequencer(pos, msgWithMeta, *msgResult, blockMetadata)
+	err = s.consensus.WriteMessageFromSequencer(msgIdx, msgWithMeta, *msgResult, blockMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -617,7 +617,7 @@ func (s *ExecutionEngine) sequenceTransactionsWithBlockMutex(header *arbostypes.
 	if err != nil {
 		return nil, err
 	}
-	s.cacheL1PriceDataOfMsg(pos, receipts, block, false)
+	s.cacheL1PriceDataOfMsg(msgIdx, receipts, block, false)
 
 	return block, nil
 }
@@ -655,7 +655,7 @@ func (s *ExecutionEngine) sequenceDelayedMessageWithBlockMutex(message *arbostyp
 
 	expectedDelayed := currentHeader.Nonce.Uint64()
 
-	pos, err := s.BlockNumberToMessageIndex(currentHeader.Number.Uint64() + 1)
+	msgIdx, err := s.BlockNumberToMessageIndex(currentHeader.Number.Uint64() + 1)
 	if err != nil {
 		return nil, err
 	}
@@ -682,7 +682,7 @@ func (s *ExecutionEngine) sequenceDelayedMessageWithBlockMutex(message *arbostyp
 		return nil, err
 	}
 
-	err = s.consensus.WriteMessageFromSequencer(pos, messageWithMeta, *msgResult, s.blockMetadataFromBlock(block, nil))
+	err = s.consensus.WriteMessageFromSequencer(msgIdx, messageWithMeta, *msgResult, s.blockMetadataFromBlock(block, nil))
 	if err != nil {
 		return nil, err
 	}
@@ -691,9 +691,9 @@ func (s *ExecutionEngine) sequenceDelayedMessageWithBlockMutex(message *arbostyp
 	if err != nil {
 		return nil, err
 	}
-	s.cacheL1PriceDataOfMsg(pos, receipts, block, true)
+	s.cacheL1PriceDataOfMsg(msgIdx, receipts, block, true)
 
-	log.Info("ExecutionEngine: Added DelayedMessages", "pos", pos, "delayed", delayedSeqNum, "block-header", block.Header())
+	log.Info("ExecutionEngine: Added DelayedMessages", "msgIdx", msgIdx, "delayed", delayedSeqNum, "block-header", block.Header())
 
 	return block, nil
 }

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -340,7 +340,7 @@ func (s *ExecutionEngine) getCurrentHeader() (*types.Header, error) {
 	return currentBlock, nil
 }
 
-func (s *ExecutionEngine) HeadMessageNumber() (arbutil.MessageIndex, error) {
+func (s *ExecutionEngine) HeadMessageIndex() (arbutil.MessageIndex, error) {
 	currentHeader, err := s.getCurrentHeader()
 	if err != nil {
 		return 0, err
@@ -348,10 +348,10 @@ func (s *ExecutionEngine) HeadMessageNumber() (arbutil.MessageIndex, error) {
 	return s.BlockNumberToMessageIndex(currentHeader.Number.Uint64())
 }
 
-func (s *ExecutionEngine) HeadMessageNumberSync(t *testing.T) (arbutil.MessageIndex, error) {
+func (s *ExecutionEngine) HeadMessageIndexSync(t *testing.T) (arbutil.MessageIndex, error) {
 	s.createBlocksMutex.Lock()
 	defer s.createBlocksMutex.Unlock()
-	return s.HeadMessageNumber()
+	return s.HeadMessageIndex()
 }
 
 func (s *ExecutionEngine) NextDelayedMessageNumber() (uint64, error) {

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -921,17 +921,17 @@ func (s *ExecutionEngine) DigestMessage(msgIdx arbutil.MessageIndex, msg *arbost
 	return s.digestMessageWithBlockMutex(msgIdx, msg, msgForPrefetch)
 }
 
-func (s *ExecutionEngine) digestMessageWithBlockMutex(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) (*execution.MessageResult, error) {
+func (s *ExecutionEngine) digestMessageWithBlockMutex(msgIdxToDigest arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) (*execution.MessageResult, error) {
 	currentHeader, err := s.getCurrentHeader()
 	if err != nil {
 		return nil, err
 	}
-	curMsg, err := s.BlockNumberToMessageIndex(currentHeader.Number.Uint64())
+	curMsgIdx, err := s.BlockNumberToMessageIndex(currentHeader.Number.Uint64())
 	if err != nil {
 		return nil, err
 	}
-	if curMsg+1 != num {
-		return nil, fmt.Errorf("wrong message number in digest got %d expected %d", num, curMsg+1)
+	if curMsgIdx+1 != msgIdxToDigest {
+		return nil, fmt.Errorf("wrong message number in digest got %d expected %d", msgIdxToDigest, curMsgIdx+1)
 	}
 
 	startTime := time.Now()
@@ -955,7 +955,7 @@ func (s *ExecutionEngine) digestMessageWithBlockMutex(num arbutil.MessageIndex, 
 	if err != nil {
 		return nil, err
 	}
-	s.cacheL1PriceDataOfMsg(num, receipts, block, false)
+	s.cacheL1PriceDataOfMsg(msgIdxToDigest, receipts, block, false)
 
 	if time.Now().After(s.nextScheduledVersionCheck) {
 		s.nextScheduledVersionCheck = time.Now().Add(time.Minute)
@@ -993,7 +993,7 @@ func (s *ExecutionEngine) digestMessageWithBlockMutex(num arbutil.MessageIndex, 
 		}
 	}
 
-	sharedmetrics.UpdateSequenceNumberInBlockGauge(num)
+	sharedmetrics.UpdateSequenceNumberInBlockGauge(msgIdxToDigest)
 	s.latestBlockMutex.Lock()
 	s.latestBlock = block
 	s.latestBlockMutex.Unlock()

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -712,8 +712,8 @@ func (s *ExecutionEngine) BlockNumberToMessageIndex(blockNum uint64) (arbutil.Me
 	return arbutil.MessageIndex(blockNum - genesis), nil
 }
 
-func (s *ExecutionEngine) MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) uint64 {
-	return uint64(messageNum) + s.GetGenesisBlockNumber()
+func (s *ExecutionEngine) MessageIndexToBlockNumber(msgIdx arbutil.MessageIndex) uint64 {
+	return uint64(msgIdx) + s.GetGenesisBlockNumber()
 }
 
 // must hold createBlockMutex

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -284,7 +284,7 @@ func (s *ExecutionEngine) Reorg(newHeadMsgIdx arbutil.MessageIndex, newMessages 
 		}
 	}()
 	blockNum := s.MessageIndexToBlockNumber(newHeadMsgIdx)
-	// We can safely cast blockNum to a uint64 as it comes from MessageCountToBlockNumber
+	// We can safely cast blockNum to a uint64 as it comes from MessageIndexToBlockNumber
 	targetBlock := s.bc.GetBlockByNumber(uint64(blockNum))
 	if targetBlock == nil {
 		log.Warn("reorg target block not found", "block", blockNum)

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -915,12 +915,12 @@ func (s *ExecutionEngine) cacheL1PriceDataOfMsg(seqNum arbutil.MessageIndex, rec
 // in parallel, creates a block by executing msgForPrefetch (msg+1) against the latest state
 // but does not store the block.
 // This helps in filling the cache, so that the next block creation is faster.
-func (s *ExecutionEngine) DigestMessage(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) (*execution.MessageResult, error) {
+func (s *ExecutionEngine) DigestMessage(msgIdx arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) (*execution.MessageResult, error) {
 	if !s.createBlocksMutex.TryLock() {
 		return nil, errors.New("createBlock mutex held")
 	}
 	defer s.createBlocksMutex.Unlock()
-	return s.digestMessageWithBlockMutex(num, msg, msgForPrefetch)
+	return s.digestMessageWithBlockMutex(msgIdx, msg, msgForPrefetch)
 }
 
 func (s *ExecutionEngine) digestMessageWithBlockMutex(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) (*execution.MessageResult, error) {

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -805,8 +805,8 @@ func (s *ExecutionEngine) resultFromHeader(header *types.Header) (*execution.Mes
 	}, nil
 }
 
-func (s *ExecutionEngine) ResultAtPos(pos arbutil.MessageIndex) (*execution.MessageResult, error) {
-	return s.resultFromHeader(s.bc.GetHeaderByNumber(s.MessageIndexToBlockNumber(pos)))
+func (s *ExecutionEngine) ResultAtMessageIndex(msgIdx arbutil.MessageIndex) (*execution.MessageResult, error) {
+	return s.resultFromHeader(s.bc.GetHeaderByNumber(s.MessageIndexToBlockNumber(msgIdx)))
 }
 
 func (s *ExecutionEngine) updateL1GasPriceEstimateMetric() {

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -433,8 +433,8 @@ func (n *ExecutionNode) SequenceDelayedMessage(message *arbostypes.L1IncomingMes
 func (n *ExecutionNode) ResultAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[*execution.MessageResult] {
 	return containers.NewReadyPromise(n.ExecEngine.ResultAtMessageIndex(msgIdx))
 }
-func (n *ExecutionNode) ArbOSVersionForMessageNumber(messageNum arbutil.MessageIndex) (uint64, error) {
-	return n.ExecEngine.ArbOSVersionForMessageNumber(messageNum)
+func (n *ExecutionNode) ArbOSVersionForMessageIndex(msgIdx arbutil.MessageIndex) (uint64, error) {
+	return n.ExecEngine.ArbOSVersionForMessageIndex(msgIdx)
 }
 
 func (n *ExecutionNode) RecordBlockCreation(

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -430,8 +430,8 @@ func (n *ExecutionNode) NextDelayedMessageNumber() (uint64, error) {
 func (n *ExecutionNode) SequenceDelayedMessage(message *arbostypes.L1IncomingMessage, delayedSeqNum uint64) error {
 	return n.ExecEngine.SequenceDelayedMessage(message, delayedSeqNum)
 }
-func (n *ExecutionNode) ResultAtPos(pos arbutil.MessageIndex) containers.PromiseInterface[*execution.MessageResult] {
-	return containers.NewReadyPromise(n.ExecEngine.ResultAtPos(pos))
+func (n *ExecutionNode) ResultAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[*execution.MessageResult] {
+	return containers.NewReadyPromise(n.ExecEngine.ResultAtMessageIndex(msgIdx))
 }
 func (n *ExecutionNode) ArbOSVersionForMessageNumber(messageNum arbutil.MessageIndex) (uint64, error) {
 	return n.ExecEngine.ArbOSVersionForMessageNumber(messageNum)

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -418,8 +418,8 @@ func (n *ExecutionNode) StopAndWait() containers.PromiseInterface[struct{}] {
 func (n *ExecutionNode) DigestMessage(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*execution.MessageResult] {
 	return containers.NewReadyPromise(n.ExecEngine.DigestMessage(num, msg, msgForPrefetch))
 }
-func (n *ExecutionNode) Reorg(count arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*execution.MessageResult] {
-	return containers.NewReadyPromise(n.ExecEngine.Reorg(count, newMessages, oldMessages))
+func (n *ExecutionNode) Reorg(newHeadMsgIdx arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*execution.MessageResult] {
+	return containers.NewReadyPromise(n.ExecEngine.Reorg(newHeadMsgIdx, newMessages, oldMessages))
 }
 func (n *ExecutionNode) HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex] {
 	return containers.NewReadyPromise(n.ExecEngine.HeadMessageIndex())

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -421,8 +421,8 @@ func (n *ExecutionNode) DigestMessage(num arbutil.MessageIndex, msg *arbostypes.
 func (n *ExecutionNode) Reorg(count arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*execution.MessageResult] {
 	return containers.NewReadyPromise(n.ExecEngine.Reorg(count, newMessages, oldMessages))
 }
-func (n *ExecutionNode) HeadMessageNumber() containers.PromiseInterface[arbutil.MessageIndex] {
-	return containers.NewReadyPromise(n.ExecEngine.HeadMessageNumber())
+func (n *ExecutionNode) HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex] {
+	return containers.NewReadyPromise(n.ExecEngine.HeadMessageIndex())
 }
 func (n *ExecutionNode) NextDelayedMessageNumber() (uint64, error) {
 	return n.ExecEngine.NextDelayedMessageNumber()

--- a/execution/gethexec/sync_monitor.go
+++ b/execution/gethexec/sync_monitor.go
@@ -73,7 +73,7 @@ func (s *SyncMonitor) SyncProgressMap() map[string]interface{} {
 
 func (s *SyncMonitor) Synced() bool {
 	if s.consensus.Synced() {
-		built, err := s.exec.HeadMessageNumber()
+		built, err := s.exec.HeadMessageIndex()
 		consensusSyncTarget := s.consensus.SyncTargetMessageCount()
 		if err == nil && built+1 >= consensusSyncTarget {
 			return true

--- a/execution/gethexec/sync_monitor.go
+++ b/execution/gethexec/sync_monitor.go
@@ -91,9 +91,9 @@ func (s *SyncMonitor) BlockMetadataByNumber(blockNum uint64) (common.BlockMetada
 	if blockNum < genesis { // Arbitrum classic block
 		return nil, nil
 	}
-	pos := arbutil.MessageIndex(blockNum - genesis)
+	msgIdx := arbutil.MessageIndex(blockNum - genesis)
 	if s.consensus != nil {
-		return s.consensus.BlockMetadataAtCount(pos + 1)
+		return s.consensus.BlockMetadataAtMessageIndex(msgIdx)
 	}
 	log.Debug("FullConsensusClient is not accessible to execution, BlockMetadataByNumber will return nil")
 	return nil, nil

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -30,7 +30,7 @@ var ErrSequencerInsertLockTaken = errors.New("insert lock taken")
 // always needed
 type ExecutionClient interface {
 	DigestMessage(msgIdx arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*MessageResult]
-	Reorg(newHeadMsgIdx arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*MessageResult]
+	Reorg(lastMsgIdxToKeep arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*MessageResult]
 	HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex]
 	ResultAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[*MessageResult]
 	MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) containers.PromiseInterface[uint64]

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -29,8 +29,8 @@ var ErrSequencerInsertLockTaken = errors.New("insert lock taken")
 
 // always needed
 type ExecutionClient interface {
-	DigestMessage(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*MessageResult]
-	Reorg(msgIdx arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*MessageResult]
+	DigestMessage(msgIdx arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*MessageResult]
+	Reorg(newHeadMsgIdx arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*MessageResult]
 	HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex]
 	ResultAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[*MessageResult]
 	MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) containers.PromiseInterface[uint64]
@@ -87,7 +87,7 @@ type ConsensusInfo interface {
 }
 
 type ConsensusSequencer interface {
-	WriteMessageFromSequencer(pos arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult MessageResult, blockMetadata common.BlockMetadata) error
+	WriteMessageFromSequencer(msgIdx arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult MessageResult, blockMetadata common.BlockMetadata) error
 	ExpectChosenSequencer() error
 }
 

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -30,7 +30,7 @@ var ErrSequencerInsertLockTaken = errors.New("insert lock taken")
 // always needed
 type ExecutionClient interface {
 	DigestMessage(msgIdx arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*MessageResult]
-	Reorg(lastMsgIdxToKeep arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*MessageResult]
+	Reorg(msgIdxOfFirstMsgToAdd arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*MessageResult]
 	HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex]
 	ResultAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[*MessageResult]
 	MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) containers.PromiseInterface[uint64]

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -31,7 +31,7 @@ var ErrSequencerInsertLockTaken = errors.New("insert lock taken")
 type ExecutionClient interface {
 	DigestMessage(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*MessageResult]
 	Reorg(count arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*MessageResult]
-	HeadMessageNumber() containers.PromiseInterface[arbutil.MessageIndex]
+	HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex]
 	ResultAtPos(pos arbutil.MessageIndex) containers.PromiseInterface[*MessageResult]
 	MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) containers.PromiseInterface[uint64]
 	BlockNumberToMessageIndex(blockNum uint64) containers.PromiseInterface[arbutil.MessageIndex]

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -69,7 +69,7 @@ type ExecutionSequencer interface {
 
 // needed for batch poster
 type ExecutionBatchPoster interface {
-	ArbOSVersionForMessageNumber(messageNum arbutil.MessageIndex) (uint64, error)
+	ArbOSVersionForMessageIndex(msgIdx arbutil.MessageIndex) (uint64, error)
 }
 
 // not implemented in execution, used as input

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -32,7 +32,7 @@ type ExecutionClient interface {
 	DigestMessage(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*MessageResult]
 	Reorg(count arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*MessageResult]
 	HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex]
-	ResultAtPos(pos arbutil.MessageIndex) containers.PromiseInterface[*MessageResult]
+	ResultAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[*MessageResult]
 	MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) containers.PromiseInterface[uint64]
 	BlockNumberToMessageIndex(blockNum uint64) containers.PromiseInterface[arbutil.MessageIndex]
 	SetFinalityData(ctx context.Context, finalityData *arbutil.FinalityData) containers.PromiseInterface[struct{}]

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -83,7 +83,7 @@ type ConsensusInfo interface {
 	Synced() bool
 	FullSyncProgressMap() map[string]interface{}
 	SyncTargetMessageCount() arbutil.MessageIndex
-	BlockMetadataAtCount(count arbutil.MessageIndex) (common.BlockMetadata, error)
+	BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) (common.BlockMetadata, error)
 }
 
 type ConsensusSequencer interface {

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -30,7 +30,7 @@ var ErrSequencerInsertLockTaken = errors.New("insert lock taken")
 // always needed
 type ExecutionClient interface {
 	DigestMessage(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*MessageResult]
-	Reorg(count arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*MessageResult]
+	Reorg(msgIdx arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*MessageResult]
 	HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex]
 	ResultAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[*MessageResult]
 	MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) containers.PromiseInterface[uint64]

--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/offchainlabs/nitro/arbnode/resourcemanager"
 	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/util/containers"
 	"github.com/offchainlabs/nitro/util/rpcclient"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
@@ -315,7 +316,7 @@ func NewBlockValidator(
 	}
 	// genesis block is impossible to validate unless genesis state is empty
 	if ret.lastValidGS.Batch == 0 && ret.legacyValidInfo == nil {
-		genesis, err := streamer.ResultAtCount(1)
+		genesis, err := streamer.ResultAtMessageIndex(0)
 		if err != nil {
 			return nil, err
 		}
@@ -489,9 +490,12 @@ func GlobalStateToMsgCount(tracker InboxTrackerInterface, streamer TransactionSt
 	if processed < count {
 		return false, 0, nil
 	}
-	res, err := streamer.ResultAtCount(count)
-	if err != nil {
-		return false, 0, err
+	res := &execution.MessageResult{}
+	if count > 0 {
+		res, err = streamer.ResultAtMessageIndex(count - 1)
+		if err != nil {
+			return false, 0, err
+		}
 	}
 	if res.BlockHash != gs.BlockHash || res.SendRoot != gs.SendRoot {
 		return false, 0, fmt.Errorf("%w: count %d hash %v expected %v, sendroot %v expected %v", ErrGlobalStateNotInChain, count, gs.BlockHash, res.BlockHash, gs.SendRoot, res.SendRoot)
@@ -589,7 +593,7 @@ func (v *BlockValidator) createNextValidationEntry(ctx context.Context) (bool, e
 	if err != nil {
 		return false, err
 	}
-	endRes, err := v.streamer.ResultAtCount(pos + 1)
+	endRes, err := v.streamer.ResultAtMessageIndex(pos)
 	if err != nil {
 		return false, err
 	}
@@ -1104,7 +1108,7 @@ func (v *BlockValidator) Reorg(ctx context.Context, count arbutil.MessageIndex) 
 		v.possiblyFatal(err)
 		return err
 	}
-	res, err := v.streamer.ResultAtCount(count)
+	res, err := v.streamer.ResultAtMessageIndex(count - 1)
 	if err != nil {
 		v.possiblyFatal(err)
 		return err
@@ -1249,10 +1253,15 @@ func (v *BlockValidator) checkLegacyValid() error {
 		log.Warn("legacy valid message count ahead of db", "current", processedCount, "required", msgCount)
 		return nil
 	}
-	result, err := v.streamer.ResultAtCount(msgCount)
-	if err != nil {
-		return err
+
+	result := &execution.MessageResult{}
+	if msgCount > 0 {
+		result, err = v.streamer.ResultAtMessageIndex(msgCount - 1)
+		if err != nil {
+			return err
+		}
 	}
+
 	if result.BlockHash != v.legacyValidInfo.BlockHash {
 		log.Error("legacy validated blockHash does not fit chain", "info.BlockHash", v.legacyValidInfo.BlockHash, "chain", result.BlockHash, "count", msgCount)
 		return fmt.Errorf("legacy validated blockHash does not fit chain")

--- a/staker/bold/bold_state_provider.go
+++ b/staker/bold/bold_state_provider.go
@@ -23,6 +23,7 @@ import (
 	l2stateprovider "github.com/offchainlabs/bold/layer2-state-provider"
 	"github.com/offchainlabs/bold/state-commitments/history"
 	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/staker"
 	challengecache "github.com/offchainlabs/nitro/staker/challenge-cache"
 	"github.com/offchainlabs/nitro/validator"
@@ -211,9 +212,12 @@ func (s *BOLDStateProvider) StatesInBatchRange(
 		if ctx.Err() != nil {
 			return nil, nil, ctx.Err()
 		}
-		executionResult, err := s.statelessValidator.InboxStreamer().ResultAtCount(arbutil.MessageIndex(pos))
-		if err != nil {
-			return nil, nil, err
+		executionResult := &execution.MessageResult{}
+		if pos > 0 {
+			executionResult, err = s.statelessValidator.InboxStreamer().ResultAtMessageIndex(pos - 1)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 		state := validator.GoGlobalState{
 			BlockHash:  executionResult.BlockHash,
@@ -271,9 +275,12 @@ func (s *BOLDStateProvider) findGlobalStateFromMessageCountAndBatch(count arbuti
 			return validator.GoGlobalState{}, fmt.Errorf("message count %v is past end of batch %v message count %v", count, batchIndex, batchMsgCount)
 		}
 	}
-	res, err := s.statelessValidator.InboxStreamer().ResultAtCount(count)
-	if err != nil {
-		return validator.GoGlobalState{}, fmt.Errorf("%s: could not check if we have result at count %d: %w", s.stateProviderConfig.ValidatorName, count, err)
+	res := &execution.MessageResult{}
+	if count > 0 {
+		res, err = s.statelessValidator.InboxStreamer().ResultAtMessageIndex(count - 1)
+		if err != nil {
+			return validator.GoGlobalState{}, fmt.Errorf("%s: could not check if we have result at count %d: %w", s.stateProviderConfig.ValidatorName, count, err)
+		}
 	}
 	return validator.GoGlobalState{
 		BlockHash:  res.BlockHash,
@@ -332,7 +339,7 @@ func (s *BOLDStateProvider) CollectMachineHashes(
 	for i, h := range cfg.StepHeights {
 		stepHeights[i] = uint64(h)
 	}
-	messageResult, err := s.statelessValidator.InboxStreamer().ResultAtCount(arbutil.MessageIndex(messageNum + 1))
+	messageResult, err := s.statelessValidator.InboxStreamer().ResultAtMessageIndex(messageNum)
 	if err != nil {
 		return nil, err
 	}
@@ -431,9 +438,12 @@ func (s *BOLDStateProvider) virtualState(msgNum arbutil.MessageIndex, limit l2st
 		return gs, fmt.Errorf("could not get limitMsgCount at %d: %w", limit, err)
 	}
 	if msgNum >= limitMsgCount {
-		result, err := s.statelessValidator.InboxStreamer().ResultAtCount(arbutil.MessageIndex(limitMsgCount))
-		if err != nil {
-			return gs, fmt.Errorf("could not get global state at limitMsgCount %d: %w", limitMsgCount, err)
+		result := &execution.MessageResult{}
+		if limitMsgCount > 0 {
+			result, err = s.statelessValidator.InboxStreamer().ResultAtMessageIndex(limitMsgCount - 1)
+			if err != nil {
+				return gs, fmt.Errorf("could not get global state at limitMsgCount %d: %w", limitMsgCount, err)
+			}
 		}
 		gs = option.Some(validator.GoGlobalState{
 			BlockHash:  result.BlockHash,

--- a/staker/legacy/block_challenge_backend.go
+++ b/staker/legacy/block_challenge_backend.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/solgen/go/challengegen"
 	"github.com/offchainlabs/nitro/staker"
 	"github.com/offchainlabs/nitro/validator"
@@ -119,9 +120,12 @@ func (b *BlockChallengeBackend) FindGlobalStateFromMessageCount(count arbutil.Me
 			return validator.GoGlobalState{}, errors.New("findBatchFromMessageCount returned bad batch")
 		}
 	}
-	res, err := b.streamer.ResultAtCount(count)
-	if err != nil {
-		return validator.GoGlobalState{}, err
+	res := &execution.MessageResult{}
+	if count > 0 {
+		res, err = b.streamer.ResultAtMessageIndex(count - 1)
+		if err != nil {
+			return validator.GoGlobalState{}, err
+		}
 	}
 	return validator.GoGlobalState{
 		BlockHash:  res.BlockHash,

--- a/staker/legacy/l1_validator.go
+++ b/staker/legacy/l1_validator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
 	"github.com/offchainlabs/nitro/staker"
 	"github.com/offchainlabs/nitro/staker/txbuilder"
@@ -344,9 +345,12 @@ func (v *L1Validator) generateNodeAction(
 				return nil, false, errors.New("batch not found on L1")
 			}
 		}
-		execResult, err := v.txStreamer.ResultAtCount(validatedCount)
-		if err != nil {
-			return nil, false, err
+		execResult := &execution.MessageResult{}
+		if validatedCount > 0 {
+			execResult, err = v.txStreamer.ResultAtMessageIndex(validatedCount - 1)
+			if err != nil {
+				return nil, false, err
+			}
 		}
 		_, gsPos, err := staker.GlobalStatePositionsAtCount(v.inboxTracker, validatedCount, batchNum)
 		if err != nil {

--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -138,9 +138,8 @@ func testChallengeProtocolBOLD(t *testing.T, spawnerOpts ...server_arb.SpawnerOp
 	)
 	defer l2nodeB.StopAndWait()
 
-	genesisA, err := l2nodeA.ExecutionClient.ResultAtPos(0).Await(ctx)
-	Require(t, err)
-	genesisB, err := l2nodeB.ExecutionClient.ResultAtPos(0).Await(ctx)
+	genesisA, err := l2nodeA.Execution.ResultAtMessageIndex(0).Await(ctx)
+	genesisB, err := l2nodeB.Execution.ResultAtMessageIndex(0).Await(ctx)
 	Require(t, err)
 	if genesisA.BlockHash != genesisB.BlockHash {
 		Fatal(t, "genesis blocks mismatch between nodes")

--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -138,8 +138,8 @@ func testChallengeProtocolBOLD(t *testing.T, spawnerOpts ...server_arb.SpawnerOp
 	)
 	defer l2nodeB.StopAndWait()
 
-	genesisA, err := l2nodeA.Execution.ResultAtMessageIndex(0).Await(ctx)
-	genesisB, err := l2nodeB.Execution.ResultAtMessageIndex(0).Await(ctx)
+	genesisA, err := l2nodeA.ExecutionClient.ResultAtMessageIndex(0).Await(ctx)
+	genesisB, err := l2nodeB.ExecutionClient.ResultAtMessageIndex(0).Await(ctx)
 	Require(t, err)
 	if genesisA.BlockHash != genesisB.BlockHash {
 		Fatal(t, "genesis blocks mismatch between nodes")

--- a/system_tests/bold_state_provider_test.go
+++ b/system_tests/bold_state_provider_test.go
@@ -290,7 +290,7 @@ func TestChallengeProtocolBOLD_StateProvider(t *testing.T) {
 		}
 
 		// Check if we agree with the last posted batch to the inbox.
-		result, err := l2node.TxStreamer.ResultAtCount(totalMessageCount)
+		result, err := l2node.TxStreamer.ResultAtMessageIndex(totalMessageCount - 1)
 		Require(t, err)
 		_ = result
 

--- a/system_tests/contract_tx_test.go
+++ b/system_tests/contract_tx_test.go
@@ -34,11 +34,11 @@ func TestContractTxDeploy(t *testing.T) {
 	builder.L2.TransferBalanceTo(t, "Faucet", from, big.NewInt(1e18), builder.L2Info)
 
 	for stateNonce := uint64(0); stateNonce < 2; stateNonce++ {
-		pos, err := builder.L2.ConsensusNode.TxStreamer.GetMessageCount()
+		msgCount, err := builder.L2.ConsensusNode.TxStreamer.GetMessageCount()
 		Require(t, err)
 		var delayedMessagesRead uint64
-		if pos > 0 {
-			lastMessage, err := builder.L2.ConsensusNode.TxStreamer.GetMessage(pos - 1)
+		if msgCount > 0 {
+			lastMessage, err := builder.L2.ConsensusNode.TxStreamer.GetMessage(msgCount - 1)
 			Require(t, err)
 			delayedMessagesRead = lastMessage.DelayedMessagesRead
 		}
@@ -71,7 +71,7 @@ func TestContractTxDeploy(t *testing.T) {
 		l2Msg = append(l2Msg, arbmath.U256Bytes(contractTx.Value)...)
 		l2Msg = append(l2Msg, contractTx.Data...)
 
-		err = builder.L2.ConsensusNode.TxStreamer.AddMessages(pos, true, []arbostypes.MessageWithMetadata{
+		err = builder.L2.ConsensusNode.TxStreamer.AddMessages(msgCount, true, []arbostypes.MessageWithMetadata{
 			{
 				Message: &arbostypes.L1IncomingMessage{
 					Header: &arbostypes.L1IncomingMessageHeader{

--- a/system_tests/meaningless_reorg_test.go
+++ b/system_tests/meaningless_reorg_test.go
@@ -37,11 +37,11 @@ func TestMeaninglessBatchReorg(t *testing.T) {
 		if i >= 500 {
 			Fatal(t, "Failed to read batch from L1")
 		}
-		msgNum, err := builder.L2.ExecNode.ExecEngine.HeadMessageNumber()
+		msgIdx, err := builder.L2.ExecNode.ExecEngine.HeadMessageIndex()
 		Require(t, err)
-		if msgNum == 1 {
+		if msgIdx == 1 {
 			break
-		} else if msgNum > 1 {
+		} else if msgIdx > 1 {
 			Fatal(t, "More than two batches in test?")
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -1899,7 +1899,7 @@ func waitForSequencer(t *testing.T, builder *NodeBuilder, block uint64) {
 		Require(t, err)
 		meta, err := builder.L2.ConsensusNode.InboxTracker.GetBatchMetadata(batchCount - 1)
 		Require(t, err)
-		msgExecuted, err := builder.L2.ExecNode.ExecEngine.HeadMessageNumber()
+		msgExecuted, err := builder.L2.ExecNode.ExecEngine.HeadMessageIndex()
 		Require(t, err)
 		return msgExecuted+1 >= arbutil.MessageIndex(msgCount) && meta.MessageCount >= arbutil.MessageIndex(msgCount)
 	})

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -1901,7 +1901,7 @@ func waitForSequencer(t *testing.T, builder *NodeBuilder, block uint64) {
 		Require(t, err)
 		msgExecuted, err := builder.L2.ExecNode.ExecEngine.HeadMessageNumber()
 		Require(t, err)
-		return msgExecuted+1 >= msgCount && meta.MessageCount >= msgCount
+		return msgExecuted+1 >= arbutil.MessageIndex(msgCount) && meta.MessageCount >= arbutil.MessageIndex(msgCount)
 	})
 }
 

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -1901,7 +1901,7 @@ func waitForSequencer(t *testing.T, builder *NodeBuilder, block uint64) {
 		Require(t, err)
 		msgExecuted, err := builder.L2.ExecNode.ExecEngine.HeadMessageIndex()
 		Require(t, err)
-		return msgExecuted+1 >= arbutil.MessageIndex(msgCount) && meta.MessageCount >= arbutil.MessageIndex(msgCount)
+		return msgExecuted+1 >= msgCount && meta.MessageCount >= msgCount
 	})
 }
 

--- a/system_tests/reorg_resequencing_test.go
+++ b/system_tests/reorg_resequencing_test.go
@@ -36,7 +36,7 @@ func TestReorgResequencing(t *testing.T) {
 	cleanup := builder.Build(t)
 	defer cleanup()
 
-	startMsgCount, err := builder.L2.ConsensusNode.TxStreamer.GetMessageCount()
+	startHeadMsgIdx, err := builder.L2.ConsensusNode.TxStreamer.GetHeadMessageIndex()
 	Require(t, err)
 
 	builder.L2Info.GenerateAccount("Intermediate")
@@ -62,7 +62,7 @@ func TestReorgResequencing(t *testing.T) {
 	}
 	verifyBalances("before reorg")
 
-	err = builder.L2.ConsensusNode.TxStreamer.ReorgTo(startMsgCount)
+	err = builder.L2.ConsensusNode.TxStreamer.ReorgTo(startHeadMsgIdx)
 	Require(t, err)
 
 	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageNumberSync(t)
@@ -71,7 +71,7 @@ func TestReorgResequencing(t *testing.T) {
 	verifyBalances("after empty reorg")
 	compareAllMsgResultsFromConsensusAndExecution(t, ctx, builder.L2, "after empty reorg")
 
-	prevMessage, err := builder.L2.ConsensusNode.TxStreamer.GetMessage(startMsgCount - 1)
+	prevMessage, err := builder.L2.ConsensusNode.TxStreamer.GetMessage(startHeadMsgIdx)
 	Require(t, err)
 	delayedIndexHash := common.BigToHash(big.NewInt(int64(prevMessage.DelayedMessagesRead)))
 	newMessage := &arbostypes.L1IncomingMessage{
@@ -85,7 +85,8 @@ func TestReorgResequencing(t *testing.T) {
 		},
 		L2msg: append(builder.L2Info.GetAddress("User4").Bytes(), arbmath.Uint64ToU256Bytes(params.Ether)...),
 	}
-	err = builder.L2.ConsensusNode.TxStreamer.AddMessages(startMsgCount, true, []arbostypes.MessageWithMetadata{{
+	nextHeadMsgIdx := startHeadMsgIdx + 1
+	err = builder.L2.ConsensusNode.TxStreamer.AddMessages(nextHeadMsgIdx, true, []arbostypes.MessageWithMetadata{{
 		Message:             newMessage,
 		DelayedMessagesRead: prevMessage.DelayedMessagesRead + 1,
 	}}, nil)
@@ -99,7 +100,7 @@ func TestReorgResequencing(t *testing.T) {
 	verifyBalances("after reorg with new deposit")
 	compareAllMsgResultsFromConsensusAndExecution(t, ctx, builder.L2, "after reorg with new deposit")
 
-	err = builder.L2.ConsensusNode.TxStreamer.ReorgTo(startMsgCount)
+	err = builder.L2.ConsensusNode.TxStreamer.ReorgTo(startHeadMsgIdx)
 	Require(t, err)
 
 	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageNumberSync(t)

--- a/system_tests/reorg_resequencing_test.go
+++ b/system_tests/reorg_resequencing_test.go
@@ -62,7 +62,7 @@ func TestReorgResequencing(t *testing.T) {
 	}
 	verifyBalances("before reorg")
 
-	err = builder.L2.ConsensusNode.TxStreamer.ReorgTo(startHeadMsgIdx)
+	err = builder.L2.ConsensusNode.TxStreamer.ReorgAt(startHeadMsgIdx + 1)
 	Require(t, err)
 
 	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageIndexSync(t)
@@ -100,7 +100,7 @@ func TestReorgResequencing(t *testing.T) {
 	verifyBalances("after reorg with new deposit")
 	compareAllMsgResultsFromConsensusAndExecution(t, ctx, builder.L2, "after reorg with new deposit")
 
-	err = builder.L2.ConsensusNode.TxStreamer.ReorgTo(startHeadMsgIdx)
+	err = builder.L2.ConsensusNode.TxStreamer.ReorgAt(startHeadMsgIdx + 1)
 	Require(t, err)
 
 	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageIndexSync(t)

--- a/system_tests/reorg_resequencing_test.go
+++ b/system_tests/reorg_resequencing_test.go
@@ -65,7 +65,7 @@ func TestReorgResequencing(t *testing.T) {
 	err = builder.L2.ConsensusNode.TxStreamer.ReorgTo(startHeadMsgIdx)
 	Require(t, err)
 
-	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageNumberSync(t)
+	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageIndexSync(t)
 	Require(t, err)
 
 	verifyBalances("after empty reorg")
@@ -92,7 +92,7 @@ func TestReorgResequencing(t *testing.T) {
 	}}, nil)
 	Require(t, err)
 
-	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageNumberSync(t)
+	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageIndexSync(t)
 	Require(t, err)
 
 	accountsWithBalance = append(accountsWithBalance, "User4")
@@ -103,7 +103,7 @@ func TestReorgResequencing(t *testing.T) {
 	err = builder.L2.ConsensusNode.TxStreamer.ReorgTo(startHeadMsgIdx)
 	Require(t, err)
 
-	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageNumberSync(t)
+	_, err = builder.L2.ExecNode.ExecEngine.HeadMessageIndexSync(t)
 	Require(t, err)
 
 	verifyBalances("after second empty reorg")

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -170,7 +170,7 @@ func compareAllMsgResultsFromConsensusAndExecution(
 		resultExec, err := testClient.ExecNode.ResultAtMessageIndex(msgIdx).Await(ctx)
 		Require(t, err)
 
-		resultConsensus, err := testClient.ConsensusNode.TxStreamer.ResultAtCount(msgCount)
+		resultConsensus, err := testClient.ConsensusNode.TxStreamer.ResultAtMessageIndex(arbutil.MessageIndex(msgIdx))
 		Require(t, err)
 
 		if !reflect.DeepEqual(resultExec, resultConsensus) {
@@ -303,10 +303,10 @@ func testLyingSequencer(t *testing.T, dasModeStr string) {
 	}
 
 	// Since NodeB is not a sequencer, it will produce blocks through Consensus.
-	// So it is expected that Consensus.ResultAtCount will not rely on Execution to retrieve results.
-	// However, since count 1 is related to genesis, and Execution is initialized through InitializeArbosInDatabase and not through Consensus,
-	// first call to Consensus.ResultAtCount with count equals to 1 will fall back to Execution.
-	// Not necessarily the first call to Consensus.ResultAtCount with count equals to 1 will happen through compareMsgResultFromConsensusAndExecution,
+	// So it is expected that Consensus.ResultAtMessageIndex will not rely on Execution to retrieve results.
+	// However, since msgIdx 0 is related to genesis, and Execution is initialized through InitializeArbosInDatabase and not through Consensus,
+	// first call to Consensus.ResultAtMessageIndex with msgIdx equals to 0 will fall back to Execution.
+	// Not necessarily the first call to Consensus.ResultAtMessageIndex with msgIdx equals to 0 will happen through compareMsgResultFromConsensusAndExecution,
 	// so we don't test this here.
 	consensusMsgCount, err := testClientB.ConsensusNode.TxStreamer.GetMessageCount()
 	Require(t, err)
@@ -314,7 +314,7 @@ func testLyingSequencer(t *testing.T, dasModeStr string) {
 		t.Fatal("consensusMsgCount is different than 2")
 	}
 	logHandler := testhelpers.InitTestLog(t, log.LvlTrace)
-	_, err = testClientB.ConsensusNode.TxStreamer.ResultAtCount(arbutil.MessageIndex(2))
+	_, err = testClientB.ConsensusNode.TxStreamer.ResultAtMessageIndex(arbutil.MessageIndex(1))
 	Require(t, err)
 	if logHandler.WasLogged(arbnode.FailedToGetMsgResultFromDB) {
 		t.Fatal("Consensus relied on execution database to return the result")

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -165,7 +165,7 @@ func compareAllMsgResultsFromConsensusAndExecution(
 	}
 
 	var lastResult *execution.MessageResult
-	for msgIdx := 0; arbutil.MessageIndex(msgIdx) <= consensusHeadMsgIdx; msgIdx++ {
+	for msgIdx := arbutil.MessageIndex(0); msgIdx <= consensusHeadMsgIdx; msgIdx++ {
 		resultExec, err := testClient.ExecNode.ResultAtMessageIndex(arbutil.MessageIndex(msgIdx)).Await(ctx)
 		Require(t, err)
 

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -153,13 +153,13 @@ func compareAllMsgResultsFromConsensusAndExecution(
 	testClient *TestClient,
 	testScenario string,
 ) *execution.MessageResult {
-	execHeadMsgNum, err := testClient.ExecNode.HeadMessageNumber().Await(context.Background())
+	execHeadMsgIdx, err := testClient.ExecNode.HeadMessageIndex().Await(context.Background())
 	Require(t, err)
 	consensusMsgCount, err := testClient.ConsensusNode.TxStreamer.GetMessageCount()
 	Require(t, err)
-	if consensusMsgCount != execHeadMsgNum+1 {
+	if consensusMsgCount != execHeadMsgIdx+1 {
 		t.Fatal(
-			"consensusMsgCount", consensusMsgCount, "is different than (execHeadMsgNum + 1)", execHeadMsgNum,
+			"consensusMsgCount", consensusMsgCount, "is different than (execHeadMsgIdx + 1)", execHeadMsgIdx,
 			"testScenario:", testScenario,
 		)
 	}

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -166,8 +166,8 @@ func compareAllMsgResultsFromConsensusAndExecution(
 
 	var lastResult *execution.MessageResult
 	for msgCount := arbutil.MessageIndex(1); msgCount <= consensusMsgCount; msgCount++ {
-		pos := msgCount - 1
-		resultExec, err := testClient.ExecNode.ResultAtPos(arbutil.MessageIndex(pos)).Await(ctx)
+		msgIdx := msgCount - 1
+		resultExec, err := testClient.ExecNode.ResultAtMessageIndex(msgIdx).Await(ctx)
 		Require(t, err)
 
 		resultConsensus, err := testClient.ConsensusNode.TxStreamer.ResultAtCount(msgCount)
@@ -176,7 +176,7 @@ func compareAllMsgResultsFromConsensusAndExecution(
 		if !reflect.DeepEqual(resultExec, resultConsensus) {
 			t.Fatal(
 				"resultExec", resultExec, "is different than resultConsensus", resultConsensus,
-				"pos:", pos,
+				"msgIdx:", msgIdx,
 				"testScenario:", testScenario,
 			)
 		}

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -1227,7 +1227,7 @@ func TestSequencerFeed_ExpressLaneAuction_InnerPayloadNoncesAreRespected_Timeboo
 // verifyTimeboostedCorrectness is used to check if the timeboosted byte array in both the sequencer's tx streamer and the client node's tx streamer (which is connected
 // to the sequencer feed) is accurate, i.e it represents correctly whether a tx is timeboosted or not
 func verifyTimeboostedCorrectness(t *testing.T, ctx context.Context, user string, tNode *arbnode.Node, tClient *ethclient.Client, isTimeboosted bool, userTx *types.Transaction, userTxBlockNum uint64) {
-	blockMetadataOfBlock, err := tNode.TxStreamer.BlockMetadataAtCount(arbutil.MessageIndex(userTxBlockNum) + 1)
+	blockMetadataOfBlock, err := tNode.TxStreamer.BlockMetadataAtMessageIndex(arbutil.MessageIndex(userTxBlockNum))
 	Require(t, err)
 	if len(blockMetadataOfBlock) == 0 {
 		t.Fatal("got empty blockMetadata byte array")

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -940,7 +940,7 @@ func TestTimeboostBulkBlockMetadataAPI(t *testing.T) {
 	}
 
 	// A Reorg event should clear the cache, hence the data fetched now should be accurate
-	Require(t, builder.L2.ConsensusNode.TxStreamer.ReorgTo(10))
+	Require(t, builder.L2.ConsensusNode.TxStreamer.ReorgAt(10))
 	err = l2rpc.CallContext(ctx, &result, "arb_getRawBlockMetadata", rpc.BlockNumber(start), rpc.BlockNumber(end))
 	Require(t, err)
 	if !bytes.Equal(updatedBlockMetadata, result[0].RawMetadata) {

--- a/system_tests/validation_mock_test.go
+++ b/system_tests/validation_mock_test.go
@@ -415,7 +415,7 @@ func (m *mockBlockRecorder) RecordBlockCreation(
 	if err != nil {
 		return nil, err
 	}
-	res, err := m.streamer.ResultAtCount(pos + 1)
+	res, err := m.streamer.ResultAtMessageIndex(pos)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Resolve NIT-2569

Different parts of Nitro (TransactionStreamer, InboxTracker, ExecutionEngine, Broadcaster, BlockValidator, etc), need to access the number of messages, or the content of a message, or the result related to processing a message.
Those properties are accessed in different ways through Nitro's code base, decreasing code readability.  
Examples: 
- In order to get the result related to processing a message, BlockValidator calls TransactionStreamer.ResultAtCount passing the message index plus one. However, in order to get the result related to processing a message, TransactionStreamer calls ExecutionEngine.ResutlAtPos passing the message index as argument.
- Variables that identify a message are named differently across the code base, such as `pos`, `num`, `seq`, `index`.

While reading the code base it is not uncommon to confuse what is the semantic meaning of a variable, such as if it is holding the number of messages, or a message identifier.

This PR is the first part of a refactor that unifies how properties related to messages are accessed through Nitro.
This PR mainly focus on refactoring TransactionStreamer, ExecutionEngine and Broadcaster.
It decreases message count usage in favor of using message indexes, such as declaring `func (n *ExecutionNode) Reorg(newHeadMsgIdx arbutil.MessageIndex, ...`, instead of `func (n *ExecutionNode) Reorg(count arbutil.MessageIndex, ...`.
It names message indexes identifiers as `msgIdx`.

If the approach of this PR is approved, then later more PRs are going to be created with the following goals:
- Spread the same approach to InboxTracker, BlockValidator, etc.
- Create a arbutil.MessageCount type, as uint64. In this way it will be easier to identify the semantic meaning of a variable.
- Represent delayed messages indexes as arbutil.MessageIndex.