### PR TITLE
Improve block validator test stability by removing batch poster MaxDelay

### DIFF
--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -63,7 +63,6 @@ func testBlockValidatorSimple(t *testing.T, opts Options) {
 
 	var delayEvery int
 	if opts.workloadLoops > 1 {
-		l1NodeConfigA.BatchPoster.MaxDelay = time.Millisecond * 500
 		delayEvery = opts.workloadLoops / 3
 	}
 


### PR DESCRIPTION
The batch poster MaxDelay config already defaults to 0 which is great, and the problem with any positive value like 500ms is that because the L1 timestamp must always increase with every block the delayed message is actually _in the future_. So it ends up waiting ~30 seconds to post instead of 500ms because it needs to wait to get to that future timestamp. When the MaxDelay is set to 0 there's a bypass in the batch poster that doesn't check the timestamp at all.