### PR TITLE
Log from batch poster for which das backends are using chunked vs legacy store

### DIFF
--- a/das/dasRpcClient.go
+++ b/das/dasRpcClient.go
@@ -101,6 +101,7 @@ func (c *DASRPCClient) Store(ctx context.Context, message []byte, timeout uint64
 	var startChunkedStoreResult StartChunkedStoreResult
 	if err := c.clnt.CallContext(ctx, &startChunkedStoreResult, "das_startChunkedStore", hexutil.Uint64(timestamp), hexutil.Uint64(nChunks), hexutil.Uint64(c.chunkSize), hexutil.Uint64(totalSize), hexutil.Uint64(timeout), hexutil.Bytes(startReqSig)); err != nil {
 		if strings.Contains(err.Error(), "the method das_startChunkedStore does not exist") {
+			log.Info("Legacy store is used by the DAS client", "url", c.url)
 			return c.legacyStore(ctx, message, timeout)
 		}
 		return nil, err


### PR DESCRIPTION
This PR logs when a DAS backend is using Legacy store due to the method `das_startChunkedStore` not being present. ([comment](https://github.com/OffchainLabs/nitro/pull/2599#pullrequestreview-2354622307))

Replaces https://github.com/OffchainLabs/nitro/pull/2599
Resolves NIT-2742