### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/cmd/conf/init.go
+++ b/cmd/conf/init.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
@@ -120,7 +121,7 @@ func (c *InitConfig) Validate() error {
 		if reorgOption >= 0 {
 			numReorgOptionsSpecified++
 			if numReorgOptionsSpecified > 1 {
-				return fmt.Errorf("at most one init reorg option can be specified")
+				return errors.New("at most one init reorg option can be specified")
 			}
 		}
 	}


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters