### PR TITLE
Stylus cache improvements

### DIFF
--- a/arbitrator/stylus/src/cache.rs
+++ b/arbitrator/stylus/src/cache.rs
@@ -29,8 +29,16 @@ pub struct LruCounters {
     pub does_not_fit: u32,
 }
 
+pub struct LongTermCounters {
+    pub hits: u32,
+    pub misses: u32,
+}
+
 pub struct InitCache {
     long_term: HashMap<CacheKey, CacheItem>,
+    long_term_size_bytes: usize,
+    long_term_counters: LongTermCounters,
+
     lru: CLruCache<CacheKey, CacheItem, RandomState, CustomWeightScale>,
     lru_counters: LruCounters,
 }
@@ -91,6 +99,20 @@ pub struct LruCacheMetrics {
     pub does_not_fit: u32,
 }
 
+#[repr(C)]
+pub struct LongTermCacheMetrics {
+    pub size_bytes: u64,
+    pub count: u32,
+    pub hits: u32,
+    pub misses: u32,
+}
+
+#[repr(C)]
+pub struct CacheMetrics {
+    pub lru: LruCacheMetrics,
+    pub long_term: LongTermCacheMetrics,
+}
+
 pub fn deserialize_module(
     module: &[u8],
     version: u16,
@@ -117,6 +139,9 @@ impl InitCache {
     fn new(size_bytes: usize) -> Self {
         Self {
             long_term: HashMap::new(),
+            long_term_size_bytes: 0,
+            long_term_counters: LongTermCounters { hits: 0, misses: 0 },
+
             lru: CLruCache::with_config(
                 CLruCacheConfig::new(NonZeroUsize::new(size_bytes).unwrap())
                     .with_scale(CustomWeightScale),
@@ -142,8 +167,11 @@ impl InitCache {
 
         // See if the item is in the long term cache
         if let Some(item) = cache.long_term.get(&key) {
-            return Some(item.data());
+            let data = item.data();
+            cache.long_term_counters.hits += 1;
+            return Some(data);
         }
+        cache.long_term_counters.misses += 1;
 
         // See if the item is in the LRU cache, promoting if so
         if let Some(item) = cache.lru.get(&key) {
@@ -174,6 +202,7 @@ impl InitCache {
         if let Some(item) = cache.lru.peek(&key).cloned() {
             if long_term_tag == Self::ARBOS_TAG {
                 cache.long_term.insert(key, item.clone());
+                cache.long_term_size_bytes += item.entry_size_estimate_bytes;
             } else {
                 // only calls get to move the key to the head of the LRU list
                 cache.lru.get(&key);
@@ -195,6 +224,7 @@ impl InitCache {
             };
         } else {
             cache.long_term.insert(key, item);
+            cache.long_term_size_bytes += entry_size_estimate_bytes;
         }
         Ok(data)
     }
@@ -207,6 +237,7 @@ impl InitCache {
         let key = CacheKey::new(module_hash, version, debug);
         let mut cache = cache!();
         if let Some(item) = cache.long_term.remove(&key) {
+            cache.long_term_size_bytes -= item.entry_size_estimate_bytes;
             if cache.lru.put_with_weight(key, item).is_err() {
                 eprintln!("{}", Self::DOES_NOT_FIT_MSG);
             }
@@ -225,21 +256,30 @@ impl InitCache {
                 eprintln!("{}", Self::DOES_NOT_FIT_MSG);
             }
         }
+        cache.long_term_size_bytes = 0;
     }
 
-    pub fn get_lru_metrics() -> LruCacheMetrics {
+    pub fn get_metrics() -> CacheMetrics {
         let mut cache = cache!();
 
-        let count = cache.lru.len();
-        let metrics = LruCacheMetrics {
-            // add 1 to each entry to account that we subtracted 1 in the weight calculation
-            size_bytes: (cache.lru.weight() + count).try_into().unwrap(),
+        let lru_count = cache.lru.len();
+        let lru_metrics = LruCacheMetrics {
+            // adds 1 to each entry to account that we subtracted 1 in the weight calculation
+            size_bytes: (cache.lru.weight() + lru_count).try_into().unwrap(),
 
-            count: count.try_into().unwrap(),
+            count: lru_count.try_into().unwrap(),
 
             hits: cache.lru_counters.hits,
             misses: cache.lru_counters.misses,
             does_not_fit: cache.lru_counters.does_not_fit,
+        };
+
+        let long_term_metrics = LongTermCacheMetrics {
+            size_bytes: cache.long_term_size_bytes.try_into().unwrap(),
+            count: cache.long_term.len().try_into().unwrap(),
+
+            hits: cache.long_term_counters.hits,
+            misses: cache.long_term_counters.misses,
         };
 
         // Empty counters.
@@ -250,8 +290,12 @@ impl InitCache {
             misses: 0,
             does_not_fit: 0,
         };
+        cache.long_term_counters = LongTermCounters { hits: 0, misses: 0 };
 
-        metrics
+        CacheMetrics {
+            lru: lru_metrics,
+            long_term: long_term_metrics,
+        }
     }
 
     // only used for testing

--- a/arbitrator/stylus/src/lib.rs
+++ b/arbitrator/stylus/src/lib.rs
@@ -11,7 +11,7 @@ use arbutil::{
     format::DebugBytes,
     Bytes32,
 };
-use cache::{deserialize_module, InitCache, LruCacheMetrics};
+use cache::{deserialize_module, InitCache, CacheMetrics};
 use evm_api::NativeRequestHandler;
 use eyre::ErrReport;
 use native::NativeInstance;
@@ -364,10 +364,10 @@ pub unsafe extern "C" fn stylus_drop_vec(vec: RustBytes) {
     }
 }
 
-/// Gets lru cache metrics.
+/// Gets cache metrics.
 #[no_mangle]
-pub extern "C" fn stylus_get_lru_cache_metrics() -> LruCacheMetrics {
-    InitCache::get_lru_metrics()
+pub extern "C" fn stylus_get_cache_metrics() -> CacheMetrics {
+    InitCache::get_metrics()
 }
 
 /// Clears lru cache.
@@ -377,18 +377,18 @@ pub extern "C" fn stylus_clear_lru_cache() {
     InitCache::clear_lru_cache()
 }
 
-/// Gets lru entry size in bytes.
+/// Gets entry size in bytes.
 /// Only used for testing purposes.
 #[no_mangle]
-pub extern "C" fn stylus_get_lru_entry_size_estimate_bytes(
+pub extern "C" fn stylus_get_entry_size_estimate_bytes(
     module: GoSliceData,
     version: u16,
     debug: bool,
 ) -> u64 {
     match deserialize_module(module.slice(), version, debug) {
         Err(error) => panic!("tried to get invalid asm!: {error}"),
-        Ok((_, _, lru_entry_size_estimate_bytes)) => {
-            lru_entry_size_estimate_bytes.try_into().unwrap()
+        Ok((_, _, entry_size_estimate_bytes)) => {
+            entry_size_estimate_bytes.try_into().unwrap()
         }
     }
 }

--- a/arbitrator/stylus/src/lib.rs
+++ b/arbitrator/stylus/src/lib.rs
@@ -11,7 +11,7 @@ use arbutil::{
     format::DebugBytes,
     Bytes32,
 };
-use cache::{deserialize_module, InitCache, CacheMetrics};
+use cache::{deserialize_module, CacheMetrics, InitCache};
 use evm_api::NativeRequestHandler;
 use eyre::ErrReport;
 use native::NativeInstance;
@@ -387,8 +387,6 @@ pub extern "C" fn stylus_get_entry_size_estimate_bytes(
 ) -> u64 {
     match deserialize_module(module.slice(), version, debug) {
         Err(error) => panic!("tried to get invalid asm!: {error}"),
-        Ok((_, _, entry_size_estimate_bytes)) => {
-            entry_size_estimate_bytes.try_into().unwrap()
-        }
+        Ok((_, _, entry_size_estimate_bytes)) => entry_size_estimate_bytes.try_into().unwrap(),
     }
 }

--- a/execution/gethexec/blockchain.go
+++ b/execution/gethexec/blockchain.go
@@ -26,20 +26,21 @@ import (
 )
 
 type CachingConfig struct {
-	Archive                            bool          `koanf:"archive"`
-	BlockCount                         uint64        `koanf:"block-count"`
-	BlockAge                           time.Duration `koanf:"block-age"`
-	TrieTimeLimit                      time.Duration `koanf:"trie-time-limit"`
-	TrieDirtyCache                     int           `koanf:"trie-dirty-cache"`
-	TrieCleanCache                     int           `koanf:"trie-clean-cache"`
-	SnapshotCache                      int           `koanf:"snapshot-cache"`
-	DatabaseCache                      int           `koanf:"database-cache"`
-	SnapshotRestoreGasLimit            uint64        `koanf:"snapshot-restore-gas-limit"`
-	MaxNumberOfBlocksToSkipStateSaving uint32        `koanf:"max-number-of-blocks-to-skip-state-saving"`
-	MaxAmountOfGasToSkipStateSaving    uint64        `koanf:"max-amount-of-gas-to-skip-state-saving"`
-	StylusLRUCacheCapacity             uint32        `koanf:"stylus-lru-cache-capacity"`
-	StateScheme                        string        `koanf:"state-scheme"`
-	StateHistory                       uint64        `koanf:"state-history"`
+	Archive                             bool          `koanf:"archive"`
+	BlockCount                          uint64        `koanf:"block-count"`
+	BlockAge                            time.Duration `koanf:"block-age"`
+	TrieTimeLimit                       time.Duration `koanf:"trie-time-limit"`
+	TrieDirtyCache                      int           `koanf:"trie-dirty-cache"`
+	TrieCleanCache                      int           `koanf:"trie-clean-cache"`
+	SnapshotCache                       int           `koanf:"snapshot-cache"`
+	DatabaseCache                       int           `koanf:"database-cache"`
+	SnapshotRestoreGasLimit             uint64        `koanf:"snapshot-restore-gas-limit"`
+	MaxNumberOfBlocksToSkipStateSaving  uint32        `koanf:"max-number-of-blocks-to-skip-state-saving"`
+	MaxAmountOfGasToSkipStateSaving     uint64        `koanf:"max-amount-of-gas-to-skip-state-saving"`
+	StylusLRUCacheCapacity              uint32        `koanf:"stylus-lru-cache-capacity"`
+	DisableStylusCacheMetricsCollection bool          `koanf:"disable-stylus-cache-metrics-collection"`
+	StateScheme                         string        `koanf:"state-scheme"`
+	StateHistory                        uint64        `koanf:"state-history"`
 }
 
 func CachingConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -55,6 +56,7 @@ func CachingConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Uint32(prefix+".max-number-of-blocks-to-skip-state-saving", DefaultCachingConfig.MaxNumberOfBlocksToSkipStateSaving, "maximum number of blocks to skip state saving to persistent storage (archive node only) -- warning: this option seems to cause issues")
 	f.Uint64(prefix+".max-amount-of-gas-to-skip-state-saving", DefaultCachingConfig.MaxAmountOfGasToSkipStateSaving, "maximum amount of gas in blocks to skip saving state to Persistent storage (archive node only) -- warning: this option seems to cause issues")
 	f.Uint32(prefix+".stylus-lru-cache-capacity", DefaultCachingConfig.StylusLRUCacheCapacity, "capacity, in megabytes, of the LRU cache that keeps initialized stylus programs")
+	f.Bool(prefix+".disable-stylus-cache-metrics-collection", DefaultCachingConfig.DisableStylusCacheMetricsCollection, "disable metrics collection for the stylus cache")
 	f.String(prefix+".state-scheme", DefaultCachingConfig.StateScheme, "scheme to use for state trie storage (hash, path)")
 	f.Uint64(prefix+".state-history", DefaultCachingConfig.StateHistory, "number of recent blocks to retain state history for (path state-scheme only)")
 }

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -976,14 +976,14 @@ func (s *ExecutionEngine) Start(ctx_in context.Context) {
 		}
 	})
 	if !s.disableStylusCacheMetricsCollection {
-		// periodically update stylus lru cache metrics
+		// periodically update stylus cache metrics
 		s.LaunchThread(func(ctx context.Context) {
 			for {
 				select {
 				case <-ctx.Done():
 					return
 				case <-time.After(time.Minute):
-					programs.GetWasmLruCacheMetrics()
+					programs.UpdateWasmCacheMetrics()
 				}
 			}
 		})

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -87,6 +87,8 @@ type ExecutionEngine struct {
 
 	reorgSequencing bool
 
+	disableStylusCacheMetricsCollection bool
+
 	prefetchBlock bool
 
 	cachedL1PriceData *L1PriceData
@@ -210,6 +212,16 @@ func (s *ExecutionEngine) EnableReorgSequencing() {
 		panic("trying to enable reorg sequencing when already set")
 	}
 	s.reorgSequencing = true
+}
+
+func (s *ExecutionEngine) DisableStylusCacheMetricsCollection() {
+	if s.Started() {
+		panic("trying to disable stylus cache metrics collection after start")
+	}
+	if s.disableStylusCacheMetricsCollection {
+		panic("trying to disable stylus cache metrics collection when already set")
+	}
+	s.disableStylusCacheMetricsCollection = true
 }
 
 func (s *ExecutionEngine) EnablePrefetchBlock() {
@@ -963,15 +975,17 @@ func (s *ExecutionEngine) Start(ctx_in context.Context) {
 			}
 		}
 	})
-	// periodically update stylus lru cache metrics
-	s.LaunchThread(func(ctx context.Context) {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(time.Minute):
-				programs.GetWasmLruCacheMetrics()
+	if !s.disableStylusCacheMetricsCollection {
+		// periodically update stylus lru cache metrics
+		s.LaunchThread(func(ctx context.Context) {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(time.Minute):
+					programs.GetWasmLruCacheMetrics()
+				}
 			}
-		}
-	})
+		})
+	}
 }

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -187,6 +187,9 @@ func CreateExecutionNode(
 	if config.EnablePrefetchBlock {
 		execEngine.EnablePrefetchBlock()
 	}
+	if config.Caching.DisableStylusCacheMetricsCollection {
+		execEngine.DisableStylusCacheMetricsCollection()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -155,19 +155,20 @@ func (tc *TestClient) EnsureTxSucceededWithTimeout(transaction *types.Transactio
 }
 
 var TestCachingConfig = gethexec.CachingConfig{
-	Archive:                            false,
-	BlockCount:                         128,
-	BlockAge:                           30 * time.Minute,
-	TrieTimeLimit:                      time.Hour,
-	TrieDirtyCache:                     1024,
-	TrieCleanCache:                     600,
-	SnapshotCache:                      400,
-	DatabaseCache:                      2048,
-	SnapshotRestoreGasLimit:            300_000_000_000,
-	MaxNumberOfBlocksToSkipStateSaving: 0,
-	MaxAmountOfGasToSkipStateSaving:    0,
-	StylusLRUCacheCapacity:             0,
-	StateScheme:                        env.GetTestStateScheme(),
+	Archive:                             false,
+	BlockCount:                          128,
+	BlockAge:                            30 * time.Minute,
+	TrieTimeLimit:                       time.Hour,
+	TrieDirtyCache:                      1024,
+	TrieCleanCache:                      600,
+	SnapshotCache:                       400,
+	DatabaseCache:                       2048,
+	SnapshotRestoreGasLimit:             300_000_000_000,
+	MaxNumberOfBlocksToSkipStateSaving:  0,
+	MaxAmountOfGasToSkipStateSaving:     0,
+	StylusLRUCacheCapacity:              0,
+	DisableStylusCacheMetricsCollection: true,
+	StateScheme:                         env.GetTestStateScheme(),
 }
 
 var DefaultTestForwarderConfig = gethexec.ForwarderConfig{

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -2008,7 +2008,7 @@ func checkWasmStoreContent(t *testing.T, wasmDb ethdb.KeyValueStore, targets []s
 	}
 }
 
-func deployWasmAndGetLruEntrySizeEstimateBytes(
+func deployWasmAndGetEntrySizeEstimateBytes(
 	t *testing.T,
 	builder *NodeBuilder,
 	auth bind.TransactOpts,
@@ -2039,12 +2039,12 @@ func deployWasmAndGetLruEntrySizeEstimateBytes(
 	module, err := statedb.TryGetActivatedAsm(rawdb.LocalTarget(), log.ModuleHash)
 	Require(t, err, ", wasmName:", wasmName)
 
-	lruEntrySizeEstimateBytes := programs.GetLruEntrySizeEstimateBytes(module, log.Version, true)
+	entrySizeEstimateBytes := programs.GetEntrySizeEstimateBytes(module, log.Version, true)
 	// just a sanity check
-	if lruEntrySizeEstimateBytes == 0 {
-		Fatal(t, "lruEntrySizeEstimateBytes is 0, wasmName:", wasmName)
+	if entrySizeEstimateBytes == 0 {
+		Fatal(t, "entrySizeEstimateBytes is 0, wasmName:", wasmName)
 	}
-	return programAddress, lruEntrySizeEstimateBytes
+	return programAddress, entrySizeEstimateBytes
 }
 
 func TestWasmLruCache(t *testing.T) {
@@ -2057,9 +2057,9 @@ func TestWasmLruCache(t *testing.T) {
 	auth.GasLimit = 32000000
 	auth.Value = oneEth
 
-	fallibleProgramAddress, fallibleLruEntrySizeEstimateBytes := deployWasmAndGetLruEntrySizeEstimateBytes(t, builder, auth, "fallible")
-	keccakProgramAddress, keccakLruEntrySizeEstimateBytes := deployWasmAndGetLruEntrySizeEstimateBytes(t, builder, auth, "keccak")
-	mathProgramAddress, mathLruEntrySizeEstimateBytes := deployWasmAndGetLruEntrySizeEstimateBytes(t, builder, auth, "math")
+	fallibleProgramAddress, fallibleLruEntrySizeEstimateBytes := deployWasmAndGetEntrySizeEstimateBytes(t, builder, auth, "fallible")
+	keccakProgramAddress, keccakLruEntrySizeEstimateBytes := deployWasmAndGetEntrySizeEstimateBytes(t, builder, auth, "keccak")
+	mathProgramAddress, mathLruEntrySizeEstimateBytes := deployWasmAndGetEntrySizeEstimateBytes(t, builder, auth, "math")
 	t.Log(
 		"lruEntrySizeEstimateBytes, ",
 		"fallible:", fallibleLruEntrySizeEstimateBytes,
@@ -2068,7 +2068,7 @@ func TestWasmLruCache(t *testing.T) {
 	)
 
 	programs.ClearWasmLruCache()
-	lruMetrics := programs.GetWasmLruCacheMetrics()
+	lruMetrics := programs.GetWasmCacheMetrics().Lru
 	if lruMetrics.Count != 0 {
 		t.Fatalf("lruMetrics.Count, expected: %v, actual: %v", 0, lruMetrics.Count)
 	}
@@ -2082,7 +2082,7 @@ func TestWasmLruCache(t *testing.T) {
 	Require(t, l2client.SendTransaction(ctx, tx))
 	_, err := EnsureTxSucceeded(ctx, l2client, tx)
 	Require(t, err)
-	lruMetrics = programs.GetWasmLruCacheMetrics()
+	lruMetrics = programs.GetWasmCacheMetrics().Lru
 	if lruMetrics.Count != 0 {
 		t.Fatalf("lruMetrics.Count, expected: %v, actual: %v", 0, lruMetrics.Count)
 	}
@@ -2098,7 +2098,7 @@ func TestWasmLruCache(t *testing.T) {
 	Require(t, l2client.SendTransaction(ctx, tx))
 	_, err = EnsureTxSucceeded(ctx, l2client, tx)
 	Require(t, err)
-	lruMetrics = programs.GetWasmLruCacheMetrics()
+	lruMetrics = programs.GetWasmCacheMetrics().Lru
 	if lruMetrics.Count != 1 {
 		t.Fatalf("lruMetrics.Count, expected: %v, actual: %v", 1, lruMetrics.Count)
 	}
@@ -2111,7 +2111,7 @@ func TestWasmLruCache(t *testing.T) {
 	Require(t, l2client.SendTransaction(ctx, tx))
 	_, err = EnsureTxSucceeded(ctx, l2client, tx)
 	Require(t, err)
-	lruMetrics = programs.GetWasmLruCacheMetrics()
+	lruMetrics = programs.GetWasmCacheMetrics().Lru
 	if lruMetrics.Count != 2 {
 		t.Fatalf("lruMetrics.Count, expected: %v, actual: %v", 2, lruMetrics.Count)
 	}
@@ -2124,7 +2124,7 @@ func TestWasmLruCache(t *testing.T) {
 	Require(t, l2client.SendTransaction(ctx, tx))
 	_, err = EnsureTxSucceeded(ctx, l2client, tx)
 	Require(t, err)
-	lruMetrics = programs.GetWasmLruCacheMetrics()
+	lruMetrics = programs.GetWasmCacheMetrics().Lru
 	if lruMetrics.Count != 2 {
 		t.Fatalf("lruMetrics.Count, expected: %v, actual: %v", 2, lruMetrics.Count)
 	}


### PR DESCRIPTION
Resolves NIT-2817

- Adds metrics for Stylus long term cache.
- Config to disable collection of Stylus metrics from Go side.