### PR TITLE
Use exec for validator docker entrypoint

### DIFF
--- a/scripts/split-val-entry.sh
+++ b/scripts/split-val-entry.sh
@@ -39,4 +39,4 @@ for port in 52000 52001; do
     done
 done
 echo launching nitro-node
-/usr/local/bin/nitro --validation.wasm.allowed-wasm-module-roots /home/user/nitro-legacy/machines,/home/user/target/machines --node.block-validator.validation-server-configs-list='[{"jwtsecret":"/tmp/nitro-val.jwt","url":"ws://127.0.0.10:52000"}, {"jwtsecret":"/tmp/nitro-val.jwt","url":"ws://127.0.0.10:52001"}]' "$@"
+exec /usr/local/bin/nitro --validation.wasm.allowed-wasm-module-roots /home/user/nitro-legacy/machines,/home/user/target/machines --node.block-validator.validation-server-configs-list='[{"jwtsecret":"/tmp/nitro-val.jwt","url":"ws://127.0.0.10:52000"}, {"jwtsecret":"/tmp/nitro-val.jwt","url":"ws://127.0.0.10:52001"}]' "$@"


### PR DESCRIPTION
This fixes SIGINT not being forwarded to the nitro node previously.