### PR TITLE
Include tx compression level in calldata units cache

### DIFF
--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -789,7 +789,8 @@ func (s *ExecutionEngine) cacheL1PriceDataOfMsg(seqNum arbutil.MessageIndex, rec
 			gasUsedForL1 += receipts[i].GasUsedForL1
 		}
 		for _, tx := range block.Transactions() {
-			callDataUnits += tx.CalldataUnits
+			_, cachedUnits := tx.GetRawCachedCalldataUnits()
+			callDataUnits += cachedUnits
 		}
 	}
 	l1GasCharged := gasUsedForL1 * block.BaseFee().Uint64()


### PR DESCRIPTION
Pulls in https://github.com/OffchainLabs/go-ethereum/pull/389

Also includes a testcase based on https://github.com/OffchainLabs/nitro/pull/2837 that I've verified catches this issue by failing without the fix applied