### PR TITLE
Do not use SetFinalizer to remove entries from preimageResolvers

### DIFF
--- a/util/containers/syncmap.go
+++ b/util/containers/syncmap.go
@@ -22,3 +22,13 @@ func (m *SyncMap[K, V]) Store(key K, val V) {
 func (m *SyncMap[K, V]) Delete(key K) {
 	m.internal.Delete(key)
 }
+
+// Only used for testing
+func (m *SyncMap[K, V]) Keys() []K {
+	s := make([]K, 0)
+	m.internal.Range(func(k, v interface{}) bool {
+		s = append(s, k.(K))
+		return true
+	})
+	return s
+}

--- a/validator/server_arb/machine.go
+++ b/validator/server_arb/machine.go
@@ -68,10 +68,10 @@ func dereferenceContextId(contextId *int64) {
 			panic(fmt.Sprintf("dereferenceContextId: resolver with ref counter not found, contextId: %v", *contextId))
 		}
 
-		refCounterAfter := resolverWithRefCounter.refCounter.Add(-1)
-		if refCounterAfter < 0 {
+		refCount := resolverWithRefCounter.refCounter.Add(-1)
+		if refCount < 0 {
 			panic(fmt.Sprintf("dereferenceContextId: ref counter is negative, contextId: %v", *contextId))
-		} else if refCounterAfter == 0 {
+		} else if refCount == 0 {
 			preimageResolvers.Delete(*contextId)
 		}
 	}

--- a/validator/server_arb/machine.go
+++ b/validator/server_arb/machine.go
@@ -77,6 +77,7 @@ func (m *ArbitratorMachine) Destroy() {
 			preimageResolvers.Delete(m.contextId)
 		}
 	}
+	m.contextId = 0
 }
 
 func machineFromPointer(ptr *C.struct_Machine) *ArbitratorMachine {

--- a/validator/server_arb/machine.go
+++ b/validator/server_arb/machine.go
@@ -74,10 +74,8 @@ func (m *ArbitratorMachine) Destroy() {
 
 	if m.contextId != nil {
 		resolverWithRefCounter, ok := preimageResolvers.Load(*m.contextId)
-		if ok {
-			if resolverWithRefCounter.refCounter.Add(-1) == 0 {
-				preimageResolvers.Delete(*m.contextId)
-			}
+		if ok && (resolverWithRefCounter.refCounter.Add(-1) == 0) {
+			preimageResolvers.Delete(*m.contextId)
 		}
 	}
 	m.contextId = nil

--- a/validator/server_arb/machine.go
+++ b/validator/server_arb/machine.go
@@ -53,6 +53,7 @@ type ArbitratorMachine struct {
 	ptr       *C.struct_Machine
 	contextId *int64 // has a finalizer attached to remove the preimage resolver from the global map
 	frozen    bool   // does not allow anything that changes machine state, not cloned with the machine
+	isHostIo  bool
 }
 
 // Assert that ArbitratorMachine implements MachineInterface
@@ -71,7 +72,14 @@ func (m *ArbitratorMachine) Destroy() {
 		// We no longer need a finalizer
 		runtime.SetFinalizer(m, nil)
 	}
-	m.contextId = nil
+
+	// there is no finalizer related to contextId when the machine is HostIo,
+	// so we need to manually remove the preimage resolver
+	if m.isHostIo && (m.contextId != nil) {
+		preimageResolvers.Delete(*m.contextId)
+	} else {
+		m.contextId = nil
+	}
 }
 
 func freeContextId(context *int64) {
@@ -110,6 +118,11 @@ func (m *ArbitratorMachine) Clone() *ArbitratorMachine {
 	defer runtime.KeepAlive(m)
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
+
+	if m.isHostIo {
+		panic("it is not allowed to clone a hostio machine")
+	}
+
 	newMach := machineFromPointer(C.arbitrator_clone_machine(m.ptr))
 	newMach.contextId = m.contextId
 	return newMach
@@ -385,7 +398,9 @@ func (m *ArbitratorMachine) SetPreimageResolver(resolver GoPreimageResolver) err
 	id := lastPreimageResolverId.Add(1)
 	preimageResolvers.Store(id, resolver)
 	m.contextId = &id
-	runtime.SetFinalizer(m.contextId, freeContextId)
+	if !m.isHostIo {
+		runtime.SetFinalizer(m.contextId, freeContextId)
+	}
 	C.arbitrator_set_context(m.ptr, u64(id))
 	return nil
 }

--- a/validator/server_arb/machine.go
+++ b/validator/server_arb/machine.go
@@ -68,6 +68,8 @@ func (m *ArbitratorMachine) Destroy() {
 	if m.ptr != nil {
 		C.arbitrator_free_machine(m.ptr)
 		m.ptr = nil
+		// We no longer need a finalizer
+		runtime.SetFinalizer(m, nil)
 	}
 	resolverWithRefCounter, ok := preimageResolvers.Load(m.contextId)
 	if ok {

--- a/validator/server_arb/machine_test.go
+++ b/validator/server_arb/machine_test.go
@@ -59,8 +59,8 @@ func TestEntriesAreDeletedFromPreimageResolversGlobalMap(t *testing.T) {
 		}
 	}
 
-	machine1ContextId := machine1.contextId
-	machine2ContextId := machine2.contextId
+	machine1ContextId := *machine1.contextId
+	machine2ContextId := *machine2.contextId
 
 	checkKeys([]int64{machine1ContextId, machine2ContextId}, "initial")
 

--- a/validator/server_arb/machine_test.go
+++ b/validator/server_arb/machine_test.go
@@ -1,0 +1,75 @@
+// Copyright 2021-2024, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package server_arb
+
+import (
+	"path"
+	"reflect"
+	"runtime"
+	"sort"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/util/testhelpers"
+)
+
+func TestEntriesAreDeletedFromPreimageResolversGlobalMap(t *testing.T) {
+	resolver := func(arbutil.PreimageType, common.Hash) ([]byte, error) {
+		return nil, nil
+	}
+
+	sortedKeys := func() []int64 {
+		keys := preimageResolvers.Keys()
+		sort.Slice(keys, func(i, j int) bool {
+			return keys[i] < keys[j]
+		})
+		return keys
+	}
+
+	// clear global map before running test
+	preimageKeys := sortedKeys()
+	for _, key := range preimageKeys {
+		preimageResolvers.Delete(key)
+	}
+
+	_, filename, _, _ := runtime.Caller(0)
+	wasmDir := path.Join(path.Dir(filename), "../../arbitrator/prover/test-cases/")
+	wasmPath := path.Join(wasmDir, "global-state.wasm")
+	modulePaths := []string{path.Join(wasmDir, "global-state-wrapper.wasm")}
+
+	machine1, err := LoadSimpleMachine(wasmPath, modulePaths, true)
+	testhelpers.RequireImpl(t, err)
+	err = machine1.SetPreimageResolver(resolver)
+	testhelpers.RequireImpl(t, err)
+
+	machine2, err := LoadSimpleMachine(wasmPath, modulePaths, true)
+	testhelpers.RequireImpl(t, err)
+	err = machine2.SetPreimageResolver(resolver)
+	testhelpers.RequireImpl(t, err)
+
+	machine1_clone1 := machine1.Clone()
+	machine1_clone2 := machine1.Clone()
+
+	checkKeys := func(expectedKeys []int64, scenario string) {
+		keys := sortedKeys()
+		if !reflect.DeepEqual(keys, expectedKeys) {
+			t.Fatal("Unexpected preimageResolversKeys got", keys, "expected", expectedKeys, "scenario", scenario)
+		}
+	}
+
+	checkKeys([]int64{machine1.contextId, machine2.contextId}, "initial")
+
+	machine1_clone1.Destroy()
+	checkKeys([]int64{machine1.contextId, machine2.contextId}, "after machine1_clone1 destroy")
+
+	machine1_clone2.Destroy()
+	checkKeys([]int64{machine1.contextId, machine2.contextId}, "after machine1_clone2 destroy")
+
+	machine2.Destroy()
+	checkKeys([]int64{machine1.contextId}, "after machine2 destroy")
+
+	machine1.Destroy()
+	checkKeys([]int64{}, "after machine1 destroy")
+}

--- a/validator/server_arb/machine_test.go
+++ b/validator/server_arb/machine_test.go
@@ -49,8 +49,8 @@ func TestEntriesAreDeletedFromPreimageResolversGlobalMap(t *testing.T) {
 	err = machine2.SetPreimageResolver(resolver)
 	testhelpers.RequireImpl(t, err)
 
-	machine1_clone1 := machine1.Clone()
-	machine1_clone2 := machine1.Clone()
+	machine1Clone1 := machine1.Clone()
+	machine1Clone2 := machine1.Clone()
 
 	checkKeys := func(expectedKeys []int64, scenario string) {
 		keys := sortedKeys()
@@ -59,17 +59,23 @@ func TestEntriesAreDeletedFromPreimageResolversGlobalMap(t *testing.T) {
 		}
 	}
 
-	checkKeys([]int64{machine1.contextId, machine2.contextId}, "initial")
+	machine1ContextId := machine1.contextId
+	machine2ContextId := machine2.contextId
 
-	machine1_clone1.Destroy()
-	checkKeys([]int64{machine1.contextId, machine2.contextId}, "after machine1_clone1 destroy")
+	checkKeys([]int64{machine1ContextId, machine2ContextId}, "initial")
+
+	machine1Clone1.Destroy()
+	checkKeys([]int64{machine1ContextId, machine2ContextId}, "after machine1Clone1 is destroyed")
 
 	machine1.Destroy()
-	checkKeys([]int64{machine1.contextId, machine2.contextId}, "after machine1 destroy")
+	checkKeys([]int64{machine1ContextId, machine2ContextId}, "after machine1 is destroyed")
 
-	machine1_clone2.Destroy()
-	checkKeys([]int64{machine2.contextId}, "after machine1_clone2 destroy")
+	machine1.Destroy()
+	checkKeys([]int64{machine1ContextId, machine2ContextId}, "after machine1 is destroyed again")
+
+	machine1Clone2.Destroy()
+	checkKeys([]int64{machine2ContextId}, "after machine1Clone2 is destroyed")
 
 	machine2.Destroy()
-	checkKeys([]int64{}, "after machine2 destroy")
+	checkKeys([]int64{}, "after machine2 is destroyed")
 }

--- a/validator/server_arb/machine_test.go
+++ b/validator/server_arb/machine_test.go
@@ -64,12 +64,12 @@ func TestEntriesAreDeletedFromPreimageResolversGlobalMap(t *testing.T) {
 	machine1_clone1.Destroy()
 	checkKeys([]int64{machine1.contextId, machine2.contextId}, "after machine1_clone1 destroy")
 
+	machine1.Destroy()
+	checkKeys([]int64{machine1.contextId, machine2.contextId}, "after machine1 destroy")
+
 	machine1_clone2.Destroy()
-	checkKeys([]int64{machine1.contextId, machine2.contextId}, "after machine1_clone2 destroy")
+	checkKeys([]int64{machine2.contextId}, "after machine1_clone2 destroy")
 
 	machine2.Destroy()
-	checkKeys([]int64{machine1.contextId}, "after machine2 destroy")
-
-	machine1.Destroy()
-	checkKeys([]int64{}, "after machine1 destroy")
+	checkKeys([]int64{}, "after machine2 destroy")
 }

--- a/validator/server_arb/machine_test.go
+++ b/validator/server_arb/machine_test.go
@@ -64,15 +64,27 @@ func TestEntriesAreDeletedFromPreimageResolversGlobalMap(t *testing.T) {
 
 	checkKeys([]int64{machine1ContextId, machine2ContextId}, "initial")
 
+	// the machine's contextId should change when setting preimage resolver for the second time,
+	// and the entry for the old context id should be deleted
+	err = machine2.SetPreimageResolver(resolver)
+	testhelpers.RequireImpl(t, err)
+	if machine2ContextId == *machine2.contextId {
+		t.Fatal("Context id didn't change after setting preimage resolver for the second time")
+	}
+	machine2ContextId = *machine2.contextId
+	checkKeys([]int64{machine1ContextId, machine2ContextId}, "after setting preimage resolver for machine2 for the second time")
+
 	machine1Clone1.Destroy()
 	checkKeys([]int64{machine1ContextId, machine2ContextId}, "after machine1Clone1 is destroyed")
 
 	machine1.Destroy()
 	checkKeys([]int64{machine1ContextId, machine2ContextId}, "after machine1 is destroyed")
 
+	// it is possible to destroy the same machine multiple times
 	machine1.Destroy()
 	checkKeys([]int64{machine1ContextId, machine2ContextId}, "after machine1 is destroyed again")
 
+	// entry for machine1ContextId should be deleted only after machine1 and all its clones are destroyed
 	machine1Clone2.Destroy()
 	checkKeys([]int64{machine2ContextId}, "after machine1Clone2 is destroyed")
 

--- a/validator/server_arb/validator_spawner.go
+++ b/validator/server_arb/validator_spawner.go
@@ -160,7 +160,6 @@ func (v *ArbitratorSpawner) execute(
 	}
 
 	mach := basemachine.Clone()
-	mach.isHostIo = true
 	defer mach.Destroy()
 	err = v.loadEntryToMachine(ctx, entry, mach)
 	if err != nil {

--- a/validator/server_arb/validator_spawner.go
+++ b/validator/server_arb/validator_spawner.go
@@ -160,6 +160,7 @@ func (v *ArbitratorSpawner) execute(
 	}
 
 	mach := basemachine.Clone()
+	mach.isHostIo = true
 	defer mach.Destroy()
 	err = v.loadEntryToMachine(ctx, entry, mach)
 	if err != nil {


### PR DESCRIPTION
Resolves NIT-2818

Arbitrator redis workers are being killed due to OOM. 
This happens when GOMEMLIMIT is set to 6144MiB and the pod's memory limit is set to 8Gi.
Not particularly sure if other GOMEMLIMIT/pod's memory limit settings also cause this issue.

pprof golang heap profile indicates that almost all heap in use is related to the ValidationInput allocation, that happens here https://github.com/OffchainLabs/nitro/blob/9a157f48ae23d4f8016f2ab2c4a39b6cb3239d85/pubsub/consumer.go#L169

![heap](https://github.com/user-attachments/assets/c8bb02ff-544f-46b0-95a5-de21bb4db77f)

Background:
- ValidationInput is in the scope of a preimage resolver that is kept in this global map https://github.com/OffchainLabs/nitro/blob/9a157f48ae23d4f8016f2ab2c4a39b6cb3239d85/validator/server_arb/machine.go#L61
- Entries are deleted from this map through a finalizer https://pkg.go.dev/runtime#SetFinalizer
`When the garbage collector finds an unreachable block with an associated finalizer, it clears the association and runs finalizer(obj) in a separate goroutine. This makes obj reachable again, but now without an associated finalizer. Assuming that SetFinalizer is not called again, the next time the garbage collector sees that obj is unreachable, it will free obj.`
`Note that because finalizers may execute arbitrarily far into the future after an object is no longer referenced, the runtime is allowed to perform a space-saving optimization that batches objects together in a single allocation slot. The finalizer for an unreferenced object in such an allocation may never run if it always exists in the same batch as a referenced object. Typically, this batching only happens for tiny (on the order of 16 bytes or less) and pointer-free objects.`

Hypothesis:
Once an entry of this map is not required anymore, with current SetFinalizer approach, it will be necessary one extra GC cycle, compared to the approach proposed in this PR, in order to free the memory related to it.
Also, since contextId has less than 16 bytes, it is possible that contextIds are kept alongside other objects, in a single allocation slot.
So the finalizer related to a contextId may never run if the contextId belongs to an allocation slot that has other objects that are still referenced.

This could potentially keep heap usage unnecessarily high, causing an OOM when a new allocation occurs. 

Proposed mitigation:
Do not use the SetFinalizer pattern for deleting preimage resolver entries.