### PR TITLE
[NIT-2587] Improve out of gas warning log

### DIFF
--- a/arbitrator/arbutil/src/evm/req.rs
+++ b/arbitrator/arbutil/src/evm/req.rs
@@ -140,8 +140,13 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         }
 
         let (res, _, cost) = self.request(EvmApiMethod::SetTrieSlots, data);
-        if res[0] != EvmApiStatus::Success.into() {
-            bail!("{}", String::from_utf8_or_hex(res));
+        let status = res
+            .first()
+            .copied()
+            .map(EvmApiStatus::from)
+            .unwrap_or(EvmApiStatus::Failure);
+        if status != EvmApiStatus::Success {
+            bail!("{:?}", status);
         }
         Ok(cost)
     }
@@ -156,8 +161,13 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         data.extend(key);
         data.extend(value);
         let (res, ..) = self.request(EvmApiMethod::SetTransientBytes32, data);
-        if res[0] != EvmApiStatus::Success.into() {
-            bail!("{}", String::from_utf8_or_hex(res));
+        let status = res
+            .first()
+            .copied()
+            .map(EvmApiStatus::from)
+            .unwrap_or(EvmApiStatus::Failure);
+        if status != EvmApiStatus::Success {
+            bail!("{:?}", status);
         }
         Ok(())
     }

--- a/arbitrator/arbutil/src/evm/req.rs
+++ b/arbitrator/arbutil/src/evm/req.rs
@@ -7,7 +7,6 @@ use crate::{
         storage::{StorageCache, StorageWord},
         user::UserOutcomeKind,
     },
-    format::Utf8OrHex,
     pricing::EVM_API_INK,
     Bytes20, Bytes32,
 };


### PR DESCRIPTION
For the setTrieSlots and setTransientBytes32 HostIOs, when there is an out-of-gas error, Nitro emits a warning line with `Caused by:\n \x02`. This commit improves this error message by printing the debug representation of the API status code and the warning becomes: `Caused by:\n OutOfGas`.
This commit also solves a potential panic when the API does not return the status code.