### PR TITLE
[NIT-2977] Add TestFastConfirmationWithdrawal

### DIFF
--- a/system_tests/fast_confirm_test.go
+++ b/system_tests/fast_confirm_test.go
@@ -45,6 +45,7 @@ import (
 )
 
 func TestFastConfirmationWithdrawal(t *testing.T) {
+	t.Parallel()
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
 	builder, stakerA, cleanupBuilder, cleanupBackgroundTx := setupFastConfirmation(ctx, t)

--- a/system_tests/fast_confirm_test.go
+++ b/system_tests/fast_confirm_test.go
@@ -61,14 +61,8 @@ func TestFastConfirmationWithdrawal(t *testing.T) {
 	tx, err := arbSys.WithdrawEth(&authL2, common.Address{})
 	Require(t, err, "ArbSys failed")
 
-	// Wait for transaction to be executed
-	time.Sleep(4 * time.Millisecond) // Geth takes a few ms for the receipt to show up
-	var receipt *types.Receipt
-	receipt, err = builder.L2.Client.TransactionReceipt(ctx, tx.Hash())
-	Require(t, err, "No receipt for txn")
-	if receipt.Status != types.ReceiptStatusSuccessful {
-		Fatal(t, "Tx failed with status code:", receipt)
-	}
+	receipt, err := builder.L2.EnsureTxSucceeded(tx)
+	Require(t, err)
 	if len(receipt.Logs) == 0 {
 		Fatal(t, "Tx didn't emit any logs")
 	}

--- a/system_tests/fast_confirm_test.go
+++ b/system_tests/fast_confirm_test.go
@@ -29,7 +29,11 @@ import (
 	"github.com/offchainlabs/nitro/arbnode/dataposter/externalsignertest"
 	"github.com/offchainlabs/nitro/arbnode/dataposter/storage"
 	"github.com/offchainlabs/nitro/arbos/l2pricing"
+	"github.com/offchainlabs/nitro/gethhook"
+	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/solgen/go/contractsgen"
+	"github.com/offchainlabs/nitro/solgen/go/node_interfacegen"
+	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/solgen/go/proxiesgen"
 	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
 	"github.com/offchainlabs/nitro/solgen/go/upgrade_executorgen"
@@ -40,9 +44,109 @@ import (
 	"github.com/offchainlabs/nitro/validator/valnode"
 )
 
+func TestFastConfirmationWithdrawal(t *testing.T) {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+	builder, stakerA, cleanupBuilder, cleanupBackgroundTx := setupFastConfirmation(ctx, t)
+	defer cleanupBuilder()
+	defer cleanupBackgroundTx()
+
+	// Withdraw ETH from L2 to L1
+	gethhook.RequireHookedGeth()
+	arbSys, err := precompilesgen.NewArbSys(types.ArbSysAddress, builder.L2.Client)
+	Require(t, err)
+	authL2 := builder.L2Info.GetDefaultTransactOpts("User", ctx)
+	authL2.Value = big.NewInt(1000)
+	tx, err := arbSys.WithdrawEth(&authL2, common.Address{})
+	Require(t, err, "ArbSys failed")
+
+	// Wait for transaction to be executed
+	time.Sleep(4 * time.Millisecond) // Geth takes a few ms for the receipt to show up
+	var receipt *types.Receipt
+	receipt, err = builder.L2.Client.TransactionReceipt(ctx, tx.Hash())
+	Require(t, err, "No receipt for txn")
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		Fatal(t, "Tx failed with status code:", receipt)
+	}
+	if len(receipt.Logs) == 0 {
+		Fatal(t, "Tx didn't emit any logs")
+	}
+
+	// Wait for staker to confirm the withdrawal
+	time.Sleep(time.Second)
+	tx, err = stakerA.Act(ctx)
+	Require(t, err)
+	if tx != nil {
+		_, err = builder.L1.EnsureTxSucceeded(tx)
+		Require(t, err)
+	}
+
+	arbSysAbi, err := precompilesgen.ArbSysMetaData.GetAbi()
+	Require(t, err, "failed to get abi")
+	withdrawTopic := arbSysAbi.Events["L2ToL1Tx"].ID
+	authL1 := builder.L1Info.GetDefaultTransactOpts("User", ctx)
+	nodeInterface, err := node_interfacegen.NewNodeInterface(types.NodeInterfaceAddress, builder.L2.Client)
+	Require(t, err)
+	merkleState, err := arbSys.SendMerkleTreeState(&bind.CallOpts{})
+	Require(t, err, "could not get merkle root")
+	bridgeBinding, err := bridgegen.NewBridge(builder.L1Info.GetAddress("Bridge"), builder.L1.Client)
+	Require(t, err)
+	outboxAddress, err := bridgeBinding.AllowedOutboxList(&bind.CallOpts{}, big.NewInt(0))
+	Require(t, err)
+	outboxBinding, err := bridgegen.NewOutbox(outboxAddress, builder.L1.Client)
+	Require(t, err)
+	// Check logs for withdraw event
+	for _, log := range receipt.Logs {
+		if log.Topics[0] == withdrawTopic {
+			parsedLog, err := arbSys.ParseL2ToL1Tx(*log)
+			Require(t, err, "Failed to parse log")
+
+			// Check NodeInterface.sol produces equivalent proofs
+			outboxProof, err := nodeInterface.ConstructOutboxProof(
+				&bind.CallOpts{}, merkleState.Size.Uint64(), parsedLog.Position.Uint64(),
+			)
+			Require(t, err)
+			// Execute the transaction on L1
+			execTx, err := outboxBinding.ExecuteTransaction(&authL1, outboxProof.Proof, parsedLog.Position, parsedLog.Caller, parsedLog.Destination, parsedLog.ArbBlockNum, parsedLog.EthBlockNum, parsedLog.Timestamp, parsedLog.Callvalue, parsedLog.Data)
+			Require(t, err)
+			time.Sleep(200 * time.Millisecond)
+			execReceipt, err := builder.L1.Client.TransactionReceipt(ctx, execTx.Hash())
+			Require(t, err, "No receipt for txn")
+			if execReceipt.Status != types.ReceiptStatusSuccessful {
+				Fatal(t, "Tx failed with status code:", receipt)
+			}
+			if len(execReceipt.Logs) == 0 {
+				Fatal(t, "Tx didn't emit any logs")
+			}
+		}
+	}
+}
+
 func TestFastConfirmation(t *testing.T) {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
+	builder, stakerA, cleanupBuilder, cleanupBackgroundTx := setupFastConfirmation(ctx, t)
+	defer cleanupBuilder()
+	defer cleanupBackgroundTx()
+
+	rollup, err := rollupgen.NewRollupAdminLogic(builder.L2.ConsensusNode.DeployInfo.Rollup, builder.L1.Client)
+	Require(t, err)
+	latestConfirmBeforeAct, err := rollup.LatestConfirmed(&bind.CallOpts{})
+	Require(t, err)
+	tx, err := stakerA.Act(ctx)
+	Require(t, err)
+	if tx != nil {
+		_, err = builder.L1.EnsureTxSucceeded(tx)
+		Require(t, err)
+	}
+	latestConfirmAfterAct, err := rollup.LatestConfirmed(&bind.CallOpts{})
+	Require(t, err)
+	if latestConfirmAfterAct <= latestConfirmBeforeAct {
+		Fatal(t, fmt.Sprintf("staker A didn't advance the latest confirmed node: want > %d, got: %d", latestConfirmBeforeAct, latestConfirmAfterAct))
+	}
+}
+
+func setupFastConfirmation(ctx context.Context, t *testing.T) (*NodeBuilder, *legacystaker.Staker, func(), func()) {
 	srv := externalsignertest.NewServer(t)
 	go func() {
 		if err := srv.Start(); err != nil {
@@ -58,10 +162,10 @@ func TestFastConfirmation(t *testing.T) {
 		types.NewArbitrumSigner(types.NewLondonSigner(builder.chainConfig.ChainID)), big.NewInt(l2pricing.InitialBaseFeeWei*2),
 		transferGas,
 	)
+	builder.L2Info.GenerateGenesisAccount("User", new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9)))
 
 	builder.nodeConfig.BatchPoster.MaxDelay = -1000 * time.Hour
-	cleanup := builder.Build(t)
-	defer cleanup()
+	cleanupBuilder := builder.Build(t)
 
 	addNewBatchPoster(ctx, t, builder, srv.Address)
 
@@ -81,9 +185,6 @@ func TestFastConfirmation(t *testing.T) {
 	balance.Mul(balance, big.NewInt(100))
 	builder.L1.TransferBalance(t, "Faucet", "Validator", balance, builder.L1Info)
 	l1auth := builder.L1Info.GetDefaultTransactOpts("Validator", ctx)
-
-	rollup, err := rollupgen.NewRollupAdminLogic(l2node.DeployInfo.Rollup, builder.L1.Client)
-	Require(t, err)
 
 	upgradeExecutor, err := upgrade_executorgen.NewUpgradeExecutor(l2node.DeployInfo.UpgradeExecutor, builder.L1.Client)
 	Require(t, err, "unable to bind upgrade executor")
@@ -191,10 +292,10 @@ func TestFastConfirmation(t *testing.T) {
 	// Continually make L2 transactions in a background thread
 	backgroundTxsCtx, cancelBackgroundTxs := context.WithCancel(ctx)
 	backgroundTxsShutdownChan := make(chan struct{})
-	defer (func() {
+	cleanupBackgroundTx := func() {
 		cancelBackgroundTxs()
 		<-backgroundTxsShutdownChan
-	})()
+	}
 	go (func() {
 		defer close(backgroundTxsShutdownChan)
 		err := makeBackgroundTxs(backgroundTxsCtx, builder)
@@ -202,20 +303,7 @@ func TestFastConfirmation(t *testing.T) {
 			log.Warn("error making background txs", "err", err)
 		}
 	})()
-
-	latestConfirmBeforeAct, err := rollup.LatestConfirmed(&bind.CallOpts{})
-	Require(t, err)
-	tx, err = stakerA.Act(ctx)
-	Require(t, err)
-	if tx != nil {
-		_, err = builder.L1.EnsureTxSucceeded(tx)
-		Require(t, err)
-	}
-	latestConfirmAfterAct, err := rollup.LatestConfirmed(&bind.CallOpts{})
-	Require(t, err)
-	if latestConfirmAfterAct <= latestConfirmBeforeAct {
-		Fatal(t, fmt.Sprintf("staker A didn't advance the latest confirmed node: want > %d, got: %d", latestConfirmBeforeAct, latestConfirmAfterAct))
-	}
+	return builder, stakerA, cleanupBuilder, cleanupBackgroundTx
 }
 
 func TestFastConfirmationWithSafe(t *testing.T) {

--- a/system_tests/fast_confirm_test.go
+++ b/system_tests/fast_confirm_test.go
@@ -104,12 +104,8 @@ func TestFastConfirmationWithdrawal(t *testing.T) {
 			// Execute the transaction on L1
 			execTx, err := outboxBinding.ExecuteTransaction(&authL1, outboxProof.Proof, parsedLog.Position, parsedLog.Caller, parsedLog.Destination, parsedLog.ArbBlockNum, parsedLog.EthBlockNum, parsedLog.Timestamp, parsedLog.Callvalue, parsedLog.Data)
 			Require(t, err)
-			time.Sleep(200 * time.Millisecond)
-			execReceipt, err := builder.L1.Client.TransactionReceipt(ctx, execTx.Hash())
-			Require(t, err, "No receipt for txn")
-			if execReceipt.Status != types.ReceiptStatusSuccessful {
-				Fatal(t, "Tx failed with status code:", receipt)
-			}
+			execReceipt, err := builder.L1.EnsureTxSucceeded(execTx)
+			Require(t, err)
 			if len(execReceipt.Logs) == 0 {
 				Fatal(t, "Tx didn't emit any logs")
 			}


### PR DESCRIPTION
Fixes: NIT-2977

Adding an end-to-end system test that sends message L2->l1, confirms it and executes it on L1.