### PR TITLE
Fix new golangci-lint lints

### DIFF
--- a/arbos/programs/api.go
+++ b/arbos/programs/api.go
@@ -4,8 +4,6 @@
 package programs
 
 import (
-	"errors"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -235,7 +233,10 @@ func newApiClosures(
 		if suberr != nil {
 			addr = zeroAddr
 		}
-		if !errors.Is(vm.ErrExecutionReverted, suberr) {
+		// This matches geth behavior of doing an exact error comparison instead of errors.Is
+		// See e.g. EVM's create method or the opCreate function for references of how geth checks this
+		//nolint:errorlint
+		if suberr != vm.ErrExecutionReverted {
 			res = nil // returnData is only provided in the revert case (opCreate)
 		}
 		interpreter.SetReturnData(res)

--- a/cmd/nitro/config_test.go
+++ b/cmd/nitro/config_test.go
@@ -95,11 +95,11 @@ func TestReloads(t *testing.T) {
 			hot := node.Type().Field(i).Tag.Get("reload") == "hot"
 			dot := path + "." + node.Type().Field(i).Name
 			if hot && cold {
-				t.Fatalf(fmt.Sprintf(
+				t.Fatalf(
 					"Option %v%v%v is reloadable but %v%v%v is not",
 					colors.Red, dot, colors.Clear,
 					colors.Red, path, colors.Clear,
-				))
+				)
 			}
 			if hot {
 				colors.PrintBlue(dot)


### PR DESCRIPTION
CI broke with golangci-lint 1.60.1 adding new lints, which are fixed here