### PR TITLE
[NIT-2814] Fix CaptureHostIO when slices are bigger than 2^16

### DIFF
--- a/arbitrator/arbutil/src/evm/req.rs
+++ b/arbitrator/arbutil/src/evm/req.rs
@@ -298,9 +298,10 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         let mut request = Vec::with_capacity(2 * 8 + 3 * 2 + name.len() + args.len() + outs.len());
         request.extend(start_ink.to_be_bytes());
         request.extend(end_ink.to_be_bytes());
-        request.extend((name.len() as u16).to_be_bytes());
-        request.extend((args.len() as u16).to_be_bytes());
-        request.extend((outs.len() as u16).to_be_bytes());
+        // u32 is enough to represent the slices lengths because the WASM environment runs in 32 bits.
+        request.extend((name.len() as u32).to_be_bytes());
+        request.extend((args.len() as u32).to_be_bytes());
+        request.extend((outs.len() as u32).to_be_bytes());
         request.extend(name.as_bytes());
         request.extend(args);
         request.extend(outs);

--- a/arbitrator/stylus/tests/write-result-len.wat
+++ b/arbitrator/stylus/tests/write-result-len.wat
@@ -1,0 +1,24 @@
+;; Copyright 2024, Offchain Labs, Inc.
+;; For license information, see https://github.com/nitro/blob/master/LICENSE
+
+(module
+    (import "vm_hooks" "read_args"    (func $read_args    (param i32)))
+    (import "vm_hooks" "write_result" (func $write_result (param i32 i32)))
+    (memory (export "memory") 2 2)
+    (func $main (export "user_entrypoint") (param $args_len i32) (result i32)
+        (local $len i32)
+
+        ;; write args to 0x0
+        (call $read_args (i32.const 0))
+
+        ;; treat first 4 bytes as size to write
+        (i32.load (i32.const 0))
+        local.set $len
+
+        ;; call write
+        (call $write_result (i32.const 0) (local.get $len))
+
+        ;; return success
+        i32.const 0
+    )
+)

--- a/arbos/programs/api.go
+++ b/arbos/programs/api.go
@@ -400,9 +400,9 @@ func newApiClosures(
 			}
 			startInk := takeU64()
 			endInk := takeU64()
-			nameLen := takeU16()
-			argsLen := takeU16()
-			outsLen := takeU16()
+			nameLen := takeU32()
+			argsLen := takeU32()
+			outsLen := takeU32()
 			name := string(takeFixed(int(nameLen)))
 			args := takeFixed(int(argsLen))
 			outs := takeFixed(int(outsLen))


### PR DESCRIPTION
Support slices bigger than 2^16 when capturing a HostIO for tracing.
This could be reproduced with the test case added in the commit.
