### PR TITLE
chainInfo supports track-block-metadata-from

### DIFF
--- a/cmd/chaininfo/chain_info.go
+++ b/cmd/chaininfo/chain_info.go
@@ -29,6 +29,7 @@ type ChainInfo struct {
 	SecondaryFeedUrl          string              `json:"secondary-feed-url"`
 	DasIndexUrl               string              `json:"das-index-url"`
 	HasGenesisState           bool                `json:"has-genesis-state"`
+	TrackBlockMetadataFrom    uint64              `json:"track-block-metadata-from,omitempty"`
 	ChainConfig               *params.ChainConfig `json:"chain-config"`
 	RollupAddresses           *RollupAddresses    `json:"rollup"`
 }

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -1023,6 +1023,8 @@ func applyChainParameters(k *koanf.Koanf, chainId uint64, chainName string, l2Ch
 	if chainInfo.DasIndexUrl != "" {
 		chainDefaults["node.batch-poster.max-size"] = 1_000_000
 	}
+	// 0 is default for any chain unless specified in the chain_defaults
+	chainDefaults["node.transaction-streamer.track-block-metadata-from"] = chainInfo.TrackBlockMetadataFrom
 	err = k.Load(confmap.Provider(chainDefaults, "."), nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
set track-block-metadata-from by chain-info

fixes: NIT-3087