### PR TITLE
Update dev test chains ArbOS versions in arbitrum_chain_info.json

### DIFF
--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -164,7 +164,7 @@
         "EnableArbOS": true,
         "AllowDebugPrecompiles": true,
         "DataAvailabilityCommittee": false,
-        "InitialArbOSVersion": 11,
+        "InitialArbOSVersion": 31,
         "InitialChainOwner": "0x0000000000000000000000000000000000000000",
         "GenesisBlockNum": 0
       }
@@ -196,7 +196,7 @@
         "EnableArbOS": true,
         "AllowDebugPrecompiles": true,
         "DataAvailabilityCommittee": true,
-        "InitialArbOSVersion": 11,
+        "InitialArbOSVersion": 31,
         "InitialChainOwner": "0x0000000000000000000000000000000000000000",
         "GenesisBlockNum": 0
       }


### PR DESCRIPTION
In the future we should get rid of the hardcoded list of chains in config_arbitrum.go (in geth) and only use this file.