### PR TITLE
[NIT-2813] Remove brotli build dir in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,7 @@ clean:
 	rm -f arbitrator/wasm-libraries/soft-float/SoftFloat/build/Wasm-Clang/*.a
 	rm -f arbitrator/wasm-libraries/forward/*.wat
 	rm -rf arbitrator/stylus/tests/*/target/ arbitrator/stylus/tests/*/*.wasm
+	rm -rf brotli/buildfiles
 	@rm -rf contracts/build contracts/cache solgen/go/
 	@rm -f .make/*
 


### PR DESCRIPTION
Currently, make clean doesn't clean brotli. This can lead to cryptic errors on MacOS after an update.