### PR TITLE
testredisproduce: trigger trim

### DIFF
--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -284,6 +284,8 @@ func TestRedisProduce(t *testing.T) {
 			if cnt := producer.promisesLen(); cnt != 0 {
 				t.Errorf("Producer still has %d unfullfilled promises", cnt)
 			}
+			// Trigger a trim
+			producer.checkResponses(ctx)
 			msgs, err := redisClient.XRange(ctx, streamName, "-", "+").Result()
 			if err != nil {
 				t.Errorf("XRange failed: %v", err)


### PR DESCRIPTION
fixes: [NIT-2713]

This should make the tests stable, by making sure we trim from redis after all promise have been fulfilled.