### PR TITLE
update default x86 architecture

### DIFF
--- a/arbos/programs/cgo_test.go
+++ b/arbos/programs/cgo_test.go
@@ -40,5 +40,13 @@ func TestCompileArch(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = resetNativeTarget()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = testCompileLoad()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -289,7 +289,7 @@ func ResizeWasmLruCache(size uint32) {
 }
 
 const DefaultTargetDescriptionArm = "arm64-linux-unknown+neon"
-const DefaultTargetDescriptionX86 = "x86_64-linux-unknown+sse4.2"
+const DefaultTargetDescriptionX86 = "x86_64-linux-unknown+sse4.2+lzcnt+bmi"
 
 func SetTarget(name rawdb.Target, description string, native bool) error {
 	output := &rustBytes{}

--- a/arbos/programs/testcompile.go
+++ b/arbos/programs/testcompile.go
@@ -178,6 +178,28 @@ func testCompileArch(store bool) error {
 	return nil
 }
 
+func resetNativeTarget() error {
+	output := &rustBytes{}
+
+	_, err := fmt.Print("resetting native target\n")
+	if err != nil {
+		return err
+	}
+
+	localCompileName := []byte("local")
+
+	status := C.stylus_target_set(goSlice(localCompileName),
+		goSlice([]byte{}),
+		output,
+		cbool(true))
+
+	if status != 0 {
+		return fmt.Errorf("failed setting compilation target arm: %v", string(output.intoBytes()))
+	}
+
+	return nil
+}
+
 func testCompileLoad() error {
 	filePath := "../../target/testdata/host.bin"
 	localTarget := rawdb.LocalTarget()


### PR DESCRIPTION
This requires BMI extension: https://en.wikipedia.org/wiki/X86_Bit_manipulation_instruction_set
makes clz instructions faster on x86

This also builds on TEST_COMPILE test to see that things built for a modified arch flags still work with Target::default