### PR TITLE
Ignores gosec G115

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,6 +44,7 @@ linters-settings:
   gosec:
     excludes:
       - G404  # checks that random numbers are securely generated
+      - G115 # Potential integer overflow when converting between integer types
 
   govet:
     enable-all: true


### PR DESCRIPTION
golangci-lint version 1.60.2 "broke" CI by pointing some overflow conversion issues in Nitro.

This PR disables this lint rule for now.