### PR TITLE
Add the installation of cbindgen to the Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,10 @@ FROM wasm-base AS wasm-libs-builder
 	# clang / lld used by soft-float wasm
 RUN apt-get update && \
     apt-get install -y clang=1:14.0-55.7~deb12u1 lld=1:14.0-55.7~deb12u1 wabt
-    # pinned rust 1.80.1
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.80.1 --target x86_64-unknown-linux-gnu wasm32-unknown-unknown wasm32-wasi
+# pinned rust 1.80.1
+RUN curl --proto '=https' --tlsv1.2 -sSf \
+		https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.80.1 \
+		--target x86_64-unknown-linux-gnu wasm32-unknown-unknown wasm32-wasi
 COPY ./Makefile ./
 COPY arbitrator/Cargo.* arbitrator/
 COPY arbitrator/arbutil arbitrator/arbutil
@@ -231,6 +233,10 @@ ENV NITRO_MODIFIED=$modified
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y wabt
+# pinned rust 1.80.1
+RUN curl --proto '=https' --tlsv1.2 -sSf \
+		https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.80.1 \
+		--target x86_64-unknown-linux-gnu wasm32-unknown-unknown wasm32-wasi
 COPY go.mod go.sum ./
 COPY go-ethereum/go.mod go-ethereum/go.sum go-ethereum/
 COPY fastcache/go.mod fastcache/go.sum fastcache/
@@ -247,7 +253,7 @@ COPY --from=brotli-library-export / target/
 COPY --from=prover-export / target/
 RUN mkdir -p target/bin
 COPY .nitro-tag.txt /nitro-tag.txt
-RUN NITRO_BUILD_IGNORE_TIMESTAMPS=1 make build
+RUN . ~/.cargo/env && NITRO_BUILD_IGNORE_TIMESTAMPS=1 make build
 
 FROM node-builder AS fuzz-builder
 RUN mkdir fuzzers/

--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,15 @@ build-wasm-bin: $(replay_wasm)
 .PHONY: build-solidity
 build-solidity: .make/solidity
 
+.PHONY: ensure-cbindgen
+ensure-cbindgen:
+	@if ! command -v cbindgen >/dev/null 2>&1; then \
+		echo "cbindgen not found. Installing..."; \
+		cargo install --force cbindgen; \
+	else \
+		echo "cbindgen already installed."; \
+	fi
+
 .PHONY: contracts
 contracts: .make/solgen
 	@printf $(done)
@@ -355,7 +364,7 @@ $(arbitrator_cases)/rust/$(wasm32_wasi)/%.wasm: $(arbitrator_cases)/rust/src/bin
 $(arbitrator_cases)/go/testcase.wasm: $(arbitrator_cases)/go/*.go .make/solgen
 	cd $(arbitrator_cases)/go && GOOS=wasip1 GOARCH=wasm go build -o testcase.wasm
 
-$(arbitrator_generated_header): $(DEP_PREDICATE) $(stylus_files)
+$(arbitrator_generated_header): $(DEP_PREDICATE) $(stylus_files) ensure-cbindgen
 	@echo creating ${PWD}/$(arbitrator_generated_header)
 	mkdir -p `dirname $(arbitrator_generated_header)`
 	cd arbitrator/stylus && cbindgen --config cbindgen.toml --crate stylus --output ../../$(arbitrator_generated_header)


### PR DESCRIPTION
In the codeql-analysis workflow, this binary is not being installed, but it is needed for one of the targets to build correctly.

This has been tested on both Linux and Mac and solves the problem.