### PR TITLE
Parent block hash

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1018,6 +1018,10 @@ func (n *Node) StopAndWait() {
 	}
 }
 
+func (n *Node) GetBatchCount() (uint64, error) {
+	return n.InboxTracker.GetBatchCount()
+}
+
 func (n *Node) FindInboxBatchContainingMessage(message arbutil.MessageIndex) (uint64, bool, error) {
 	return n.InboxTracker.FindInboxBatchContainingMessage(message)
 }

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1022,6 +1022,11 @@ func (n *Node) GetBatchCount() (uint64, error) {
 	return n.InboxTracker.GetBatchCount()
 }
 
+func (n *Node) GetBlockByNumber(ctx context.Context, blockNum uint64) (*types.Block, error) {
+	// #nosec G115
+	return n.L1Reader.Client().BlockByNumber(ctx, big.NewInt(int64(blockNum)))
+}
+
 func (n *Node) FindInboxBatchContainingMessage(message arbutil.MessageIndex) (uint64, bool, error) {
 	return n.InboxTracker.FindInboxBatchContainingMessage(message)
 }

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -78,6 +78,7 @@ type FullExecutionClient interface {
 type BatchFetcher interface {
 	FindInboxBatchContainingMessage(message arbutil.MessageIndex) (uint64, bool, error)
 	GetBatchParentChainBlock(seqNum uint64) (uint64, error)
+	GetBatchCount() (uint64, error)
 }
 
 type ConsensusInfo interface {

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbutil"
@@ -79,6 +80,7 @@ type BatchFetcher interface {
 	FindInboxBatchContainingMessage(message arbutil.MessageIndex) (uint64, bool, error)
 	GetBatchParentChainBlock(seqNum uint64) (uint64, error)
 	GetBatchCount() (uint64, error)
+	GetBlockByNumber(ctx context.Context, blockNum uint64) (*types.Block, error)
 }
 
 type ConsensusInfo interface {

--- a/execution/nodeInterface/NodeInterface.go
+++ b/execution/nodeInterface/NodeInterface.go
@@ -736,24 +736,29 @@ func (n NodeInterface) L2BlockRangeForL1(c ctx, evm mech, l1BlockNum uint64) (ui
 	return firstBlock, lastBlock, nil
 }
 
-func (n NodeInterface) GetParentBlockNumThatIncludesChildBlock(c ctx, evm mech, childBlockNum uint64) (uint64, error) {
+func (n NodeInterface) GetParentBlockNumThatIncludesChildBlock(c ctx, evm mech, childBlockNum uint64) (uint64, common.Hash, error) {
 	node, err := gethExecFromNodeInterfaceBackend(n.backend)
 	if err != nil {
-		return 0, err
+		return 0, common.Hash{}, err
 	}
 	fetcher := node.ExecEngine.GetBatchFetcher()
 	if fetcher == nil {
-		return 0, errors.New("batch fetcher not set")
+		return 0, common.Hash{}, errors.New("batch fetcher not set")
 	}
 
 	batch, err := n.FindBatchContainingBlock(c, nil, childBlockNum)
 	if err != nil {
-		return 0, err
+		return 0, common.Hash{}, err
 	}
 
 	parentBlockNum, err := fetcher.GetBatchParentChainBlock(batch)
 	if err != nil {
-		return 0, err
+		return 0, common.Hash{}, err
 	}
-	return parentBlockNum, nil
+	parentBlock, err := fetcher.GetBlockByNumber(n.context, parentBlockNum)
+	if err != nil {
+		return 0, common.Hash{}, err
+	}
+
+	return parentBlockNum, parentBlock.Hash(), nil
 }

--- a/execution/nodeInterface/NodeInterface.go
+++ b/execution/nodeInterface/NodeInterface.go
@@ -736,7 +736,7 @@ func (n NodeInterface) L2BlockRangeForL1(c ctx, evm mech, l1BlockNum uint64) (ui
 	return firstBlock, lastBlock, nil
 }
 
-func (n NodeInterface) GetParentBlockNumThatIncludesChildBlock(c ctx, childBlockNum uint64) (uint64, error) {
+func (n NodeInterface) GetParentBlockNumThatIncludesChildBlock(c ctx, evm mech, childBlockNum uint64) (uint64, error) {
 	node, err := gethExecFromNodeInterfaceBackend(n.backend)
 	if err != nil {
 		return 0, err

--- a/execution/nodeInterface/NodeInterface.go
+++ b/execution/nodeInterface/NodeInterface.go
@@ -735,3 +735,25 @@ func (n NodeInterface) L2BlockRangeForL1(c ctx, evm mech, l1BlockNum uint64) (ui
 	}
 	return firstBlock, lastBlock, nil
 }
+
+func (n NodeInterface) GetParentBlockNumThatIncludesChildBlock(c ctx, childBlockNum uint64) (uint64, error) {
+	node, err := gethExecFromNodeInterfaceBackend(n.backend)
+	if err != nil {
+		return 0, err
+	}
+	fetcher := node.ExecEngine.GetBatchFetcher()
+	if fetcher == nil {
+		return 0, errors.New("batch fetcher not set")
+	}
+
+	batch, err := n.FindBatchContainingBlock(c, nil, childBlockNum)
+	if err != nil {
+		return 0, err
+	}
+
+	parentBlockNum, err := fetcher.GetBatchParentChainBlock(batch)
+	if err != nil {
+		return 0, err
+	}
+	return parentBlockNum, nil
+}

--- a/execution/nodeInterface/NodeInterface.go
+++ b/execution/nodeInterface/NodeInterface.go
@@ -736,7 +736,7 @@ func (n NodeInterface) L2BlockRangeForL1(c ctx, evm mech, l1BlockNum uint64) (ui
 	return firstBlock, lastBlock, nil
 }
 
-func (n NodeInterface) GetParentBlockNumThatIncludesChildBlock(c ctx, evm mech, childBlockNum uint64) (uint64, common.Hash, error) {
+func (n NodeInterface) GetParentBlockThatIncludesChildBlock(c ctx, evm mech, childBlockNum uint64) (uint64, common.Hash, error) {
 	node, err := gethExecFromNodeInterfaceBackend(n.backend)
 	if err != nil {
 		return 0, common.Hash{}, err

--- a/system_tests/nodeinterface_test.go
+++ b/system_tests/nodeinterface_test.go
@@ -184,7 +184,7 @@ func TestGetL1Confirmations(t *testing.T) {
 	}
 }
 
-func TestGetParentBlockNumThatIncludesChildBlockSucceeds(t *testing.T) {
+func TestGetParentBlockThatIncludesChildBlockSucceeds(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -211,7 +211,7 @@ func TestGetParentBlockNumThatIncludesChildBlockSucceeds(t *testing.T) {
 
 	nodeInterface, err := node_interfacegen.NewNodeInterface(types.NodeInterfaceAddress, builder.L2.Client)
 	Require(t, err)
-	parentChainBlock, err := nodeInterface.GetParentBlockNumThatIncludesChildBlock(nil, childChainBlock)
+	parentChainBlock, err := nodeInterface.GetParentBlockThatIncludesChildBlock(nil, childChainBlock)
 	Require(t, err)
 	colors.PrintMint("Child chain block:", childChainBlock)
 	colors.PrintMint("Parent chain block:", parentChainBlock)
@@ -221,9 +221,9 @@ func TestGetParentBlockNumThatIncludesChildBlockSucceeds(t *testing.T) {
 	}
 }
 
-// Test GetParentBlockNumThatIncludesChildBlock fails when the batch poster is not enabled, so the
+// Test GetParentBlockThatIncludesChildBlock fails when the batch poster is not enabled, so the
 // batch never gets posted to L1.
-func TestGetParentBlockNumThatIncludesChildBlockFails(t *testing.T) {
+func TestGetParentBlockThatIncludesChildBlockFails(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -240,7 +240,7 @@ func TestGetParentBlockNumThatIncludesChildBlockFails(t *testing.T) {
 
 	nodeInterface, err := node_interfacegen.NewNodeInterface(types.NodeInterfaceAddress, builder.L2.Client)
 	Require(t, err)
-	_, err = nodeInterface.GetParentBlockNumThatIncludesChildBlock(nil, childChainBlock)
+	_, err = nodeInterface.GetParentBlockThatIncludesChildBlock(nil, childChainBlock)
 	if err.Error() != "execution reverted" {
 		Fatal(t, "expected error")
 	}

--- a/system_tests/nodeinterface_test.go
+++ b/system_tests/nodeinterface_test.go
@@ -216,7 +216,7 @@ func TestGetParentBlockNumThatIncludesChildBlockSucceeds(t *testing.T) {
 	colors.PrintMint("Child chain block:", childChainBlock)
 	colors.PrintMint("Parent chain block:", parentChainBlock)
 
-	if parentChainBlock != firstParentChainBlock+1 {
+	if parentChainBlock.ParentBlockNum != firstParentChainBlock+1 {
 		Fatal(t, "unexpected parent chain block")
 	}
 }


### PR DESCRIPTION
Adds an API to retrieve the parent chain block that includes a given child chain block number