### PR TITLE
Use EIP712 signing scheme for bids

### DIFF
--- a/timeboost/bid_cache.go
+++ b/timeboost/bid_cache.go
@@ -50,16 +50,16 @@ func (bc *bidCache) topTwoBids() *auctionResult {
 			result.secondPlace = result.firstPlace
 			result.firstPlace = bid
 		} else if bid.Amount.Cmp(result.firstPlace.Amount) == 0 {
-			if bid.BigIntHash().Cmp(result.firstPlace.BigIntHash()) > 0 {
+			if bid.bigIntHash().Cmp(result.firstPlace.bigIntHash()) > 0 {
 				result.secondPlace = result.firstPlace
 				result.firstPlace = bid
-			} else if result.secondPlace == nil || bid.BigIntHash().Cmp(result.secondPlace.BigIntHash()) > 0 {
+			} else if result.secondPlace == nil || bid.bigIntHash().Cmp(result.secondPlace.bigIntHash()) > 0 {
 				result.secondPlace = bid
 			}
 		} else if result.secondPlace == nil || bid.Amount.Cmp(result.secondPlace.Amount) > 0 {
 			result.secondPlace = bid
 		} else if bid.Amount.Cmp(result.secondPlace.Amount) == 0 {
-			if bid.BigIntHash().Cmp(result.secondPlace.BigIntHash()) > 0 {
+			if bid.bigIntHash().Cmp(result.secondPlace.bigIntHash()) > 0 {
 				result.secondPlace = bid
 			}
 		}

--- a/timeboost/bid_validator_test.go
+++ b/timeboost/bid_validator_test.go
@@ -2,8 +2,6 @@ package timeboost
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -131,14 +129,15 @@ func TestBidValidator_validateBid_perRoundBidLimitReached(t *testing.T) {
 	}
 	auctionContractAddr := common.Address{'a'}
 	bv := BidValidator{
-		chainId:                 big.NewInt(1),
-		initialRoundTimestamp:   time.Now().Add(-time.Second),
-		reservePrice:            big.NewInt(2),
-		roundDuration:           time.Minute,
-		auctionClosingDuration:  45 * time.Second,
-		bidsPerSenderInRound:    make(map[common.Address]uint8),
-		maxBidsPerSenderInRound: 5,
-		auctionContractAddr:     auctionContractAddr,
+		chainId:                        big.NewInt(1),
+		initialRoundTimestamp:          time.Now().Add(-time.Second),
+		reservePrice:                   big.NewInt(2),
+		roundDuration:                  time.Minute,
+		auctionClosingDuration:         45 * time.Second,
+		bidsPerSenderInRound:           make(map[common.Address]uint8),
+		maxBidsPerSenderInRound:        5,
+		auctionContractAddr:            auctionContractAddr,
+		auctionContractDomainSeparator: common.Hash{},
 	}
 	privateKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -150,7 +149,11 @@ func TestBidValidator_validateBid_perRoundBidLimitReached(t *testing.T) {
 		Amount:                 big.NewInt(3),
 		Signature:              []byte{'a'},
 	}
-	signature, err := buildSignature(privateKey, bid.ToMessageBytes())
+
+	bidHash, err := bid.ToEIP712Hash(bv.auctionContractDomainSeparator)
+	require.NoError(t, err)
+
+	signature, err := crypto.Sign(bidHash[:], privateKey)
 	require.NoError(t, err)
 
 	bid.Signature = signature
@@ -161,15 +164,6 @@ func TestBidValidator_validateBid_perRoundBidLimitReached(t *testing.T) {
 	_, err = bv.validateBid(bid, balanceCheckerFn)
 	require.ErrorIs(t, err, ErrTooManyBids)
 
-}
-
-func buildSignature(privateKey *ecdsa.PrivateKey, data []byte) ([]byte, error) {
-	prefixedData := crypto.Keccak256(append([]byte(fmt.Sprintf("\x19Ethereum Signed Message:\n%d", len(data))), data...))
-	signature, err := crypto.Sign(prefixedData, privateKey)
-	if err != nil {
-		return nil, err
-	}
-	return signature, nil
 }
 
 func buildValidBid(t *testing.T, auctionContractAddr common.Address) *Bid {
@@ -184,7 +178,10 @@ func buildValidBid(t *testing.T, auctionContractAddr common.Address) *Bid {
 		Signature:              []byte{'a'},
 	}
 
-	signature, err := buildSignature(privateKey, bid.ToMessageBytes())
+	bidHash, err := bid.ToEIP712Hash(common.Hash{})
+	require.NoError(t, err)
+
+	signature, err := crypto.Sign(bidHash[:], privateKey)
 	require.NoError(t, err)
 
 	bid.Signature = signature


### PR DESCRIPTION
The ExpressLaneAuction contract auction resolution methods take Bid objects as arguments which were previously expected to have the signature field populated by using the "\x19Ethereum Signed Message:..." hashing scheme applied over bid, contract, and chain details, then signed. The contracts were updated to use EIP 712 which standardizes a hashing scheme for structured data.

Briefly, EIP 712 produces the hash to be signed as follows: keccak256("\x19\x01" ‖ domainSeparator ‖ hashStruct(message)). The domainSeparator includes chain and contract details to prevent replay attacks, and in our code we just fetch it from the contract using domainSeparator() which internally uses the OpenZepplin library to calculate it for the contract. hashStruct encodes type information about the struct, in this case the "Bid(uint64 round,address expressLaneController,uint256 amount)" along with the data. Geth has an implementation of hashStruct that we use here.

The BidderClient generates the signature and the BidValidator uses the signature and the hash to recover the sender, so these are the places that needed to be updated. This PR also removes Bid.ToMessageBytes as this serialization format was only used for generating the data to be signed under the old scheme, and makes private ValidatedBid.bidBytes and bigIntHash() since these are only used for tiebreaking in the BidCache and nothing to do with signing.

# Testing done
Bidding and auction resolution works again after updating to the new contracts.
```
timeboost-auctioneer-1     | INFO [11-27|23:21:47.007] Resolving auction with single bid        round=3                                                     
sequencer-1                | INFO [11-27|23:21:47.008] Prioritizing auction resolution transaction from auctioneer txHash=0x6ff8058fd7ffb30089a9199a422675d8
a882a3cf541e925e8a4799c638314af9                                                                                                                            
sequencer-1                | INFO [11-27|23:21:47.008] Popped the auction resolution tx         txHash=6ff805..314af9                                       
sequencer-1                | INFO [11-27|23:21:47.183] New express lane controller assigned     round=3 controller=0xC3c76AaAA7C483c5099aeC225bA5E4269373F16
b                                                                                                                                                           
sequencer-1                | WARN [11-27|23:21:47.183] New express lane controller did not match previous controller round=3 previous=0x00000000000000000000
00000000000000000000 new=0xC3c76AaAA7C483c5099aeC225bA5E4269373F16b                                                                                         
timeboost-auctioneer-1     | INFO [11-27|23:21:48.011] Auction resolved successfully            txHash=0x6ff8058fd7ffb30089a9199a422675d8a882a3cf541e925e8a4
799c638314af9   
```