### PR TITLE
Close opened files explicitly instead of relying on the GC

### DIFF
--- a/arbnode/resourcemanager/resource_management.go
+++ b/arbnode/resourcemanager/resource_management.go
@@ -256,6 +256,7 @@ func readIntFromFile(fileName string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	defer file.Close()
 
 	var limit int
 	if _, err = fmt.Fscanf(file, "%d", &limit); err != nil {
@@ -269,6 +270,7 @@ func readFromMemStats(fileName string, re *regexp.Regexp) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -423,6 +423,7 @@ func extractSnapshot(archive string, location string, importWasm bool) error {
 	if err != nil {
 		return fmt.Errorf("couln't open init '%v' archive: %w", archive, err)
 	}
+	defer reader.Close()
 	stat, err := reader.Stat()
 	if err != nil {
 		return err


### PR DESCRIPTION
This avoids bloating the number of open files, particulaly in the resource_management.go case.

`file.Close()` returns an error but we don't care about it in these cases, because we're just reading the file not writing to it.