### PR TITLE
Refactor RoundTimingInfo, fix auctionCloseTicker

### DIFF
--- a/execution/gethexec/express_lane_service.go
+++ b/execution/gethexec/express_lane_service.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/offchainlabs/nitro/solgen/go/express_lane_auctiongen"
 	"github.com/offchainlabs/nitro/timeboost"
-	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
@@ -49,9 +48,7 @@ type expressLaneService struct {
 	transactionPublisher     transactionPublisher
 	auctionContractAddr      common.Address
 	apiBackend               *arbitrum.APIBackend
-	initialTimestamp         time.Time
-	roundDuration            time.Duration
-	auctionClosing           time.Duration
+	roundTimingInfo          timeboost.RoundTimingInfo
 	earlySubmissionGrace     time.Duration
 	chainConfig              *params.ChainConfig
 	logs                     chan []*types.Log
@@ -143,8 +140,7 @@ func newExpressLaneService(
 	retries := 0
 
 pending:
-	var roundTimingInfo timeboost.RoundTimingInfo
-	roundTimingInfo, err = auctionContract.RoundTimingInfo(&bind.CallOpts{})
+	rawRoundTimingInfo, err := auctionContract.RoundTimingInfo(&bind.CallOpts{})
 	if err != nil {
 		const maxRetries = 5
 		if errors.Is(err, bind.ErrNoCode) && retries < maxRetries {
@@ -156,23 +152,20 @@ pending:
 		}
 		return nil, err
 	}
-	if err = roundTimingInfo.Validate(nil); err != nil {
+	roundTimingInfo, err := timeboost.NewRoundTimingInfo(rawRoundTimingInfo)
+	if err != nil {
 		return nil, err
 	}
-	initialTimestamp := time.Unix(roundTimingInfo.OffsetTimestamp, 0)
-	roundDuration := arbmath.SaturatingCast[time.Duration](roundTimingInfo.RoundDurationSeconds) * time.Second
-	auctionClosingDuration := arbmath.SaturatingCast[time.Duration](roundTimingInfo.AuctionClosingSeconds) * time.Second
+
 	return &expressLaneService{
 		transactionPublisher:     transactionPublisher,
 		auctionContract:          auctionContract,
 		apiBackend:               apiBackend,
 		chainConfig:              chainConfig,
-		initialTimestamp:         initialTimestamp,
-		auctionClosing:           auctionClosingDuration,
+		roundTimingInfo:          *roundTimingInfo,
 		earlySubmissionGrace:     earlySubmissionGrace,
 		roundControl:             lru.NewCache[uint64, *expressLaneControl](8), // Keep 8 rounds cached.
 		auctionContractAddr:      auctionContractAddr,
-		roundDuration:            roundDuration,
 		logs:                     make(chan []*types.Log, 10_000),
 		messagesBySequenceNumber: make(map[uint64]*timeboost.ExpressLaneSubmission),
 	}, nil
@@ -184,7 +177,7 @@ func (es *expressLaneService) Start(ctxIn context.Context) {
 	// Log every new express lane auction round.
 	es.LaunchThread(func(ctx context.Context) {
 		log.Info("Watching for new express lane rounds")
-		waitTime := timeboost.TimeTilNextRound(es.initialTimestamp, es.roundDuration)
+		waitTime := es.roundTimingInfo.TimeTilNextRound()
 		// Wait until the next round starts
 		select {
 		case <-ctx.Done():
@@ -193,7 +186,7 @@ func (es *expressLaneService) Start(ctxIn context.Context) {
 			// First tick happened, now set up regular ticks
 		}
 
-		ticker := time.NewTicker(es.roundDuration)
+		ticker := time.NewTicker(es.roundTimingInfo.Round)
 		defer ticker.Stop()
 
 		for {
@@ -201,7 +194,9 @@ func (es *expressLaneService) Start(ctxIn context.Context) {
 			case <-ctx.Done():
 				return
 			case t := <-ticker.C:
-				round := timeboost.CurrentRound(es.initialTimestamp, es.roundDuration)
+				round := es.roundTimingInfo.RoundNumber()
+				// TODO (BUG?) is there a race here where messages for a new round can come
+				// in before this tick has been processed?
 				log.Info(
 					"New express lane auction round",
 					"round", round,
@@ -318,23 +313,11 @@ func (es *expressLaneService) Start(ctxIn context.Context) {
 }
 
 func (es *expressLaneService) currentRoundHasController() bool {
-	currRound := timeboost.CurrentRound(es.initialTimestamp, es.roundDuration)
-	control, ok := es.roundControl.Get(currRound)
+	control, ok := es.roundControl.Get(es.roundTimingInfo.RoundNumber())
 	if !ok {
 		return false
 	}
 	return control.controller != (common.Address{})
-}
-
-func (es *expressLaneService) isWithinAuctionCloseWindow(arrivalTime time.Time) bool {
-	// Calculate the next round start time
-	elapsedTime := arrivalTime.Sub(es.initialTimestamp)
-	elapsedRounds := elapsedTime / es.roundDuration
-	nextRoundStart := es.initialTimestamp.Add((elapsedRounds + 1) * es.roundDuration)
-	// Calculate the time to the next round
-	timeToNextRound := nextRoundStart.Sub(arrivalTime)
-	// Check if the arrival timestamp is within AUCTION_CLOSING_DURATION of TIME_TO_NEXT_ROUND
-	return timeToNextRound <= es.auctionClosing
 }
 
 // Sequence express lane submission skips validation of the express lane message itself,
@@ -402,18 +385,16 @@ func (es *expressLaneService) validateExpressLaneTx(msg *timeboost.ExpressLaneSu
 	}
 
 	for {
-		currentRound := timeboost.CurrentRound(es.initialTimestamp, es.roundDuration)
+		currentRound := es.roundTimingInfo.RoundNumber()
 		if msg.Round == currentRound {
 			break
 		}
 
-		currentTime := time.Now()
-		if msg.Round == currentRound+1 &&
-			timeboost.TimeTilNextRoundAfterTimestamp(es.initialTimestamp, currentTime, es.roundDuration) <= es.earlySubmissionGrace {
-			// If it becomes the next round in between checking the currentRound
-			// above, and here, then this will be a negative duration which is
-			// treated as time.Sleep(0), which is fine.
-			time.Sleep(timeboost.TimeTilNextRoundAfterTimestamp(es.initialTimestamp, currentTime, es.roundDuration))
+		timeTilNextRound := es.roundTimingInfo.TimeTilNextRound()
+		// We allow txs to come in for the next round if it is close enough to that round,
+		// but we sleep until the round starts.
+		if msg.Round == currentRound+1 && timeTilNextRound <= es.earlySubmissionGrace {
+			time.Sleep(timeTilNextRound)
 		} else {
 			return errors.Wrapf(timeboost.ErrBadRoundNumber, "express lane tx round %d does not match current round %d", msg.Round, currentRound)
 		}

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -594,7 +594,7 @@ func (s *Sequencer) PublishAuctionResolutionTransaction(ctx context.Context, tx 
 	if sender != auctioneerAddr {
 		return fmt.Errorf("sender %#x is not the auctioneer address %#x", sender, auctioneerAddr)
 	}
-	if !s.expressLaneService.isWithinAuctionCloseWindow(arrivalTime) {
+	if !s.expressLaneService.roundTimingInfo.IsWithinAuctionCloseWindow(arrivalTime) {
 		return fmt.Errorf("transaction arrival time not within auction closure window: %v", arrivalTime)
 	}
 	txBytes, err := tx.MarshalBinary()

--- a/timeboost/bid_validator_test.go
+++ b/timeboost/bid_validator_test.go
@@ -101,11 +101,13 @@ func TestBidValidator_validateBid(t *testing.T) {
 
 	for _, tt := range tests {
 		bv := BidValidator{
-			chainId:                 big.NewInt(1),
-			initialRoundTimestamp:   time.Now().Add(-time.Second * 3),
+			chainId: big.NewInt(1),
+			roundTimingInfo: RoundTimingInfo{
+				Offset:         time.Now().Add(-time.Second * 3),
+				Round:          10 * time.Second,
+				AuctionClosing: 5 * time.Second,
+			},
 			reservePrice:            big.NewInt(2),
-			roundDuration:           10 * time.Second,
-			auctionClosingDuration:  5 * time.Second,
 			auctionContract:         setup.expressLaneAuction,
 			auctionContractAddr:     setup.expressLaneAuctionAddr,
 			bidsPerSenderInRound:    make(map[common.Address]uint8),
@@ -129,11 +131,13 @@ func TestBidValidator_validateBid_perRoundBidLimitReached(t *testing.T) {
 	}
 	auctionContractAddr := common.Address{'a'}
 	bv := BidValidator{
-		chainId:                        big.NewInt(1),
-		initialRoundTimestamp:          time.Now().Add(-time.Second),
+		chainId: big.NewInt(1),
+		roundTimingInfo: RoundTimingInfo{
+			Offset:         time.Now().Add(-time.Second),
+			Round:          time.Minute,
+			AuctionClosing: 45 * time.Second,
+		},
 		reservePrice:                   big.NewInt(2),
-		roundDuration:                  time.Minute,
-		auctionClosingDuration:         45 * time.Second,
 		bidsPerSenderInRound:           make(map[common.Address]uint8),
 		maxBidsPerSenderInRound:        5,
 		auctionContractAddr:            auctionContractAddr,

--- a/timeboost/bidder_client.go
+++ b/timeboost/bidder_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -20,7 +19,6 @@ import (
 	"github.com/offchainlabs/nitro/cmd/util"
 	"github.com/offchainlabs/nitro/solgen/go/express_lane_auctiongen"
 	"github.com/offchainlabs/nitro/timeboost/bindings"
-	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/containers"
 	"github.com/offchainlabs/nitro/util/signature"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
@@ -67,8 +65,7 @@ type BidderClient struct {
 	auctionContract        *express_lane_auctiongen.ExpressLaneAuction
 	biddingTokenContract   *bindings.MockERC20
 	auctioneerClient       *rpc.Client
-	initialRoundTimestamp  time.Time
-	roundDuration          time.Duration
+	roundTimingInfo        RoundTimingInfo
 	domainValue            []byte
 }
 
@@ -96,18 +93,16 @@ func NewBidderClient(
 	if err != nil {
 		return nil, err
 	}
-	var roundTimingInfo RoundTimingInfo
-	roundTimingInfo, err = auctionContract.RoundTimingInfo(&bind.CallOpts{
+	rawRoundTimingInfo, err := auctionContract.RoundTimingInfo(&bind.CallOpts{
 		Context: ctx,
 	})
 	if err != nil {
 		return nil, err
 	}
-	if err = roundTimingInfo.Validate(nil); err != nil {
+	roundTimingInfo, err := NewRoundTimingInfo(rawRoundTimingInfo)
+	if err != nil {
 		return nil, err
 	}
-	initialTimestamp := time.Unix(int64(roundTimingInfo.OffsetTimestamp), 0)
-	roundDuration := arbmath.SaturatingCast[time.Duration](roundTimingInfo.RoundDurationSeconds) * time.Second
 	txOpts, signer, err := util.OpenWallet("bidder-client", &cfg.Wallet, chainId)
 	if err != nil {
 		return nil, errors.Wrap(err, "opening wallet")
@@ -138,8 +133,7 @@ func NewBidderClient(
 		auctionContract:        auctionContract,
 		biddingTokenContract:   biddingTokenContract,
 		auctioneerClient:       bidValidatorClient,
-		initialRoundTimestamp:  initialTimestamp,
-		roundDuration:          roundDuration,
+		roundTimingInfo:        *roundTimingInfo,
 		domainValue:            domainValue,
 	}, nil
 }
@@ -205,7 +199,7 @@ func (bd *BidderClient) Bid(
 		ChainId:                bd.chainId,
 		ExpressLaneController:  expressLaneController,
 		AuctionContractAddress: bd.auctionContractAddress,
-		Round:                  CurrentRound(bd.initialRoundTimestamp, bd.roundDuration) + 1,
+		Round:                  bd.roundTimingInfo.RoundNumber() + 1,
 		Amount:                 amount,
 	}
 	bidHash, err := newBid.ToEIP712Hash(domainSeparator)

--- a/timeboost/roundtiminginfo.go
+++ b/timeboost/roundtiminginfo.go
@@ -7,21 +7,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/offchainlabs/nitro/solgen/go/express_lane_auctiongen"
 	"github.com/offchainlabs/nitro/util/arbmath"
 )
 
-// Solgen solidity bindings don't give names to return structs, give it a name for convenience.
-type RoundTimingInfo struct {
-	OffsetTimestamp          int64
-	RoundDurationSeconds     uint64
-	AuctionClosingSeconds    uint64
-	ReserveSubmissionSeconds uint64
-}
-
-// Validate the RoundTimingInfo fields.
-// resolutionWaitTime is an additional parameter passed into the auctioneer that it
-// needs to validate against the other fields.
-func (c *RoundTimingInfo) Validate(resolutionWaitTime *time.Duration) error {
+// Validate the express_lane_auctiongen.RoundTimingInfo fields.
+// Returns errors in terms of the solidity field names to ease debugging.
+func validateRoundTimingInfo(c *express_lane_auctiongen.RoundTimingInfo) error {
 	roundDuration := arbmath.SaturatingCast[time.Duration](c.RoundDurationSeconds) * time.Second
 	auctionClosing := arbmath.SaturatingCast[time.Duration](c.AuctionClosingSeconds) * time.Second
 	reserveSubmission := arbmath.SaturatingCast[time.Duration](c.ReserveSubmissionSeconds) * time.Second
@@ -49,14 +41,93 @@ func (c *RoundTimingInfo) Validate(resolutionWaitTime *time.Duration) error {
 			combinedClosingTime/time.Second)
 	}
 
-	// Validate resolution wait time if provided
-	if resolutionWaitTime != nil {
-		// Resolution wait time shouldn't be more than 50% of auction closing time
-		if *resolutionWaitTime > auctionClosing/2 {
-			return fmt.Errorf("resolution wait time (%v) must not exceed 50%% of auction closing time (%v)",
-				*resolutionWaitTime, auctionClosing)
-		}
+	return nil
+}
+
+// RoundTimingInfo holds the information from the Solidity type of the same name,
+// validated and converted into higher level time types, with helpful methods
+// for calculating round number, if a round is closed, and time til close.
+type RoundTimingInfo struct {
+	Offset            time.Time
+	Round             time.Duration
+	AuctionClosing    time.Duration
+	ReserveSubmission time.Duration
+}
+
+// Convert from solgen bindings to domain type
+func NewRoundTimingInfo(c express_lane_auctiongen.RoundTimingInfo) (*RoundTimingInfo, error) {
+	if err := validateRoundTimingInfo(&c); err != nil {
+		return nil, err
 	}
 
+	return &RoundTimingInfo{
+		Offset:            time.Unix(c.OffsetTimestamp, 0),
+		Round:             arbmath.SaturatingCast[time.Duration](c.RoundDurationSeconds) * time.Second,
+		AuctionClosing:    arbmath.SaturatingCast[time.Duration](c.AuctionClosingSeconds) * time.Second,
+		ReserveSubmission: arbmath.SaturatingCast[time.Duration](c.ReserveSubmissionSeconds) * time.Second,
+	}, nil
+}
+
+// resolutionWaitTime is an additional parameter that the Auctioneer
+// needs to validate against other timing fields.
+func (info *RoundTimingInfo) ValidateResolutionWaitTime(resolutionWaitTime time.Duration) error {
+	// Resolution wait time shouldn't be more than 50% of auction closing time
+	if resolutionWaitTime > info.AuctionClosing/2 {
+		return fmt.Errorf("resolution wait time (%v) must not exceed 50%% of auction closing time (%v)",
+			resolutionWaitTime, info.AuctionClosing)
+	}
 	return nil
+}
+
+// RoundNumber returns the round number as of now.
+func (info *RoundTimingInfo) RoundNumber() uint64 {
+	return info.RoundNumberAt(time.Now())
+}
+
+// RoundNumberAt returns the round number as of some timestamp.
+func (info *RoundTimingInfo) RoundNumberAt(currentTime time.Time) uint64 {
+	return arbmath.SaturatingUCast[uint64](currentTime.Sub(info.Offset) / info.Round)
+	// info.Round has already been validated to be nonzero during construction.
+}
+
+// TimeTilNextRound returns the time til the next round as of now.
+func (info *RoundTimingInfo) TimeTilNextRound() time.Duration {
+	return info.TimeTilNextRoundAt(time.Now())
+}
+
+// TimeTilNextRoundAt returns the time til the next round,
+// where the next round is determined from the timestamp passed in.
+func (info *RoundTimingInfo) TimeTilNextRoundAt(currentTime time.Time) time.Duration {
+	return time.Until(info.TimeOfNextRoundAt(currentTime))
+}
+
+func (info *RoundTimingInfo) TimeOfNextRound() time.Time {
+	return info.TimeOfNextRoundAt(time.Now())
+}
+
+func (info *RoundTimingInfo) TimeOfNextRoundAt(currentTime time.Time) time.Time {
+	roundNum := info.RoundNumberAt(currentTime)
+	return info.Offset.Add(info.Round * arbmath.SaturatingCast[time.Duration](roundNum+1))
+}
+
+func (info *RoundTimingInfo) durationIntoRound(timestamp time.Time) time.Duration {
+	secondsSinceOffset := uint64(timestamp.Sub(info.Offset).Seconds())
+	roundDurationSeconds := uint64(info.Round.Seconds())
+	return arbmath.SaturatingCast[time.Duration](secondsSinceOffset % roundDurationSeconds)
+}
+
+func (info *RoundTimingInfo) isAuctionRoundClosed() bool {
+	return info.isAuctionRoundClosedAt(time.Now())
+}
+
+func (info *RoundTimingInfo) isAuctionRoundClosedAt(currentTime time.Time) bool {
+	if currentTime.Before(info.Offset) {
+		return false
+	}
+
+	return info.durationIntoRound(currentTime)*time.Second >= info.Round-info.AuctionClosing
+}
+
+func (info *RoundTimingInfo) IsWithinAuctionCloseWindow(timestamp time.Time) bool {
+	return info.TimeTilNextRoundAt(timestamp) <= info.AuctionClosing
 }

--- a/timeboost/ticker.go
+++ b/timeboost/ticker.go
@@ -2,98 +2,43 @@ package timeboost
 
 import (
 	"time"
-
-	"github.com/offchainlabs/nitro/util/arbmath"
 )
 
-type auctionCloseTicker struct {
-	c                      chan time.Time
-	done                   chan bool
-	roundDuration          time.Duration
-	auctionClosingDuration time.Duration
+type roundTicker struct {
+	c               chan time.Time
+	done            chan bool
+	roundTimingInfo RoundTimingInfo
 }
 
-func newAuctionCloseTicker(roundDuration, auctionClosingDuration time.Duration) *auctionCloseTicker {
-	return &auctionCloseTicker{
-		c:                      make(chan time.Time, 1),
-		done:                   make(chan bool),
-		roundDuration:          roundDuration,
-		auctionClosingDuration: auctionClosingDuration,
+func newRoundTicker(roundTimingInfo RoundTimingInfo) *roundTicker {
+	return &roundTicker{
+		c:               make(chan time.Time, 1),
+		done:            make(chan bool),
+		roundTimingInfo: roundTimingInfo,
 	}
 }
 
-func (t *auctionCloseTicker) start() {
+func (t *roundTicker) tickAtAuctionClose() {
+	t.start(t.roundTimingInfo.AuctionClosing)
+}
+
+func (t *roundTicker) tickAtReserveSubmissionDeadline() {
+	t.start(t.roundTimingInfo.AuctionClosing + t.roundTimingInfo.ReserveSubmission)
+}
+
+func (t *roundTicker) start(timeBeforeRoundStart time.Duration) {
 	for {
-		now := time.Now()
-		// Calculate the start of the next round
-		startOfNextRound := now.Truncate(t.roundDuration).Add(t.roundDuration)
-		// Subtract AUCTION_CLOSING_SECONDS seconds to get the tick time
-		nextTickTime := startOfNextRound.Add(-t.auctionClosingDuration)
-		// Ensure we are not setting a past tick time
-		if nextTickTime.Before(now) {
-			// If the calculated tick time is in the past, move to the next interval
-			nextTickTime = nextTickTime.Add(t.roundDuration)
+		nextTick := t.roundTimingInfo.TimeTilNextRound() - timeBeforeRoundStart
+		if nextTick < 0 {
+			nextTick += t.roundTimingInfo.Round
 		}
-		// Calculate how long to wait until the next tick
-		waitTime := nextTickTime.Sub(now)
 
 		select {
-		case <-time.After(waitTime):
+		case <-time.After(nextTick):
 			t.c <- time.Now()
 		case <-t.done:
 			close(t.c)
 			return
 		}
 	}
-}
-
-// CurrentRound returns the current round number.
-func CurrentRound(initialRoundTimestamp time.Time, roundDuration time.Duration) uint64 {
-	return RoundAtTimestamp(initialRoundTimestamp, time.Now(), roundDuration)
-}
-
-// CurrentRound returns the round number as of some timestamp.
-func RoundAtTimestamp(initialRoundTimestamp time.Time, currentTime time.Time, roundDuration time.Duration) uint64 {
-	if roundDuration == 0 {
-		return 0
-	}
-	return arbmath.SaturatingUCast[uint64](currentTime.Sub(initialRoundTimestamp) / roundDuration)
-}
-
-func isAuctionRoundClosed(
-	timestamp time.Time,
-	initialTimestamp time.Time,
-	roundDuration time.Duration,
-	auctionClosingDuration time.Duration,
-) bool {
-	if timestamp.Before(initialTimestamp) {
-		return false
-	}
-	timeInRound := timeIntoRound(timestamp, initialTimestamp, roundDuration)
-	return arbmath.SaturatingCast[time.Duration](timeInRound)*time.Second >= roundDuration-auctionClosingDuration
-}
-
-func timeIntoRound(
-	timestamp time.Time,
-	initialTimestamp time.Time,
-	roundDuration time.Duration,
-) uint64 {
-	secondsSinceOffset := uint64(timestamp.Sub(initialTimestamp).Seconds())
-	roundDurationSeconds := uint64(roundDuration.Seconds())
-	return secondsSinceOffset % roundDurationSeconds
-}
-
-func TimeTilNextRound(
-	initialTimestamp time.Time,
-	roundDuration time.Duration) time.Duration {
-	return TimeTilNextRoundAfterTimestamp(initialTimestamp, time.Now(), roundDuration)
-}
-
-func TimeTilNextRoundAfterTimestamp(
-	initialTimestamp time.Time,
-	currentTime time.Time,
-	roundDuration time.Duration) time.Duration {
-	currentRoundNum := RoundAtTimestamp(initialTimestamp, currentTime, roundDuration)
-	nextRoundStart := initialTimestamp.Add(roundDuration * arbmath.SaturatingCast[time.Duration](currentRoundNum+1))
-	return time.Until(nextRoundStart)
 }

--- a/timeboost/ticker_test.go
+++ b/timeboost/ticker_test.go
@@ -9,32 +9,34 @@ import (
 
 func Test_auctionClosed(t *testing.T) {
 	t.Parallel()
-	roundDuration := time.Minute
-	auctionClosingDuration := time.Second * 15
-	now := time.Now()
-	waitTime := roundDuration - time.Duration(now.Second())*time.Second - time.Duration(now.Nanosecond())
-	initialTimestamp := now.Add(waitTime)
+	roundTimingInfo := RoundTimingInfo{
+		Offset:         time.Now(),
+		Round:          time.Minute,
+		AuctionClosing: time.Second * 15,
+	}
+
+	initialTimestamp := time.Now()
 
 	// We should not have closed the round yet, and the time into the round should be less than a second.
-	isClosed := isAuctionRoundClosed(initialTimestamp, initialTimestamp, roundDuration, auctionClosingDuration)
+	isClosed := roundTimingInfo.isAuctionRoundClosedAt(initialTimestamp)
 	require.False(t, isClosed)
 
 	// Wait right before auction closure (before the 45 second mark).
-	timestamp := initialTimestamp.Add((roundDuration - auctionClosingDuration) - time.Second)
-	isClosed = isAuctionRoundClosed(timestamp, initialTimestamp, roundDuration, auctionClosingDuration)
+	timestamp := initialTimestamp.Add((roundTimingInfo.Round - roundTimingInfo.AuctionClosing) - time.Second)
+	isClosed = roundTimingInfo.isAuctionRoundClosedAt(timestamp)
 	require.False(t, isClosed)
 
 	// Wait a second more and the auction should be closed.
-	timestamp = initialTimestamp.Add(roundDuration - auctionClosingDuration)
-	isClosed = isAuctionRoundClosed(timestamp, initialTimestamp, roundDuration, auctionClosingDuration)
+	timestamp = initialTimestamp.Add(roundTimingInfo.Round - roundTimingInfo.AuctionClosing)
+	isClosed = roundTimingInfo.isAuctionRoundClosedAt(timestamp)
 	require.True(t, isClosed)
 
 	// Future timestamp should also be closed, until we reach the new round
-	for i := float64(0); i < auctionClosingDuration.Seconds(); i++ {
-		timestamp = initialTimestamp.Add((roundDuration - auctionClosingDuration) + time.Second*time.Duration(i))
-		isClosed = isAuctionRoundClosed(timestamp, initialTimestamp, roundDuration, auctionClosingDuration)
+	for i := float64(0); i < roundTimingInfo.AuctionClosing.Seconds(); i++ {
+		timestamp = initialTimestamp.Add((roundTimingInfo.Round - roundTimingInfo.AuctionClosing) + time.Second*time.Duration(i))
+		isClosed = roundTimingInfo.isAuctionRoundClosedAt(timestamp)
 		require.True(t, isClosed)
 	}
-	isClosed = isAuctionRoundClosed(initialTimestamp.Add(roundDuration), initialTimestamp, roundDuration, auctionClosingDuration)
+	isClosed = roundTimingInfo.isAuctionRoundClosedAt(initialTimestamp.Add(roundTimingInfo.Round))
 	require.False(t, isClosed)
 }


### PR DESCRIPTION
The logic for the calculations of "when does the next round start?", "what round is it?", "is the auction closed?", was spread throughout the code and required passing around multiple separate variables that all come from the RoundTimingInfo from the ExpressLaneAuction contract and should never change. This commit adds a domain specific RoundTimingInfo that validates these fields on construction and consolidates the aforementioned calculations.

This commit also contanis a fix for auctionCloseTicker, now roundTicker. It used to assume the initial Offset timestamp fetched from the ExpressLaneAuction contract would always start on a minute boundary, and the round length would be a minute which is not always the case. This commit changes it to be called roundTicker and it now uses standard methods on the new RoundTimingInfo which take into account all possibilities for initial offset and round duration.

# Testing done 
Unit tests pass.

Re-ran https://github.com/OffchainLabs/timeboost-test against local nitro testnode with offset set to 30s within the minute, it passes up until the end when it has run out of time in the round due to the test also assuming minute boundaries.