### PR TITLE
Wait for the insertion mutex in WriteMessageFromSequencer

### DIFF
--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -952,9 +952,7 @@ func (s *TransactionStreamer) WriteMessageFromSequencer(
 	if err := s.ExpectChosenSequencer(); err != nil {
 		return err
 	}
-	if !s.insertionMutex.TryLock() {
-		return execution.ErrSequencerInsertLockTaken
-	}
+	s.insertionMutex.Lock()
 	defer s.insertionMutex.Unlock()
 
 	msgCount, err := s.GetMessageCount()

--- a/system_tests/reorg_resequencing_test.go
+++ b/system_tests/reorg_resequencing_test.go
@@ -1,9 +1,6 @@
 // Copyright 2021-2022, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-//go:build cionly
-// +build cionly
-
 package arbtest
 
 import (
@@ -18,7 +15,6 @@ import (
 	"github.com/offchainlabs/nitro/util/arbmath"
 )
 
-// This is a flaky test.
 // During a reorg:
 // 1. TransactionStreamer, holding insertionMutex lock, calls ExecutionEngine, which then adds old messages to a channel.
 // After that, and before releasing the lock, TransactionStreamer does more computations.


### PR DESCRIPTION
Fixes NIT-2687

Also fixes an issue I noticed where if the SyncMonitor happened to call `FeedPendingMessageCount` at the wrong time on the tx streamer it could prevent the sequencer from writing a message because the insertion mutex would be held.