### PR TITLE
Log the DAS public key on startup

### DIFF
--- a/das/sign_after_store_das_writer.go
+++ b/das/sign_after_store_das_writer.go
@@ -81,6 +81,7 @@ func NewSignAfterStoreDASWriter(ctx context.Context, config DataAvailabilityConf
 	if err != nil {
 		return nil, err
 	}
+	log.Info("DAS public key used for signing", "key", hexutil.Encode(blsSignatures.PublicKeyToBytes(publicKey)))
 
 	keyset := &daprovider.DataAvailabilityKeyset{
 		AssumedHonest: 1,


### PR DESCRIPTION
This PR logs the public key that DAS uses to sign data.

Resolves NIT-2809