### PR TITLE
Fix new integer cast overflow lints

### DIFF
--- a/system_tests/contract_tx_test.go
+++ b/system_tests/contract_tx_test.go
@@ -51,6 +51,7 @@ func TestContractTxDeploy(t *testing.T) {
 			0xF3, // RETURN
 		}
 		var requestId common.Hash
+		// #nosec G115
 		requestId[0] = uint8(stateNonce)
 		contractTx := &types.ArbitrumContractTx{
 			ChainId:   params.ArbitrumDevTestChainConfig().ChainID,

--- a/util/blobs/blobs.go
+++ b/util/blobs/blobs.go
@@ -41,6 +41,7 @@ func fillBlobBits(blob []byte, data []byte) ([]byte, error) {
 			accBits += 8
 			data = data[1:]
 		}
+		// #nosec G115
 		blob[fieldElement*32] = uint8(acc & ((1 << spareBlobBits) - 1))
 		accBits -= spareBlobBits
 		if accBits < 0 {
@@ -88,6 +89,7 @@ func DecodeBlobs(blobs []kzg4844.Blob) ([]byte, error) {
 			acc |= uint16(blob[fieldIndex*32]) << accBits
 			accBits += spareBlobBits
 			if accBits >= 8 {
+				// #nosec G115
 				rlpData = append(rlpData, uint8(acc))
 				acc >>= 8
 				accBits -= 8


### PR DESCRIPTION
golangci-lint v1.60.3 finds three new instances of an integer cast that can overflow compared to v1.60.2. They're all false positives though, so this PR just ignores them. The two in blobs.go are intentional to only read/write a byte of data, and the one in contract_tx_test.go never overflows because the for loop only goes up to 2 (and it's a test anyways).