### PR TITLE
Update to brotli v1.1.0

### DIFF
--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -129,9 +129,9 @@ jobs:
           path: |
             target/include/brotli/
             target/lib-wasm/
-            target/lib/libbrotlicommon-static.a
-            target/lib/libbrotlienc-static.a
-            target/lib/libbrotlidec-static.a
+            target/lib/libbrotlicommon.a
+            target/lib/libbrotlienc.a
+            target/lib/libbrotlidec.a
           key: ${{ runner.os }}-brotli-3-${{ hashFiles('scripts/build-brotli.sh') }}-${{ hashFiles('.github/workflows/arbitrator-ci.yaml') }}
           restore-keys: ${{ runner.os }}-brotli-2-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,9 @@ jobs:
           path: |
             target/include/brotli/
             target/lib-wasm/
-            target/lib/libbrotlicommon-static.a
-            target/lib/libbrotlienc-static.a
-            target/lib/libbrotlidec-static.a
+            target/lib/libbrotlicommon.a
+            target/lib/libbrotlienc.a
+            target/lib/libbrotlidec.a
           key: ${{ runner.os }}-brotli-${{ hashFiles('scripts/build-brotli.sh') }}-${{ hashFiles('.github/workflows/arbitrator-ci.yaml') }}-${{ matrix.test-mode }}
           restore-keys: ${{ runner.os }}-brotli-
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -108,9 +108,9 @@ jobs:
         path: |
           target/include/brotli/
           target/lib-wasm/
-          target/lib/libbrotlicommon-static.a
-          target/lib/libbrotlienc-static.a
-          target/lib/libbrotlidec-static.a
+          target/lib/libbrotlicommon.a
+          target/lib/libbrotlienc.a
+          target/lib/libbrotlidec.a
         key: ${{ runner.os }}-brotli-3a-${{ hashFiles('scripts/build-brotli.sh') }}-${{ hashFiles('.github/workflows/arbitrator-ci.yaml') }}
         restore-keys: ${{ runner.os }}-brotli-
 

--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,7 @@ clean:
 	rm -f arbitrator/wasm-libraries/soft-float/SoftFloat/build/Wasm-Clang/*.o
 	rm -f arbitrator/wasm-libraries/soft-float/SoftFloat/build/Wasm-Clang/*.a
 	rm -f arbitrator/wasm-libraries/forward/*.wat
+	rm -rf brotli/buildfiles
 	rm -rf arbitrator/stylus/tests/*/target/ arbitrator/stylus/tests/*/*.wasm
 	@rm -rf contracts/build contracts/cache solgen/go/
 	@rm -f .make/*
@@ -558,15 +559,15 @@ contracts/test/prover/proofs/%.json: $(arbitrator_cases)/%.wasm $(prover_bin)
 .make/cbrotli-lib: $(DEP_PREDICATE) $(ORDER_ONLY_PREDICATE) .make
 	test -f target/include/brotli/encode.h || ./scripts/build-brotli.sh -l
 	test -f target/include/brotli/decode.h || ./scripts/build-brotli.sh -l
-	test -f target/lib/libbrotlicommon-static.a || ./scripts/build-brotli.sh -l
-	test -f target/lib/libbrotlienc-static.a || ./scripts/build-brotli.sh -l
-	test -f target/lib/libbrotlidec-static.a || ./scripts/build-brotli.sh -l
+	test -f target/lib/libbrotlicommon.a || ./scripts/build-brotli.sh -l
+	test -f target/lib/libbrotlienc.a || ./scripts/build-brotli.sh -l
+	test -f target/lib/libbrotlidec.a || ./scripts/build-brotli.sh -l
 	@touch $@
 
 .make/cbrotli-wasm: $(DEP_PREDICATE) $(ORDER_ONLY_PREDICATE) .make
-	test -f target/lib-wasm/libbrotlicommon-static.a || ./scripts/build-brotli.sh -w -d
-	test -f target/lib-wasm/libbrotlienc-static.a || ./scripts/build-brotli.sh -w -d
-	test -f target/lib-wasm/libbrotlidec-static.a || ./scripts/build-brotli.sh -w -d
+	test -f target/lib-wasm/libbrotlicommon.a || ./scripts/build-brotli.sh -w -d
+	test -f target/lib-wasm/libbrotlienc.a || ./scripts/build-brotli.sh -w -d
+	test -f target/lib-wasm/libbrotlidec.a || ./scripts/build-brotli.sh -w -d
 	@touch $@
 
 .make/wasm-lib: $(DEP_PREDICATE) arbitrator/wasm-libraries/soft-float/SoftFloat/build/Wasm-Clang/softfloat.a  $(ORDER_ONLY_PREDICATE) .make

--- a/arbitrator/brotli/build.rs
+++ b/arbitrator/brotli/build.rs
@@ -12,7 +12,7 @@ fn main() {
         println!("cargo:rustc-link-search=../target/lib/");
         println!("cargo:rustc-link-search=../../target/lib/");
     }
-    println!("cargo:rustc-link-lib=static=brotlienc-static");
-    println!("cargo:rustc-link-lib=static=brotlidec-static");
-    println!("cargo:rustc-link-lib=static=brotlicommon-static");
+    println!("cargo:rustc-link-lib=static=brotlienc");
+    println!("cargo:rustc-link-lib=static=brotlidec");
+    println!("cargo:rustc-link-lib=static=brotlicommon");
 }

--- a/arbitrator/wasm-libraries/arbcompress/build.rs
+++ b/arbitrator/wasm-libraries/arbcompress/build.rs
@@ -5,7 +5,7 @@ fn main() {
     // Tell Cargo that if the given file changes, to rerun this build script.
     println!("cargo:rustc-link-search=../../target/lib-wasm/");
     println!("cargo:rustc-link-search=../target/lib/");
-    println!("cargo:rustc-link-lib=static=brotlienc-static");
-    println!("cargo:rustc-link-lib=static=brotlidec-static");
-    println!("cargo:rustc-link-lib=static=brotlicommon-static");
+    println!("cargo:rustc-link-lib=static=brotlienc");
+    println!("cargo:rustc-link-lib=static=brotlidec");
+    println!("cargo:rustc-link-lib=static=brotlicommon");
 }

--- a/scripts/build-brotli.sh
+++ b/scripts/build-brotli.sh
@@ -96,7 +96,7 @@ if $BUILD_WASM; then
     mkdir -p buildfiles/install-wasm
     TEMP_INSTALL_DIR_ABS=`cd -P buildfiles/install-wasm; pwd`
     cd buildfiles/build-wasm
-    cmake ../../ -DCMAKE_C_COMPILER=emcc -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fPIC -DCMAKE_INSTALL_PREFIX="$TEMP_INSTALL_DIR_ABS" -DCMAKE_AR=`which emar` -DCMAKE_RANLIB=`which touch`
+    cmake ../../ -DCMAKE_C_COMPILER=emcc -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fPIC -DCMAKE_INSTALL_PREFIX="$TEMP_INSTALL_DIR_ABS" -DCMAKE_AR=`which emar` -DCMAKE_RANLIB=`which touch` -DBUILD_SHARED_LIBS=OFF
     make -j
     make install
     cp -rv "$TEMP_INSTALL_DIR_ABS/lib" "$TARGET_DIR_ABS/lib-wasm"
@@ -106,7 +106,7 @@ fi
 if $BUILD_LOCAL; then
     mkdir -p buildfiles/build-local
     cd buildfiles/build-local
-    cmake ../../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$TARGET_DIR_ABS"
+    cmake ../../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$TARGET_DIR_ABS" -DBUILD_SHARED_LIBS=OFF
     make -j
     make install
     cd ..


### PR DESCRIPTION
The previous pin was almost 3 years old, and was causing some ugly warnings during builds.

This change also deals with google/brotli@641bec0 which stopped creating the static libraries by default and switched to only building them with `-DBUILD_SHARED_LIBS=OFF`.

Also, now that the static libraries are unambiguous, the `-static` suffix was removed from the library names.