### PR TITLE
Fix typographical errors in documentation and comments

### DIFF
--- a/arbnode/resourcemanager/resource_management.go
+++ b/arbnode/resourcemanager/resource_management.go
@@ -114,7 +114,7 @@ func newHttpServer(inner http.Handler, c LimitChecker) *httpServer {
 }
 
 // ServeHTTP passes req to inner unless any configured system resource
-// limit is exceeded, in which case it returns a HTTP 429 error.
+// limit is exceeded, in which case it returns an HTTP 429 error.
 func (s *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 	exceeded, err := s.c.IsLimitExceeded()

--- a/das/aggregator.go
+++ b/das/aggregator.go
@@ -53,7 +53,7 @@ var parsedBackendsConf BackendConfigList
 
 func AggregatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultAggregatorConfig.Enable, "enable storage of sequencer batch data from a list of RPC endpoints; this should only be used by the batch poster and not in combination with other DAS storage types")
-	f.Int(prefix+".assumed-honest", DefaultAggregatorConfig.AssumedHonest, "Number of assumed honest backends (H). If there are N backends, K=N+1-H valid responses are required to consider an Store request to be successful.")
+	f.Int(prefix+".assumed-honest", DefaultAggregatorConfig.AssumedHonest, "Number of assumed honest backends (H). If there are N backends, K=N+1-H valid responses are required to consider a Store request to be successful.")
 	f.Var(&parsedBackendsConf, prefix+".backends", "JSON RPC backend configuration. This can be specified on the command line as a JSON array, eg: [{\"url\": \"...\", \"pubkey\": \"...\"},...], or as a JSON array in the config file.")
 	f.Int(prefix+".max-store-chunk-body-size", DefaultAggregatorConfig.MaxStoreChunkBodySize, "maximum HTTP POST body size to use for individual batch chunks, including JSON RPC overhead and an estimated overhead of 512B of headers")
 }

--- a/das/google_cloud_storage_service.go
+++ b/das/google_cloud_storage_service.go
@@ -72,7 +72,7 @@ type GoogleCloudStorageServiceConfig struct {
 var DefaultGoogleCloudStorageServiceConfig = GoogleCloudStorageServiceConfig{}
 
 func GoogleCloudConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Bool(prefix+".enable", DefaultGoogleCloudStorageServiceConfig.Enable, "EXPERIMENTAL/unsupported - enable storage/retrieval of sequencer batch data from an Google Cloud Storage bucket")
+	f.Bool(prefix+".enable", DefaultGoogleCloudStorageServiceConfig.Enable, "EXPERIMENTAL/unsupported - enable storage/retrieval of sequencer batch data from a Google Cloud Storage bucket")
 	f.String(prefix+".access-token", DefaultGoogleCloudStorageServiceConfig.AccessToken, "Google Cloud Storage access token")
 	f.String(prefix+".bucket", DefaultGoogleCloudStorageServiceConfig.Bucket, "Google Cloud Storage bucket")
 	f.String(prefix+".object-prefix", DefaultGoogleCloudStorageServiceConfig.ObjectPrefix, "prefix to add to Google Cloud Storage objects")

--- a/linters/testdata/src/koanf/a/a.go
+++ b/linters/testdata/src/koanf/a/a.go
@@ -22,7 +22,7 @@ var defaultConfig = Config{
 	LogLevel: 2,
 }
 
-// Instantiating a type an taking reference.
+// Instantiating a type a taking reference.
 var defaultConfigPtr = &Config{
 	LogType: 3,
 	Metrics: 4,

--- a/staker/legacy/fast_confirm.go
+++ b/staker/legacy/fast_confirm.go
@@ -209,7 +209,7 @@ func (f *FastConfirmSafe) checkApprovedHashAndExecTransaction(ctx context.Contex
 
 		// If the owner has approved the hash, we add the signature to the transaction.
 		// We add the signature in the format r, s, v.
-		// We set v to 1, as it is the only possible value for a approved hash.
+		// We set v to 1, as it is the only possible value for an approved hash.
 		// We set r to the owner's address.
 		// We set s to the empty hash.
 		// Refer to the Safe contract for more information.

--- a/system_tests/stylus_trace_test.go
+++ b/system_tests/stylus_trace_test.go
@@ -423,7 +423,7 @@ func TestStylusOpcodeTraceCreate(t *testing.T) {
 	checkOpcode(t, result, 11, vm.POP, create2Addr[:])
 }
 
-// TestStylusOpcodeTraceEquivalence compares a Stylus trace with a equivalent Solidity/EVM trace. Notice
+// TestStylusOpcodeTraceEquivalence compares a Stylus trace with an equivalent Solidity/EVM trace. Notice
 // the Stylus trace does not contain all opcodes from the Solidity/EVM trace. Instead, this test
 // only checks that both traces contain the same basic opcodes.
 func TestStylusOpcodeTraceEquivalence(t *testing.T) {

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -141,7 +141,7 @@ func BigToUintOrPanic(value *big.Int) uint64 {
 	return value.Uint64()
 }
 
-// UfracToBigFloat casts an rational to a big float
+// UfracToBigFloat casts a rational to a big float
 func UfracToBigFloat(numerator, denominator uint64) *big.Float {
 	float := new(big.Float)
 	float.Quo(UintToBigFloat(numerator), UintToBigFloat(denominator))
@@ -242,7 +242,7 @@ func BigMulByInt(multiplicand *big.Int, multiplier int64) *big.Int {
 	return new(big.Int).Mul(multiplicand, big.NewInt(multiplier))
 }
 
-// BigMulByUint multiply a huge by a unsigned integer
+// BigMulByUint multiply a huge by an unsigned integer
 func BigMulByUint(multiplicand *big.Int, multiplier uint64) *big.Int {
 	return new(big.Int).Mul(multiplicand, new(big.Int).SetUint64(multiplier))
 }


### PR DESCRIPTION
This PR addresses several typographical errors in comments across multiple files to improve clarity and correctness. 
These updates do not impact the functionality of the codebase.

#### **Changes Include:**

1. **File:** `resource_management.go`  
   - Corrected "a HTTP" to "an HTTP."

2. **File:** `aggregator.go`  
   - Corrected "an Store" to "a Store."

3. **File:** `google_cloud_storage_service.go`  
   - Corrected "an Google" to "a Google."

4. **File:** `a.go`  
   - Corrected "an taking" to "a taking."

5. **File:** `fast_confirm.go`  
   - Corrected "a approved" to "an approved."

6. **File:** `stylus_trace_test.go`  
   - Corrected "a equivalent" to "an equivalent."

7. **File:** `math.go`  
   - Corrected "an rational" to "a rational."  
   - Corrected "a unsigned" to "an unsigned."