### PR TITLE
Use new rust toolchain action for Go CI

### DIFF
--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -78,9 +78,12 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         id: install-rust-nightly
         with:
-          toolchain: 'nightly'
+          toolchain: 'nightly-2024-08-06'
           targets: 'wasm32-wasi, wasm32-unknown-unknown'
           components: 'rust-src, rustfmt, clippy'
+
+      - name: Set STYLUS_NIGHTLY_VER environment variable
+          echo "STYLUS_NIGHTLY_VER=$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
 
       - name: Cache Rust intermediate build products
         uses: actions/cache@v3

--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -83,7 +83,7 @@ jobs:
           components: 'rust-src, rustfmt, clippy'
 
       - name: Set STYLUS_NIGHTLY_VER environment variable
-          echo "STYLUS_NIGHTLY_VER=$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
+        run: echo "STYLUS_NIGHTLY_VER=$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
 
       - name: Cache Rust intermediate build products
         uses: actions/cache@v3

--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -171,7 +171,7 @@ jobs:
         run: cargo fmt -p arbutil -p prover -p jit -p stylus --manifest-path arbitrator/Cargo.toml -- --check
 
       - name: Rustfmt - langs/rust
-        args: cargo fmt --all --manifest-path arbitrator/langs/rust/Cargo.toml -- --check
+        run: cargo fmt --all --manifest-path arbitrator/langs/rust/Cargo.toml -- --check
 
       - name: Make proofs from test cases
         run: make -j test-gen-proofs

--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -162,22 +162,13 @@ jobs:
         run: cargo clippy --all --manifest-path arbitrator/Cargo.toml -- -D warnings
 
       - name: Run rust tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -p arbutil -p prover -p jit -p stylus --release --manifest-path arbitrator/prover/Cargo.toml
+        run: cargo test -p arbutil -p prover -p jit -p stylus --release --manifest-path arbitrator/prover/Cargo.toml
 
       - name: Rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -p arbutil -p prover -p jit -p stylus --manifest-path arbitrator/Cargo.toml -- --check
+        run: cargo fmt -p arbutil -p prover -p jit -p stylus --manifest-path arbitrator/Cargo.toml -- --check
 
       - name: Rustfmt - langs/rust
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --manifest-path arbitrator/langs/rust/Cargo.toml -- --check
+        args: cargo fmt --all --manifest-path arbitrator/langs/rust/Cargo.toml -- --check
 
       - name: Make proofs from test cases
         run: make -j test-gen-proofs

--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -83,7 +83,7 @@ jobs:
           components: 'rust-src, rustfmt, clippy'
 
       - name: Set STYLUS_NIGHTLY_VER environment variable
-        run: echo "STYLUS_NIGHTLY_VER=$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
+        run: echo "STYLUS_NIGHTLY_VER=+$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
 
       - name: Cache Rust intermediate build products
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           components: 'rust-src, rustfmt, clippy'
 
       - name: Set STYLUS_NIGHTLY_VER environment variable
-          echo "STYLUS_NIGHTLY_VER=$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
+        run: echo "STYLUS_NIGHTLY_VER=$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,17 +56,19 @@ jobs:
       - name: Install rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: 'wasm32-unknown-unknown, wasm32-wasi'
+          toolchain: 'stable'
+          components: 'llvm-tools-preview, rustfmt, clippy'
+
+      - name: Install rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        id: install-rust-nightly
+        with:
+          toolchain: 'nightly'
+          targets: 'wasm32-wasi, wasm32-unknown-unknown'
+          components: 'rust-src, rustfmt, clippy'
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Install rust nightly
-        uses: actions-rs/toolchain@v1
-        id: install-rust-nightly
-        with:
-          profile: minimal
-          toolchain: "nightly"
 
       - name: Install rust wasm targets
         run: rustup target add wasm32-wasi wasm32-unknown-unknown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           components: 'rust-src, rustfmt, clippy'
 
       - name: Set STYLUS_NIGHTLY_VER environment variable
-        run: echo "STYLUS_NIGHTLY_VER=$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
+        run: echo "STYLUS_NIGHTLY_VER=+$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,26 +57,22 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 'stable'
+          targets: 'wasm32-wasi, wasm32-unknown-unknown'
           components: 'llvm-tools-preview, rustfmt, clippy'
 
       - name: Install rust nightly
         uses: dtolnay/rust-toolchain@nightly
         id: install-rust-nightly
         with:
-          toolchain: 'nightly'
+          toolchain: 'nightly-2024-08-06'
           targets: 'wasm32-wasi, wasm32-unknown-unknown'
           components: 'rust-src, rustfmt, clippy'
 
+      - name: Set STYLUS_NIGHTLY_VER environment variable
+          echo "STYLUS_NIGHTLY_VER=$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Install rust wasm targets
-        run: rustup target add wasm32-wasi wasm32-unknown-unknown
-
-      - name: Install nightly wasm targets
-        run: |
-          rustup component add rust-src --toolchain nightly
-          rustup target add wasm32-unknown-unknown --toolchain nightly
 
       - name: Cache Build Products
         uses: actions/cache@v3


### PR DESCRIPTION
The one we previously used in Go CI has been deprecated and archived. This PR switches it to the new one already used in arbitrator CI. It also gets rid of the deprecated actions-rs/cargo action in arbitrator CI. Hopefully this PR will fix CI.