### PR TITLE
Return false if nil is passed to IsNotExistError

### DIFF
--- a/util/dbutil/dbutil.go
+++ b/util/dbutil/dbutil.go
@@ -6,7 +6,7 @@ package dbutil
 import (
 	"errors"
 	"fmt"
-	"os"
+	"io/fs"
 	"regexp"
 
 	"github.com/cockroachdb/pebble"
@@ -22,13 +22,15 @@ func IsErrNotFound(err error) bool {
 var pebbleNotExistErrorRegex = regexp.MustCompile("pebble: database .* does not exist")
 
 func isPebbleNotExistError(err error) bool {
-	return pebbleNotExistErrorRegex.MatchString(err.Error())
+	return err != nil && pebbleNotExistErrorRegex.MatchString(err.Error())
 }
 
 func isLeveldbNotExistError(err error) bool {
-	return os.IsNotExist(err)
+	return errors.Is(err, fs.ErrNotExist)
 }
 
+// IsNotExistError returns true if the error is a "database not found" error.
+// It must return false if err is nil.
 func IsNotExistError(err error) bool {
 	return isLeveldbNotExistError(err) || isPebbleNotExistError(err)
 }

--- a/util/dbutil/dbutil_test.go
+++ b/util/dbutil/dbutil_test.go
@@ -28,6 +28,9 @@ func testIsNotExistError(t *testing.T, dbEngine string, isNotExist func(error) b
 	if isNotExist(err) {
 		t.Fatalf("Classified other error as not exist, err: %v", err)
 	}
+	if isNotExist(nil) {
+		t.Fatal("Classified nil as not exist")
+	}
 }
 
 func TestIsNotExistError(t *testing.T) {


### PR DESCRIPTION
This matches behavior with `errors.Is`