### PR TITLE
Attempt to clear from PEL again after successfull deletion of Lower

### DIFF
--- a/pubsub/producer.go
+++ b/pubsub/producer.go
@@ -201,8 +201,9 @@ func (p *Producer[Request, Response]) clearMessages(ctx context.Context) time.Du
 			}
 			if _, err := p.client.XDel(ctx, p.redisStream, pelData.Lower).Result(); err != nil {
 				log.Error("error deleting PEL's lower message thats past its TTL", "msgID", pelData.Lower, "err", err)
-				return 0
+				return 5 * p.cfg.CheckResultInterval
 			}
+			return 0
 		}
 	}
 	return 5 * p.cfg.CheckResultInterval


### PR DESCRIPTION
This PR is an improvement to the new redis stream implementation (https://github.com/OffchainLabs/nitro/pull/2581) that attempts to clear messages from PEL (pending entries list) right after successful removal of the current Lower message.

Resolves NIT-2844