### PR TITLE
Fixes errcheck errors pointed by golangci-lint

### DIFF
--- a/arbnode/delayed.go
+++ b/arbnode/delayed.go
@@ -334,6 +334,7 @@ func (b *DelayedBridge) parseMessage(ctx context.Context, ethLog types.Log) (*bi
 		if err != nil {
 			return nil, nil, err
 		}
+		// nolint:errcheck
 		return parsedLog.MessageNum, args["messageData"].([]byte), nil
 	default:
 		return nil, nil, errors.New("unexpected log type")

--- a/arbnode/sequencer_inbox.go
+++ b/arbnode/sequencer_inbox.go
@@ -124,6 +124,7 @@ func (m *SequencerInboxBatch) getSequencerData(ctx context.Context, client *ethc
 		if err != nil {
 			return nil, err
 		}
+		// nolint:errcheck
 		return args["data"].([]byte), nil
 	case batchDataSeparateEvent:
 		var numberAsHash common.Hash

--- a/broadcastclient/broadcastclient_test.go
+++ b/broadcastclient/broadcastclient_test.go
@@ -138,6 +138,7 @@ func TestInvalidSignature(t *testing.T) {
 	badPrivateKey, err := crypto.GenerateKey()
 	Require(t, err)
 	badPublicKey := badPrivateKey.Public()
+	// nolint:errcheck
 	badSequencerAddr := crypto.PubkeyToAddress(*badPublicKey.(*ecdsa.PublicKey))
 	config := DefaultTestConfig
 
@@ -202,6 +203,7 @@ func (ts *dummyTransactionStreamer) AddBroadcastMessages(feedMessages []*m.Broad
 }
 
 func newTestBroadcastClient(config Config, listenerAddress net.Addr, chainId uint64, currentMessageCount arbutil.MessageIndex, txStreamer TransactionStreamerInterface, confirmedSequenceNumberListener chan arbutil.MessageIndex, feedErrChan chan error, validAddr *common.Address) (*BroadcastClient, error) {
+	// nolint:errcheck
 	port := listenerAddress.(*net.TCPAddr).Port
 	var av contracts.AddressVerifierInterface
 	if validAddr != nil {

--- a/broadcaster/backlog/backlog.go
+++ b/broadcaster/backlog/backlog.go
@@ -328,7 +328,9 @@ func newBacklogSegment() *backlogSegment {
 func IsBacklogSegmentNil(segment BacklogSegment) bool {
 	if segment == nil {
 		return true
-	} else if segment.(*backlogSegment) == nil {
+	}
+	// nolint:errcheck
+	if segment.(*backlogSegment) == nil {
 		return true
 	}
 	return false

--- a/cmd/genericconf/filehandler_test.go
+++ b/cmd/genericconf/filehandler_test.go
@@ -55,6 +55,7 @@ func readLogMessagesFromJSONFile(t *testing.T, path string) ([]string, error) {
 		if !ok {
 			testhelpers.FailImpl(t, "Incorrect record, msg key is missing", "record", record)
 		}
+		// nolint:errcheck
 		messages = append(messages, msg.(string))
 	}
 	if errors.Is(err, io.EOF) {

--- a/das/reader_aggregator_strategies_test.go
+++ b/das/reader_aggregator_strategies_test.go
@@ -72,7 +72,9 @@ func TestDAS_SimpleExploreExploit(t *testing.T) {
 		}
 
 		for i := 0; i < len(was) && doMatch; i++ {
+			// nolint:errcheck
 			if expected[i].(*dummyReader).int != was[i].(*dummyReader).int {
+				// nolint:errcheck
 				Fail(t, fmt.Sprintf("expected %d, was %d", expected[i].(*dummyReader).int, was[i].(*dummyReader).int))
 			}
 		}

--- a/execution/nodeInterface/NodeInterface.go
+++ b/execution/nodeInterface/NodeInterface.go
@@ -525,6 +525,7 @@ func (n NodeInterface) GasEstimateL1Component(
 	if err := args.CallDefaults(randomGas, evm.Context.BaseFee, evm.ChainConfig().ChainID); err != nil {
 		return 0, nil, nil, err
 	}
+	// nolint:errcheck
 	msg := args.ToMessage(evm.Context.BaseFee, randomGas, n.header, evm.StateDB.(*state.StateDB), core.MessageEthcallMode)
 
 	pricing := c.State.L1PricingState()
@@ -581,6 +582,7 @@ func (n NodeInterface) GasEstimateComponents(
 	if err := args.CallDefaults(gasCap, evm.Context.BaseFee, evm.ChainConfig().ChainID); err != nil {
 		return 0, 0, nil, nil, err
 	}
+	// nolint:errcheck
 	msg := args.ToMessage(evm.Context.BaseFee, gasCap, n.header, evm.StateDB.(*state.StateDB), core.MessageGasEstimationMode)
 	brotliCompressionLevel, err := c.State.BrotliCompressionLevel()
 	if err != nil {

--- a/linters/koanf/handlers.go
+++ b/linters/koanf/handlers.go
@@ -126,6 +126,7 @@ func checkFlagDefs(pass *analysis.Pass, f *ast.FuncDecl, cnt map[string]int) Res
 		if !ok {
 			continue
 		}
+		// nolint:errcheck
 		handleSelector(pass, callE.Args[1].(*ast.SelectorExpr), -1, cnt)
 		if normSL := normalizeTag(sl); !strings.EqualFold(normSL, s) {
 			res.Errors = append(res.Errors, koanfError{

--- a/system_tests/seq_coordinator_test.go
+++ b/system_tests/seq_coordinator_test.go
@@ -153,6 +153,7 @@ func TestRedisSeqCoordinatorPriorities(t *testing.T) {
 
 	nodeForwardTarget := func(nodeNum int) int {
 		execNode := testNodes[nodeNum].ExecNode
+		// nolint:errcheck
 		fwTarget := execNode.TxPublisher.(*gethexec.TxPreChecker).TransactionPublisher.(*gethexec.Sequencer).ForwardTarget()
 		if fwTarget == "" {
 			return -1
@@ -323,6 +324,7 @@ func testCoordinatorMessageSync(t *testing.T, successCase bool) {
 	// nodeB doesn't sequence transactions, but adds messages related to them to its output feed.
 	// nodeBOutputFeedReader reads those messages from this feed and processes them.
 	// nodeBOutputFeedReader doesn't read messages from L1 since none of the nodes posts to L1.
+	// nolint:errcheck
 	nodeBPort := testClientB.ConsensusNode.BroadcastServer.ListenerAddr().(*net.TCPAddr).Port
 	nodeConfigNodeBOutputFeedReader := arbnode.ConfigDefaultL1NonSequencerTest()
 	nodeConfigNodeBOutputFeedReader.Feed.Input = *newBroadcastClientConfigTest(nodeBPort)

--- a/system_tests/seq_reject_test.go
+++ b/system_tests/seq_reject_test.go
@@ -35,6 +35,7 @@ func TestSequencerRejection(t *testing.T) {
 
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
 	builder.takeOwnership = false
+	// nolint:errcheck
 	port := builderSeq.L2.ConsensusNode.BroadcastServer.ListenerAddr().(*net.TCPAddr).Port
 	builder.nodeConfig.Feed.Input = *newBroadcastClientConfigTest(port)
 	cleanup := builder.Build(t)

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -61,6 +61,7 @@ func TestSequencerFeed(t *testing.T) {
 	defer cleanupSeq()
 	seqInfo, seqNode, seqClient := builderSeq.L2Info, builderSeq.L2.ConsensusNode, builderSeq.L2.Client
 
+	// nolint:errcheck
 	port := seqNode.BroadcastServer.ListenerAddr().(*net.TCPAddr).Port
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
 	builder.nodeConfig.Feed.Input = *newBroadcastClientConfigTest(port)
@@ -107,6 +108,7 @@ func TestRelayedSequencerFeed(t *testing.T) {
 	Require(t, err)
 
 	config := relay.ConfigDefault
+	// nolint:errcheck
 	port := seqNode.BroadcastServer.ListenerAddr().(*net.TCPAddr).Port
 	config.Node.Feed.Input = *newBroadcastClientConfigTest(port)
 	config.Node.Feed.Output = *newBroadcasterConfigTest()
@@ -119,6 +121,7 @@ func TestRelayedSequencerFeed(t *testing.T) {
 	Require(t, err)
 	defer currentRelay.StopAndWait()
 
+	// nolint:errcheck
 	port = currentRelay.GetListenerAddr().(*net.TCPAddr).Port
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
 	builder.nodeConfig.Feed.Input = *newBroadcastClientConfigTest(port)
@@ -219,6 +222,7 @@ func testLyingSequencer(t *testing.T, dasModeStr string) {
 	defer cleanupC()
 	l2clientC, nodeC := testClientC.Client, testClientC.ConsensusNode
 
+	// nolint:errcheck
 	port := nodeC.BroadcastServer.ListenerAddr().(*net.TCPAddr).Port
 
 	// The client node, connects to lying sequencer's feed
@@ -361,6 +365,7 @@ func testBlockHashComparison(t *testing.T, blockHash *common.Hash, mustMismatch 
 	}
 	defer wsBroadcastServer.StopAndWait()
 
+	// nolint:errcheck
 	port := wsBroadcastServer.ListenerAddr().(*net.TCPAddr).Port
 
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
@@ -468,6 +473,7 @@ func TestPopulateFeedBacklog(t *testing.T) {
 
 	// Creates a sink node that will read from the output feed of the previous node.
 	nodeConfigSink := builder.nodeConfig
+	// nolint:errcheck
 	port := builder.L2.ConsensusNode.BroadcastServer.ListenerAddr().(*net.TCPAddr).Port
 	nodeConfigSink.Feed.Input = *newBroadcastClientConfigTest(port)
 	testClientSink, cleanupSink := builder.Build2ndNode(t, &SecondNodeParams{nodeConfig: nodeConfigSink})

--- a/util/containers/syncmap.go
+++ b/util/containers/syncmap.go
@@ -12,6 +12,7 @@ func (m *SyncMap[K, V]) Load(key K) (V, bool) {
 		var empty V
 		return empty, false
 	}
+	// nolint:errcheck
 	return val.(V), true
 }
 
@@ -27,6 +28,7 @@ func (m *SyncMap[K, V]) Delete(key K) {
 func (m *SyncMap[K, V]) Keys() []K {
 	s := make([]K, 0)
 	m.internal.Range(func(k, v interface{}) bool {
+		// nolint:errcheck
 		s = append(s, k.(K))
 		return true
 	})

--- a/util/testhelpers/port_test.go
+++ b/util/testhelpers/port_test.go
@@ -14,9 +14,11 @@ func TestFreeTCPPortListener(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// nolint:errcheck
 	if aListener.Addr().(*net.TCPAddr).Port == bListener.Addr().(*net.TCPAddr).Port {
 		t.Errorf("FreeTCPPortListener() got same port: %v, %v", aListener, bListener)
 	}
+	// nolint:errcheck
 	if aListener.Addr().(*net.TCPAddr).Port == 0 || bListener.Addr().(*net.TCPAddr).Port == 0 {
 		t.Errorf("FreeTCPPortListener() got port 0")
 	}


### PR DESCRIPTION
errcheck errors are being generated by golangci-lint version 1.62.0.
Those errors were not being generated by previous golangci-lint versions.
This PR solves the issue.