### PR TITLE
TestArbos11To32Upgrade

### DIFF
--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -26,8 +26,9 @@ jobs:
           status_state="pending"
           declare -Ar exceptions=(
             [contracts]=origin/develop
+            [contracts]=origin/pre-bold
             [nitro-testnode]=origin/master
-            
+
             #TODO Rachel to check these are the intended branches.
             [arbitrator/langs/c]=origin/vm-storage-cache
             [arbitrator/tools/wasmer]=origin/adopt-v4.2.8
@@ -38,7 +39,7 @@ jobs:
             if [[ -v exceptions[$mod] ]]; then
               branch=${exceptions[$mod]}
             fi
-            
+
             if ! git -C $mod merge-base --is-ancestor HEAD $branch; then
               echo $mod diverges from $branch
               divergent=1

--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           status_state="pending"
           declare -Ar exceptions=(
-            [contracts]=origin/develop
             [contracts]=origin/pre-bold
             [nitro-testnode]=origin/master
 

--- a/system_tests/arbos_upgrade_test.go
+++ b/system_tests/arbos_upgrade_test.go
@@ -125,13 +125,13 @@ func TestArbos11To32Upgrade(t *testing.T) {
 	_, err = builder.L2.EnsureTxSucceeded(tx)
 	Require(t, err)
 
-	// generates a new block to trigger the upgrade
-	builder.L2Info.GenerateAccount("User2")
-	tx = builder.L2Info.PrepareTx("Owner", "User2", builder.L2Info.TransferGas, big.NewInt(1e12), nil)
-	err = builder.L2.Client.SendTransaction(ctx, tx)
-	Require(t, err)
-	_, err = builder.L2.EnsureTxSucceeded(tx)
-	Require(t, err)
+	// // generates a new block to trigger the upgrade
+	// builder.L2Info.GenerateAccount("User2")
+	// tx = builder.L2Info.PrepareTx("Owner", "User2", builder.L2Info.TransferGas, big.NewInt(1e12), nil)
+	// err = builder.L2.Client.SendTransaction(ctx, tx)
+	// Require(t, err)
+	// _, err = builder.L2.EnsureTxSucceeded(tx)
+	// Require(t, err)
 
 	checkArbOSVersion(t, builder.L2, finalVersion, "final")
 	_, err = contract.Mcopy(&auth)

--- a/system_tests/arbos_upgrade_test.go
+++ b/system_tests/arbos_upgrade_test.go
@@ -88,12 +88,20 @@ func TestArbos11To32Upgrade(t *testing.T) {
 	finalVersion := uint64(32)
 
 	builder := NewNodeBuilder(ctx).
-		DefaultConfig(t, false).
+		DefaultConfig(t, true).
 		WithArbOSVersion(initialVersion)
 	cleanup := builder.Build(t)
 	defer cleanup()
 
 	auth := builder.L2Info.GetDefaultTransactOpts("Owner", ctx)
+
+	// makes Owner a chain owner
+	arbDebug, err := precompilesgen.NewArbDebug(types.ArbDebugAddress, builder.L2.Client)
+	Require(t, err)
+	tx, err := arbDebug.BecomeChainOwner(&auth)
+	Require(t, err)
+	_, err = EnsureTxSucceeded(ctx, builder.L2.Client, tx)
+	Require(t, err)
 
 	// deploys test contract
 	_, tx, contract, err := mocksgen.DeployArbOS11To32UpgradeTest(&auth, builder.L2.Client)

--- a/system_tests/arbos_upgrade_test.go
+++ b/system_tests/arbos_upgrade_test.go
@@ -55,7 +55,6 @@ func TestScheduleArbosUpgrade(t *testing.T) {
 		t.Errorf("expected completed scheduled upgrade to be ignored, got version %v timestamp %v", scheduled.ArbosVersion, scheduled.ScheduledForTimestamp)
 	}
 
-	// TODO: Once we have an ArbOS 30, test a real upgrade with it
 	// We can't test 11 -> 20 because 11 doesn't have the GetScheduledUpgrade method we want to test
 	var testVersion uint64 = 100
 	var testTimestamp uint64 = 1 << 62

--- a/system_tests/arbos_upgrade_test.go
+++ b/system_tests/arbos_upgrade_test.go
@@ -1,0 +1,64 @@
+// Copyright 2021-2024, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
+
+package arbtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
+)
+
+func TestScheduleArbosUpgrade(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
+	cleanup := builder.Build(t)
+	defer cleanup()
+
+	auth := builder.L2Info.GetDefaultTransactOpts("Owner", ctx)
+
+	arbOwnerPublic, err := precompilesgen.NewArbOwnerPublic(common.HexToAddress("0x6b"), builder.L2.Client)
+	Require(t, err, "could not bind ArbOwner contract")
+
+	arbOwner, err := precompilesgen.NewArbOwner(common.HexToAddress("0x70"), builder.L2.Client)
+	Require(t, err, "could not bind ArbOwner contract")
+
+	callOpts := &bind.CallOpts{Context: ctx}
+	scheduled, err := arbOwnerPublic.GetScheduledUpgrade(callOpts)
+	Require(t, err, "failed to call GetScheduledUpgrade before scheduling upgrade")
+	if scheduled.ArbosVersion != 0 || scheduled.ScheduledForTimestamp != 0 {
+		t.Errorf("expected no upgrade to be scheduled, got version %v timestamp %v", scheduled.ArbosVersion, scheduled.ScheduledForTimestamp)
+	}
+
+	// Schedule a noop upgrade, which should test GetScheduledUpgrade in the same way an already completed upgrade would.
+	tx, err := arbOwner.ScheduleArbOSUpgrade(&auth, 1, 1)
+	Require(t, err)
+	_, err = builder.L2.EnsureTxSucceeded(tx)
+	Require(t, err)
+
+	scheduled, err = arbOwnerPublic.GetScheduledUpgrade(callOpts)
+	Require(t, err, "failed to call GetScheduledUpgrade after scheduling noop upgrade")
+	if scheduled.ArbosVersion != 0 || scheduled.ScheduledForTimestamp != 0 {
+		t.Errorf("expected completed scheduled upgrade to be ignored, got version %v timestamp %v", scheduled.ArbosVersion, scheduled.ScheduledForTimestamp)
+	}
+
+	// TODO: Once we have an ArbOS 30, test a real upgrade with it
+	// We can't test 11 -> 20 because 11 doesn't have the GetScheduledUpgrade method we want to test
+	var testVersion uint64 = 100
+	var testTimestamp uint64 = 1 << 62
+	tx, err = arbOwner.ScheduleArbOSUpgrade(&auth, 100, 1<<62)
+	Require(t, err)
+	_, err = builder.L2.EnsureTxSucceeded(tx)
+	Require(t, err)
+
+	scheduled, err = arbOwnerPublic.GetScheduledUpgrade(callOpts)
+	Require(t, err, "failed to call GetScheduledUpgrade after scheduling upgrade")
+	if scheduled.ArbosVersion != testVersion || scheduled.ScheduledForTimestamp != testTimestamp {
+		t.Errorf("expected upgrade to be scheduled for version %v timestamp %v, got version %v timestamp %v", testVersion, testTimestamp, scheduled.ArbosVersion, scheduled.ScheduledForTimestamp)
+	}
+}

--- a/system_tests/arbos_upgrade_test.go
+++ b/system_tests/arbos_upgrade_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/solgen/go/mocksgen"

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -504,57 +504,6 @@ func TestGetBrotliCompressionLevel(t *testing.T) {
 	}
 }
 
-func TestScheduleArbosUpgrade(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
-	cleanup := builder.Build(t)
-	defer cleanup()
-
-	auth := builder.L2Info.GetDefaultTransactOpts("Owner", ctx)
-
-	arbOwnerPublic, err := precompilesgen.NewArbOwnerPublic(common.HexToAddress("0x6b"), builder.L2.Client)
-	Require(t, err, "could not bind ArbOwner contract")
-
-	arbOwner, err := precompilesgen.NewArbOwner(common.HexToAddress("0x70"), builder.L2.Client)
-	Require(t, err, "could not bind ArbOwner contract")
-
-	callOpts := &bind.CallOpts{Context: ctx}
-	scheduled, err := arbOwnerPublic.GetScheduledUpgrade(callOpts)
-	Require(t, err, "failed to call GetScheduledUpgrade before scheduling upgrade")
-	if scheduled.ArbosVersion != 0 || scheduled.ScheduledForTimestamp != 0 {
-		t.Errorf("expected no upgrade to be scheduled, got version %v timestamp %v", scheduled.ArbosVersion, scheduled.ScheduledForTimestamp)
-	}
-
-	// Schedule a noop upgrade, which should test GetScheduledUpgrade in the same way an already completed upgrade would.
-	tx, err := arbOwner.ScheduleArbOSUpgrade(&auth, 1, 1)
-	Require(t, err)
-	_, err = builder.L2.EnsureTxSucceeded(tx)
-	Require(t, err)
-
-	scheduled, err = arbOwnerPublic.GetScheduledUpgrade(callOpts)
-	Require(t, err, "failed to call GetScheduledUpgrade after scheduling noop upgrade")
-	if scheduled.ArbosVersion != 0 || scheduled.ScheduledForTimestamp != 0 {
-		t.Errorf("expected completed scheduled upgrade to be ignored, got version %v timestamp %v", scheduled.ArbosVersion, scheduled.ScheduledForTimestamp)
-	}
-
-	// TODO: Once we have an ArbOS 30, test a real upgrade with it
-	// We can't test 11 -> 20 because 11 doesn't have the GetScheduledUpgrade method we want to test
-	var testVersion uint64 = 100
-	var testTimestamp uint64 = 1 << 62
-	tx, err = arbOwner.ScheduleArbOSUpgrade(&auth, 100, 1<<62)
-	Require(t, err)
-	_, err = builder.L2.EnsureTxSucceeded(tx)
-	Require(t, err)
-
-	scheduled, err = arbOwnerPublic.GetScheduledUpgrade(callOpts)
-	Require(t, err, "failed to call GetScheduledUpgrade after scheduling upgrade")
-	if scheduled.ArbosVersion != testVersion || scheduled.ScheduledForTimestamp != testTimestamp {
-		t.Errorf("expected upgrade to be scheduled for version %v timestamp %v, got version %v timestamp %v", testVersion, testTimestamp, scheduled.ArbosVersion, scheduled.ScheduledForTimestamp)
-	}
-}
-
 func TestArbStatistics(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Resolves NIT-2975

Adds a test which guarantees that there is no problem if a transaction that executes an instruction like mcopy, that is available in ArbOS 32 but not in ArbOS 11, is included in the same block that the ArbOS 11 to 32 upgrade happens.

Depends on https://github.com/OffchainLabs/nitro-contracts/pull/284