### PR TITLE
update stake-token to WETH on L1 for 3.5.1 branch

### DIFF
--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -44,7 +44,7 @@
       "sequencer-inbox": "0x1c479675ad559dc151f6ec7ed3fbf8cee79582b6",
       "validator-utils": "0x9e40625f52829cf04bc4839f186d621ee33b0e67",
       "validator-wallet-creator": "0x960953f7c69cd2bc2322db9223a815c680ccc7ea",
-      "stake-token": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "stake-token": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "deployed-at": 15411056
     }
   },
@@ -91,7 +91,7 @@
       "sequencer-inbox": "0x211e1c4c7f1bf5351ac850ed10fd68cffcf6c21b",
       "validator-utils": "0x2B081fbaB646D9013f2699BebEf62B7e7d7F0976",
       "validator-wallet-creator": "0xe05465Aab36ba1277dAE36aa27a7B74830e74DE4",
-      "stake-token": "0x765277eebeca2e31912c9946eae1021199b39c61",
+      "stake-token": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "deployed-at": 15016829
     }
   },


### PR DESCRIPTION
This small PR updates the "stake-token" address for Arbitrum Nova and Arbitrum One in `cmd/chaininfo/arbitrum_chain_info.json` to `0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2`, which is the L1 WETH contract address https://etherscan.io/address/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2