### PR TITLE
Fix inverted expiry logic for DAS S3 backends

### DIFF
--- a/das/s3_storage_service.go
+++ b/das/s3_storage_service.go
@@ -110,7 +110,7 @@ func (s3s *S3StorageService) Put(ctx context.Context, value []byte, timeout uint
 		Bucket: aws.String(s3s.bucket),
 		Key:    aws.String(s3s.objectPrefix + EncodeStorageServiceKey(dastree.Hash(value))),
 		Body:   bytes.NewReader(value)}
-	if !s3s.discardAfterTimeout {
+	if s3s.discardAfterTimeout {
 		expires := time.Unix(int64(timeout), 0)
 		putObjectInput.Expires = &expires
 	}

--- a/das/syncing_fallback_storage.go
+++ b/das/syncing_fallback_storage.go
@@ -105,9 +105,9 @@ type l1SyncService struct {
 	lastBatchAcc   common.Hash
 }
 
-// The original syncing process had a bug, so the file was renamed to cause any mirrors
-// in the wild to re-sync from their configured starting block number.
-const nextBlockNoFilename = "nextBlockNumberV2"
+// The filename has been updated when we have discovered bugs that may have impacted
+// syncing, to cause mirrors to re-sync.
+const nextBlockNoFilename = "nextBlockNumberV3"
 
 func readSyncStateOrDefault(syncDir string, dflt uint64) uint64 {
 	if syncDir == "" {


### PR DESCRIPTION
Also force a resync of all mirrors since if they were using S3, they may be missing data in S3.