### PR TITLE
Attempt to Reduce Flakiness of BoLD Virtual Block System Tests

### DIFF
--- a/staker/bold/bold_state_provider.go
+++ b/staker/bold/bold_state_provider.go
@@ -38,10 +38,6 @@ var (
 
 var executionNodeOfflineGauge = metrics.NewRegisteredGauge("arb/state_provider/execution_node_offline", nil)
 
-var (
-	ErrChainCatchingUp = errors.New("chain catching up")
-)
-
 type BOLDStateProvider struct {
 	validator                *staker.BlockValidator
 	statelessValidator       *staker.StatelessBlockValidator
@@ -171,7 +167,7 @@ func (s *BOLDStateProvider) isStateValidatedAndMessageCountPastThreshold(
 		return false, err
 	}
 	if lastValidatedGs == nil {
-		return false, ErrChainCatchingUp
+		return false, l2stateprovider.ErrChainCatchingUp
 	}
 	stateValidated := gs.Batch < lastValidatedGs.GlobalState.Batch || (gs.Batch == lastValidatedGs.GlobalState.Batch && gs.PosInBatch <= lastValidatedGs.GlobalState.PosInBatch)
 	return stateValidated, nil

--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -881,7 +881,7 @@ func makeBoldBatch(
 		if i == divergeAtIndex {
 			value++
 		}
-		err := writeTxToBatchBold(batchBuffer, l2Info.PrepareTx("Owner", "Destination", 1000000, big.NewInt(value), []byte{}))
+		err := writeTxToBatchBold(batchBuffer, l2Info.PrepareTx("Owner", "Faucet", 1000000, big.NewInt(value), []byte{}))
 		Require(t, err)
 	}
 	compressed, err := arbcompress.CompressWell(batchBuffer.Bytes())

--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -881,7 +881,7 @@ func makeBoldBatch(
 		if i == divergeAtIndex {
 			value++
 		}
-		err := writeTxToBatchBold(batchBuffer, l2Info.PrepareTx("Owner", "Faucet", 1000000, big.NewInt(value), []byte{}))
+		err := writeTxToBatchBold(batchBuffer, l2Info.PrepareTx("Owner", "Destination", 1000000, big.NewInt(value), []byte{}))
 		Require(t, err)
 	}
 	compressed, err := arbcompress.CompressWell(batchBuffer.Bytes())

--- a/system_tests/bold_new_challenge_test.go
+++ b/system_tests/bold_new_challenge_test.go
@@ -157,23 +157,6 @@ func testChallengeProtocolBOLDVirtualBlocks(t *testing.T, wrongAtFirstVirtual bo
 	builder.L1Info.GenerateAccount("EvilAsserter")
 	fundBoldStaker(t, ctx, builder, "EvilAsserter")
 
-	TransferBalance(t, "Faucet", "Faucet", common.Big0, builder.L2Info, builder.L2.Client, ctx)
-
-	// Wait for both nodes' chains to catch up to at least a batch that includes the self-transfer
-	// from above. This makes sure that nodes have at least caught up to the required rollup chain state
-	// by reading batches from the parent chain.
-	nodeAExec := builder.L2.ExecNode
-	nodeBExec := evilNode.ExecNode
-	for {
-		nodeALatest := nodeAExec.Backend.APIBackend().CurrentHeader()
-		nodeBLatest := nodeBExec.Backend.APIBackend().CurrentHeader()
-		isCaughtUp := nodeALatest.Number.Uint64() == 2
-		areEqual := nodeALatest.Number.Uint64() == nodeBLatest.Number.Uint64()
-		if isCaughtUp && areEqual {
-			break
-		}
-	}
-
 	assertionChain, cleanupHonestChallengeManager := startBoldChallengeManager(t, ctx, builder, builder.L2, "HonestAsserter", nil)
 	defer cleanupHonestChallengeManager()
 
@@ -189,6 +172,8 @@ func testChallengeProtocolBOLDVirtualBlocks(t *testing.T, wrongAtFirstVirtual bo
 		return p
 	})
 	defer cleanupEvilChallengeManager()
+
+	TransferBalance(t, "Faucet", "Faucet", common.Big0, builder.L2Info, builder.L2.Client, ctx)
 
 	// Everything's setup, now just wait for the challenge to complete and ensure the honest party won
 


### PR DESCRIPTION
This PR attempts to reduce the ERROR log messages from bold system tests by using the standard l2stateprovider.ErrChainCatchingUp in the implementation of the bold state provider. Before this change, we would be seeing this with a ~20% occurrence

```
25-01-21T02:08:08.1359719Z ERROR[01-21|01:22:36.272] Could not submit latest assertion        err="could not get execution state at batch count 1 with parent block hash 0x0000000000000000000000000000000000000000000000000000000000000000: chain catching up" validatorName=HonestAsserter
```

The problem was that, in poster.go and sync.go in the bold/assertions package the l2stateprovider.ErrChainCatchingUp error is caught and logged at a lower severity, INFO, but the bold state provider implementation was not using that error type, opting instead to use its own.

This should have the effect of having a couple-hundred fewer ERROR-level log messages. But, it may not actually reduce the flakiness of the these challenge tests.