### PR TITLE
Fix SequenceNumber attribute and decode order

### DIFF
--- a/execution/gethexec/express_lane_service.go
+++ b/execution/gethexec/express_lane_service.go
@@ -239,19 +239,19 @@ func (es *expressLaneService) sequenceExpressLaneSubmission(
 		return timeboost.ErrNoOnchainController
 	}
 	// Check if the submission nonce is too low.
-	if msg.Sequence < control.sequence {
+	if msg.SequenceNumber < control.sequence {
 		return timeboost.ErrSequenceNumberTooLow
 	}
 	// Check if a duplicate submission exists already, and reject if so.
-	if _, exists := es.messagesBySequenceNumber[msg.Sequence]; exists {
+	if _, exists := es.messagesBySequenceNumber[msg.SequenceNumber]; exists {
 		return timeboost.ErrDuplicateSequenceNumber
 	}
 	// Log an informational warning if the message's sequence number is in the future.
-	if msg.Sequence > control.sequence {
-		log.Warn("Received express lane submission with future sequence number", "sequence", msg.Sequence)
+	if msg.SequenceNumber > control.sequence {
+		log.Warn("Received express lane submission with future sequence number", "sequence", msg.SequenceNumber)
 	}
 	// Put into the sequence number map.
-	es.messagesBySequenceNumber[msg.Sequence] = msg
+	es.messagesBySequenceNumber[msg.SequenceNumber] = msg
 
 	for {
 		// Get the next message in the sequence.
@@ -266,7 +266,7 @@ func (es *expressLaneService) sequenceExpressLaneSubmission(
 			false, /* no delay, as it should go through express lane */
 		); err != nil {
 			// If the tx failed, clear it from the sequence map.
-			delete(es.messagesBySequenceNumber, msg.Sequence)
+			delete(es.messagesBySequenceNumber, msg.SequenceNumber)
 			return err
 		}
 		// Increase the global round sequence number.

--- a/execution/gethexec/express_lane_service.go
+++ b/execution/gethexec/express_lane_service.go
@@ -248,7 +248,7 @@ func (es *expressLaneService) sequenceExpressLaneSubmission(
 	}
 	// Log an informational warning if the message's sequence number is in the future.
 	if msg.SequenceNumber > control.sequence {
-		log.Warn("Received express lane submission with future sequence number", "sequence", msg.SequenceNumber)
+		log.Warn("Received express lane submission with future sequence number", "SequenceNumber", msg.SequenceNumber)
 	}
 	// Put into the sequence number map.
 	es.messagesBySequenceNumber[msg.SequenceNumber] = msg

--- a/execution/gethexec/express_lane_service_test.go
+++ b/execution/gethexec/express_lane_service_test.go
@@ -242,7 +242,7 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_nonceTooLow(t *testin
 		sequence: 1,
 	})
 	msg := &timeboost.ExpressLaneSubmission{
-		Sequence: 0,
+		SequenceNumber: 0,
 	}
 	publishFn := func(parentCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions, delay bool) error {
 		return nil
@@ -262,7 +262,7 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_duplicateNonce(t *tes
 		sequence: 1,
 	})
 	msg := &timeboost.ExpressLaneSubmission{
-		Sequence: 2,
+		SequenceNumber: 2,
 	}
 	numPublished := 0
 	publishFn := func(parentCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions, delay bool) error {
@@ -299,19 +299,19 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_outOfOrder(t *testing
 	}
 	messages := []*timeboost.ExpressLaneSubmission{
 		{
-			Sequence: 10,
+			SequenceNumber: 10,
 		},
 		{
-			Sequence: 5,
+			SequenceNumber: 5,
 		},
 		{
-			Sequence: 1,
+			SequenceNumber: 1,
 		},
 		{
-			Sequence: 4,
+			SequenceNumber: 4,
 		},
 		{
-			Sequence: 2,
+			SequenceNumber: 2,
 		},
 	}
 	for _, msg := range messages {
@@ -322,7 +322,7 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_outOfOrder(t *testing
 	require.Equal(t, 2, numPublished)
 	require.Equal(t, len(messages), len(els.messagesBySequenceNumber))
 
-	err := els.sequenceExpressLaneSubmission(ctx, &timeboost.ExpressLaneSubmission{Sequence: 3}, publishFn)
+	err := els.sequenceExpressLaneSubmission(ctx, &timeboost.ExpressLaneSubmission{SequenceNumber: 3}, publishFn)
 	require.NoError(t, err)
 	require.Equal(t, 5, numPublished)
 }
@@ -350,19 +350,19 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_erroredTx(t *testing.
 	}
 	messages := []*timeboost.ExpressLaneSubmission{
 		{
-			Sequence:    1,
+			SequenceNumber:    1,
 			Transaction: &types.Transaction{},
 		},
 		{
-			Sequence:    3,
+			SequenceNumber:    3,
 			Transaction: &types.Transaction{},
 		},
 		{
-			Sequence:    2,
+			SequenceNumber:    2,
 			Transaction: nil,
 		},
 		{
-			Sequence:    2,
+			SequenceNumber:    2,
 			Transaction: &types.Transaction{},
 		},
 	}

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -676,7 +676,7 @@ func (elc *expressLaneClient) SendTransaction(ctx context.Context, transaction *
 		Round:                  hexutil.Uint64(timeboost.CurrentRound(elc.initialRoundTimestamp, elc.roundDuration)),
 		AuctionContractAddress: elc.auctionContractAddr,
 		Transaction:            encodedTx,
-		Sequence:               hexutil.Uint64(elc.sequence),
+		SequenceNumber:         hexutil.Uint64(elc.sequence),
 		Signature:              hexutil.Bytes{},
 	}
 	msgGo, err := timeboost.JsonSubmissionToGo(msg)

--- a/timeboost/types.go
+++ b/timeboost/types.go
@@ -139,7 +139,7 @@ type JsonExpressLaneSubmission struct {
 	AuctionContractAddress common.Address                     `json:"auctionContractAddress"`
 	Transaction            hexutil.Bytes                      `json:"transaction"`
 	Options                *arbitrum_types.ConditionalOptions `json:"options"`
-	Sequence               hexutil.Uint64
+	SequenceNumber         hexutil.Uint64
 	Signature              hexutil.Bytes `json:"signature"`
 }
 
@@ -149,7 +149,7 @@ type ExpressLaneSubmission struct {
 	AuctionContractAddress common.Address
 	Transaction            *types.Transaction
 	Options                *arbitrum_types.ConditionalOptions `json:"options"`
-	Sequence               uint64
+	SequenceNumber         uint64
 	Signature              []byte
 }
 
@@ -164,7 +164,7 @@ func JsonSubmissionToGo(submission *JsonExpressLaneSubmission) (*ExpressLaneSubm
 		AuctionContractAddress: submission.AuctionContractAddress,
 		Transaction:            tx,
 		Options:                submission.Options,
-		Sequence:               uint64(submission.Sequence),
+		SequenceNumber:         uint64(submission.SequenceNumber),
 		Signature:              submission.Signature,
 	}, nil
 }
@@ -180,7 +180,7 @@ func (els *ExpressLaneSubmission) ToJson() (*JsonExpressLaneSubmission, error) {
 		AuctionContractAddress: els.AuctionContractAddress,
 		Transaction:            encoded,
 		Options:                els.Options,
-		Sequence:               hexutil.Uint64(els.Sequence),
+		SequenceNumber:         hexutil.Uint64(els.SequenceNumber),
 		Signature:              els.Signature,
 	}, nil
 }
@@ -189,13 +189,13 @@ func (els *ExpressLaneSubmission) ToMessageBytes() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.Write(domainValue)
 	buf.Write(padBigInt(els.ChainId))
-	seqBuf := make([]byte, 8)
-	binary.BigEndian.PutUint64(seqBuf, els.Sequence)
-	buf.Write(seqBuf)
 	buf.Write(els.AuctionContractAddress[:])
 	roundBuf := make([]byte, 8)
 	binary.BigEndian.PutUint64(roundBuf, els.Round)
 	buf.Write(roundBuf)
+	seqBuf := make([]byte, 8)
+	binary.BigEndian.PutUint64(seqBuf, els.SequenceNumber)
+	buf.Write(seqBuf)
 	rlpTx, err := els.Transaction.MarshalBinary()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds changes to the attribute `Sequence` of the `ExpressLaneSubmission` and `JsonExpressLaneSubmission` structs to conform with the [specs](https://github.com/OffchainLabs/timeboost-design/blob/main/implementation_design.md) :

- Sequence is renamed to SequenceNumber
- When casting the struct to a byte array (in `ToMessageBytes()`, it should be placed after the `round` and before the serialized transaction to obtain the correct data signed by the client.

Fixes NIT-2877