### PR TITLE
node config: always add targets in the same order

### DIFF
--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"sync/atomic"
 	"testing"
 
@@ -59,6 +60,11 @@ func (c *StylusTargetConfig) Validate() error {
 	for target := range targetsSet {
 		targets = append(targets, target)
 	}
+	sort.Slice(
+		targets,
+		func(i, j int) bool {
+			return targets[i] < targets[j]
+		})
 	c.wasmTargets = targets
 	return nil
 }


### PR DESCRIPTION
This prevents an errored change in StylusTargetConfig from a change in the order of targets