### PR TITLE
Timeboost: Don't store or publish to feed, blockMetadata of blocks lower than TrackBlockMetadataFrom config option

### DIFF
--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -98,7 +98,7 @@ func TransactionStreamerConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Int(prefix+".max-broadcaster-queue-size", DefaultTransactionStreamerConfig.MaxBroadcasterQueueSize, "maximum cache of pending broadcaster messages")
 	f.Int64(prefix+".max-reorg-resequence-depth", DefaultTransactionStreamerConfig.MaxReorgResequenceDepth, "maximum number of messages to attempt to resequence on reorg (0 = never resequence, -1 = always resequence)")
 	f.Duration(prefix+".execute-message-loop-delay", DefaultTransactionStreamerConfig.ExecuteMessageLoopDelay, "delay when polling calls to execute messages")
-	f.Uint64(prefix+".track-block-metadata-from", DefaultTransactionStreamerConfig.TrackBlockMetadataFrom, "this is the block number starting from which missing of blockmetadata is being tracked in the local disk. This is also the starting position for bulk syncing of missing blockmetadata. Setting to zero (default value) disables this")
+	f.Uint64(prefix+".track-block-metadata-from", DefaultTransactionStreamerConfig.TrackBlockMetadataFrom, "this is the block number starting from which blockmetadata is being tracked in the local disk and is being published to the feed. This is also the starting position for bulk syncing of missing blockmetadata. Setting to zero (default value) disables this")
 }
 
 func NewTransactionStreamer(
@@ -492,13 +492,9 @@ func (s *TransactionStreamer) getMessageWithMetadataAndBlockInfo(seqNum arbutil.
 		return nil, err
 	}
 
-	key = dbKey(blockMetadataInputFeedPrefix, uint64(seqNum))
-	blockMetadata, err := s.db.Get(key)
+	blockMetadata, err := s.BlockMetadataAtCount(seqNum + 1)
 	if err != nil {
-		if !dbutil.IsErrNotFound(err) {
-			return nil, err
-		}
-		blockMetadata = nil
+		return nil, err
 	}
 
 	msgWithBlockInfo := arbostypes.MessageWithMetadataAndBlockInfo{
@@ -1026,6 +1022,9 @@ func (s *TransactionStreamer) WriteMessageFromSequencer(
 	if err := s.writeMessages(pos, []arbostypes.MessageWithMetadataAndBlockInfo{msgWithBlockInfo}, nil); err != nil {
 		return err
 	}
+	if s.trackBlockMetadataFrom == 0 || pos < s.trackBlockMetadataFrom {
+		msgWithBlockInfo.BlockMetadata = nil
+	}
 	s.broadcastMessages([]arbostypes.MessageWithMetadataAndBlockInfo{msgWithBlockInfo}, pos)
 
 	return nil
@@ -1071,22 +1070,24 @@ func (s *TransactionStreamer) writeMessage(pos arbutil.MessageIndex, msg arbosty
 		return err
 	}
 
-	if msg.BlockMetadata != nil {
-		// Only store non-nil BlockMetadata to db. In case of a reorg, we dont have to explicitly
-		// clear out BlockMetadata of the reorged message, since those messages will be handled by s.reorg()
-		// This also allows update of BatchGasCost in message without mistakenly erasing BlockMetadata
-		key = dbKey(blockMetadataInputFeedPrefix, uint64(pos))
-		return batch.Put(key, msg.BlockMetadata)
-	} else if s.trackBlockMetadataFrom != 0 && pos >= s.trackBlockMetadataFrom {
-		// Mark that blockMetadata is missing only if it isn't already present. This check prevents unnecessary marking
-		// when updating BatchGasCost or when adding messages from seq-coordinator redis that doesn't have block metadata
-		prevBlockMetadata, err := s.BlockMetadataAtCount(pos + 1)
-		if err != nil {
-			return err
-		}
-		if prevBlockMetadata == nil {
-			key = dbKey(missingBlockMetadataInputFeedPrefix, uint64(pos))
-			return batch.Put(key, nil)
+	if s.trackBlockMetadataFrom != 0 && pos >= s.trackBlockMetadataFrom {
+		if msg.BlockMetadata != nil {
+			// Only store non-nil BlockMetadata to db. In case of a reorg, we dont have to explicitly
+			// clear out BlockMetadata of the reorged message, since those messages will be handled by s.reorg()
+			// This also allows update of BatchGasCost in message without mistakenly erasing BlockMetadata
+			key = dbKey(blockMetadataInputFeedPrefix, uint64(pos))
+			return batch.Put(key, msg.BlockMetadata)
+		} else {
+			// Mark that blockMetadata is missing only if it isn't already present. This check prevents unnecessary marking
+			// when updating BatchGasCost or when adding messages from seq-coordinator redis that doesn't have block metadata
+			prevBlockMetadata, err := s.BlockMetadataAtCount(pos + 1)
+			if err != nil {
+				return err
+			}
+			if prevBlockMetadata == nil {
+				key = dbKey(missingBlockMetadataInputFeedPrefix, uint64(pos))
+				return batch.Put(key, nil)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR makes it that blockMetadata of a block is only tracked i.e `added to disk` and `published to feed` only if the flag/config option 
```
--node..transaction-streamer.track-block-metadata-from
```
is set and the block number is greater than or equal to this value. 

This change applies to both sequencer and non-sequencer nodes. This config option should be enabled (set to a non-zero value) if a node wishes to utilize timeboost block metadata in any manner.

Resolves NIT-3094