### PR TITLE
Export IMAGE_TAG in buildspec

### DIFF
--- a/.github/buildspec.yml
+++ b/.github/buildspec.yml
@@ -1,5 +1,9 @@
 version: 0.2
 
+env:
+  exported-variables:
+    - IMAGE_TAG
+
 phases:
   pre_build:
     commands:


### PR DESCRIPTION
Allows the use of the calculated image tag for later stages without having to replicate the logic.