### PR TITLE
Fixes block hash retrieval in PopulateFeedBacklog

### DIFF
--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -300,7 +300,7 @@ func (t *InboxTracker) PopulateFeedBacklog(broadcastServer *broadcaster.Broadcas
 			return fmt.Errorf("error getting message %v: %w", seqNum, err)
 		}
 
-		msgResult, err := t.txStreamer.ResultAtCount(seqNum)
+		msgResult, err := t.txStreamer.ResultAtCount(seqNum + 1)
 		var blockHash *common.Hash
 		if err == nil {
 			blockHash = &msgResult.BlockHash

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -457,8 +457,8 @@ func TestPopulateFeedBacklog(t *testing.T) {
 	_, err = builder.L2.EnsureTxSucceeded(tx)
 	Require(t, err)
 
-	// Shutdown node and starts a new one with same data dir and feed output enabled.
-	// The new node will populate the feedbacklog since already a message, related to the
+	// Shutdown node and starts a new one with same data dir and output feed enabled.
+	// The new node will populate the feedbacklog since already has a message, related to the
 	// transaction previously sent, stored in disk.
 	builder.L2.cleanup()
 	builder.l2StackConfig.DataDir = dataDir
@@ -466,7 +466,7 @@ func TestPopulateFeedBacklog(t *testing.T) {
 	cleanup := builder.BuildL2OnL1(t)
 	defer cleanup()
 
-	// Creates a sink node, that will read from the feed output of the previous node.
+	// Creates a sink node that will read from the output feed of the previous node.
 	nodeConfigSink := builder.nodeConfig
 	port := builder.L2.ConsensusNode.BroadcastServer.ListenerAddr().(*net.TCPAddr).Port
 	nodeConfigSink.Feed.Input = *newBroadcastClientConfigTest(port)


### PR DESCRIPTION
Fixes block hash retrieval in PopulateFeedBacklog.
It also adds a test that covers PopulateFeedBacklog.

This issue mainly affects the output feed of nodes during startup, which will have incorrect block hashes in the beginning.
With incorrect block hashes, nodes relying on the output feed will incorrectly log an error: "BlockHash from feed doesn't match locally computed hash. Check feed source.".
Those incorrect error logs are transient though, since after PopulateFeedBacklog is executed, the output feed will start being fed with correct block hashes.
