### PR TITLE
remove parent-chain.wallet from config dump

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -900,10 +900,8 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 	// Don't print wallet passwords
 	if nodeConfig.Conf.Dump {
 		err = confighelpers.DumpConfig(k, map[string]interface{}{
-			"parent-chain.wallet.password":    "",
-			"parent-chain.wallet.private-key": "",
-			"chain.dev-wallet.password":       "",
-			"chain.dev-wallet.private-key":    "",
+			"chain.dev-wallet.password":    "",
+			"chain.dev-wallet.private-key": "",
 		})
 		if err != nil {
 			return nil, nil, err

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -900,8 +900,12 @@ func ParseNode(ctx context.Context, args []string) (*NodeConfig, *genericconf.Wa
 	// Don't print wallet passwords
 	if nodeConfig.Conf.Dump {
 		err = confighelpers.DumpConfig(k, map[string]interface{}{
-			"chain.dev-wallet.password":    "",
-			"chain.dev-wallet.private-key": "",
+			"node.batch-poster.parent-chain-wallet.password":    "",
+			"node.batch-poster.parent-chain-wallet.private-key": "",
+			"node.staker.parent-chain-wallet.password":          "",
+			"node.staker.parent-chain-wallet.private-key":       "",
+			"chain.dev-wallet.password":                         "",
+			"chain.dev-wallet.private-key":                      "",
 		})
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
Resolves NIT-2738

`parent-chain.wallet` config option was removed in  https://github.com/OffchainLabs/nitro/pull/2381

This PR removes clearing of outdated `parent-chain.wallet.password` and `parent-chain.wallet.private-key` when dumping a config.

Instead, the PR adds clearing of:
* `node.batch-poster.parent-chain-wallet.password`
* `node.batch-poster.parent-chain-wallet.private-key`
* `node.staker.parent-chain.wallet.password`
* `node.staker.parent-chain.wallet.private-key`