### PR TITLE
Deduplicate arbitrator RustBytes types

### DIFF
--- a/arbitrator/prover/src/lib.rs
+++ b/arbitrator/prover/src/lib.rs
@@ -36,6 +36,7 @@ use once_cell::sync::OnceCell;
 use static_assertions::const_assert_eq;
 use std::{
     ffi::CStr,
+    marker::PhantomData,
     num::NonZeroUsize,
     os::raw::{c_char, c_int},
     path::Path,
@@ -59,11 +60,67 @@ pub struct CByteArray {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy)]
-pub struct RustByteArray {
+pub struct RustSlice<'a> {
+    pub ptr: *const u8,
+    pub len: usize,
+    pub phantom: PhantomData<&'a [u8]>,
+}
+
+impl<'a> RustSlice<'a> {
+    pub fn new(slice: &'a [u8]) -> Self {
+        if slice.is_empty() {
+            return Self {
+                ptr: ptr::null(),
+                len: 0,
+                phantom: PhantomData,
+            };
+        }
+        Self {
+            ptr: slice.as_ptr(),
+            len: slice.len(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+#[repr(C)]
+pub struct RustBytes {
     pub ptr: *mut u8,
     pub len: usize,
-    pub capacity: usize,
+    pub cap: usize,
+}
+
+impl RustBytes {
+    pub unsafe fn into_vec(self) -> Vec<u8> {
+        Vec::from_raw_parts(self.ptr, self.len, self.cap)
+    }
+
+    pub unsafe fn write(&mut self, mut vec: Vec<u8>) {
+        if vec.capacity() == 0 {
+            *self = RustBytes {
+                ptr: ptr::null_mut(),
+                len: 0,
+                cap: 0,
+            };
+            return;
+        }
+        self.ptr = vec.as_mut_ptr();
+        self.len = vec.len();
+        self.cap = vec.capacity();
+        std::mem::forget(vec);
+    }
+}
+
+/// Frees the vector. Does nothing when the vector is null.
+///
+/// # Safety
+///
+/// Must only be called once per vec.
+#[no_mangle]
+pub unsafe extern "C" fn free_rust_bytes(vec: RustBytes) {
+    if !vec.ptr.is_null() {
+        drop(vec.into_vec())
+    }
 }
 
 #[no_mangle]
@@ -410,18 +467,6 @@ pub unsafe extern "C" fn arbitrator_module_root(mach: *mut Machine) -> Bytes32 {
 
 #[no_mangle]
 #[cfg(feature = "native")]
-pub unsafe extern "C" fn arbitrator_gen_proof(mach: *mut Machine) -> RustByteArray {
-    let mut proof = (*mach).serialize_proof();
-    let ret = RustByteArray {
-        ptr: proof.as_mut_ptr(),
-        len: proof.len(),
-        capacity: proof.capacity(),
-    };
-    std::mem::forget(proof);
-    ret
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn arbitrator_free_proof(proof: RustByteArray) {
-    drop(Vec::from_raw_parts(proof.ptr, proof.len, proof.capacity))
+pub unsafe extern "C" fn arbitrator_gen_proof(mach: *mut Machine, out: *mut RustBytes) {
+    (*out).write((*mach).serialize_proof());
 }

--- a/arbitrator/stylus/src/evm_api.rs
+++ b/arbitrator/stylus/src/evm_api.rs
@@ -1,11 +1,12 @@
 // Copyright 2022-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
-use crate::{GoSliceData, RustSlice};
+use crate::GoSliceData;
 use arbutil::evm::{
     api::{EvmApiMethod, Gas, EVM_API_METHOD_REQ_OFFSET},
     req::RequestHandler,
 };
+use prover::RustSlice;
 
 #[repr(C)]
 pub struct NativeRequestHandler {

--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -464,7 +464,7 @@ func (vec *rustBytes) intoBytes() []byte {
 }
 
 func (vec *rustBytes) drop() {
-	C.stylus_drop_vec(*vec)
+	C.free_rust_bytes(*vec)
 }
 
 func goSlice(slice []byte) C.GoSliceData {

--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -450,10 +450,16 @@ func addressToBytes20(addr common.Address) bytes20 {
 }
 
 func (slice *rustSlice) read() []byte {
+	if slice.len == 0 {
+		return nil
+	}
 	return arbutil.PointerToSlice((*byte)(slice.ptr), int(slice.len))
 }
 
 func (vec *rustBytes) read() []byte {
+	if vec.len == 0 {
+		return nil
+	}
 	return arbutil.PointerToSlice((*byte)(vec.ptr), int(vec.len))
 }
 

--- a/validator/server_arb/machine.go
+++ b/validator/server_arb/machine.go
@@ -304,9 +304,10 @@ func (m *ArbitratorMachine) ProveNextStep() []byte {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	rustProof := C.arbitrator_gen_proof(m.ptr)
-	proofBytes := C.GoBytes(unsafe.Pointer(rustProof.ptr), C.int(rustProof.len))
-	C.arbitrator_free_proof(rustProof)
+	output := &C.RustBytes{}
+	C.arbitrator_gen_proof(m.ptr, output)
+	proofBytes := C.GoBytes(unsafe.Pointer(output.ptr), C.int(output.len))
+	C.free_rust_bytes(*output)
 
 	return proofBytes
 }

--- a/validator/server_arb/machine.go
+++ b/validator/server_arb/machine.go
@@ -306,8 +306,11 @@ func (m *ArbitratorMachine) ProveNextStep() []byte {
 
 	output := &C.RustBytes{}
 	C.arbitrator_gen_proof(m.ptr, output)
+	defer C.free_rust_bytes(*output)
+	if output.len == 0 {
+		return nil
+	}
 	proofBytes := C.GoBytes(unsafe.Pointer(output.ptr), C.int(output.len))
-	C.free_rust_bytes(*output)
 
 	return proofBytes
 }


### PR DESCRIPTION
Previously, we had one for Stylus and another for the arbitrator prover library, despite them doing basically the same thing. This deduplicates them to use the same type.