### PR TITLE
Update the pin check to expect the v2-main branch of nitro-contracts

### DIFF
--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           status_state="pending"
           declare -Ar exceptions=(
-            [contracts]=origin/pre-bold
+            [contracts]=origin/v2-main
             [nitro-testnode]=origin/master
 
             #TODO Rachel to check these are the intended branches.


### PR DESCRIPTION
This will immediately start failing once it's merged in, but, then we should be able to merge in https://github.com/OffchainLabs/nitro/pull/2914 which (in addition to adding the test, also sets the pin for the contracts submodule to v2-main.)