### PR TITLE
Remove cargo fmt check for rust from nitro repo

### DIFF
--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -170,15 +170,6 @@ jobs:
       - name: Check stylus_bechmark
         run: cargo check --manifest-path arbitrator/tools/stylus_benchmark/Cargo.toml
 
-      - name: Rustfmt
-        run: cargo fmt -p arbutil -p prover -p jit -p stylus --manifest-path arbitrator/Cargo.toml -- --check
-
-      - name: Rustfmt - langs/rust
-        run: cargo fmt --all --manifest-path arbitrator/langs/rust/Cargo.toml -- --check
-
-      - name: Rustfmt - tools/stylus_benchmark
-        run: cargo fmt --all --manifest-path arbitrator/tools/stylus_benchmark/Cargo.toml -- --check
-
       - name: Make proofs from test cases
         run: make -j test-gen-proofs
 

--- a/Makefile
+++ b/Makefile
@@ -577,9 +577,6 @@ contracts/test/prover/proofs/%.json: $(arbitrator_cases)/%.wasm $(prover_bin)
 
 .make/fmt: $(DEP_PREDICATE) build-node-deps .make/yarndeps $(ORDER_ONLY_PREDICATE) .make
 	golangci-lint run --disable-all -E gofmt --fix
-	cargo fmt -p arbutil -p prover -p jit -p stylus --manifest-path arbitrator/Cargo.toml -- --check
-	cargo fmt --all --manifest-path arbitrator/wasm-testsuite/Cargo.toml -- --check
-	cargo fmt --all --manifest-path arbitrator/langs/rust/Cargo.toml -- --check
 	yarn --cwd contracts prettier:solidity
 	@touch $@
 


### PR DESCRIPTION
It made sense to have fmt checks for rust when the SDK was part of nitro repo but that's not the case any more so doesn't make any sense today, hence removing the checks. 
