### PR TITLE
pre-bold instead of develop as the exception branch used to check submodule pin for nitro-contracts

### DIFF
--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -25,9 +25,9 @@ jobs:
         run: |
           status_state="pending"
           declare -Ar exceptions=(
-            [contracts]=origin/develop
+            [contracts]=origin/pre-bold
             [nitro-testnode]=origin/master
-            
+
             #TODO Rachel to check these are the intended branches.
             [arbitrator/langs/c]=origin/vm-storage-cache
             [arbitrator/tools/wasmer]=origin/adopt-v4.2.8
@@ -38,7 +38,7 @@ jobs:
             if [[ -v exceptions[$mod] ]]; then
               branch=${exceptions[$mod]}
             fi
-            
+
             if ! git -C $mod merge-base --is-ancestor HEAD $branch; then
               echo $mod diverges from $branch
               divergent=1


### PR DESCRIPTION
As described in https://github.com/OffchainLabs/nitro-contracts/pull/284, current version of develop branch of nitro-contracts is not compatible with nitro, so a pre-bold branch, checked out from main, was created to support changes that should be introduced to nitro while bold is not fully integrated to it.

This PR uses pre-bold instead of develop as the exception branch used to check submodule pin for nitro-contracts.
This unblocks https://github.com/OffchainLabs/nitro/pull/2837, that pins pre-bold branch of nitro-contracts and needs "Submodule Pin Check" to be reported.
The workflow related to "Submodule Pin Check" only runs scripts that are in nitro's master branch.

The changes of this PR should be reverted once nitro starts supporting the develop branch of nitro-contracts again.