### PR TITLE
Add Gas and Ink types in rust

### DIFF
--- a/arbitrator/arbutil/src/evm/api.rs
+++ b/arbitrator/arbutil/src/evm/api.rs
@@ -73,19 +73,93 @@ impl DataReader for VecReader {
     }
 }
 
+macro_rules! derive_math {
+    ($t:ident) => {
+        impl std::ops::Add for $t {
+            type Output = Self;
+
+            fn add(self, rhs: Self) -> Self {
+                Self(self.0 + rhs.0)
+            }
+        }
+
+        impl std::ops::AddAssign for $t {
+            fn add_assign(&mut self, rhs: Self) {
+                self.0 += rhs.0;
+            }
+        }
+
+        impl std::ops::Sub for $t {
+            type Output = Self;
+
+            fn sub(self, rhs: Self) -> Self {
+                Self(self.0 - rhs.0)
+            }
+        }
+
+        impl std::ops::SubAssign for $t {
+            fn sub_assign(&mut self, rhs: Self) {
+                self.0 -= rhs.0;
+            }
+        }
+
+        impl std::ops::Mul<u64> for $t {
+            type Output = Self;
+
+            fn mul(self, rhs: u64) -> Self {
+                Self(self.0 * rhs)
+            }
+        }
+
+        impl std::ops::Mul<$t> for u64 {
+            type Output = $t;
+
+            fn mul(self, rhs: $t) -> $t {
+                $t(self * rhs.0)
+            }
+        }
+
+        impl $t {
+            pub const fn saturating_add(self, rhs: Self) -> Self {
+                Self(self.0.saturating_add(rhs.0))
+            }
+
+            pub const fn saturating_sub(self, rhs: Self) -> Self {
+                Self(self.0.saturating_sub(rhs.0))
+            }
+
+            pub fn to_be_bytes(self) -> [u8; 8] {
+                self.0.to_be_bytes()
+            }
+        }
+    };
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[must_use]
+pub struct Gas(pub u64);
+
+derive_math!(Gas);
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[must_use]
+pub struct Ink(pub u64);
+
+derive_math!(Ink);
+
 pub trait EvmApi<D: DataReader>: Send + 'static {
     /// Reads the 32-byte value in the EVM state trie at offset `key`.
     /// Returns the value and the access cost in gas.
     /// Analogous to `vm.SLOAD`.
-    fn get_bytes32(&mut self, key: Bytes32, evm_api_gas_to_use: u64) -> (Bytes32, u64);
+    fn get_bytes32(&mut self, key: Bytes32, evm_api_gas_to_use: Gas) -> (Bytes32, Gas);
 
     /// Stores the given value at the given key in Stylus VM's cache of the EVM state trie.
     /// Note that the actual values only get written after calls to `set_trie_slots`.
-    fn cache_bytes32(&mut self, key: Bytes32, value: Bytes32) -> u64;
+    fn cache_bytes32(&mut self, key: Bytes32, value: Bytes32) -> Gas;
 
     /// Persists any dirty values in the storage cache to the EVM state trie, dropping the cache entirely if requested.
     /// Analogous to repeated invocations of `vm.SSTORE`.
-    fn flush_storage_cache(&mut self, clear: bool, gas_left: u64) -> Result<u64>;
+    fn flush_storage_cache(&mut self, clear: bool, gas_left: Gas) -> Result<Gas>;
 
     /// Reads the 32-byte value in the EVM's transient state trie at offset `key`.
     /// Analogous to `vm.TLOAD`.
@@ -102,10 +176,10 @@ pub trait EvmApi<D: DataReader>: Send + 'static {
         &mut self,
         contract: Bytes20,
         calldata: &[u8],
-        gas_left: u64,
-        gas_req: u64,
+        gas_left: Gas,
+        gas_req: Gas,
         value: Bytes32,
-    ) -> (u32, u64, UserOutcomeKind);
+    ) -> (u32, Gas, UserOutcomeKind);
 
     /// Delegate-calls the contract at the given address.
     /// Returns the EVM return data's length, the gas cost, and whether the call succeeded.
@@ -114,9 +188,9 @@ pub trait EvmApi<D: DataReader>: Send + 'static {
         &mut self,
         contract: Bytes20,
         calldata: &[u8],
-        gas_left: u64,
-        gas_req: u64,
-    ) -> (u32, u64, UserOutcomeKind);
+        gas_left: Gas,
+        gas_req: Gas,
+    ) -> (u32, Gas, UserOutcomeKind);
 
     /// Static-calls the contract at the given address.
     /// Returns the EVM return data's length, the gas cost, and whether the call succeeded.
@@ -125,9 +199,9 @@ pub trait EvmApi<D: DataReader>: Send + 'static {
         &mut self,
         contract: Bytes20,
         calldata: &[u8],
-        gas_left: u64,
-        gas_req: u64,
-    ) -> (u32, u64, UserOutcomeKind);
+        gas_left: Gas,
+        gas_req: Gas,
+    ) -> (u32, Gas, UserOutcomeKind);
 
     /// Deploys a new contract using the init code provided.
     /// Returns the new contract's address on success, or the error reason on failure.
@@ -137,8 +211,8 @@ pub trait EvmApi<D: DataReader>: Send + 'static {
         &mut self,
         code: Vec<u8>,
         endowment: Bytes32,
-        gas: u64,
-    ) -> (eyre::Result<Bytes20>, u32, u64);
+        gas: Gas,
+    ) -> (eyre::Result<Bytes20>, u32, Gas);
 
     /// Deploys a new contract using the init code provided, with an address determined in part by the `salt`.
     /// Returns the new contract's address on success, or the error reason on failure.
@@ -149,8 +223,8 @@ pub trait EvmApi<D: DataReader>: Send + 'static {
         code: Vec<u8>,
         endowment: Bytes32,
         salt: Bytes32,
-        gas: u64,
-    ) -> (eyre::Result<Bytes20>, u32, u64);
+        gas: Gas,
+    ) -> (eyre::Result<Bytes20>, u32, Gas);
 
     /// Returns the EVM return data.
     /// Analogous to `vm.RETURNDATACOPY`.
@@ -164,21 +238,21 @@ pub trait EvmApi<D: DataReader>: Send + 'static {
     /// Gets the balance of the given account.
     /// Returns the balance and the access cost in gas.
     /// Analogous to `vm.BALANCE`.
-    fn account_balance(&mut self, address: Bytes20) -> (Bytes32, u64);
+    fn account_balance(&mut self, address: Bytes20) -> (Bytes32, Gas);
 
     /// Returns the code and the access cost in gas.
     /// Analogous to `vm.EXTCODECOPY`.
-    fn account_code(&mut self, address: Bytes20, gas_left: u64) -> (D, u64);
+    fn account_code(&mut self, address: Bytes20, gas_left: Gas) -> (D, Gas);
 
     /// Gets the hash of the given address's code.
     /// Returns the hash and the access cost in gas.
     /// Analogous to `vm.EXTCODEHASH`.
-    fn account_codehash(&mut self, address: Bytes20) -> (Bytes32, u64);
+    fn account_codehash(&mut self, address: Bytes20) -> (Bytes32, Gas);
 
     /// Determines the cost in gas of allocating additional wasm pages.
     /// Note: has the side effect of updating Geth's memory usage tracker.
     /// Not analogous to any EVM opcode.
-    fn add_pages(&mut self, pages: u16) -> u64;
+    fn add_pages(&mut self, pages: u16) -> Gas;
 
     /// Captures tracing information for hostio invocations during native execution.
     fn capture_hostio(
@@ -186,7 +260,7 @@ pub trait EvmApi<D: DataReader>: Send + 'static {
         name: &str,
         args: &[u8],
         outs: &[u8],
-        start_ink: u64,
-        end_ink: u64,
+        start_ink: Ink,
+        end_ink: Ink,
     );
 }

--- a/arbitrator/arbutil/src/evm/mod.rs
+++ b/arbitrator/arbutil/src/evm/mod.rs
@@ -2,6 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 use crate::{Bytes20, Bytes32};
+use api::Gas;
 
 pub mod api;
 pub mod req;
@@ -9,70 +10,70 @@ pub mod storage;
 pub mod user;
 
 // params.SstoreSentryGasEIP2200
-pub const SSTORE_SENTRY_GAS: u64 = 2300;
+pub const SSTORE_SENTRY_GAS: Gas = Gas(2300);
 
 // params.ColdAccountAccessCostEIP2929
-pub const COLD_ACCOUNT_GAS: u64 = 2600;
+pub const COLD_ACCOUNT_GAS: Gas = Gas(2600);
 
 // params.ColdSloadCostEIP2929
-pub const COLD_SLOAD_GAS: u64 = 2100;
+pub const COLD_SLOAD_GAS: Gas = Gas(2100);
 
 // params.WarmStorageReadCostEIP2929
-pub const WARM_SLOAD_GAS: u64 = 100;
+pub const WARM_SLOAD_GAS: Gas = Gas(100);
 
 // params.WarmStorageReadCostEIP2929 (see enable1153 in jump_table.go)
-pub const TLOAD_GAS: u64 = WARM_SLOAD_GAS;
-pub const TSTORE_GAS: u64 = WARM_SLOAD_GAS;
+pub const TLOAD_GAS: Gas = WARM_SLOAD_GAS;
+pub const TSTORE_GAS: Gas = WARM_SLOAD_GAS;
 
 // params.LogGas and params.LogDataGas
-pub const LOG_TOPIC_GAS: u64 = 375;
-pub const LOG_DATA_GAS: u64 = 8;
+pub const LOG_TOPIC_GAS: Gas = Gas(375);
+pub const LOG_DATA_GAS: Gas = Gas(8);
 
 // params.CopyGas
-pub const COPY_WORD_GAS: u64 = 3;
+pub const COPY_WORD_GAS: Gas = Gas(3);
 
 // params.Keccak256Gas
-pub const KECCAK_256_GAS: u64 = 30;
-pub const KECCAK_WORD_GAS: u64 = 6;
+pub const KECCAK_256_GAS: Gas = Gas(30);
+pub const KECCAK_WORD_GAS: Gas = Gas(6);
 
 // vm.GasQuickStep (see gas.go)
-pub const GAS_QUICK_STEP: u64 = 2;
+pub const GAS_QUICK_STEP: Gas = Gas(2);
 
 // vm.GasQuickStep (see jump_table.go)
-pub const ADDRESS_GAS: u64 = GAS_QUICK_STEP;
+pub const ADDRESS_GAS: Gas = GAS_QUICK_STEP;
 
 // vm.GasQuickStep (see eips.go)
-pub const BASEFEE_GAS: u64 = GAS_QUICK_STEP;
+pub const BASEFEE_GAS: Gas = GAS_QUICK_STEP;
 
 // vm.GasQuickStep (see eips.go)
-pub const CHAINID_GAS: u64 = GAS_QUICK_STEP;
+pub const CHAINID_GAS: Gas = GAS_QUICK_STEP;
 
 // vm.GasQuickStep (see jump_table.go)
-pub const COINBASE_GAS: u64 = GAS_QUICK_STEP;
+pub const COINBASE_GAS: Gas = GAS_QUICK_STEP;
 
 // vm.GasQuickStep (see jump_table.go)
-pub const GASLIMIT_GAS: u64 = GAS_QUICK_STEP;
+pub const GASLIMIT_GAS: Gas = GAS_QUICK_STEP;
 
 // vm.GasQuickStep (see jump_table.go)
-pub const NUMBER_GAS: u64 = GAS_QUICK_STEP;
+pub const NUMBER_GAS: Gas = GAS_QUICK_STEP;
 
 // vm.GasQuickStep (see jump_table.go)
-pub const TIMESTAMP_GAS: u64 = GAS_QUICK_STEP;
+pub const TIMESTAMP_GAS: Gas = GAS_QUICK_STEP;
 
 // vm.GasQuickStep (see jump_table.go)
-pub const GASLEFT_GAS: u64 = GAS_QUICK_STEP;
+pub const GASLEFT_GAS: Gas = GAS_QUICK_STEP;
 
 // vm.GasQuickStep (see jump_table.go)
-pub const CALLER_GAS: u64 = GAS_QUICK_STEP;
+pub const CALLER_GAS: Gas = GAS_QUICK_STEP;
 
 // vm.GasQuickStep (see jump_table.go)
-pub const CALLVALUE_GAS: u64 = GAS_QUICK_STEP;
+pub const CALLVALUE_GAS: Gas = GAS_QUICK_STEP;
 
 // vm.GasQuickStep (see jump_table.go)
-pub const GASPRICE_GAS: u64 = GAS_QUICK_STEP;
+pub const GASPRICE_GAS: Gas = GAS_QUICK_STEP;
 
 // vm.GasQuickStep (see jump_table.go)
-pub const ORIGIN_GAS: u64 = GAS_QUICK_STEP;
+pub const ORIGIN_GAS: Gas = GAS_QUICK_STEP;
 
 pub const ARBOS_VERSION_STYLUS_CHARGING_FIXES: u64 = 32;
 

--- a/arbitrator/arbutil/src/evm/req.rs
+++ b/arbitrator/arbutil/src/evm/req.rs
@@ -12,8 +12,10 @@ use crate::{
 use eyre::{bail, eyre, Result};
 use std::collections::hash_map::Entry;
 
+use super::api::{Gas, Ink};
+
 pub trait RequestHandler<D: DataReader>: Send + 'static {
-    fn request(&mut self, req_type: EvmApiMethod, req_data: impl AsRef<[u8]>) -> (Vec<u8>, D, u64);
+    fn request(&mut self, req_type: EvmApiMethod, req_data: impl AsRef<[u8]>) -> (Vec<u8>, D, Gas);
 }
 
 pub struct EvmApiRequestor<D: DataReader, H: RequestHandler<D>> {
@@ -33,7 +35,7 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApiRequestor<D, H> {
         }
     }
 
-    fn request(&mut self, req_type: EvmApiMethod, req_data: impl AsRef<[u8]>) -> (Vec<u8>, D, u64) {
+    fn request(&mut self, req_type: EvmApiMethod, req_data: impl AsRef<[u8]>) -> (Vec<u8>, D, Gas) {
         self.handler.request(req_type, req_data)
     }
 
@@ -43,10 +45,10 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApiRequestor<D, H> {
         call_type: EvmApiMethod,
         contract: Bytes20,
         input: &[u8],
-        gas_left: u64,
-        gas_req: u64,
+        gas_left: Gas,
+        gas_req: Gas,
         value: Bytes32,
-    ) -> (u32, u64, UserOutcomeKind) {
+    ) -> (u32, Gas, UserOutcomeKind) {
         let mut request = Vec::with_capacity(20 + 32 + 8 + 8 + input.len());
         request.extend(contract);
         request.extend(value);
@@ -71,8 +73,8 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApiRequestor<D, H> {
         code: Vec<u8>,
         endowment: Bytes32,
         salt: Option<Bytes32>,
-        gas: u64,
-    ) -> (Result<Bytes20>, u32, u64) {
+        gas: Gas,
+    ) -> (Result<Bytes20>, u32, Gas) {
         let mut request = Vec::with_capacity(8 + 2 * 32 + code.len());
         request.extend(gas.to_be_bytes());
         request.extend(endowment);
@@ -98,7 +100,7 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApiRequestor<D, H> {
 }
 
 impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
-    fn get_bytes32(&mut self, key: Bytes32, evm_api_gas_to_use: u64) -> (Bytes32, u64) {
+    fn get_bytes32(&mut self, key: Bytes32, evm_api_gas_to_use: Gas) -> (Bytes32, Gas) {
         let cache = &mut self.storage_cache;
         let mut cost = cache.read_gas();
 
@@ -110,7 +112,7 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         (value.value, cost)
     }
 
-    fn cache_bytes32(&mut self, key: Bytes32, value: Bytes32) -> u64 {
+    fn cache_bytes32(&mut self, key: Bytes32, value: Bytes32) -> Gas {
         let cost = self.storage_cache.write_gas();
         match self.storage_cache.entry(key) {
             Entry::Occupied(mut key) => key.get_mut().value = value,
@@ -119,7 +121,7 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         cost
     }
 
-    fn flush_storage_cache(&mut self, clear: bool, gas_left: u64) -> Result<u64> {
+    fn flush_storage_cache(&mut self, clear: bool, gas_left: Gas) -> Result<Gas> {
         let mut data = Vec::with_capacity(64 * self.storage_cache.len() + 8);
         data.extend(gas_left.to_be_bytes());
 
@@ -134,7 +136,7 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
             self.storage_cache.clear();
         }
         if data.len() == 8 {
-            return Ok(0); // no need to make request
+            return Ok(Gas(0)); // no need to make request
         }
 
         let (res, _, cost) = self.request(EvmApiMethod::SetTrieSlots, data);
@@ -174,10 +176,10 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         &mut self,
         contract: Bytes20,
         input: &[u8],
-        gas_left: u64,
-        gas_req: u64,
+        gas_left: Gas,
+        gas_req: Gas,
         value: Bytes32,
-    ) -> (u32, u64, UserOutcomeKind) {
+    ) -> (u32, Gas, UserOutcomeKind) {
         self.call_request(
             EvmApiMethod::ContractCall,
             contract,
@@ -192,9 +194,9 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         &mut self,
         contract: Bytes20,
         input: &[u8],
-        gas_left: u64,
-        gas_req: u64,
-    ) -> (u32, u64, UserOutcomeKind) {
+        gas_left: Gas,
+        gas_req: Gas,
+    ) -> (u32, Gas, UserOutcomeKind) {
         self.call_request(
             EvmApiMethod::DelegateCall,
             contract,
@@ -209,9 +211,9 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         &mut self,
         contract: Bytes20,
         input: &[u8],
-        gas_left: u64,
-        gas_req: u64,
-    ) -> (u32, u64, UserOutcomeKind) {
+        gas_left: Gas,
+        gas_req: Gas,
+    ) -> (u32, Gas, UserOutcomeKind) {
         self.call_request(
             EvmApiMethod::StaticCall,
             contract,
@@ -226,8 +228,8 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         &mut self,
         code: Vec<u8>,
         endowment: Bytes32,
-        gas: u64,
-    ) -> (Result<Bytes20>, u32, u64) {
+        gas: Gas,
+    ) -> (Result<Bytes20>, u32, Gas) {
         self.create_request(EvmApiMethod::Create1, code, endowment, None, gas)
     }
 
@@ -236,8 +238,8 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         code: Vec<u8>,
         endowment: Bytes32,
         salt: Bytes32,
-        gas: u64,
-    ) -> (Result<Bytes20>, u32, u64) {
+        gas: Gas,
+    ) -> (Result<Bytes20>, u32, Gas) {
         self.create_request(EvmApiMethod::Create2, code, endowment, Some(salt), gas)
     }
 
@@ -258,15 +260,15 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         Ok(())
     }
 
-    fn account_balance(&mut self, address: Bytes20) -> (Bytes32, u64) {
+    fn account_balance(&mut self, address: Bytes20) -> (Bytes32, Gas) {
         let (res, _, cost) = self.request(EvmApiMethod::AccountBalance, address);
         (res.try_into().unwrap(), cost)
     }
 
-    fn account_code(&mut self, address: Bytes20, gas_left: u64) -> (D, u64) {
+    fn account_code(&mut self, address: Bytes20, gas_left: Gas) -> (D, Gas) {
         if let Some((stored_address, data)) = self.last_code.as_ref() {
             if address == *stored_address {
-                return (data.clone(), 0);
+                return (data.clone(), Gas(0));
             }
         }
         let mut req = Vec::with_capacity(20 + 8);
@@ -278,12 +280,12 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         (data, cost)
     }
 
-    fn account_codehash(&mut self, address: Bytes20) -> (Bytes32, u64) {
+    fn account_codehash(&mut self, address: Bytes20) -> (Bytes32, Gas) {
         let (res, _, cost) = self.request(EvmApiMethod::AccountCodeHash, address);
         (res.try_into().unwrap(), cost)
     }
 
-    fn add_pages(&mut self, pages: u16) -> u64 {
+    fn add_pages(&mut self, pages: u16) -> Gas {
         self.request(EvmApiMethod::AddPages, pages.to_be_bytes()).2
     }
 
@@ -292,8 +294,8 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         name: &str,
         args: &[u8],
         outs: &[u8],
-        start_ink: u64,
-        end_ink: u64,
+        start_ink: Ink,
+        end_ink: Ink,
     ) {
         let mut request = Vec::with_capacity(2 * 8 + 3 * 2 + name.len() + args.len() + outs.len());
         request.extend(start_ink.to_be_bytes());
@@ -305,6 +307,7 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         request.extend(name.as_bytes());
         request.extend(args);
         request.extend(outs);
-        self.request(EvmApiMethod::CaptureHostIO, request);
+        // ignore response (including gas) as we're just tracing
+        _ = self.request(EvmApiMethod::CaptureHostIO, request);
     }
 }

--- a/arbitrator/arbutil/src/evm/storage.rs
+++ b/arbitrator/arbutil/src/evm/storage.rs
@@ -5,6 +5,8 @@ use crate::Bytes32;
 use fnv::FnvHashMap as HashMap;
 use std::ops::{Deref, DerefMut};
 
+use super::api::Gas;
+
 /// Represents the EVM word at a given key.
 #[derive(Debug)]
 pub struct StorageWord {
@@ -37,23 +39,23 @@ pub struct StorageCache {
 }
 
 impl StorageCache {
-    pub const REQUIRED_ACCESS_GAS: u64 = 10;
+    pub const REQUIRED_ACCESS_GAS: Gas = Gas(10);
 
-    pub fn read_gas(&mut self) -> u64 {
+    pub fn read_gas(&mut self) -> Gas {
         self.reads += 1;
         match self.reads {
-            0..=32 => 0,
-            33..=128 => 2,
-            _ => 10,
+            0..=32 => Gas(0),
+            33..=128 => Gas(2),
+            _ => Gas(10),
         }
     }
 
-    pub fn write_gas(&mut self) -> u64 {
+    pub fn write_gas(&mut self) -> Gas {
         self.writes += 1;
         match self.writes {
-            0..=8 => 0,
-            9..=64 => 7,
-            _ => 10,
+            0..=8 => Gas(0),
+            9..=64 => Gas(7),
+            _ => Gas(10),
         }
     }
 }

--- a/arbitrator/arbutil/src/pricing.rs
+++ b/arbitrator/arbutil/src/pricing.rs
@@ -1,20 +1,22 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
+use crate::evm::api::Ink;
+
 /// For hostios that may return something.
-pub const HOSTIO_INK: u64 = 8400;
+pub const HOSTIO_INK: Ink = Ink(8400);
 
 /// For hostios that include pointers.
-pub const PTR_INK: u64 = 13440 - HOSTIO_INK;
+pub const PTR_INK: Ink = Ink(13440 - HOSTIO_INK.0);
 
 /// For hostios that involve an API cost.
-pub const EVM_API_INK: u64 = 59673;
+pub const EVM_API_INK: Ink = Ink(59673);
 
 /// For hostios that involve a div or mod.
-pub const DIV_INK: u64 = 20000;
+pub const DIV_INK: Ink = Ink(20000);
 
 /// For hostios that involve a mulmod.
-pub const MUL_MOD_INK: u64 = 24100;
+pub const MUL_MOD_INK: Ink = Ink(24100);
 
 /// For hostios that involve an addmod.
-pub const ADD_MOD_INK: u64 = 21000;
+pub const ADD_MOD_INK: Ink = Ink(21000);

--- a/arbitrator/jit/src/program.rs
+++ b/arbitrator/jit/src/program.rs
@@ -6,6 +6,7 @@
 use crate::caller_env::JitEnv;
 use crate::machine::{Escape, MaybeEscape, WasmEnvMut};
 use crate::stylus_backend::exec_wasm;
+use arbutil::evm::api::Gas;
 use arbutil::Bytes32;
 use arbutil::{evm::EvmData, format::DebugBytes, heapify};
 use caller_env::{GuestPtr, MemAccess};
@@ -131,7 +132,7 @@ pub fn new_program(
 
     // buy ink
     let pricing = config.stylus.pricing;
-    let ink = pricing.gas_to_ink(gas);
+    let ink = pricing.gas_to_ink(Gas(gas));
 
     let Some(module) = exec.module_asms.get(&compiled_hash).cloned() else {
         return Err(Escape::Failure(format!(
@@ -217,7 +218,7 @@ pub fn set_response(
     let raw_data = mem.read_slice(raw_data_ptr, raw_data_len as usize);
 
     let thread = exec.threads.last_mut().unwrap();
-    thread.set_response(id, result, raw_data, gas)
+    thread.set_response(id, result, raw_data, Gas(gas))
 }
 
 /// sends previos response

--- a/arbitrator/prover/src/machine.rs
+++ b/arbitrator/prover/src/machine.rs
@@ -1816,7 +1816,7 @@ impl Machine {
     }
 
     #[cfg(feature = "native")]
-    pub fn call_user_func(&mut self, func: &str, args: Vec<Value>, ink: u64) -> Result<Vec<Value>> {
+    pub fn call_user_func(&mut self, func: &str, args: Vec<Value>, ink: arbutil::evm::api::Ink) -> Result<Vec<Value>> {
         self.set_ink(ink);
         self.call_function("user", func, args)
     }

--- a/arbitrator/prover/src/merkle.rs
+++ b/arbitrator/prover/src/merkle.rs
@@ -549,8 +549,7 @@ mod test {
         let mut empty_node = Bytes32([
             57, 29, 211, 154, 252, 227, 18, 99, 65, 126, 203, 166, 252, 232, 32, 3, 98, 194, 254,
             186, 118, 14, 139, 192, 101, 156, 55, 194, 101, 11, 11, 168,
-        ])
-        .clone();
+        ]);
         for _ in 0..64 {
             print!("Bytes32([");
             for i in 0..32 {
@@ -607,7 +606,7 @@ mod test {
             for layer in 0..64 {
                 // empty_hash_at is just a lookup, but empty_hash is calculated iteratively.
                 assert_eq!(empty_hash_at(ty, layer), &empty_hash);
-                empty_hash = hash_node(ty, &empty_hash, &empty_hash);
+                empty_hash = hash_node(ty, empty_hash, empty_hash);
             }
         }
     }

--- a/arbitrator/prover/src/programs/config.rs
+++ b/arbitrator/prover/src/programs/config.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::field_reassign_with_default)]
 
 use crate::{programs::meter, value::FunctionType};
+use arbutil::evm::api::{Gas, Ink};
 use derivative::Derivative;
 use fnv::FnvHashMap as HashMap;
 use std::fmt::Debug;
@@ -72,12 +73,12 @@ impl PricingParams {
         Self { ink_price }
     }
 
-    pub fn gas_to_ink(&self, gas: u64) -> u64 {
-        gas.saturating_mul(self.ink_price.into())
+    pub fn gas_to_ink(&self, gas: Gas) -> Ink {
+        Ink(gas.0.saturating_mul(self.ink_price.into()))
     }
 
-    pub fn ink_to_gas(&self, ink: u64) -> u64 {
-        ink / self.ink_price as u64 // never 0
+    pub fn ink_to_gas(&self, ink: Ink) -> Gas {
+        Gas(ink.0 / self.ink_price as u64) // ink_price is never 0
     }
 }
 

--- a/arbitrator/prover/src/programs/memory.rs
+++ b/arbitrator/prover/src/programs/memory.rs
@@ -1,6 +1,8 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
+use arbutil::evm::api::Gas;
+
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct MemoryModel {
@@ -28,20 +30,20 @@ impl MemoryModel {
     }
 
     /// Determines the gas cost of allocating `new` pages given `open` are active and `ever` have ever been.
-    pub fn gas_cost(&self, new: u16, open: u16, ever: u16) -> u64 {
+    pub fn gas_cost(&self, new: u16, open: u16, ever: u16) -> Gas {
         let new_open = open.saturating_add(new);
         let new_ever = ever.max(new_open);
 
         // free until expansion beyond the first few
         if new_ever <= self.free_pages {
-            return 0;
+            return Gas(0);
         }
 
         let credit = |pages: u16| pages.saturating_sub(self.free_pages);
         let adding = credit(new_open).saturating_sub(credit(open)) as u64;
         let linear = adding.saturating_mul(self.page_gas.into());
         let expand = Self::exp(new_ever) - Self::exp(ever);
-        linear.saturating_add(expand)
+        Gas(linear.saturating_add(expand))
     }
 
     fn exp(pages: u16) -> u64 {
@@ -85,7 +87,7 @@ fn test_model() {
         let mut pages = 0;
         while pages < 128 {
             let jump = jump.min(128 - pages);
-            total += model.gas_cost(jump, pages, pages);
+            total += model.gas_cost(jump, pages, pages).0;
             pages += jump;
         }
         assert_eq!(total, 31999998);
@@ -98,7 +100,7 @@ fn test_model() {
         let mut adds = 0;
         while ever < 128 {
             let jump = jump.min(128 - open);
-            total += model.gas_cost(jump, open, ever);
+            total += model.gas_cost(jump, open, ever).0;
             open += jump;
             ever = ever.max(open);
 
@@ -114,12 +116,12 @@ fn test_model() {
     }
 
     // check saturation
-    assert_eq!(u64::MAX, model.gas_cost(129, 0, 0));
-    assert_eq!(u64::MAX, model.gas_cost(u16::MAX, 0, 0));
+    assert_eq!(Gas(u64::MAX), model.gas_cost(129, 0, 0));
+    assert_eq!(Gas(u64::MAX), model.gas_cost(u16::MAX, 0, 0));
 
     // check free pages
     let model = MemoryModel::new(128, 1000);
-    assert_eq!(0, model.gas_cost(128, 0, 0));
-    assert_eq!(0, model.gas_cost(128, 0, 128));
-    assert_eq!(u64::MAX, model.gas_cost(129, 0, 0));
+    assert_eq!(Gas(0), model.gas_cost(128, 0, 0));
+    assert_eq!(Gas(0), model.gas_cost(128, 0, 128));
+    assert_eq!(Gas(u64::MAX), model.gas_cost(129, 0, 0));
 }

--- a/arbitrator/prover/src/programs/meter.rs
+++ b/arbitrator/prover/src/programs/meter.rs
@@ -9,7 +9,7 @@ use crate::{
     value::FunctionType,
     Machine,
 };
-use arbutil::{evm, operator::OperatorInfo, Bytes32};
+use arbutil::{evm::{self, api::{Gas, Ink}}, operator::OperatorInfo, Bytes32};
 use derivative::Derivative;
 use eyre::Result;
 use fnv::FnvHashMap as HashMap;
@@ -188,15 +188,15 @@ impl<'a, F: OpcodePricer> FuncMiddleware<'a> for FuncMeter<'a, F> {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MachineMeter {
-    Ready(u64),
+    Ready(Ink),
     Exhausted,
 }
 
 impl MachineMeter {
-    pub fn ink(self) -> u64 {
+    pub fn ink(self) -> Ink {
         match self {
             Self::Ready(ink) => ink,
-            Self::Exhausted => 0,
+            Self::Exhausted => Ink(0),
         }
     }
 
@@ -210,8 +210,8 @@ impl MachineMeter {
 
 /// We don't implement `From` since it's unclear what 0 would map to
 #[allow(clippy::from_over_into)]
-impl Into<u64> for MachineMeter {
-    fn into(self) -> u64 {
+impl Into<Ink> for MachineMeter {
+    fn into(self) -> Ink {
         self.ink()
     }
 }
@@ -219,7 +219,7 @@ impl Into<u64> for MachineMeter {
 impl Display for MachineMeter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Ready(ink) => write!(f, "{ink} ink"),
+            Self::Ready(ink) => write!(f, "{} ink", ink.0),
             Self::Exhausted => write!(f, "exhausted"),
         }
     }
@@ -241,7 +241,7 @@ pub trait MeteredMachine {
     fn ink_left(&self) -> MachineMeter;
     fn set_meter(&mut self, meter: MachineMeter);
 
-    fn set_ink(&mut self, ink: u64) {
+    fn set_ink(&mut self, ink: Ink) {
         self.set_meter(MachineMeter::Ready(ink));
     }
 
@@ -250,14 +250,14 @@ pub trait MeteredMachine {
         Err(OutOfInkError)
     }
 
-    fn ink_ready(&mut self) -> Result<u64, OutOfInkError> {
+    fn ink_ready(&mut self) -> Result<Ink, OutOfInkError> {
         let MachineMeter::Ready(ink_left) = self.ink_left() else {
             return self.out_of_ink();
         };
         Ok(ink_left)
     }
 
-    fn buy_ink(&mut self, ink: u64) -> Result<(), OutOfInkError> {
+    fn buy_ink(&mut self, ink: Ink) -> Result<(), OutOfInkError> {
         let ink_left = self.ink_ready()?;
         if ink_left < ink {
             return self.out_of_ink();
@@ -267,7 +267,7 @@ pub trait MeteredMachine {
     }
 
     /// Checks if the user has enough ink, but doesn't burn any
-    fn require_ink(&mut self, ink: u64) -> Result<(), OutOfInkError> {
+    fn require_ink(&mut self, ink: Ink) -> Result<(), OutOfInkError> {
         let ink_left = self.ink_ready()?;
         if ink_left < ink {
             return self.out_of_ink();
@@ -277,18 +277,18 @@ pub trait MeteredMachine {
 
     /// Pays for a write into the client.
     fn pay_for_write(&mut self, bytes: u32) -> Result<(), OutOfInkError> {
-        self.buy_ink(sat_add_mul(5040, 30, bytes.saturating_sub(32)))
+        self.buy_ink(Ink(sat_add_mul(5040, 30, bytes.saturating_sub(32))))
     }
 
     /// Pays for a read into the host.
     fn pay_for_read(&mut self, bytes: u32) -> Result<(), OutOfInkError> {
-        self.buy_ink(sat_add_mul(16381, 55, bytes.saturating_sub(32)))
+        self.buy_ink(Ink(sat_add_mul(16381, 55, bytes.saturating_sub(32))))
     }
 
     /// Pays for both I/O and keccak.
     fn pay_for_keccak(&mut self, bytes: u32) -> Result<(), OutOfInkError> {
         let words = evm::evm_words(bytes).saturating_sub(2);
-        self.buy_ink(sat_add_mul(121800, 21000, words))
+        self.buy_ink(Ink(sat_add_mul(121800, 21000, words)))
     }
 
     /// Pays for copying bytes from geth.
@@ -305,14 +305,14 @@ pub trait MeteredMachine {
                 false => break,
             }
         }
-        self.buy_ink(3000 + exp * 17500)
+        self.buy_ink(Ink(3000 + exp * 17500))
     }
 }
 
 pub trait GasMeteredMachine: MeteredMachine {
     fn pricing(&self) -> PricingParams;
 
-    fn gas_left(&self) -> Result<u64, OutOfInkError> {
+    fn gas_left(&self) -> Result<Gas, OutOfInkError> {
         let pricing = self.pricing();
         match self.ink_left() {
             MachineMeter::Ready(ink) => Ok(pricing.ink_to_gas(ink)),
@@ -320,13 +320,13 @@ pub trait GasMeteredMachine: MeteredMachine {
         }
     }
 
-    fn buy_gas(&mut self, gas: u64) -> Result<(), OutOfInkError> {
+    fn buy_gas(&mut self, gas: Gas) -> Result<(), OutOfInkError> {
         let pricing = self.pricing();
         self.buy_ink(pricing.gas_to_ink(gas))
     }
 
     /// Checks if the user has enough gas, but doesn't burn any
-    fn require_gas(&mut self, gas: u64) -> Result<(), OutOfInkError> {
+    fn require_gas(&mut self, gas: Gas) -> Result<(), OutOfInkError> {
         let pricing = self.pricing();
         self.require_ink(pricing.gas_to_ink(gas))
     }
@@ -350,7 +350,7 @@ impl MeteredMachine for Machine {
             }};
         }
 
-        let ink = || convert!(self.get_global(STYLUS_INK_LEFT));
+        let ink = || Ink(convert!(self.get_global(STYLUS_INK_LEFT)));
         let status: u32 = convert!(self.get_global(STYLUS_INK_STATUS));
 
         match status {
@@ -362,7 +362,7 @@ impl MeteredMachine for Machine {
     fn set_meter(&mut self, meter: MachineMeter) {
         let ink = meter.ink();
         let status = meter.status();
-        self.set_global(STYLUS_INK_LEFT, ink.into()).unwrap();
+        self.set_global(STYLUS_INK_LEFT, ink.0.into()).unwrap();
         self.set_global(STYLUS_INK_STATUS, status.into()).unwrap();
     }
 }

--- a/arbitrator/prover/src/test.rs
+++ b/arbitrator/prover/src/test.rs
@@ -1,8 +1,6 @@
 // Copyright 2022-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-#![cfg(test)]
-
 use crate::binary;
 use brotli::Dictionary;
 use eyre::Result;
@@ -64,7 +62,7 @@ pub fn test_compress() -> Result<()> {
         let deflate = brotli::compress(data, 11, 22, dict).unwrap();
         let inflate = brotli::decompress(&deflate, dict).unwrap();
         assert_eq!(hex::encode(inflate), hex::encode(data));
-        assert!(&deflate != &last);
+        assert!(deflate != last);
         last = deflate;
     }
     Ok(())

--- a/arbitrator/stylus/src/env.rs
+++ b/arbitrator/stylus/src/env.rs
@@ -3,7 +3,7 @@
 
 use arbutil::{
     evm::{
-        api::{DataReader, EvmApi},
+        api::{DataReader, EvmApi, Ink},
         EvmData,
     },
     pricing,
@@ -74,7 +74,7 @@ impl<D: DataReader, E: EvmApi<D>> WasmEnv<D, E> {
 
     pub fn start<'a>(
         env: &'a mut WasmEnvMut<'_, D, E>,
-        ink: u64,
+        ink: Ink,
     ) -> Result<HostioInfo<'a, D, E>, Escape> {
         let mut info = Self::program(env)?;
         info.buy_ink(pricing::HOSTIO_INK + ink)?;
@@ -88,7 +88,7 @@ impl<D: DataReader, E: EvmApi<D>> WasmEnv<D, E> {
             env,
             memory,
             store,
-            start_ink: 0,
+            start_ink: Ink(0),
         };
         if info.env.evm_data.tracing {
             info.start_ink = info.ink_ready()?;
@@ -114,16 +114,16 @@ pub struct MeterData {
 }
 
 impl MeterData {
-    pub fn ink(&self) -> u64 {
-        unsafe { self.ink_left.as_ref().val.u64 }
+    pub fn ink(&self) -> Ink {
+        Ink(unsafe { self.ink_left.as_ref().val.u64 })
     }
 
     pub fn status(&self) -> u32 {
         unsafe { self.ink_status.as_ref().val.u32 }
     }
 
-    pub fn set_ink(&mut self, ink: u64) {
-        unsafe { self.ink_left.as_mut().val = RawValue { u64: ink } }
+    pub fn set_ink(&mut self, ink: Ink) {
+        unsafe { self.ink_left.as_mut().val = RawValue { u64: ink.0 } }
     }
 
     pub fn set_status(&mut self, status: u32) {
@@ -140,7 +140,7 @@ pub struct HostioInfo<'a, D: DataReader, E: EvmApi<D>> {
     pub env: &'a mut WasmEnv<D, E>,
     pub memory: Memory,
     pub store: StoreMut<'a>,
-    pub start_ink: u64,
+    pub start_ink: Ink,
 }
 
 impl<'a, D: DataReader, E: EvmApi<D>> HostioInfo<'a, D, E> {

--- a/arbitrator/stylus/src/evm_api.rs
+++ b/arbitrator/stylus/src/evm_api.rs
@@ -3,7 +3,7 @@
 
 use crate::{GoSliceData, RustSlice};
 use arbutil::evm::{
-    api::{EvmApiMethod, EVM_API_METHOD_REQ_OFFSET},
+    api::{EvmApiMethod, Gas, EVM_API_METHOD_REQ_OFFSET},
     req::RequestHandler,
 };
 
@@ -31,7 +31,7 @@ impl RequestHandler<GoSliceData> for NativeRequestHandler {
         &mut self,
         req_type: EvmApiMethod,
         req_data: impl AsRef<[u8]>,
-    ) -> (Vec<u8>, GoSliceData, u64) {
+    ) -> (Vec<u8>, GoSliceData, Gas) {
         let mut result = GoSliceData::null();
         let mut raw_data = GoSliceData::null();
         let mut cost = 0;
@@ -45,6 +45,6 @@ impl RequestHandler<GoSliceData> for NativeRequestHandler {
                 ptr!(raw_data),
             )
         };
-        (result.slice().to_vec(), raw_data, cost)
+        (result.slice().to_vec(), raw_data, Gas(cost))
     }
 }

--- a/arbitrator/stylus/src/host.rs
+++ b/arbitrator/stylus/src/host.rs
@@ -6,7 +6,7 @@
 use crate::env::{Escape, HostioInfo, MaybeEscape, WasmEnv, WasmEnvMut};
 use arbutil::{
     evm::{
-        api::{DataReader, EvmApi},
+        api::{DataReader, EvmApi, Gas, Ink},
         EvmData,
     },
     Color,
@@ -82,7 +82,7 @@ where
         println!("{} {text}", "Stylus says:".yellow());
     }
 
-    fn trace(&mut self, name: &str, args: &[u8], outs: &[u8], end_ink: u64) {
+    fn trace(&mut self, name: &str, args: &[u8], outs: &[u8], end_ink: Ink) {
         let start_ink = self.start_ink;
         self.evm_api
             .capture_hostio(name, args, outs, start_ink, end_ink);
@@ -168,7 +168,7 @@ pub(crate) fn call_contract<D: DataReader, E: EvmApi<D>>(
 ) -> Result<u8, Escape> {
     hostio!(
         env,
-        call_contract(contract, data, data_len, value, gas, ret_len)
+        call_contract(contract, data, data_len, value, Gas(gas), ret_len)
     )
 }
 
@@ -182,7 +182,7 @@ pub(crate) fn delegate_call_contract<D: DataReader, E: EvmApi<D>>(
 ) -> Result<u8, Escape> {
     hostio!(
         env,
-        delegate_call_contract(contract, data, data_len, gas, ret_len)
+        delegate_call_contract(contract, data, data_len, Gas(gas), ret_len)
     )
 }
 
@@ -196,7 +196,7 @@ pub(crate) fn static_call_contract<D: DataReader, E: EvmApi<D>>(
 ) -> Result<u8, Escape> {
     hostio!(
         env,
-        static_call_contract(contract, data, data_len, gas, ret_len)
+        static_call_contract(contract, data, data_len, Gas(gas), ret_len)
     )
 }
 
@@ -334,13 +334,13 @@ pub(crate) fn contract_address<D: DataReader, E: EvmApi<D>>(
 pub(crate) fn evm_gas_left<D: DataReader, E: EvmApi<D>>(
     mut env: WasmEnvMut<D, E>,
 ) -> Result<u64, Escape> {
-    hostio!(env, evm_gas_left())
+    hostio!(env, evm_gas_left()).map(|g| g.0)
 }
 
 pub(crate) fn evm_ink_left<D: DataReader, E: EvmApi<D>>(
     mut env: WasmEnvMut<D, E>,
 ) -> Result<u64, Escape> {
-    hostio!(env, evm_ink_left())
+    hostio!(env, evm_ink_left()).map(|i| i.0)
 }
 
 pub(crate) fn math_div<D: DataReader, E: EvmApi<D>>(

--- a/arbitrator/stylus/src/lib.rs
+++ b/arbitrator/stylus/src/lib.rs
@@ -3,7 +3,7 @@
 
 use arbutil::{
     evm::{
-        api::DataReader,
+        api::{DataReader, Gas, Ink},
         req::EvmApiRequestor,
         user::{UserOutcome, UserOutcomeKind},
         EvmData,
@@ -279,7 +279,7 @@ pub unsafe extern "C" fn stylus_call(
     let evm_api = EvmApiRequestor::new(req_handler);
     let pricing = config.pricing;
     let output = &mut *output;
-    let ink = pricing.gas_to_ink(*gas);
+    let ink = pricing.gas_to_ink(Gas(*gas));
 
     // Safety: module came from compile_user_wasm and we've paid for memory expansion
     let instance = unsafe {
@@ -302,10 +302,10 @@ pub unsafe extern "C" fn stylus_call(
         Ok(outcome) => output.write_outcome(outcome),
     };
     let ink_left = match status {
-        UserOutcomeKind::OutOfStack => 0, // take all gas when out of stack
+        UserOutcomeKind::OutOfStack => Ink(0), // take all gas when out of stack
         _ => instance.ink_left().into(),
     };
-    *gas = pricing.ink_to_gas(ink_left);
+    *gas = pricing.ink_to_gas(ink_left).0;
     status
 }
 

--- a/arbitrator/stylus/src/native.rs
+++ b/arbitrator/stylus/src/native.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use arbutil::{
     evm::{
-        api::{DataReader, EvmApi},
+        api::{DataReader, EvmApi, Ink},
         EvmData,
     },
     operator::OperatorCode,
@@ -270,7 +270,7 @@ impl<D: DataReader, E: EvmApi<D>> NativeInstance<D, E> {
         global.set(store, value.into()).map_err(ErrReport::msg)
     }
 
-    pub fn call_func<R>(&mut self, func: TypedFunction<(), R>, ink: u64) -> Result<R>
+    pub fn call_func<R>(&mut self, func: TypedFunction<(), R>, ink: Ink) -> Result<R>
     where
         R: WasmTypeList,
     {

--- a/arbitrator/stylus/src/run.rs
+++ b/arbitrator/stylus/src/run.rs
@@ -4,18 +4,18 @@
 #![allow(clippy::redundant_closure_call)]
 
 use crate::{env::Escape, native::NativeInstance};
-use arbutil::evm::api::{DataReader, EvmApi};
+use arbutil::evm::api::{DataReader, EvmApi, Ink};
 use arbutil::evm::user::UserOutcome;
 use eyre::{eyre, Result};
 use prover::machine::Machine;
 use prover::programs::{prelude::*, STYLUS_ENTRY_POINT};
 
 pub trait RunProgram {
-    fn run_main(&mut self, args: &[u8], config: StylusConfig, ink: u64) -> Result<UserOutcome>;
+    fn run_main(&mut self, args: &[u8], config: StylusConfig, ink: Ink) -> Result<UserOutcome>;
 }
 
 impl RunProgram for Machine {
-    fn run_main(&mut self, args: &[u8], config: StylusConfig, ink: u64) -> Result<UserOutcome> {
+    fn run_main(&mut self, args: &[u8], config: StylusConfig, ink: Ink) -> Result<UserOutcome> {
         macro_rules! call {
             ($module:expr, $func:expr, $args:expr) => {
                 call!($module, $func, $args, |error| UserOutcome::Failure(error))
@@ -65,7 +65,7 @@ impl RunProgram for Machine {
 }
 
 impl<D: DataReader, E: EvmApi<D>> RunProgram for NativeInstance<D, E> {
-    fn run_main(&mut self, args: &[u8], config: StylusConfig, ink: u64) -> Result<UserOutcome> {
+    fn run_main(&mut self, args: &[u8], config: StylusConfig, ink: Ink) -> Result<UserOutcome> {
         use UserOutcome::*;
 
         self.set_ink(ink);

--- a/arbitrator/stylus/src/test/api.rs
+++ b/arbitrator/stylus/src/test/api.rs
@@ -4,7 +4,7 @@
 use crate::{native, run::RunProgram};
 use arbutil::{
     evm::{
-        api::{EvmApi, VecReader},
+        api::{EvmApi, Gas, Ink, VecReader},
         user::UserOutcomeKind,
         EvmData,
     },
@@ -68,24 +68,24 @@ impl TestEvmApi {
 }
 
 impl EvmApi<VecReader> for TestEvmApi {
-    fn get_bytes32(&mut self, key: Bytes32, _evm_api_gas_to_use: u64) -> (Bytes32, u64) {
+    fn get_bytes32(&mut self, key: Bytes32, _evm_api_gas_to_use: Gas) -> (Bytes32, Gas) {
         let storage = &mut self.storage.lock();
         let storage = storage.get_mut(&self.program).unwrap();
         let value = storage.get(&key).cloned().unwrap_or_default();
-        (value, 2100) // pretend worst case
+        (value, Gas(2100)) // pretend worst case
     }
 
-    fn cache_bytes32(&mut self, key: Bytes32, value: Bytes32) -> u64 {
+    fn cache_bytes32(&mut self, key: Bytes32, value: Bytes32) -> Gas {
         let storage = &mut self.storage.lock();
         let storage = storage.get_mut(&self.program).unwrap();
         storage.insert(key, value);
-        0
+        Gas(0)
     }
 
-    fn flush_storage_cache(&mut self, _clear: bool, _gas_left: u64) -> Result<u64> {
+    fn flush_storage_cache(&mut self, _clear: bool, _gas_left: Gas) -> Result<Gas> {
         let storage = &mut self.storage.lock();
         let storage = storage.get_mut(&self.program).unwrap();
-        Ok(22100 * storage.len() as u64) // pretend worst case
+        Ok(Gas(22100) * storage.len() as u64) // pretend worst case
     }
 
     fn get_transient_bytes32(&mut self, _key: Bytes32) -> Bytes32 {
@@ -102,10 +102,10 @@ impl EvmApi<VecReader> for TestEvmApi {
         &mut self,
         contract: Bytes20,
         calldata: &[u8],
-        _gas_left: u64,
-        gas_req: u64,
+        _gas_left: Gas,
+        gas_req: Gas,
         _value: Bytes32,
-    ) -> (u32, u64, UserOutcomeKind) {
+    ) -> (u32, Gas, UserOutcomeKind) {
         let compile = self.compile.clone();
         let evm_data = self.evm_data;
         let config = *self.configs.lock().get(&contract).unwrap();
@@ -122,7 +122,7 @@ impl EvmApi<VecReader> for TestEvmApi {
         let (status, outs) = outcome.into_data();
         let outs_len = outs.len() as u32;
 
-        let ink_left: u64 = native.ink_left().into();
+        let ink_left: Ink = native.ink_left().into();
         let gas_left = config.pricing.ink_to_gas(ink_left);
         *self.write_result.lock() = outs;
         (outs_len, gas - gas_left, status)
@@ -132,9 +132,9 @@ impl EvmApi<VecReader> for TestEvmApi {
         &mut self,
         _contract: Bytes20,
         _calldata: &[u8],
-        _gas_left: u64,
-        _gas_req: u64,
-    ) -> (u32, u64, UserOutcomeKind) {
+        _gas_left: Gas,
+        _gas_req: Gas,
+    ) -> (u32, Gas, UserOutcomeKind) {
         todo!("delegate call not yet supported")
     }
 
@@ -142,9 +142,9 @@ impl EvmApi<VecReader> for TestEvmApi {
         &mut self,
         contract: Bytes20,
         calldata: &[u8],
-        gas_left: u64,
-        gas_req: u64,
-    ) -> (u32, u64, UserOutcomeKind) {
+        gas_left: Gas,
+        gas_req: Gas,
+    ) -> (u32, Gas, UserOutcomeKind) {
         println!("note: overriding static call with call");
         self.contract_call(contract, calldata, gas_left, gas_req, Bytes32::default())
     }
@@ -153,8 +153,8 @@ impl EvmApi<VecReader> for TestEvmApi {
         &mut self,
         _code: Vec<u8>,
         _endowment: Bytes32,
-        _gas: u64,
-    ) -> (Result<Bytes20>, u32, u64) {
+        _gas: Gas,
+    ) -> (Result<Bytes20>, u32, Gas) {
         unimplemented!("create1 not supported")
     }
 
@@ -163,8 +163,8 @@ impl EvmApi<VecReader> for TestEvmApi {
         _code: Vec<u8>,
         _endowment: Bytes32,
         _salt: Bytes32,
-        _gas: u64,
-    ) -> (Result<Bytes20>, u32, u64) {
+        _gas: Gas,
+    ) -> (Result<Bytes20>, u32, Gas) {
         unimplemented!("create2 not supported")
     }
 
@@ -176,19 +176,19 @@ impl EvmApi<VecReader> for TestEvmApi {
         Ok(()) // pretend a log was emitted
     }
 
-    fn account_balance(&mut self, _address: Bytes20) -> (Bytes32, u64) {
+    fn account_balance(&mut self, _address: Bytes20) -> (Bytes32, Gas) {
         unimplemented!()
     }
 
-    fn account_code(&mut self, _address: Bytes20, _gas_left: u64) -> (VecReader, u64) {
+    fn account_code(&mut self, _address: Bytes20, _gas_left: Gas) -> (VecReader, Gas) {
         unimplemented!()
     }
 
-    fn account_codehash(&mut self, _address: Bytes20) -> (Bytes32, u64) {
+    fn account_codehash(&mut self, _address: Bytes20) -> (Bytes32, Gas) {
         unimplemented!()
     }
 
-    fn add_pages(&mut self, new: u16) -> u64 {
+    fn add_pages(&mut self, new: u16) -> Gas {
         let model = MemoryModel::new(2, 1000);
         let (open, ever) = *self.pages.lock();
 
@@ -203,8 +203,8 @@ impl EvmApi<VecReader> for TestEvmApi {
         _name: &str,
         _args: &[u8],
         _outs: &[u8],
-        _start_ink: u64,
-        _end_ink: u64,
+        _start_ink: Ink,
+        _end_ink: Ink,
     ) {
         unimplemented!()
     }

--- a/arbitrator/stylus/src/test/mod.rs
+++ b/arbitrator/stylus/src/test/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::{env::WasmEnv, native::NativeInstance, run::RunProgram, test::api::TestEvmApi};
 use arbutil::{
-    evm::{api::VecReader, user::UserOutcome},
+    evm::{api::{Ink, VecReader}, user::UserOutcome},
     Bytes20, Bytes32, Color,
 };
 use eyre::{bail, Result};
@@ -41,7 +41,7 @@ impl TestInstance {
         };
         let mut native = Self::new_from_store(path, store, imports)?;
         native.set_meter_data();
-        native.set_ink(u64::MAX);
+        native.set_ink(Ink(u64::MAX));
         native.set_stack(u32::MAX);
         Ok(native)
     }
@@ -107,8 +107,8 @@ fn expensive_add(op: &Operator, _tys: &SigMap) -> u64 {
     }
 }
 
-pub fn random_ink(min: u64) -> u64 {
-    rand::thread_rng().gen_range(min..=u64::MAX)
+pub fn random_ink(min: u64) -> Ink {
+    Ink(rand::thread_rng().gen_range(min..=u64::MAX))
 }
 
 pub fn random_bytes20() -> Bytes20 {
@@ -135,7 +135,7 @@ fn uniform_cost_config() -> StylusConfig {
     stylus_config
 }
 
-fn test_configs() -> (CompileConfig, StylusConfig, u64) {
+fn test_configs() -> (CompileConfig, StylusConfig, Ink) {
     (
         test_compile_config(),
         uniform_cost_config(),
@@ -165,12 +165,12 @@ fn new_test_machine(path: &str, compile: &CompileConfig) -> Result<Machine> {
         Arc::new(|_, _, _| panic!("tried to read preimage")),
         Some(stylus_data),
     )?;
-    mach.set_ink(u64::MAX);
+    mach.set_ink(Ink(u64::MAX));
     mach.set_stack(u32::MAX);
     Ok(mach)
 }
 
-fn run_native(native: &mut TestInstance, args: &[u8], ink: u64) -> Result<Vec<u8>> {
+fn run_native(native: &mut TestInstance, args: &[u8], ink: Ink) -> Result<Vec<u8>> {
     let config = native.env().config.expect("no config");
     match native.run_main(args, config, ink)? {
         UserOutcome::Success(output) => Ok(output),
@@ -182,7 +182,7 @@ fn run_machine(
     machine: &mut Machine,
     args: &[u8],
     config: StylusConfig,
-    ink: u64,
+    ink: Ink,
 ) -> Result<Vec<u8>> {
     match machine.run_main(args, config, ink)? {
         UserOutcome::Success(output) => Ok(output),

--- a/arbitrator/stylus/src/test/wavm.rs
+++ b/arbitrator/stylus/src/test/wavm.rs
@@ -2,6 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
 use crate::test::{new_test_machine, test_compile_config};
+use arbutil::evm::api::Ink;
 use eyre::Result;
 use prover::{programs::prelude::*, Machine};
 
@@ -15,8 +16,8 @@ fn test_ink() -> Result<()> {
 
     macro_rules! exhaust {
         ($ink:expr) => {
-            machine.set_ink($ink);
-            assert_eq!(machine.ink_left(), MachineMeter::Ready($ink));
+            machine.set_ink(Ink($ink));
+            assert_eq!(machine.ink_left(), MachineMeter::Ready(Ink($ink)));
             assert!(call(machine, 32).is_err());
             assert_eq!(machine.ink_left(), MachineMeter::Exhausted);
         };
@@ -26,12 +27,12 @@ fn test_ink() -> Result<()> {
     exhaust!(50);
     exhaust!(99);
 
-    let mut ink_left = 500;
+    let mut ink_left = Ink(500);
     machine.set_ink(ink_left);
-    while ink_left > 0 {
+    while ink_left > Ink(0) {
         assert_eq!(machine.ink_left(), MachineMeter::Ready(ink_left));
         assert_eq!(call(machine, 64)?, vec![65_u32.into()]);
-        ink_left -= 100;
+        ink_left -= Ink(100);
     }
     assert!(call(machine, 32).is_err());
     assert_eq!(machine.ink_left(), MachineMeter::Exhausted);

--- a/arbitrator/wasm-libraries/user-host-trait/src/lib.rs
+++ b/arbitrator/wasm-libraries/user-host-trait/src/lib.rs
@@ -5,7 +5,7 @@ use arbutil::{
     crypto,
     evm::{
         self,
-        api::{DataReader, EvmApi},
+        api::{DataReader, EvmApi, Gas, Ink},
         storage::StorageCache,
         user::UserOutcomeKind,
         EvmData, ARBOS_VERSION_STYLUS_CHARGING_FIXES,
@@ -88,7 +88,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
     }
 
     fn say<D: Display>(&self, text: D);
-    fn trace(&mut self, name: &str, args: &[u8], outs: &[u8], end_ink: u64);
+    fn trace(&mut self, name: &str, args: &[u8], outs: &[u8], end_ink: Ink);
 
     fn write_bytes20(&self, ptr: GuestPtr, src: Bytes20) -> Result<(), Self::MemoryErr> {
         self.write_slice(ptr, &src.0)
@@ -147,7 +147,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
 
         // require for cache-miss case, preserve wrong behavior for old arbos
         let evm_api_gas_to_use = if arbos_version < ARBOS_VERSION_STYLUS_CHARGING_FIXES {
-            EVM_API_INK
+            Gas(EVM_API_INK.0)
         } else {
             self.pricing().ink_to_gas(EVM_API_INK)
         };
@@ -253,7 +253,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
         data: GuestPtr,
         data_len: u32,
         value: GuestPtr,
-        gas: u64,
+        gas: Gas,
         ret_len: GuestPtr,
     ) -> Result<u8, Self::Err> {
         let value = Some(value);
@@ -282,7 +282,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
         contract: GuestPtr,
         data: GuestPtr,
         data_len: u32,
-        gas: u64,
+        gas: Gas,
         ret_len: GuestPtr,
     ) -> Result<u8, Self::Err> {
         let call = |api: &mut Self::A, contract, data: &_, left, req, _| {
@@ -312,7 +312,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
         contract: GuestPtr,
         data: GuestPtr,
         data_len: u32,
-        gas: u64,
+        gas: Gas,
         ret_len: GuestPtr,
     ) -> Result<u8, Self::Err> {
         let call = |api: &mut Self::A, contract, data: &_, left, req, _| {
@@ -329,7 +329,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
         calldata: GuestPtr,
         calldata_len: u32,
         value: Option<GuestPtr>,
-        gas: u64,
+        gas: Gas,
         return_data_len: GuestPtr,
         call: F,
         name: &str,
@@ -339,10 +339,10 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
             &mut Self::A,
             Address,
             &[u8],
-            u64,
-            u64,
+            Gas,
+            Gas,
             Option<Wei>,
-        ) -> (u32, u64, UserOutcomeKind),
+        ) -> (u32, Gas, UserOutcomeKind),
     {
         self.buy_ink(HOSTIO_INK + 3 * PTR_INK + EVM_API_INK)?;
         self.pay_for_read(calldata_len)?;
@@ -465,12 +465,12 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
         salt: Option<GuestPtr>,
         contract: GuestPtr,
         revert_data_len: GuestPtr,
-        cost: u64,
+        cost: Ink,
         call: F,
         name: &str,
     ) -> Result<(), Self::Err>
     where
-        F: FnOnce(&mut Self::A, Vec<u8>, Bytes32, Option<Wei>, u64) -> (Result<Address>, u32, u64),
+        F: FnOnce(&mut Self::A, Vec<u8>, Bytes32, Option<Wei>, Gas) -> (Result<Address>, u32, Gas),
     {
         self.buy_ink(HOSTIO_INK + cost)?;
         self.pay_for_read(code_len)?;
@@ -745,7 +745,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
     /// equivalent to that of the EVM's [`GAS`] opcode.
     ///
     /// [`GAS`]: https://www.evm.codes/#5a
-    fn evm_gas_left(&mut self) -> Result<u64, Self::Err> {
+    fn evm_gas_left(&mut self) -> Result<Gas, Self::Err> {
         self.buy_ink(HOSTIO_INK)?;
         let gas = self.gas_left()?;
         trace!("evm_gas_left", self, &[], be!(gas), gas)
@@ -757,7 +757,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
     ///
     /// [`GAS`]: https://www.evm.codes/#5a
     /// [`Ink and Gas`]: https://developer.arbitrum.io/TODO
-    fn evm_ink_left(&mut self) -> Result<u64, Self::Err> {
+    fn evm_ink_left(&mut self) -> Result<Ink, Self::Err> {
         self.buy_ink(HOSTIO_INK)?;
         let ink = self.ink_ready()?;
         trace!("evm_ink_left", self, &[], be!(ink), ink)


### PR DESCRIPTION
This should help prevent future incidents like the one in storage_load where an ink cost was mistakenly used as an amount of gas.