### PR TITLE
Gives preference to IPv4 when connecting to Sequencer's feed

### DIFF
--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -280,6 +280,18 @@ func (bc *BroadcastClient) connect(ctx context.Context, nextSeqNum arbutil.Messa
 			MinVersion: tls.VersionTLS12,
 		},
 		Extensions: extensions,
+		NetDial: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			var netDialer net.Dialer
+			// For tcp connections, prefer IPv4 over IPv6 to avoid rate limiting issues
+			if network == "tcp" {
+				conn, err := netDialer.DialContext(ctx, "tcp4", addr)
+				if err == nil {
+					return conn, nil
+				}
+				return netDialer.DialContext(ctx, "tcp6", addr)
+			}
+			return netDialer.DialContext(ctx, network, addr)
+		},
 	}
 
 	if bc.isShuttingDown() {


### PR DESCRIPTION
Resolves NIT-1325.

Gives preference to IPv4 when connecting to Sequencer's feed to avoid rate limiting issues.

[IPv6 rate limiting is not great today](https://adam-p.ca/blog/2022/02/ipv6-rate-limiting/).