### PR TITLE
Express lane timeboost auctioneer rpc forwarding and sequencer coordinator

### DIFF
--- a/execution/gethexec/forwarder.go
+++ b/execution/gethexec/forwarder.go
@@ -141,10 +141,12 @@ func (f *TxForwarder) PublishTransaction(inctx context.Context, tx *types.Transa
 		} else {
 			err = arbitrum.SendConditionalTransactionRPC(ctx, rpcClient, tx, options)
 		}
+		if err != nil {
+			log.Warn("error forwarding transaction to a backup target", "target", f.targets[pos], "err", err)
+		}
 		if err == nil || !f.tryNewForwarderErrors.MatchString(err.Error()) {
 			return err
 		}
-		log.Warn("error forwarding transaction to a backup target", "target", f.targets[pos], "err", err)
 	}
 	return errors.New("failed to publish transaction to any of the forwarding targets")
 }
@@ -157,10 +159,12 @@ func (f *TxForwarder) PublishExpressLaneTransaction(inctx context.Context, msg *
 	defer cancelFunc()
 	for pos, rpcClient := range f.rpcClients {
 		err := sendExpressLaneTransactionRPC(ctx, rpcClient, msg)
+		if err != nil {
+			log.Warn("error forwarding express lane transaction to a backup target", "target", f.targets[pos], "err", err)
+		}
 		if err == nil || !f.tryNewForwarderErrors.MatchString(err.Error()) {
 			return err
 		}
-		log.Warn("error forwarding transaction to a backup target", "target", f.targets[pos], "err", err)
 	}
 	return errors.New("failed to publish transaction to any of the forwarding targets")
 }
@@ -181,10 +185,12 @@ func (f *TxForwarder) PublishAuctionResolutionTransaction(inctx context.Context,
 	defer cancelFunc()
 	for pos, rpcClient := range f.rpcClients {
 		err := sendAuctionResolutionTransactionRPC(ctx, rpcClient, tx)
+		if err != nil {
+			log.Warn("error forwarding auction resolution transaction to a backup target", "target", f.targets[pos], "err", err)
+		}
 		if err == nil || !f.tryNewForwarderErrors.MatchString(err.Error()) {
 			return err
 		}
-		log.Warn("error forwarding transaction to a backup target", "target", f.targets[pos], "err", err)
 	}
 	return errors.New("failed to publish transaction to any of the forwarding targets")
 }

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -281,7 +281,7 @@ func CreateExecutionNode(
 		Version:       "1.0",
 		Service:       NewArbTimeboostAuctioneerAPI(txPublisher),
 		Public:        false,
-		Authenticated: true, // Only exposed via JWT Auth to the auctioneer.
+		Authenticated: false,
 	})
 	apis = append(apis, rpc.API{
 		Namespace: "timeboost",

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -514,7 +514,10 @@ func (s *Sequencer) PublishAuctionResolutionTransaction(ctx context.Context, tx 
 		return err
 	}
 	if forwarder != nil {
-		return fmt.Errorf("sequencer is currently not the chosen one, cannot accept auction resolution tx")
+		err := forwarder.PublishAuctionResolutionTransaction(ctx, tx)
+		if !errors.Is(err, ErrNoSequencer) {
+			return err
+		}
 	}
 
 	arrivalTime := time.Now()

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 	"net"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -72,9 +71,8 @@ func testTxsHandlingDuringSequencerSwap(t *testing.T, dueToCrash bool) {
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(tmpDir))
 	})
-	jwtSecretPath := filepath.Join(tmpDir, "sequencer.jwt")
 
-	auctionContractAddr, aliceBidderClient, bobBidderClient, roundDuration, builderSeq, cleanupSeq, forwarder, cleanupForwarder := setupExpressLaneAuction(t, tmpDir, ctx, jwtSecretPath, withForwardingSeq)
+	auctionContractAddr, aliceBidderClient, bobBidderClient, roundDuration, builderSeq, cleanupSeq, forwarder, cleanupForwarder := setupExpressLaneAuction(t, tmpDir, ctx, withForwardingSeq)
 	seqB, seqClientB, seqInfo := builderSeq.L2.ConsensusNode, builderSeq.L2.Client, builderSeq.L2Info
 	seqA := forwarder.ConsensusNode
 	if !dueToCrash {
@@ -206,9 +204,8 @@ func TestForwardingExpressLaneTxs(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(tmpDir))
 	})
-	jwtSecretPath := filepath.Join(tmpDir, "sequencer.jwt")
 
-	auctionContractAddr, aliceBidderClient, bobBidderClient, roundDuration, builderSeq, cleanupSeq, forwarder, cleanupForwarder := setupExpressLaneAuction(t, tmpDir, ctx, jwtSecretPath, withForwardingSeq)
+	auctionContractAddr, aliceBidderClient, bobBidderClient, roundDuration, builderSeq, cleanupSeq, forwarder, cleanupForwarder := setupExpressLaneAuction(t, tmpDir, ctx, withForwardingSeq)
 	seqClient, seqInfo := builderSeq.L2.Client, builderSeq.L2Info
 	defer cleanupSeq()
 	defer cleanupForwarder()
@@ -252,9 +249,8 @@ func TestExpressLaneTransactionHandlingComplex(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(tmpDir))
 	})
-	jwtSecretPath := filepath.Join(tmpDir, "sequencer.jwt")
 
-	auctionContractAddr, aliceBidderClient, bobBidderClient, roundDuration, builderSeq, cleanupSeq, _, _ := setupExpressLaneAuction(t, tmpDir, ctx, jwtSecretPath, 0)
+	auctionContractAddr, aliceBidderClient, bobBidderClient, roundDuration, builderSeq, cleanupSeq, _, _ := setupExpressLaneAuction(t, tmpDir, ctx, 0)
 	seq, seqClient, seqInfo := builderSeq.L2.ConsensusNode, builderSeq.L2.Client, builderSeq.L2Info
 	defer cleanupSeq()
 
@@ -350,9 +346,8 @@ func TestExpressLaneTransactionHandling(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(tmpDir))
 	})
-	jwtSecretPath := filepath.Join(tmpDir, "sequencer.jwt")
 
-	auctionContractAddr, aliceBidderClient, bobBidderClient, roundDuration, builderSeq, cleanupSeq, _, _ := setupExpressLaneAuction(t, tmpDir, ctx, jwtSecretPath, 0)
+	auctionContractAddr, aliceBidderClient, bobBidderClient, roundDuration, builderSeq, cleanupSeq, _, _ := setupExpressLaneAuction(t, tmpDir, ctx, 0)
 	seq, seqClient, seqInfo := builderSeq.L2.ConsensusNode, builderSeq.L2.Client, builderSeq.L2Info
 	defer cleanupSeq()
 
@@ -944,9 +939,8 @@ func TestSequencerFeed_ExpressLaneAuction_ExpressLaneTxsHaveAdvantage(t *testing
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(tmpDir))
 	})
-	jwtSecretPath := filepath.Join(tmpDir, "sequencer.jwt")
 
-	auctionContractAddr, aliceBidderClient, bobBidderClient, roundDuration, builderSeq, cleanupSeq, _, _ := setupExpressLaneAuction(t, tmpDir, ctx, jwtSecretPath, 0)
+	auctionContractAddr, aliceBidderClient, bobBidderClient, roundDuration, builderSeq, cleanupSeq, _, _ := setupExpressLaneAuction(t, tmpDir, ctx, 0)
 	seq, seqClient, seqInfo := builderSeq.L2.ConsensusNode, builderSeq.L2.Client, builderSeq.L2Info
 	defer cleanupSeq()
 
@@ -991,8 +985,7 @@ func TestSequencerFeed_ExpressLaneAuction_InnerPayloadNoncesAreRespected_Timeboo
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(tmpDir))
 	})
-	jwtSecretPath := filepath.Join(tmpDir, "sequencer.jwt")
-	auctionContractAddr, aliceBidderClient, bobBidderClient, roundDuration, builderSeq, cleanupSeq, feedListener, cleanupFeedListener := setupExpressLaneAuction(t, tmpDir, ctx, jwtSecretPath, withFeedListener)
+	auctionContractAddr, aliceBidderClient, bobBidderClient, roundDuration, builderSeq, cleanupSeq, feedListener, cleanupFeedListener := setupExpressLaneAuction(t, tmpDir, ctx, withFeedListener)
 	seq, seqClient, seqInfo := builderSeq.L2.ConsensusNode, builderSeq.L2.Client, builderSeq.L2Info
 	defer cleanupSeq()
 	defer cleanupFeedListener()
@@ -1268,11 +1261,9 @@ func setupExpressLaneAuction(
 	t *testing.T,
 	dbDirPath string,
 	ctx context.Context,
-	jwtSecretPath string,
 	extraNodeTy extraNodeType,
 ) (common.Address, *timeboost.BidderClient, *timeboost.BidderClient, time.Duration, *NodeBuilder, func(), *TestClient, func()) {
 	seqPort := getRandomPort(t)
-	seqAuthPort := getRandomPort(t)
 	forwarderPort := getRandomPort(t)
 
 	nodeNames := []string{fmt.Sprintf("http://127.0.0.1:%d", seqPort), fmt.Sprintf("http://127.0.0.1:%d", forwarderPort)}
@@ -1282,10 +1273,7 @@ func setupExpressLaneAuction(
 	builderSeq := NewNodeBuilder(ctx).DefaultConfig(t, true)
 	builderSeq.l2StackConfig.HTTPHost = "localhost"
 	builderSeq.l2StackConfig.HTTPPort = seqPort
-	builderSeq.l2StackConfig.HTTPModules = []string{"eth", "arb", "debug", "timeboost"}
-	builderSeq.l2StackConfig.AuthPort = seqAuthPort
-	builderSeq.l2StackConfig.AuthModules = []string{"eth", "arb", "debug", "timeboost", "auctioneer"}
-	builderSeq.l2StackConfig.JWTSecret = jwtSecretPath
+	builderSeq.l2StackConfig.HTTPModules = []string{"eth", "arb", "debug", "timeboost", "auctioneer"}
 	builderSeq.nodeConfig.Feed.Output = *newBroadcasterConfigTest()
 	builderSeq.nodeConfig.Dangerous.NoSequencerCoordinator = false
 	builderSeq.nodeConfig.SeqCoordinator.Enable = true
@@ -1314,8 +1302,6 @@ func setupExpressLaneAuction(
 		forwarderNodeCfg.SeqCoordinator.MyUrl = nodeNames[1]
 		forwarderNodeCfg.SeqCoordinator.DeleteFinalizedMsgs = false
 		builderSeq.l2StackConfig.HTTPPort = forwarderPort
-		builderSeq.l2StackConfig.AuthPort = getRandomPort(t)
-		builderSeq.l2StackConfig.JWTSecret = jwtSecretPath
 		extraNode, cleanupExtraNode = builderSeq.Build2ndNode(t, &SecondNodeParams{nodeConfig: forwarderNodeCfg})
 	case withFeedListener:
 		tcpAddr, ok := seqNode.BroadcastServer.ListenerAddr().(*net.TCPAddr)
@@ -1533,11 +1519,10 @@ func setupExpressLaneAuction(
 	bidValidator.Start(ctx)
 
 	auctioneerCfg := &timeboost.AuctioneerServerConfig{
-		SequencerEndpoint:      fmt.Sprintf("http://localhost:%d", seqAuthPort),
+		SequencerEndpoint:      fmt.Sprintf("http://localhost:%d", seqPort),
 		AuctionContractAddress: proxyAddr.Hex(),
 		RedisURL:               redisURL,
 		ConsumerConfig:         pubsub.TestConsumerConfig,
-		SequencerJWTPath:       jwtSecretPath,
 		DbDirectory:            dbDirPath,
 		Wallet: genericconf.WalletConfig{
 			PrivateKey: fmt.Sprintf("00%x", seqInfo.Accounts["AuctionContract"].PrivateKey.D.Bytes()),

--- a/timeboost/sequencer_endpoint_manager.go
+++ b/timeboost/sequencer_endpoint_manager.go
@@ -1,0 +1,137 @@
+// Copyright 2024-2025, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package timeboost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/offchainlabs/nitro/util/redisutil"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
+)
+
+type SequencerEndpointManager interface {
+	GetSequencerRPC(ctx context.Context) (*rpc.Client, bool, error)
+}
+
+type RedisEndpointManager struct {
+	stopwaiter.StopWaiterSafe
+	redisCoordinator *redisutil.RedisCoordinator
+	jwtPath          string
+	clientMutex      sync.Mutex
+	client           *rpc.Client
+	clientUrl        string
+}
+
+func NewRedisEndpointManager(redisCoordinator *redisutil.RedisCoordinator, jwtPath string) SequencerEndpointManager {
+	return &RedisEndpointManager{
+		redisCoordinator: redisCoordinator,
+		jwtPath:          jwtPath,
+	}
+}
+
+func (m *RedisEndpointManager) GetSequencerRPC(ctx context.Context) (*rpc.Client, bool, error) {
+	sequencerUrl, err := m.redisCoordinator.CurrentChosenSequencer(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get current sequencer: %w", err)
+	}
+	if sequencerUrl == "" {
+		sequencerUrl, err = m.redisCoordinator.RecommendSequencerWantingLockout(ctx)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to get recommended sequencer: %w", err)
+		}
+		if sequencerUrl == "" {
+			return nil, false, errors.New("no sequencer available")
+		}
+	}
+
+	m.clientMutex.Lock()
+	defer m.clientMutex.Unlock()
+
+	if m.client != nil {
+		// Check if we're still using the correct sequencer
+		if err == nil && m.clientUrl == sequencerUrl {
+			return m.client, false, nil
+		}
+		// Sequencer changed, close old client
+		m.client.Close()
+		m.client = nil
+	}
+
+	client, err := createRPCClient(ctx, sequencerUrl, m.jwtPath)
+	if err != nil {
+		return nil, false, err
+	}
+	log.Info("Created sequencer client", "url", sequencerUrl)
+
+	m.client = client
+	m.clientUrl = sequencerUrl
+	return client, true, nil
+}
+
+type StaticEndpointManager struct {
+	endpoint string
+	jwtPath  string
+	client   *rpc.Client
+}
+
+func NewStaticEndpointManager(endpoint string, jwtPath string) SequencerEndpointManager {
+	return &StaticEndpointManager{
+		endpoint: endpoint,
+		jwtPath:  jwtPath,
+	}
+}
+
+func (m *StaticEndpointManager) GetSequencerRPC(ctx context.Context) (*rpc.Client, bool, error) {
+	new := false
+	if m.client == nil {
+		client, err := createRPCClient(ctx, m.endpoint, m.jwtPath)
+		if err != nil {
+			return nil, false, err
+		}
+		m.client = client
+		new = true
+	}
+	return m.client, new, nil
+}
+
+func createRPCClient(ctx context.Context, endpoint string, jwtPath string) (*rpc.Client, error) {
+	if jwtPath == "" {
+		return rpc.DialContext(ctx, endpoint)
+	}
+
+	// Create RPC client with JWT auth
+	sequencerJwtStr, err := os.ReadFile(jwtPath)
+	if err != nil {
+		return nil, err
+	}
+	sequencerJwt, err := hexutil.Decode(string(sequencerJwtStr))
+	if err != nil {
+		return nil, err
+	}
+
+	return rpc.DialOptions(ctx, endpoint, rpc.WithHTTPAuth(func(h http.Header) error {
+		claims := jwt.MapClaims{
+			"iat": time.Now().Unix(),
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+		tokenString, err := token.SignedString(sequencerJwt)
+		if err != nil {
+			return fmt.Errorf("could not produce signed JWT token: %w", err)
+		}
+		h.Set("Authorization", fmt.Sprintf("Bearer %s", tokenString))
+		return nil
+	}))
+}


### PR DESCRIPTION
This PR enables forwarding of express lane auction resolution txs ("auctioneer" namespace) and disables the requirement for JWT auth since the auction resolution method is already checked for signature by the auctioneer.

It also adds two new options for the autonomous-auctioneer which allow it to discover the active sequencer so that it can send its auction resolution transactions directly to it. If the sequencer is using the redis coordinator to manage which sequencer is active, then the same redis url can be passed as an option to the auctioneer.

The new options are:
    --auctioneer-server.redis-coordinator-url
    --auctioneer-server.use-redis-coordinator


# Testing done
## Forwaring feature
Tested with nitro-testnode timeboost-mode branch: https://github.com/OffchainLabs/nitro-testnode/pull/95

```
./test-node.bash --init-force --dev --l2-timeboost --redundantsequencers 1 2>&1 | tee run_`date +%s`.log
```

Tested running timeboost-test https://github.com/OffchainLabs/timeboost-test targeting the forwarding sequencer with the following configuration, and observed that auction resolution messages are forwarded correctly and resolution occurs.
```
$ cat .env
# Account parameters key
PRIVATE_KEY=0x5c5c2c164ead6e3f0aa2e8db343277538e644edf994cdf048ca5ca633c822d5e
CONTENDER_PRIVATE_KEY=0xab65119bd544c8557915190bd5254f6462372c6633b4aba337c38ca59bb11793

# Chain parameters
RPC=http://localhost:8547
CHAIN_ID=412346
SEQUENCER_ENDPOINT=http://localhost:8547

# Timeboost parameters
TB_AUCTION_CONTRACT_ADDRESS=0x7DD3F2a3fAeF3B9F2364c335163244D3388Feb83
TB_BID_VALIDATOR_ENDPOINT=http://localhost:9372
AUCTION_STARTS_AT_SECONDS_IN_MINUTE=5   # Adding some leeway (5 seconds) to the auction starting time
AUCTION_ENDS_AT_SECONDS_IN_MINUTE=50    # Adding some leeway (5 seconds) to the auction ending time

# Bidding parameters
BID_AMOUNT_WEI=20
CONTENDER_BID_AMOUNT_WEI=10
 
# Debugging parameters
SEND_TRANSACTION_TO_TRIGGER_NEW_BLOCKS=true
SECONDS_TO_WAIT_BETWEEN_EL_TRANSACTIONS=2
ONLY_BIDDING_MODE=false
```

## Auctioneer using Sequencer Coordinator
 Tested with nitro-testnode timeboost-mode branch: https://github.com/OffchainLabs/nitro-testnode/pull/95

```
./test-node.bash --init-force --dev --l2-timeboost --redundantsequencers 2 2>&1 | tee run_`date +%s`.log
```

Ran timeboost-test as above, then disabled the primary sequencer
```
$ docker compose stop sequencer_b
```
then ran timeboost-test again.

Observed switchover in auctioneer logs:
```
INFO [01-28|17:50:47.001] Created sequencer client                 url=http://sequencer_c:8547
```

Checked logs from sequencer to see that correct sequencer was receiving the auction resolution message.
```
$ grep Prioritizing run_1738085748.log
sequencer_b-1              | INFO [01-28|17:48:47.008] Prioritizing auction resolution transaction from auctioneer txHash=0x694b0b72d772175779f6cd2254a805af73b879f8e8c5c427b5dc59188fb7b5fc
sequencer_c-1              | INFO [01-28|17:50:47.010] Prioritizing auction resolution transaction from auctioneer txHash=0x587bc0bfd3864f6fce67d49418648691c183cb4e6e89221887d97ce4cdf3660b
```