### PR TITLE
Add Mac OSX environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,14 @@ ifneq ($(origin GOLANG_LDFLAGS),undefined)
  GOLANG_PARAMS = -ldflags="-extldflags '-ldl' $(GOLANG_LDFLAGS)"
 endif
 
+UNAME_S := $(shell uname -s)
+
+# In Mac OSX, there are a lot of warnings emitted if these environment variables aren't set.
+ifeq ($(UNAME_S), Darwin)
+  export MACOSX_DEPLOYMENT_TARGET := $(shell sw_vers -productVersion)
+  export CGO_LDFLAGS := -Wl,-no_warn_duplicate_libraries
+endif
+
 precompile_names = AddressTable Aggregator BLS Debug FunctionTable GasInfo Info osTest Owner RetryableTx Statistics Sys
 precompiles = $(patsubst %,./solgen/generated/%.go, $(precompile_names))
 


### PR DESCRIPTION
The unfortunate thing is that it would still be good for developers to set these in their shell environment so that if they do end up running any "go" commands directly from the CLI, they won't be bombarded with all the linker warnings. But, at least this makes the default experience of using the make files a little nicer.