### PR TITLE
Arbwasm revert fix

### DIFF
--- a/precompiles/ArbWasm.go
+++ b/precompiles/ArbWasm.go
@@ -5,6 +5,8 @@ package precompiles
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	gethparams "github.com/ethereum/go-ethereum/params"
 	"github.com/offchainlabs/nitro/arbos/programs"
 	"github.com/offchainlabs/nitro/arbos/util"
 	"github.com/offchainlabs/nitro/util/arbmath"
@@ -133,6 +135,9 @@ func (con ArbWasm) MinInitGas(c ctx, _ mech) (uint64, uint64, error) {
 	params, err := c.State.Programs().Params()
 	init := uint64(params.MinInitGas) * programs.MinInitGasUnits
 	cached := uint64(params.MinCachedInitGas) * programs.MinCachedGasUnits
+	if c.State.ArbOSVersion() < gethparams.ArbosVersion_StylusChargingFixes {
+		return 0, 0, vm.ErrExecutionReverted
+	}
 	return init, cached, err
 }
 


### PR DESCRIPTION
pulls in: https://github.com/OffchainLabs/nitro-contracts/pull/249

This PR only makes ArbWasm revert in arbos < 32 and not-revert in 32.
The way this is achieved is tested in a separate PR: https://github.com/OffchainLabs/nitro/pull/2655