### PR TITLE
Start tracking metadata in sepolia

### DIFF
--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -211,6 +211,7 @@
     "chain-name": "sepolia-rollup",
     "sequencer-url": "https://sepolia-rollup-sequencer.arbitrum.io/rpc",
     "feed-url": "wss://sepolia-rollup.arbitrum.io/feed",
+    "track-block-metadata-from": 123000000,
     "chain-config": {
       "chainId": 421614,
       "homesteadBlock": 0,


### PR DESCRIPTION
Add configuration for block to start tracking sepolia metadata.
