### PR TITLE
Remove default nitro-val RPC request size limit

### DIFF
--- a/cmd/nitro-val/nitro_val.go
+++ b/cmd/nitro-val/nitro_val.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"math"
 	_ "net/http/pprof" // #nosec G108
 	"os"
 	"os/signal"
@@ -66,6 +67,7 @@ func mainImpl() int {
 	}
 	stackConf := DefaultValidationNodeStackConfig
 	stackConf.DataDir = "" // ephemeral
+	stackConf.HTTPBodyLimit = math.MaxInt
 	nodeConfig.HTTP.Apply(&stackConf)
 	nodeConfig.WS.Apply(&stackConf)
 	nodeConfig.Auth.Apply(&stackConf)

--- a/cmd/nitro-val/nitro_val.go
+++ b/cmd/nitro-val/nitro_val.go
@@ -68,7 +68,7 @@ func mainImpl() int {
 	stackConf := DefaultValidationNodeStackConfig
 	stackConf.DataDir = "" // ephemeral
 	stackConf.HTTPBodyLimit = math.MaxInt
-	stackConf.WSReadLimit = math.MinInt64
+	stackConf.WSReadLimit = math.MaxInt64
 	nodeConfig.HTTP.Apply(&stackConf)
 	nodeConfig.WS.Apply(&stackConf)
 	nodeConfig.Auth.Apply(&stackConf)

--- a/cmd/nitro-val/nitro_val.go
+++ b/cmd/nitro-val/nitro_val.go
@@ -68,6 +68,7 @@ func mainImpl() int {
 	stackConf := DefaultValidationNodeStackConfig
 	stackConf.DataDir = "" // ephemeral
 	stackConf.HTTPBodyLimit = math.MaxInt
+	stackConf.WSReadLimit = math.MinInt64
 	nodeConfig.HTTP.Apply(&stackConf)
 	nodeConfig.WS.Apply(&stackConf)
 	nodeConfig.Auth.Apply(&stackConf)


### PR DESCRIPTION
Fixes: NIT-2725

Pulls in https://github.com/OffchainLabs/go-ethereum/pull/350