### PR TITLE
Hex encode bidder signatures in S3 published CSVs

### DIFF
--- a/timeboost/db.go
+++ b/timeboost/db.go
@@ -1,6 +1,7 @@
 package timeboost
 
 import (
+	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"os"
@@ -120,7 +121,7 @@ func (d *SqliteDatabase) InsertBid(b *ValidatedBid) error {
 		"AuctionContractAddress": b.AuctionContractAddress.Hex(),
 		"Round":                  b.Round,
 		"Amount":                 b.Amount.String(),
-		"Signature":              b.Signature,
+		"Signature":              hex.EncodeToString(b.Signature),
 	}
 	_, err := d.sqlDB.NamedExec(query, params)
 	if err != nil {

--- a/timeboost/db_test.go
+++ b/timeboost/db_test.go
@@ -1,6 +1,7 @@
 package timeboost
 
 import (
+	"encoding/hex"
 	"math/big"
 	"os"
 	"testing"
@@ -93,7 +94,7 @@ func TestInsertBids(t *testing.T) {
 			bid.AuctionContractAddress.Hex(),
 			bid.Round,
 			bid.Amount.String(),
-			bid.Signature,
+			hex.EncodeToString(bid.Signature),
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 	}
 


### PR DESCRIPTION
Previously the signature field, which is just raw bytes, was being written directly into the bid history CSVs which are published to S3 by the auctioneer.

The uploaded files are for consumption by external parties and not used by the auctioneer after they have been uploaded so no changes are needed to read the files.

This change is being made pre-mainnet so we don't need to worry about fixing existing files.