### PR TITLE
Remove fast confirmer config

### DIFF
--- a/staker/staker.go
+++ b/staker/staker.go
@@ -320,7 +320,7 @@ func NewStaker(
 		return nil, err
 	}
 	// Only use gnosis safe fast confirmation, if the safe address is different from the wallet address, else it's not a safe contract.
-	if fastConfirmer != (common.Address{}) && config.EnableFastConfirmation && wallet.AddressOrZero() != fastConfirmer {
+	if fastConfirmer != (common.Address{}) && config.EnableFastConfirmation && wallet.AddressOrZero() != (common.Address{}) && wallet.AddressOrZero() != fastConfirmer {
 		fastConfirmSafe, err = NewFastConfirmSafe(
 			callOpts,
 			fastConfirmer,
@@ -331,6 +331,13 @@ func NewStaker(
 		)
 		if err != nil {
 			return nil, err
+		}
+		isOwner, err := fastConfirmSafe.safe.IsOwner(&callOpts, wallet.AddressOrZero())
+		if err != nil {
+			return nil, err
+		}
+		if !isOwner {
+			log.Info("fast confirmer is not part of owners of safe", "fastConfirmer", fastConfirmer, "wallet", wallet.AddressOrZero())
 		}
 	}
 	return &Staker{

--- a/staker/staker.go
+++ b/staker/staker.go
@@ -344,7 +344,11 @@ func NewStaker(
 			return nil, err
 		}
 		if !isOwner {
-			log.Info("fast confirmer is not part of owners of safe", "fastConfirmer", fastConfirmer, "wallet", wallet.AddressOrZero())
+			// If the wallet is not an owner of the safe, we can't use it for fast confirmation
+			// So disable fast confirmation.
+			fastConfirmer = common.Address{}
+			fastConfirmSafe = nil
+			log.Info("Staker wallet address is not part of owners of safe so cannot use it for fast confirmation", "fastConfirmer", fastConfirmer, "wallet", wallet.AddressOrZero())
 		}
 	}
 	inactiveValidatedNodes := btree.NewG(2, func(a, b validatedNode) bool {

--- a/system_tests/fast_confirm_test.go
+++ b/system_tests/fast_confirm_test.go
@@ -122,7 +122,6 @@ func TestFastConfirmation(t *testing.T) {
 	Require(t, err)
 
 	valConfig := staker.TestL1ValidatorConfig
-	valConfig.EnableFastConfirmation = true
 	parentChainID, err := builder.L1.Client.ChainID(ctx)
 	if err != nil {
 		t.Fatalf("Failed to get parent chain id: %v", err)
@@ -324,8 +323,6 @@ func TestFastConfirmationWithSafe(t *testing.T) {
 	Require(t, err)
 
 	valConfig := staker.TestL1ValidatorConfig
-	valConfig.EnableFastConfirmation = true
-	valConfig.FastConfirmSafeAddress = safeAddress.String()
 
 	parentChainID, err := builder.L1.Client.ChainID(ctx)
 	if err != nil {

--- a/system_tests/fast_confirm_test.go
+++ b/system_tests/fast_confirm_test.go
@@ -157,6 +157,8 @@ func TestFastConfirmation(t *testing.T) {
 	Require(t, err)
 	err = stateless.Start(ctx)
 	Require(t, err)
+	err = valWallet.Initialize(ctx)
+	Require(t, err)
 	stakerA, err := staker.NewStaker(
 		l2node.L1Reader,
 		valWallet,
@@ -171,10 +173,6 @@ func TestFastConfirmation(t *testing.T) {
 	)
 	Require(t, err)
 	err = stakerA.Initialize(ctx)
-	if stakerA.Strategy() != staker.WatchtowerStrategy {
-		err = valWallet.Initialize(ctx)
-		Require(t, err)
-	}
 	Require(t, err)
 	cfg := arbnode.ConfigDefaultL1NonSequencerTest()
 	signerCfg, err := externalSignerTestCfg(srv.Address, srv.URL())

--- a/system_tests/fast_confirm_test.go
+++ b/system_tests/fast_confirm_test.go
@@ -359,6 +359,8 @@ func TestFastConfirmationWithSafe(t *testing.T) {
 	Require(t, err)
 	err = statelessA.Start(ctx)
 	Require(t, err)
+	err = valWalletA.Initialize(ctx)
+	Require(t, err)
 	stakerA, err := staker.NewStaker(
 		l2nodeA.L1Reader,
 		valWalletA,
@@ -373,8 +375,6 @@ func TestFastConfirmationWithSafe(t *testing.T) {
 	)
 	Require(t, err)
 	err = stakerA.Initialize(ctx)
-	Require(t, err)
-	err = valWalletA.Initialize(ctx)
 	Require(t, err)
 	cfg := arbnode.ConfigDefaultL1NonSequencerTest()
 	signerCfg, err := externalSignerTestCfg(srv.Address, srv.URL())
@@ -409,6 +409,8 @@ func TestFastConfirmationWithSafe(t *testing.T) {
 	Require(t, err)
 	err = statelessB.Start(ctx)
 	Require(t, err)
+	err = valWalletB.Initialize(ctx)
+	Require(t, err)
 	stakerB, err := staker.NewStaker(
 		l2nodeB.L1Reader,
 		valWalletB,
@@ -423,8 +425,6 @@ func TestFastConfirmationWithSafe(t *testing.T) {
 	)
 	Require(t, err)
 	err = stakerB.Initialize(ctx)
-	Require(t, err)
-	err = valWalletB.Initialize(ctx)
 	Require(t, err)
 
 	builder.L2Info.GenerateAccount("BackgroundUser")


### PR DESCRIPTION
Based on harry's suggestion removing the dependency on config for fast confirmation, we can just fetch all the info from on chain. 