### PR TITLE
refactor: use a more straightforward return value

### DIFF
--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -377,7 +377,7 @@ func (p Programs) programExists(codeHash common.Hash, time uint64, params *Stylu
 	}
 	activatedAt := program.activatedAt
 	expired := activatedAt == 0 || hoursToAge(time, activatedAt) > am.DaysToSeconds(params.ExpiryDays)
-	return program.version, expired, program.cached, err
+	return program.version, expired, program.cached, nil
 }
 
 func (p Programs) ProgramKeepalive(codeHash common.Hash, time uint64, params *StylusParams) (*big.Int, error) {

--- a/arbos/storage/storage.go
+++ b/arbos/storage/storage.go
@@ -669,7 +669,7 @@ func (sbbi *StorageBackedBigInt) Get() (*big.Int, error) {
 	if asBig.Bit(255) != 0 {
 		asBig = new(big.Int).Sub(asBig, twoToThe256)
 	}
-	return asBig, err
+	return asBig, nil
 }
 
 // Warning: this will panic if it underflows or overflows with a system burner


### PR DESCRIPTION
use a more straightforward return value