### PR TITLE
Fix memory leak when getting stylus cache metrics

### DIFF
--- a/arbitrator/stylus/src/lib.rs
+++ b/arbitrator/stylus/src/lib.rs
@@ -365,6 +365,10 @@ pub unsafe extern "C" fn stylus_drop_vec(vec: RustBytes) {
 }
 
 /// Gets cache metrics.
+///
+/// # Safety
+///
+/// `output` must not be null.
 #[no_mangle]
 pub unsafe extern "C" fn stylus_get_cache_metrics(output: *mut CacheMetrics) {
     let output = &mut *output;

--- a/arbitrator/stylus/src/lib.rs
+++ b/arbitrator/stylus/src/lib.rs
@@ -366,8 +366,9 @@ pub unsafe extern "C" fn stylus_drop_vec(vec: RustBytes) {
 
 /// Gets cache metrics.
 #[no_mangle]
-pub extern "C" fn stylus_get_cache_metrics() -> CacheMetrics {
-    InitCache::get_metrics()
+pub unsafe extern "C" fn stylus_get_cache_metrics(output: *mut CacheMetrics) {
+    let output = &mut *output;
+    InitCache::get_metrics(output);
 }
 
 /// Clears lru cache.

--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -339,7 +339,8 @@ func SetWasmLruCacheCapacity(capacityBytes uint64) {
 }
 
 func UpdateWasmCacheMetrics() {
-	metrics := C.stylus_get_cache_metrics()
+	metrics := &C.CacheMetrics{}
+	C.stylus_get_cache_metrics(metrics)
 
 	stylusLRUCacheSizeBytesGauge.Update(int64(metrics.lru.size_bytes))
 	stylusLRUCacheCountGauge.Update(int64(metrics.lru.count))
@@ -373,7 +374,8 @@ type WasmCacheMetrics struct {
 
 // Used for testing
 func GetWasmCacheMetrics() *WasmCacheMetrics {
-	metrics := C.stylus_get_cache_metrics()
+	metrics := &C.CacheMetrics{}
+	C.stylus_get_cache_metrics(metrics)
 
 	return &WasmCacheMetrics{
 		Lru: WasmLruCacheMetrics{


### PR DESCRIPTION
Resolves NIT-2842

Fixes memory leak when getting stylus cache metrics.
For a more detailed description check https://github.com/OffchainLabs/nitro/pull/2705#discussion_r1792692452