### PR TITLE
Remove compiler warnings in test code.

### DIFF
--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -1304,7 +1304,7 @@ func setupConfigWithDAS(
 			URL:    "http://" + rpcLis.Addr().String(),
 			Pubkey: blsPubToBase64(dasSignerKey),
 		}
-		l1NodeConfigA.DataAvailability.RPCAggregator = aggConfigForBackend(t, beConfigA)
+		l1NodeConfigA.DataAvailability.RPCAggregator = aggConfigForBackend(beConfigA)
 		l1NodeConfigA.DataAvailability.Enable = true
 		l1NodeConfigA.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
 		l1NodeConfigA.DataAvailability.RestAggregator.Enable = true

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -89,7 +89,7 @@ func blsPubToBase64(pubkey *blsSignatures.PublicKey) string {
 	return string(encodedPubkey)
 }
 
-func aggConfigForBackend(t *testing.T, backendConfig das.BackendConfig) das.AggregatorConfig {
+func aggConfigForBackend(backendConfig das.BackendConfig) das.AggregatorConfig {
 	return das.AggregatorConfig{
 		Enable:                true,
 		AssumedHonest:         1,
@@ -115,7 +115,7 @@ func TestDASRekey(t *testing.T) {
 
 		// Setup DAS config
 		builder.nodeConfig.DataAvailability.Enable = true
-		builder.nodeConfig.DataAvailability.RPCAggregator = aggConfigForBackend(t, backendConfigA)
+		builder.nodeConfig.DataAvailability.RPCAggregator = aggConfigForBackend(backendConfigA)
 		builder.nodeConfig.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
 		builder.nodeConfig.DataAvailability.RestAggregator.Enable = true
 		builder.nodeConfig.DataAvailability.RestAggregator.Urls = []string{restServerUrlA}
@@ -153,7 +153,7 @@ func TestDASRekey(t *testing.T) {
 	authorizeDASKeyset(t, ctx, pubkeyB, builder.L1Info, builder.L1.Client)
 
 	// Restart the node on the new keyset against the new DAS server running on the same disk as the first with new keys
-	builder.nodeConfig.DataAvailability.RPCAggregator = aggConfigForBackend(t, backendConfigB)
+	builder.nodeConfig.DataAvailability.RPCAggregator = aggConfigForBackend(backendConfigB)
 	builder.l2StackConfig = testhelpers.CreateStackConfigForTest(builder.dataDir)
 	cleanup := builder.BuildL2OnL1(t)
 	defer cleanup()
@@ -268,7 +268,7 @@ func TestDASComplexConfigAndRestMirror(t *testing.T) {
 		URL:    "http://" + rpcLis.Addr().String(),
 		Pubkey: blsPubToBase64(pubkey),
 	}
-	builder.nodeConfig.DataAvailability.RPCAggregator = aggConfigForBackend(t, beConfigA)
+	builder.nodeConfig.DataAvailability.RPCAggregator = aggConfigForBackend(beConfigA)
 	builder.nodeConfig.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
 	builder.nodeConfig.DataAvailability.RestAggregator.Enable = true
 	builder.nodeConfig.DataAvailability.RestAggregator.Urls = []string{"http://" + restLis.Addr().String()}

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -199,7 +199,7 @@ func user(suffix string, idx int) string {
 }
 
 // tryWithTimeout calls function f() repeatedly foruntil it succeeds.
-func tryWithTimeout(ctx context.Context, f func() error, duration time.Duration) error {
+func tryWithTimeout(f func() error, duration time.Duration) error {
 	for {
 		select {
 		case <-time.After(duration):
@@ -263,7 +263,7 @@ func TestRedisForwarder(t *testing.T) {
 		tx := builder.L2Info.PrepareTx(userA, userB, builder.L2Info.TransferGas, transferAmount, nil)
 
 		sendFunc := func() error { return forwardingClient.SendTransaction(ctx, tx) }
-		if err := tryWithTimeout(ctx, sendFunc, DefaultTestForwarderConfig.UpdateInterval*10); err != nil {
+		if err := tryWithTimeout(sendFunc, DefaultTestForwarderConfig.UpdateInterval*10); err != nil {
 			t.Fatalf("Client: %v, error sending transaction: %v", i, err)
 		}
 		_, err := EnsureTxSucceeded(ctx, seqClients[i], tx)
@@ -308,7 +308,7 @@ func TestRedisForwarderFallbackNoRedis(t *testing.T) {
 	builder.L2Info.GenerateAccount(user)
 	tx := builder.L2Info.PrepareTx("Owner", "User2", builder.L2Info.TransferGas, transferAmount, nil)
 	sendFunc := func() error { return forwardingClient.SendTransaction(ctx, tx) }
-	err := tryWithTimeout(ctx, sendFunc, DefaultTestForwarderConfig.UpdateInterval*10)
+	err := tryWithTimeout(sendFunc, DefaultTestForwarderConfig.UpdateInterval*10)
 	Require(t, err)
 
 	_, err = builder.L2.EnsureTxSucceeded(tx)

--- a/system_tests/program_recursive_test.go
+++ b/system_tests/program_recursive_test.go
@@ -31,7 +31,7 @@ func testProgramRecursiveCall(t *testing.T, builder *NodeBuilder, slotVals map[s
 	ctx := builder.ctx
 	slot := common.HexToHash("0x11223344556677889900aabbccddeeff")
 	val := common.Hash{}
-	args := []byte{}
+	var args []byte
 	if recurse[0].opcode == vm.SSTORE {
 		// send event from storage on sstore
 		val = rander.GetHash()

--- a/system_tests/recreatestate_rpc_test.go
+++ b/system_tests/recreatestate_rpc_test.go
@@ -361,10 +361,8 @@ func testSkippingSavingStateAndRecreatingAfterRestart(t *testing.T, cacheConfig 
 	Require(t, err)
 
 	l2info.GenerateAccount("User2")
-	var txs []*types.Transaction
 	for i := genesis; i < uint64(txCount)+genesis; i++ {
 		tx := l2info.PrepareTx("Owner", "User2", l2info.TransferGas, common.Big1, nil)
-		txs = append(txs, tx)
 		err := client.SendTransaction(ctx, tx)
 		Require(t, err)
 		receipt, err := EnsureTxSucceeded(ctx, client, tx)

--- a/system_tests/retryable_test.go
+++ b/system_tests/retryable_test.go
@@ -223,7 +223,7 @@ func TestSubmitRetryableImmediateSuccess(t *testing.T) {
 		Fatal(t, "l1Receipt indicated failure")
 	}
 
-	waitForL1DelayBlocks(t, ctx, builder)
+	waitForL1DelayBlocks(t, builder)
 
 	receipt, err := builder.L2.EnsureTxSucceeded(lookupL2Tx(l1Receipt))
 	Require(t, err)
@@ -295,7 +295,7 @@ func testSubmitRetryableEmptyEscrow(t *testing.T, arbosVersion uint64) {
 		Fatal(t, "l1Receipt indicated failure")
 	}
 
-	waitForL1DelayBlocks(t, ctx, builder)
+	waitForL1DelayBlocks(t, builder)
 
 	l2Tx := lookupL2Tx(l1Receipt)
 	receipt, err := builder.L2.EnsureTxSucceeded(l2Tx)
@@ -362,7 +362,7 @@ func TestSubmitRetryableFailThenRetry(t *testing.T) {
 		Fatal(t, "l1Receipt indicated failure")
 	}
 
-	waitForL1DelayBlocks(t, ctx, builder)
+	waitForL1DelayBlocks(t, builder)
 
 	receipt, err := builder.L2.EnsureTxSucceeded(lookupL2Tx(l1Receipt))
 	Require(t, err)
@@ -480,7 +480,7 @@ func TestSubmissionGasCosts(t *testing.T) {
 		Fatal(t, "l1Receipt indicated failure")
 	}
 
-	waitForL1DelayBlocks(t, ctx, builder)
+	waitForL1DelayBlocks(t, builder)
 
 	submissionTxOuter := lookupL2Tx(l1Receipt)
 	submissionReceipt, err := builder.L2.EnsureTxSucceeded(submissionTxOuter)
@@ -586,7 +586,7 @@ func TestSubmissionGasCosts(t *testing.T) {
 	}
 }
 
-func waitForL1DelayBlocks(t *testing.T, ctx context.Context, builder *NodeBuilder) {
+func waitForL1DelayBlocks(t *testing.T, builder *NodeBuilder) {
 	// sending l1 messages creates l1 blocks.. make enough to get that delayed inbox message in
 	for i := 0; i < 30; i++ {
 		builder.L1.SendWaitTestTransactions(t, []*types.Transaction{
@@ -622,7 +622,7 @@ func TestDepositETH(t *testing.T) {
 	if l1Receipt.Status != types.ReceiptStatusSuccessful {
 		t.Errorf("Got transaction status: %v, want: %v", l1Receipt.Status, types.ReceiptStatusSuccessful)
 	}
-	waitForL1DelayBlocks(t, ctx, builder)
+	waitForL1DelayBlocks(t, builder)
 
 	l2Receipt, err := builder.L2.EnsureTxSucceeded(lookupL2Tx(l1Receipt))
 	if err != nil {
@@ -681,7 +681,7 @@ func TestArbitrumContractTx(t *testing.T) {
 	if receipt.Status != types.ReceiptStatusSuccessful {
 		t.Errorf("L1 transaction: %v has failed", l1tx.Hash())
 	}
-	waitForL1DelayBlocks(t, ctx, builder)
+	waitForL1DelayBlocks(t, builder)
 	_, err = builder.L2.EnsureTxSucceeded(lookupL2Tx(receipt))
 	if err != nil {
 		t.Fatalf("EnsureTxSucceeded(%v) unexpected error: %v", unsignedTx.Hash(), err)
@@ -750,7 +750,7 @@ func TestL1FundedUnsignedTransaction(t *testing.T) {
 	if receipt.Status != types.ReceiptStatusSuccessful {
 		t.Errorf("L1 transaction: %v has failed", l1tx.Hash())
 	}
-	waitForL1DelayBlocks(t, ctx, builder)
+	waitForL1DelayBlocks(t, builder)
 	receipt, err = builder.L2.EnsureTxSucceeded(unsignedTx)
 	if err != nil {
 		t.Fatalf("EnsureTxSucceeded(%v) unexpected error: %v", unsignedTx.Hash(), err)
@@ -802,7 +802,7 @@ func TestRetryableSubmissionAndRedeemFees(t *testing.T) {
 		Fatal(t, "l1Receipt indicated failure")
 	}
 
-	waitForL1DelayBlocks(t, ctx, builder)
+	waitForL1DelayBlocks(t, builder)
 
 	submissionTxOuter := lookupL2Tx(l1Receipt)
 	submissionReceipt, err := builder.L2.EnsureTxSucceeded(submissionTxOuter)
@@ -971,7 +971,7 @@ func TestRetryableRedeemBlockGasUsage(t *testing.T) {
 	if l1Receipt.Status != types.ReceiptStatusSuccessful {
 		Fatal(t, "l1Receipt indicated failure")
 	}
-	waitForL1DelayBlocks(t, ctx, builder)
+	waitForL1DelayBlocks(t, builder)
 	submissionReceipt, err := EnsureTxSucceeded(ctx, l2client, lookupL2Tx(l1Receipt))
 	Require(t, err)
 	if len(submissionReceipt.Logs) != 2 {

--- a/system_tests/triedb_race_test.go
+++ b/system_tests/triedb_race_test.go
@@ -75,7 +75,7 @@ func TestTrieDBCommitRace(t *testing.T) {
 		for _, root := range roots {
 			err := bc.TrieDB().Dereference(root)
 			Require(t, err)
-			time.Sleep(1)
+			time.Sleep(time.Nanosecond)
 		}
 	}
 	close(quit)


### PR DESCRIPTION
Mostly removing unused arguments from functions, but also explicitly setting a 1 nanosecond sleep which was implicit before.