### PR TITLE
[NIT-3006] fix: BlockValidator is added twice to LatestStakedNotifiers in pre-BOLD case

### DIFF
--- a/staker/legacy/staker.go
+++ b/staker/legacy/staker.go
@@ -323,9 +323,6 @@ func NewStaker(
 		return nil, err
 	}
 	stakerLastSuccessfulActionGauge.Update(time.Now().Unix())
-	if config().StartValidationFromStaked && blockValidator != nil {
-		stakedNotifiers = append(stakedNotifiers, blockValidator)
-	}
 	inactiveValidatedNodes := btree.NewG(2, func(a, b validatedNode) bool {
 		return a.number < b.number || (a.number == b.number && a.hash.Cmp(b.hash) < 0)
 	})


### PR DESCRIPTION
Fixes: NIT-3006