### PR TITLE
Fix arbitrator validation tests

### DIFF
--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -92,7 +92,7 @@ func testBlockValidatorSimple(t *testing.T, opts Options) {
 		validatorConfig.BlockValidator.RedisValidationClientConfig = redis.ValidationClientConfig{}
 	}
 
-	AddDefaultValNode(t, ctx, validatorConfig, !opts.arbitrator, redisURL, opts.wasmRootDir)
+	AddValNode(t, ctx, validatorConfig, !opts.arbitrator, redisURL, opts.wasmRootDir)
 
 	testClientB, cleanupB := builder.Build2ndNode(t, &SecondNodeParams{nodeConfig: validatorConfig})
 	defer cleanupB()

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -364,7 +364,7 @@ func (b *NodeBuilder) BuildL2OnL1(t *testing.T) func() {
 		validatorTxOptsPtr = &validatorTxOpts
 	}
 
-	AddDefaultValNode(t, b.ctx, b.nodeConfig, true, "", b.valnodeConfig.Wasm.RootPath)
+	AddValNodeIfNeeded(t, b.ctx, b.nodeConfig, true, "", b.valnodeConfig.Wasm.RootPath)
 
 	Require(t, b.execConfig.Validate())
 	execConfig := b.execConfig
@@ -400,7 +400,7 @@ func (b *NodeBuilder) BuildL2OnL1(t *testing.T) func() {
 func (b *NodeBuilder) BuildL2(t *testing.T) func() {
 	b.L2 = NewTestClient(b.ctx)
 
-	AddDefaultValNode(t, b.ctx, b.nodeConfig, true, "", b.valnodeConfig.Wasm.RootPath)
+	AddValNodeIfNeeded(t, b.ctx, b.nodeConfig, true, "", b.valnodeConfig.Wasm.RootPath)
 
 	var chainDb ethdb.Database
 	var arbDb ethdb.Database
@@ -891,10 +891,14 @@ func currentRootModule(t *testing.T) common.Hash {
 	return locator.LatestWasmModuleRoot()
 }
 
-func AddDefaultValNode(t *testing.T, ctx context.Context, nodeConfig *arbnode.Config, useJit bool, redisURL string, wasmRootDir string) {
-	if !nodeConfig.ValidatorRequired() {
+func AddValNodeIfNeeded(t *testing.T, ctx context.Context, nodeConfig *arbnode.Config, useJit bool, redisURL string, wasmRootDir string) {
+	if !nodeConfig.ValidatorRequired() || nodeConfig.BlockValidator.ValidationServerConfigs[0].URL != "" {
 		return
 	}
+	AddValNode(t, ctx, nodeConfig, useJit, redisURL, wasmRootDir)
+}
+
+func AddValNode(t *testing.T, ctx context.Context, nodeConfig *arbnode.Config, useJit bool, redisURL string, wasmRootDir string) {
 	conf := valnode.TestValidationConfig
 	conf.UseJit = useJit
 	conf.Wasm.RootPath = wasmRootDir
@@ -1168,7 +1172,7 @@ func Create2ndNodeWithConfig(
 	l2blockchain, err := gethexec.WriteOrTestBlockChain(l2chainDb, coreCacheConfig, initReader, chainConfig, initMessage, ExecConfigDefaultTest().TxLookupLimit, 0)
 	Require(t, err)
 
-	AddDefaultValNode(t, ctx, nodeConfig, true, "", valnodeConfig.Wasm.RootPath)
+	AddValNodeIfNeeded(t, ctx, nodeConfig, true, "", valnodeConfig.Wasm.RootPath)
 
 	Require(t, execConfig.Validate())
 	Require(t, nodeConfig.Validate())

--- a/system_tests/program_recursive_test.go
+++ b/system_tests/program_recursive_test.go
@@ -136,7 +136,7 @@ func testProgramResursiveCalls(t *testing.T, tests [][]multiCallRecurse, jit boo
 	validatorConfig.BlockValidator.Enable = true
 	emptyRedisURL := ""
 	defaultWasmRootPath := ""
-	AddDefaultValNode(t, ctx, validatorConfig, jit, emptyRedisURL, defaultWasmRootPath)
+	AddValNode(t, ctx, validatorConfig, jit, emptyRedisURL, defaultWasmRootPath)
 	valClient, valCleanup := builder.Build2ndNode(t, &SecondNodeParams{nodeConfig: validatorConfig})
 	defer valCleanup()
 

--- a/util/testhelpers/github/releases.go
+++ b/util/testhelpers/github/releases.go
@@ -47,7 +47,7 @@ func LatestConsensusRelease(ctx context.Context) (*ConsensusRelease, error) {
 	}
 	var found *ConsensusRelease
 	for _, release := range releases {
-		if strings.HasPrefix(release.GetTagName(), "consensus") {
+		if strings.HasPrefix(release.GetTagName(), "consensus") && !release.GetPrerelease() {
 			if found, err = fromRelease(release); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Even though we were creating an arbitrator validation node and assigning it to the nitro node, this was overwritten by BuildL2 which would then create a new non-arbitrator validation node and override the validation server URL.