### PR TITLE
**Fix Typo in `main.rs`**

### DIFF
--- a/arbitrator/wasm-testsuite/src/main.rs
+++ b/arbitrator/wasm-testsuite/src/main.rs
@@ -279,7 +279,7 @@ fn main() -> eyre::Result<()> {
     }
 
     'next: for (index, command) in case.commands.into_iter().enumerate() {
-        // each iteration represets a test case
+        // each iteration represents a test case
 
         macro_rules! test_success {
             ($func:expr, $args:expr, $expected:expr) => {


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `main.rs`**

## Description  
This pull request fixes a typo in the `main.rs` file, improving the clarity of the comment.

### Changes Made:
- **File Modified:** `arbitrator/wasm-testsuite/src/main.rs`
- **Summary of Changes:**  
  - Corrected the typo in the comment from `represets` to `represents`.

## Checklist  
- [x] Fixed the typo in the comment.
- [x] Verified that the project builds and runs correctly after the change.
- [x] Ensured the correction adheres to the project's contributing guidelines.

## Additional Notes  
This update enhances the readability of the code comments, ensuring better comprehension for developers working on the project.

---

**Allow edits by maintainers:** [x]
