### PR TITLE
[NIT-2991] Get rid of receiver methods on aliased cgo types

### DIFF
--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -109,7 +109,7 @@ func activateProgramInternal(
 		(*u64)(gasLeft),
 	))
 
-	module, msg, err := status_mod.toResult(output.intoBytes(), debug)
+	module, msg, err := status_mod.toResult(rustBytesIntoBytes(output), debug)
 	if err != nil {
 		if debug {
 			log.Warn("activation failed", "err", err, "msg", msg, "program", addressForLogging)
@@ -119,7 +119,7 @@ func activateProgramInternal(
 		}
 		return nil, nil, err
 	}
-	hash := moduleHash.toHash()
+	hash := bytes32ToHash(moduleHash)
 	targets := db.Database().WasmTargets()
 	type result struct {
 		target ethdb.WasmTarget
@@ -141,7 +141,7 @@ func activateProgramInternal(
 					goSlice([]byte(target)),
 					output,
 				)
-				asm := output.intoBytes()
+				asm := rustBytesIntoBytes(output)
 				if status_asm != 0 {
 					results <- result{target, nil, fmt.Errorf("%w: %s", ErrProgramActivation, string(asm))}
 					return
@@ -279,7 +279,7 @@ func callProgram(
 	))
 
 	depth := interpreter.Depth()
-	data, msg, err := status.toResult(output.intoBytes(), debug)
+	data, msg, err := status.toResult(rustBytesIntoBytes(output), debug)
 	if status == userFailure && debug {
 		log.Warn("program failure", "err", err, "msg", msg, "program", address, "depth", depth)
 	}
@@ -292,7 +292,7 @@ func callProgram(
 //export handleReqImpl
 func handleReqImpl(apiId usize, req_type u32, data *rustSlice, costPtr *u64, out_response *C.GoSliceData, out_raw_data *C.GoSliceData) {
 	api := getApi(apiId)
-	reqData := data.read()
+	reqData := readRustSlice(data)
 	reqType := RequestType(req_type - EvmApiMethodReqOffset)
 	response, raw_data, cost := api.handler(reqType, reqData)
 	*costPtr = u64(cost)
@@ -418,14 +418,14 @@ func SetTarget(name ethdb.WasmTarget, description string, native bool) error {
 		cbool(native),
 	))
 	if status != userSuccess {
-		msg := arbutil.ToStringOrHex(output.intoBytes())
+		msg := arbutil.ToStringOrHex(rustBytesIntoBytes(output))
 		log.Error("failed to set stylus compilation target", "status", status, "msg", msg)
 		return fmt.Errorf("failed to set stylus compilation target, status %v: %v", status, msg)
 	}
 	return nil
 }
 
-func (value bytes32) toHash() common.Hash {
+func bytes32ToHash(value *bytes32) common.Hash {
 	hash := common.Hash{}
 	for index, b := range value.bytes {
 		hash[index] = byte(b)
@@ -449,27 +449,27 @@ func addressToBytes20(addr common.Address) bytes20 {
 	return value
 }
 
-func (slice *rustSlice) read() []byte {
+func readRustSlice(slice *rustSlice) []byte {
 	if slice.len == 0 {
 		return nil
 	}
 	return arbutil.PointerToSlice((*byte)(slice.ptr), int(slice.len))
 }
 
-func (vec *rustBytes) read() []byte {
+func readRustBytes(vec *rustBytes) []byte {
 	if vec.len == 0 {
 		return nil
 	}
 	return arbutil.PointerToSlice((*byte)(vec.ptr), int(vec.len))
 }
 
-func (vec *rustBytes) intoBytes() []byte {
-	slice := vec.read()
-	vec.drop()
+func rustBytesIntoBytes(vec *rustBytes) []byte {
+	slice := readRustBytes(vec)
+	dropRustBytes(vec)
 	return slice
 }
 
-func (vec *rustBytes) drop() {
+func dropRustBytes(vec *rustBytes) {
 	C.free_rust_bytes(*vec)
 }
 

--- a/arbos/programs/testcompile.go
+++ b/arbos/programs/testcompile.go
@@ -35,10 +35,10 @@ func Wat2Wasm(wat []byte) ([]byte, error) {
 	status := C.wat_to_wasm(goSlice(wat), output)
 
 	if status != 0 {
-		return nil, fmt.Errorf("failed reading wat file: %v", string(output.intoBytes()))
+		return nil, fmt.Errorf("failed reading wat file: %v", string(rustBytesIntoBytes(output)))
 	}
 
-	return output.intoBytes(), nil
+	return rustBytesIntoBytes(output), nil
 }
 
 func testCompileArch(store bool) error {
@@ -66,7 +66,7 @@ func testCompileArch(store bool) error {
 		cbool(nativeArm64))
 
 	if status != 0 {
-		return fmt.Errorf("failed setting compilation target arm: %v", string(output.intoBytes()))
+		return fmt.Errorf("failed setting compilation target arm: %v", string(rustBytesIntoBytes(output)))
 	}
 
 	status = C.stylus_target_set(goSlice(amd64CompileName),
@@ -75,7 +75,7 @@ func testCompileArch(store bool) error {
 		cbool(nativeAmd64))
 
 	if status != 0 {
-		return fmt.Errorf("failed setting compilation target amd: %v", string(output.intoBytes()))
+		return fmt.Errorf("failed setting compilation target amd: %v", string(rustBytesIntoBytes(output)))
 	}
 
 	source, err := os.ReadFile("../../arbitrator/stylus/tests/add.wat")
@@ -107,7 +107,7 @@ func testCompileArch(store bool) error {
 		output,
 	)
 	if status == 0 {
-		return fmt.Errorf("succeeded compiling non-existent arch: %v", string(output.intoBytes()))
+		return fmt.Errorf("succeeded compiling non-existent arch: %v", string(rustBytesIntoBytes(output)))
 	}
 
 	status = C.stylus_compile(
@@ -118,7 +118,7 @@ func testCompileArch(store bool) error {
 		output,
 	)
 	if status != 0 {
-		return fmt.Errorf("failed compiling native: %v", string(output.intoBytes()))
+		return fmt.Errorf("failed compiling native: %v", string(rustBytesIntoBytes(output)))
 	}
 	if store && !nativeAmd64 && !nativeArm64 {
 		_, err := fmt.Printf("writing host file\n")
@@ -126,7 +126,7 @@ func testCompileArch(store bool) error {
 			return err
 		}
 
-		err = os.WriteFile("../../target/testdata/host.bin", output.intoBytes(), 0644)
+		err = os.WriteFile("../../target/testdata/host.bin", rustBytesIntoBytes(output), 0644)
 		if err != nil {
 			return err
 		}
@@ -140,7 +140,7 @@ func testCompileArch(store bool) error {
 		output,
 	)
 	if status != 0 {
-		return fmt.Errorf("failed compiling arm: %v", string(output.intoBytes()))
+		return fmt.Errorf("failed compiling arm: %v", string(rustBytesIntoBytes(output)))
 	}
 	if store {
 		_, err := fmt.Printf("writing arm file\n")
@@ -148,7 +148,7 @@ func testCompileArch(store bool) error {
 			return err
 		}
 
-		err = os.WriteFile("../../target/testdata/arm64.bin", output.intoBytes(), 0644)
+		err = os.WriteFile("../../target/testdata/arm64.bin", rustBytesIntoBytes(output), 0644)
 		if err != nil {
 			return err
 		}
@@ -162,7 +162,7 @@ func testCompileArch(store bool) error {
 		output,
 	)
 	if status != 0 {
-		return fmt.Errorf("failed compiling amd: %v", string(output.intoBytes()))
+		return fmt.Errorf("failed compiling amd: %v", string(rustBytesIntoBytes(output)))
 	}
 	if store {
 		_, err := fmt.Printf("writing amd64 file\n")
@@ -170,7 +170,7 @@ func testCompileArch(store bool) error {
 			return err
 		}
 
-		err = os.WriteFile("../../target/testdata/amd64.bin", output.intoBytes(), 0644)
+		err = os.WriteFile("../../target/testdata/amd64.bin", rustBytesIntoBytes(output), 0644)
 		if err != nil {
 			return err
 		}
@@ -195,7 +195,7 @@ func resetNativeTarget() error {
 		cbool(true))
 
 	if status != 0 {
-		return fmt.Errorf("failed setting compilation target arm: %v", string(output.intoBytes()))
+		return fmt.Errorf("failed setting compilation target arm: %v", string(rustBytesIntoBytes(output)))
 	}
 
 	return nil
@@ -260,7 +260,7 @@ func testCompileLoad() error {
 		return err
 	}
 
-	_, msg, err := status.toResult(output.intoBytes(), true)
+	_, msg, err := status.toResult(rustBytesIntoBytes(output), true)
 	if status == userFailure {
 		err = fmt.Errorf("%w: %v", err, msg)
 	}


### PR DESCRIPTION
Fixes: NIT-2991