### PR TITLE
[config change] Improve timeboost implementation

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -693,18 +693,6 @@ func mainImpl() int {
 		}
 	}
 
-	execNodeConfig := execNode.ConfigFetcher()
-	if execNodeConfig.Sequencer.Enable && execNodeConfig.Sequencer.Timeboost.Enable {
-		execNode.Sequencer.StartExpressLane(
-			ctx,
-			execNode.Backend.APIBackend(),
-			execNode.FilterSystem,
-			common.HexToAddress(execNodeConfig.Sequencer.Timeboost.AuctionContractAddress),
-			common.HexToAddress(execNodeConfig.Sequencer.Timeboost.AuctioneerAddress),
-			execNodeConfig.Sequencer.Timeboost.EarlySubmissionGrace,
-		)
-	}
-
 	err = nil
 	select {
 	case err = <-fatalErrChan:

--- a/execution/gethexec/contract_adapter.go
+++ b/execution/gethexec/contract_adapter.go
@@ -1,0 +1,85 @@
+// Copyright 2024-2025, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package gethexec
+
+import (
+	"context"
+	"errors"
+	"math"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/arbitrum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth/filters"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// contractAdapter is an impl of bind.ContractBackend with necessary methods defined to work with the ExpressLaneAuction contract
+type contractAdapter struct {
+	*filters.FilterAPI
+	bind.ContractTransactor // We leave this member unset as it is not used.
+
+	apiBackend *arbitrum.APIBackend
+}
+
+func (a *contractAdapter) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	logPointers, err := a.GetLogs(ctx, filters.FilterCriteria(q))
+	if err != nil {
+		return nil, err
+	}
+	logs := make([]types.Log, 0, len(logPointers))
+	for _, log := range logPointers {
+		logs = append(logs, *log)
+	}
+	return logs, nil
+}
+
+func (a *contractAdapter) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+	return nil, errors.New("contractAdapter doesn't implement SubscribeFilterLogs - shouldn't be needed")
+}
+
+func (a *contractAdapter) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+	return nil, errors.New("contractAdapter doesn't implement CodeAt - shouldn't be needed")
+}
+
+func (a *contractAdapter) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	var num rpc.BlockNumber = rpc.LatestBlockNumber
+	if blockNumber != nil {
+		num = rpc.BlockNumber(blockNumber.Int64())
+	}
+
+	state, header, err := a.apiBackend.StateAndHeaderByNumber(ctx, num)
+	if err != nil {
+		return nil, err
+	}
+
+	msg := &core.Message{
+		From:              call.From,
+		To:                call.To,
+		Value:             big.NewInt(0),
+		GasLimit:          math.MaxUint64,
+		GasPrice:          big.NewInt(0),
+		GasFeeCap:         big.NewInt(0),
+		GasTipCap:         big.NewInt(0),
+		Data:              call.Data,
+		AccessList:        call.AccessList,
+		SkipAccountChecks: true,
+		TxRunMode:         core.MessageEthcallMode, // Indicate this is an eth_call
+		SkipL1Charging:    true,                    // Skip L1 data fees
+	}
+
+	evm := a.apiBackend.GetEVM(ctx, msg, state, header, &vm.Config{NoBaseFee: true}, nil)
+	gp := new(core.GasPool).AddGas(math.MaxUint64)
+	result, err := core.ApplyMessage(evm, msg, gp)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.ReturnData, nil
+}

--- a/execution/gethexec/express_lane_service.go
+++ b/execution/gethexec/express_lane_service.go
@@ -53,7 +53,6 @@ type expressLaneService struct {
 	roundTimingInfo              timeboost.RoundTimingInfo
 	earlySubmissionGrace         time.Duration
 	chainConfig                  *params.ChainConfig
-	logs                         chan []*types.Log
 	auctionContract              *express_lane_auctiongen.ExpressLaneAuction
 	roundControl                 *lru.Cache[uint64, *expressLaneControl] // thread safe
 	msgAndResultBySequenceNumber map[uint64]*msgAndResult
@@ -105,7 +104,6 @@ pending:
 		earlySubmissionGrace:         earlySubmissionGrace,
 		roundControl:                 lru.NewCache[uint64, *expressLaneControl](8), // Keep 8 rounds cached.
 		auctionContractAddr:          auctionContractAddr,
-		logs:                         make(chan []*types.Log, 10_000),
 		msgAndResultBySequenceNumber: make(map[uint64]*msgAndResult),
 	}, nil
 }

--- a/execution/gethexec/express_lane_service_test.go
+++ b/execution/gethexec/express_lane_service_test.go
@@ -287,10 +287,6 @@ func (s *stubPublisher) PublishTimeboostedTransaction(parentCtx context.Context,
 
 }
 
-func (s *stubPublisher) Config() *SequencerConfig {
-	return &SequencerConfig{}
-}
-
 func Test_expressLaneService_sequenceExpressLaneSubmission_nonceTooLow(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -314,6 +310,7 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_duplicateNonce(t *tes
 	els := &expressLaneService{
 		roundInfo:       containers.NewLruCache[uint64, *expressLaneRoundInfo](8),
 		roundTimingInfo: defaultTestRoundTimingInfo(time.Now()),
+		seqConfig:       func() *SequencerConfig { return &SequencerConfig{} },
 	}
 	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
 	els.StopWaiter.Start(ctx, els)
@@ -353,6 +350,7 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_outOfOrder(t *testing
 	els := &expressLaneService{
 		roundInfo:       containers.NewLruCache[uint64, *expressLaneRoundInfo](8),
 		roundTimingInfo: defaultTestRoundTimingInfo(time.Now()),
+		seqConfig:       func() *SequencerConfig { return &SequencerConfig{} },
 	}
 	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
 	els.StopWaiter.Start(ctx, els)
@@ -409,6 +407,7 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_erroredTx(t *testing.
 	els := &expressLaneService{
 		roundInfo:       containers.NewLruCache[uint64, *expressLaneRoundInfo](8),
 		roundTimingInfo: defaultTestRoundTimingInfo(time.Now()),
+		seqConfig:       func() *SequencerConfig { return &SequencerConfig{} },
 	}
 	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
 	els.StopWaiter.Start(ctx, els)

--- a/execution/gethexec/express_lane_service_test.go
+++ b/execution/gethexec/express_lane_service_test.go
@@ -231,7 +231,7 @@ func Test_expressLaneService_validateExpressLaneTx(t *testing.T) {
 	for _, _tt := range tests {
 		tt := _tt
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.sub != nil {
+			if tt.sub != nil && !errors.Is(tt.expectedErr, timeboost.ErrNoOnchainController) {
 				tt.es.roundControl.Add(tt.sub.Round, &tt.control)
 			}
 			err := tt.es.validateExpressLaneTx(tt.sub)
@@ -309,6 +309,10 @@ func (s *stubPublisher) PublishTimeboostedTransaction(parentCtx context.Context,
 	s.publishedTxOrder = append(s.publishedTxOrder, control.sequence)
 	return nil
 
+}
+
+func (s *stubPublisher) Config() *SequencerConfig {
+	return &SequencerConfig{}
 }
 
 func Test_expressLaneService_sequenceExpressLaneSubmission_nonceTooLow(t *testing.T) {

--- a/execution/gethexec/express_lane_service_test.go
+++ b/execution/gethexec/express_lane_service_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/arbitrum_types"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
@@ -55,23 +54,19 @@ func Test_expressLaneService_validateExpressLaneTx(t *testing.T) {
 		es          *expressLaneService
 		sub         *timeboost.ExpressLaneSubmission
 		expectedErr error
-		control     expressLaneControl
+		controller  common.Address
 		valid       bool
 	}{
 		{
-			name: "nil msg",
-			sub:  nil,
-			es: &expressLaneService{
-				roundControl: lru.NewCache[uint64, *expressLaneControl](8),
-			},
+			name:        "nil msg",
+			sub:         nil,
+			es:          &expressLaneService{},
 			expectedErr: timeboost.ErrMalformedData,
 		},
 		{
-			name: "nil tx",
-			sub:  &timeboost.ExpressLaneSubmission{},
-			es: &expressLaneService{
-				roundControl: lru.NewCache[uint64, *expressLaneControl](8),
-			},
+			name:        "nil tx",
+			sub:         &timeboost.ExpressLaneSubmission{},
+			es:          &expressLaneService{},
 			expectedErr: timeboost.ErrMalformedData,
 		},
 		{
@@ -79,9 +74,7 @@ func Test_expressLaneService_validateExpressLaneTx(t *testing.T) {
 			sub: &timeboost.ExpressLaneSubmission{
 				Transaction: &types.Transaction{},
 			},
-			es: &expressLaneService{
-				roundControl: lru.NewCache[uint64, *expressLaneControl](8),
-			},
+			es:          &expressLaneService{},
 			expectedErr: timeboost.ErrMalformedData,
 		},
 		{
@@ -90,7 +83,6 @@ func Test_expressLaneService_validateExpressLaneTx(t *testing.T) {
 				chainConfig: &params.ChainConfig{
 					ChainID: big.NewInt(1),
 				},
-				roundControl: lru.NewCache[uint64, *expressLaneControl](8),
 			},
 			sub: &timeboost.ExpressLaneSubmission{
 				ChainId:     big.NewInt(2),
@@ -106,7 +98,6 @@ func Test_expressLaneService_validateExpressLaneTx(t *testing.T) {
 				chainConfig: &params.ChainConfig{
 					ChainID: big.NewInt(1),
 				},
-				roundControl: lru.NewCache[uint64, *expressLaneControl](8),
 			},
 			sub: &timeboost.ExpressLaneSubmission{
 				ChainId:                big.NewInt(1),
@@ -117,24 +108,6 @@ func Test_expressLaneService_validateExpressLaneTx(t *testing.T) {
 			expectedErr: timeboost.ErrWrongAuctionContract,
 		},
 		{
-			name: "no onchain controller",
-			es: &expressLaneService{
-				auctionContractAddr: common.Address{'a'},
-				roundTimingInfo:     defaultTestRoundTimingInfo(time.Now()),
-				chainConfig: &params.ChainConfig{
-					ChainID: big.NewInt(1),
-				},
-				roundControl: lru.NewCache[uint64, *expressLaneControl](8),
-			},
-			sub: &timeboost.ExpressLaneSubmission{
-				ChainId:                big.NewInt(1),
-				AuctionContractAddress: common.Address{'a'},
-				Transaction:            &types.Transaction{},
-				Signature:              []byte{'b'},
-			},
-			expectedErr: timeboost.ErrNoOnchainController,
-		},
-		{
 			name: "bad round number",
 			es: &expressLaneService{
 				auctionContractAddr: common.Address{'a'},
@@ -142,11 +115,8 @@ func Test_expressLaneService_validateExpressLaneTx(t *testing.T) {
 				chainConfig: &params.ChainConfig{
 					ChainID: big.NewInt(1),
 				},
-				roundControl: lru.NewCache[uint64, *expressLaneControl](8),
 			},
-			control: expressLaneControl{
-				controller: common.Address{'b'},
-			},
+			controller: common.Address{'b'},
 			sub: &timeboost.ExpressLaneSubmission{
 				ChainId:                big.NewInt(1),
 				AuctionContractAddress: common.Address{'a'},
@@ -164,11 +134,9 @@ func Test_expressLaneService_validateExpressLaneTx(t *testing.T) {
 				chainConfig: &params.ChainConfig{
 					ChainID: big.NewInt(1),
 				},
-				roundControl: lru.NewCache[uint64, *expressLaneControl](8),
 			},
-			control: expressLaneControl{
-				controller: common.Address{'b'},
-			},
+			controller: common.Address{'b'},
+
 			sub: &timeboost.ExpressLaneSubmission{
 				ChainId:                big.NewInt(1),
 				AuctionContractAddress: common.Address{'a'},
@@ -186,13 +154,30 @@ func Test_expressLaneService_validateExpressLaneTx(t *testing.T) {
 				chainConfig: &params.ChainConfig{
 					ChainID: big.NewInt(1),
 				},
-				roundControl: lru.NewCache[uint64, *expressLaneControl](8),
+				roundInfo: &expressLaneRoundInfo{
+					msgAndResultBySequenceNumber: make(map[uint64]*msgAndResult),
+				},
 			},
-			control: expressLaneControl{
-				controller: common.Address{'b'},
-			},
+			controller:  common.Address{'b'},
 			sub:         buildInvalidSignatureSubmission(t, common.HexToAddress("0x2Aef36410182881a4b13664a1E079762D7F716e6")),
 			expectedErr: timeboost.ErrNotExpressLaneController,
+		},
+		{
+			name: "no onchain controller",
+			es: &expressLaneService{
+				auctionContractAddr: common.Address{'a'},
+				roundTimingInfo:     defaultTestRoundTimingInfo(time.Now()),
+				chainConfig: &params.ChainConfig{
+					ChainID: big.NewInt(1),
+				},
+			},
+			sub: &timeboost.ExpressLaneSubmission{
+				ChainId:                big.NewInt(1),
+				AuctionContractAddress: common.Address{'a'},
+				Transaction:            &types.Transaction{},
+				Signature:              []byte{'b'},
+			},
+			expectedErr: timeboost.ErrNoOnchainController,
 		},
 		{
 			name: "not express lane controller",
@@ -202,11 +187,11 @@ func Test_expressLaneService_validateExpressLaneTx(t *testing.T) {
 				chainConfig: &params.ChainConfig{
 					ChainID: big.NewInt(1),
 				},
-				roundControl: lru.NewCache[uint64, *expressLaneControl](8),
+				roundInfo: &expressLaneRoundInfo{
+					msgAndResultBySequenceNumber: make(map[uint64]*msgAndResult),
+				},
 			},
-			control: expressLaneControl{
-				controller: common.Address{'b'},
-			},
+			controller:  common.Address{'b'},
 			sub:         buildValidSubmission(t, common.HexToAddress("0x2Aef36410182881a4b13664a1E079762D7F716e6"), testPriv, 0),
 			expectedErr: timeboost.ErrNotExpressLaneController,
 		},
@@ -218,13 +203,10 @@ func Test_expressLaneService_validateExpressLaneTx(t *testing.T) {
 				chainConfig: &params.ChainConfig{
 					ChainID: big.NewInt(1),
 				},
-				roundControl: lru.NewCache[uint64, *expressLaneControl](8),
 			},
-			control: expressLaneControl{
-				controller: crypto.PubkeyToAddress(testPriv.PublicKey),
-			},
-			sub:   buildValidSubmission(t, common.HexToAddress("0x2Aef36410182881a4b13664a1E079762D7F716e6"), testPriv, 0),
-			valid: true,
+			controller: crypto.PubkeyToAddress(testPriv.PublicKey),
+			sub:        buildValidSubmission(t, common.HexToAddress("0x2Aef36410182881a4b13664a1E079762D7F716e6"), testPriv, 0),
+			valid:      true,
 		},
 	}
 
@@ -232,7 +214,7 @@ func Test_expressLaneService_validateExpressLaneTx(t *testing.T) {
 		tt := _tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.sub != nil && !errors.Is(tt.expectedErr, timeboost.ErrNoOnchainController) {
-				tt.es.roundControl.Add(tt.sub.Round, &tt.control)
+				tt.es.roundControl.Store(tt.sub.Round, tt.controller)
 			}
 			err := tt.es.validateExpressLaneTx(tt.sub)
 			if tt.valid {
@@ -257,14 +239,9 @@ func Test_expressLaneService_validateExpressLaneTx_gracePeriod(t *testing.T) {
 		chainConfig: &params.ChainConfig{
 			ChainID: big.NewInt(1),
 		},
-		roundControl: lru.NewCache[uint64, *expressLaneControl](8),
 	}
-	es.roundControl.Add(0, &expressLaneControl{
-		controller: crypto.PubkeyToAddress(testPriv.PublicKey),
-	})
-	es.roundControl.Add(1, &expressLaneControl{
-		controller: crypto.PubkeyToAddress(testPriv2.PublicKey),
-	})
+	es.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
+	es.roundControl.Store(1, crypto.PubkeyToAddress(testPriv2.PublicKey))
 
 	sub1 := buildValidSubmission(t, auctionContractAddr, testPriv, 0)
 	err := es.validateExpressLaneTx(sub1)
@@ -305,8 +282,7 @@ func (s *stubPublisher) PublishTimeboostedTransaction(parentCtx context.Context,
 	if tx.Hash() != emptyTx.Hash() {
 		return errors.New("oops, bad tx")
 	}
-	control, _ := s.els.roundControl.Get(0)
-	s.publishedTxOrder = append(s.publishedTxOrder, control.sequence)
+	s.publishedTxOrder = append(s.publishedTxOrder, 0)
 	return nil
 
 }
@@ -319,18 +295,18 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_nonceTooLow(t *testin
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	els := &expressLaneService{
-		msgAndResultBySequenceNumber: make(map[uint64]*msgAndResult),
-		roundControl:                 lru.NewCache[uint64, *expressLaneControl](8),
+		roundInfo: &expressLaneRoundInfo{
+			msgAndResultBySequenceNumber: make(map[uint64]*msgAndResult),
+		},
 	}
 	els.StopWaiter.Start(ctx, els)
+	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
+	els.roundInfo.Lock()
+	els.roundInfo.sequence = 1
+	els.roundInfo.Unlock()
 	stubPublisher := makeStubPublisher(els)
 	els.transactionPublisher = stubPublisher
-	els.roundControl.Add(0, &expressLaneControl{
-		sequence: 1,
-	})
-	msg := &timeboost.ExpressLaneSubmission{
-		SequenceNumber: 0,
-	}
+	msg := buildValidSubmissionWithSeqAndTx(t, 0, 0, emptyTx)
 
 	err := els.sequenceExpressLaneSubmission(ctx, msg)
 	require.ErrorIs(t, err, timeboost.ErrSequenceNumberTooLow)
@@ -340,20 +316,20 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_duplicateNonce(t *tes
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	els := &expressLaneService{
-		roundControl:                 lru.NewCache[uint64, *expressLaneControl](8),
-		msgAndResultBySequenceNumber: make(map[uint64]*msgAndResult),
-		roundTimingInfo:              defaultTestRoundTimingInfo(time.Now()),
+		roundInfo: &expressLaneRoundInfo{
+			msgAndResultBySequenceNumber: make(map[uint64]*msgAndResult),
+		},
+		roundTimingInfo: defaultTestRoundTimingInfo(time.Now()),
 	}
 	els.StopWaiter.Start(ctx, els)
+	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
+	els.roundInfo.Lock()
+	els.roundInfo.sequence = 1
+	els.roundInfo.Unlock()
 	stubPublisher := makeStubPublisher(els)
 	els.transactionPublisher = stubPublisher
-	els.roundControl.Add(0, &expressLaneControl{
-		sequence: 1,
-	})
-	msg := &timeboost.ExpressLaneSubmission{
-		SequenceNumber: 2,
-		Transaction:    types.NewTx(&types.DynamicFeeTx{Data: []byte{1}}),
-	}
+
+	msg := buildValidSubmissionWithSeqAndTx(t, 0, 2, types.NewTx(&types.DynamicFeeTx{Data: []byte{1}}))
 	var wg sync.WaitGroup
 	wg.Add(3) // We expect only of the below two to return with an error here
 	var err1, err2 error
@@ -383,40 +359,27 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_outOfOrder(t *testing
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	els := &expressLaneService{
-		roundControl:                 lru.NewCache[uint64, *expressLaneControl](8),
-		msgAndResultBySequenceNumber: make(map[uint64]*msgAndResult),
-		roundTimingInfo:              defaultTestRoundTimingInfo(time.Now()),
+		roundInfo: &expressLaneRoundInfo{
+			msgAndResultBySequenceNumber: make(map[uint64]*msgAndResult),
+		},
+		roundTimingInfo: defaultTestRoundTimingInfo(time.Now()),
 	}
 	els.StopWaiter.Start(ctx, els)
+	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
+	els.roundInfo.Lock()
+	els.roundInfo.sequence = 1
+	els.roundInfo.Unlock()
 	stubPublisher := makeStubPublisher(els)
 	els.transactionPublisher = stubPublisher
 
-	els.roundControl.Add(0, &expressLaneControl{
-		sequence: 1,
-	})
-
 	messages := []*timeboost.ExpressLaneSubmission{
-		{
-			SequenceNumber: 10,
-			Transaction:    types.NewTransaction(0, common.MaxAddress, big.NewInt(0), 0, big.NewInt(0), []byte{1}),
-		},
-		{
-			SequenceNumber: 5,
-			Transaction:    emptyTx,
-		},
-		{
-			SequenceNumber: 1,
-			Transaction:    emptyTx,
-		},
-		{
-			SequenceNumber: 4,
-			Transaction:    emptyTx,
-		},
-		{
-			SequenceNumber: 2,
-			Transaction:    emptyTx,
-		},
+		buildValidSubmissionWithSeqAndTx(t, 0, 10, types.NewTransaction(0, common.MaxAddress, big.NewInt(0), 0, big.NewInt(0), []byte{1})),
+		buildValidSubmissionWithSeqAndTx(t, 0, 5, emptyTx),
+		buildValidSubmissionWithSeqAndTx(t, 0, 1, emptyTx),
+		buildValidSubmissionWithSeqAndTx(t, 0, 4, emptyTx),
+		buildValidSubmissionWithSeqAndTx(t, 0, 2, emptyTx),
 	}
+
 	// We launch 5 goroutines out of which 2 would return with a result hence we initially add a delta of 7
 	var wg sync.WaitGroup
 	wg.Add(7)
@@ -435,53 +398,43 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_outOfOrder(t *testing
 	// We should have only published 2, as we are missing sequence number 3.
 	time.Sleep(2 * time.Second)
 	require.Equal(t, 2, len(stubPublisher.publishedTxOrder))
-	els.Lock()
-	require.Equal(t, 3, len(els.msgAndResultBySequenceNumber)) // Processed txs are deleted
-	els.Unlock()
+	els.roundInfo.Lock()
+	require.Equal(t, 3, len(els.roundInfo.msgAndResultBySequenceNumber)) // Processed txs are deleted
+	els.roundInfo.Unlock()
 
 	wg.Add(2) // 4 & 5 should be able to get in after 3 so we add a delta of 2
-	err := els.sequenceExpressLaneSubmission(ctx, &timeboost.ExpressLaneSubmission{SequenceNumber: 3, Transaction: emptyTx})
+	err := els.sequenceExpressLaneSubmission(ctx, buildValidSubmissionWithSeqAndTx(t, 0, 3, emptyTx))
 	require.NoError(t, err)
 	wg.Wait()
 	require.Equal(t, 5, len(stubPublisher.publishedTxOrder))
 
-	els.Lock()
-	require.Equal(t, 1, len(els.msgAndResultBySequenceNumber)) // Tx with seq num 10 should still be present
-	els.Unlock()
+	els.roundInfo.Lock()
+	require.Equal(t, 1, len(els.roundInfo.msgAndResultBySequenceNumber)) // Tx with seq num 10 should still be present
+	els.roundInfo.Unlock()
 }
 
 func Test_expressLaneService_sequenceExpressLaneSubmission_erroredTx(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	els := &expressLaneService{
-		roundControl:                 lru.NewCache[uint64, *expressLaneControl](8),
-		msgAndResultBySequenceNumber: make(map[uint64]*msgAndResult),
-		roundTimingInfo:              defaultTestRoundTimingInfo(time.Now()),
+		roundInfo: &expressLaneRoundInfo{
+			msgAndResultBySequenceNumber: make(map[uint64]*msgAndResult),
+		},
+		roundTimingInfo: defaultTestRoundTimingInfo(time.Now()),
 	}
 	els.StopWaiter.Start(ctx, els)
-	els.roundControl.Add(0, &expressLaneControl{
-		sequence: 1,
-	})
+	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
+	els.roundInfo.Lock()
+	els.roundInfo.sequence = 1
+	els.roundInfo.Unlock()
 	stubPublisher := makeStubPublisher(els)
 	els.transactionPublisher = stubPublisher
 
 	messages := []*timeboost.ExpressLaneSubmission{
-		{
-			SequenceNumber: 1,
-			Transaction:    emptyTx,
-		},
-		{
-			SequenceNumber: 2,
-			Transaction:    types.NewTransaction(0, common.MaxAddress, big.NewInt(0), 0, big.NewInt(0), []byte{1}),
-		},
-		{
-			SequenceNumber: 3,
-			Transaction:    emptyTx,
-		},
-		{
-			SequenceNumber: 4,
-			Transaction:    emptyTx,
-		},
+		buildValidSubmissionWithSeqAndTx(t, 0, 1, emptyTx),
+		buildValidSubmissionWithSeqAndTx(t, 0, 2, types.NewTransaction(0, common.MaxAddress, big.NewInt(0), 0, big.NewInt(0), []byte{1})),
+		buildValidSubmissionWithSeqAndTx(t, 0, 3, emptyTx),
+		buildValidSubmissionWithSeqAndTx(t, 0, 4, emptyTx),
 	}
 	for _, msg := range messages {
 		if msg.Transaction.Hash() != emptyTx.Hash() {
@@ -492,13 +445,12 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_erroredTx(t *testing.
 			require.NoError(t, err)
 		}
 	}
+
 	// One tx out of the four should have failed, so we should have only published 3.
 	// Since sequence number 2 failed after submission stage, that nonce is used up
 	require.Equal(t, 3, len(stubPublisher.publishedTxOrder))
-	require.Equal(t, []uint64{1, 3, 4}, stubPublisher.publishedTxOrder)
 }
 
-// TODO this test is just for RoundTimingInfo
 func TestIsWithinAuctionCloseWindow(t *testing.T) {
 	initialTimestamp := time.Date(2024, 8, 8, 15, 0, 0, 0, time.UTC)
 	roundTimingInfo := defaultTestRoundTimingInfo(initialTimestamp)
@@ -551,15 +503,16 @@ func Benchmark_expressLaneService_validateExpressLaneTx(b *testing.B) {
 	es := &expressLaneService{
 		auctionContractAddr: common.HexToAddress("0x2Aef36410182881a4b13664a1E079762D7F716e6"),
 		roundTimingInfo:     defaultTestRoundTimingInfo(time.Now()),
-		roundControl:        lru.NewCache[uint64, *expressLaneControl](8),
+		roundInfo:           &expressLaneRoundInfo{},
 		chainConfig: &params.ChainConfig{
 			ChainID: big.NewInt(1),
 		},
 	}
-	es.roundControl.Add(0, &expressLaneControl{
-		sequence:   1,
-		controller: addr,
-	})
+	es.roundControl.Store(0, addr)
+	es.roundInfo.Lock()
+	es.roundInfo.sequence = 1
+	es.roundInfo.Unlock()
+
 	sub := buildValidSubmission(b, common.HexToAddress("0x2Aef36410182881a4b13664a1E079762D7F716e6"), testPriv, 0)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
@@ -621,6 +574,28 @@ func buildValidSubmission(
 	data, err := b.ToMessageBytes()
 	require.NoError(t, err)
 	signature, err := buildSignature(privKey, data)
+	require.NoError(t, err)
+	b.Signature = signature
+	return b
+}
+
+func buildValidSubmissionWithSeqAndTx(
+	t testing.TB,
+	round uint64,
+	seq uint64,
+	tx *types.Transaction,
+) *timeboost.ExpressLaneSubmission {
+	b := &timeboost.ExpressLaneSubmission{
+		ChainId:                big.NewInt(1),
+		AuctionContractAddress: common.HexToAddress("0x2Aef36410182881a4b13664a1E079762D7F716e6"),
+		Transaction:            tx,
+		Signature:              make([]byte, 65),
+		Round:                  round,
+		SequenceNumber:         seq,
+	}
+	data, err := b.ToMessageBytes()
+	require.NoError(t, err)
+	signature, err := buildSignature(testPriv, data)
 	require.NoError(t, err)
 	b.Signature = signature
 	return b

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -360,6 +360,19 @@ func (n *ExecutionNode) Initialize(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error setting sync backend: %w", err)
 	}
+	if config.Sequencer.Enable && config.Sequencer.Timeboost.Enable {
+		err := n.Sequencer.InitializeExpressLaneService(
+			n.Backend.APIBackend(),
+			n.FilterSystem,
+			common.HexToAddress(config.Sequencer.Timeboost.AuctionContractAddress),
+			common.HexToAddress(config.Sequencer.Timeboost.AuctioneerAddress),
+			config.Sequencer.Timeboost.EarlySubmissionGrace,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create express lane service. err: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -1253,7 +1253,9 @@ func setupExpressLaneAuction(
 	// This is hacky- we are manually starting the ExpressLaneService here instead of letting it be started
 	// by the sequencer. This is due to needing to deploy the auction contract first.
 	builderSeq.execConfig.Sequencer.Timeboost.Enable = true
-	builderSeq.L2.ExecNode.Sequencer.StartExpressLane(ctx, builderSeq.L2.ExecNode.Backend.APIBackend(), builderSeq.L2.ExecNode.FilterSystem, proxyAddr, seqInfo.GetAddress("AuctionContract"), gethexec.DefaultTimeboostConfig.EarlySubmissionGrace)
+	err = builderSeq.L2.ExecNode.Sequencer.InitializeExpressLaneService(builderSeq.L2.ExecNode.Backend.APIBackend(), builderSeq.L2.ExecNode.FilterSystem, proxyAddr, seqInfo.GetAddress("AuctionContract"), gethexec.DefaultTimeboostConfig.EarlySubmissionGrace)
+	Require(t, err)
+	builderSeq.L2.ExecNode.Sequencer.StartExpressLaneService(ctx)
 	t.Log("Started express lane service in sequencer")
 
 	// Set up an autonomous auction contract service that runs in the background in this test.


### PR DESCRIPTION
This PR addresses review comments on the main PR, particularly this thread https://github.com/OffchainLabs/nitro/pull/2561#pullrequestreview-2452584907

We add a new config option to Timeboost config 
```
`--execution.sequencer.timeboost.max-queued-tx-count` -> maximum allowed number of express lane txs with future sequence number to be queued. Set 0 to disable this check and a negative value to prevent queuing of any future sequence number transactions.
```