### PR TITLE
Add cbindgen to both workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        
+      - name: Install cbindgen
+        run: cargo install --force cbindgen
 
       - name: Cache Build Products
         uses: actions/cache@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,12 +81,14 @@ jobs:
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
 
+    - name: Install cbindgen
+      run: cargo install --force cbindgen
+
     - name: Cache Rust Build Products
       uses: actions/cache@v3
       with:
         path: |
-          ~/.cargo/registry/
-          ~/.cargo/git/
+          ~/.cargo/
           arbitrator/target/
           arbitrator/wasm-libraries/target/
           arbitrator/wasm-libraries/soft-float/SoftFloat/build
@@ -128,7 +130,7 @@ jobs:
         restore-keys: ${{ runner.os }}-go-
 
     - name: Build all lint dependencies
-      run: cargo install --force cbindgen && make -j build-node-deps
+      run: make -j build-node-deps
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun


### PR DESCRIPTION
It turns out that the ci.yml workflow was also failing because of the removal of cbindgen from the Ubuntu 24.04 image used by the GitHub action runners.

This change also moves the installation of cbindgen earlier in the codequl-analysis.yml file and expands the scope of what is cached after a rust installation to include the cbindgen binary (which is installed in ~/.cargo/bin)