### PR TITLE
Bump default message pruner min batches left to 1k

### DIFF
--- a/arbnode/message_pruner.go
+++ b/arbnode/message_pruner.go
@@ -46,7 +46,7 @@ type MessagePrunerConfigFetcher func() *MessagePrunerConfig
 var DefaultMessagePrunerConfig = MessagePrunerConfig{
 	Enable:         true,
 	PruneInterval:  time.Minute,
-	MinBatchesLeft: 2,
+	MinBatchesLeft: 1000,
 }
 
 func MessagePrunerConfigAddOptions(prefix string, f *flag.FlagSet) {


### PR DESCRIPTION
This'll ensure the message pruner isn't too far ahead of what's actually committed to disk on the geth blockchain side. Keeping this many batches' messages also won't take up that much disk space.