### PR TITLE
Avoids leaking execution.rpc.classic-redirect URL

### DIFF
--- a/system_tests/classic_redirect_test.go
+++ b/system_tests/classic_redirect_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/rpc"
+
 	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 

--- a/system_tests/classic_redirect_test.go
+++ b/system_tests/classic_redirect_test.go
@@ -1,0 +1,42 @@
+// Copyright 2021-2025, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
+
+package arbtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/offchainlabs/nitro/util/testhelpers"
+)
+
+func TestClassicRedirectURLNotLeaked(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// nitro will expect that listener provides an RPC server.
+	// However we don't need to provide a real RPC server here, so calls to it will fail
+	listener, err := testhelpers.FreeTCPPortListener()
+	Require(t, err)
+	defer listener.Close()
+
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
+	builder.execConfig.RPC.ClassicRedirect = "http://" + listener.Addr().String()
+	builder.execConfig.RPC.ClassicRedirectTimeout = time.Second
+	cleanup := builder.Build(t)
+	defer cleanup()
+
+	l2rpc := builder.L2.Stack.Attach()
+
+	var result traceResult
+	err = l2rpc.CallContext(ctx, &result, "arbtrace_call", callTxArgs{}, []string{"trace"}, rpc.BlockNumberOrHash{})
+	// checks that it errors and that the error message does not contains the classic redirect URL
+	expectedErrMsg := "Failed to call fallback API"
+	if err == nil || err.Error() != expectedErrMsg {
+		t.Fatalf("Expected error message to be %s, got %v", expectedErrMsg, err)
+	}
+}


### PR DESCRIPTION
Resolves NIT-3061

Avoids leaking --execution.rpc.classic-redirect URL, that can contain sensitive information such as API keys.

Depends on https://github.com/OffchainLabs/go-ethereum/pull/403