### PR TITLE
feat: disable sequencer MaxTxDataSize check against sequencer inbox MaxDataSize when DA is enabled

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -580,12 +580,15 @@ func mainImpl() int {
 			return 1
 		}
 	}
-	// If sequencer is enabled, validate MaxTxDataSize to be at least 5kB below the batch poster's MaxSize to allow space for headers and such.
-	// And since batchposter's MaxSize is to be at least 10kB below the sequencer inbox’s maxDataSize, this leads to another condition of atlest 15kB below the sequencer inbox’s maxDataSize.
 	if nodeConfig.Execution.Sequencer.Enable {
-		if nodeConfig.Execution.Sequencer.MaxTxDataSize > nodeConfig.Node.BatchPoster.MaxSize-5000 ||
-			nodeConfig.Execution.Sequencer.MaxTxDataSize > seqInboxMaxDataSize-15000 {
-			log.Error("sequencer's MaxTxDataSize too large")
+		// Validate MaxTxDataSize to be at least 5kB below the batch poster's MaxSize to allow space for headers and such.
+		if nodeConfig.Execution.Sequencer.MaxTxDataSize > nodeConfig.Node.BatchPoster.MaxSize-5000 {
+			log.Error("sequencer's MaxTxDataSize too large compared to the batchPoster's MaxSize")
+			return 1
+		}
+		// If DA is not enabled then since batchposter's MaxSize is to be at least 10kB below the sequencer inbox’s maxDataSize, this leads to another condition of atlest 15kB below the sequencer inbox’s maxDataSize.
+		if nodeConfig.Execution.Sequencer.MaxTxDataSize > seqInboxMaxDataSize-15000 && !nodeConfig.Node.DataAvailability.Enable {
+			log.Error("sequencer's MaxTxDataSize too large compared to the sequencer inbox's MaxDataSize")
 			return 1
 		}
 	}


### PR DESCRIPTION
currently when DA is enabled the batch poster MaxSize check against the sequencer inbox MaxDataSize is disabled. hoping for the same behavior on the sequencer MaxTxDataSize check so that we can increase an orbit chain's max transaction size when Anytrust is enabled.

keeping the check of the sequencer MaxTxDataSize against the batchPoster MaxSize as i'm assuming this is needed even when using an alt DA.

by doing this, we can theoretically increase the sequencer MaxTxDataSize to ~212KB(limited by another check in the sequencer logic against arbostypes.MaxL2MessageSize) provided that we also bump the batchPoster MaxSize appropriately.

originally was going to create a new dangerous flag for the sequencer that would disable all of these checks. however, i think this is a potentially simpler fix as comparing the sequencer MaxTxDataSize with the sequencer inbox MaxDataSize is probably not needed when the Anytrust commitment in the sequencer inbox is a small/fixed size. would greatly appreciate any details if this is not a correct assumption to make.

i'm still trying to get my local `nitro` build behaving correctly so I can properly add unit tests in `config_test.go`.

original discussion in Slack for context(in the #alchemy-arbitrum-raas channel): https://alchemyinsights.slack.com/archives/C06SZ7EKS2H/p1730259929195879