### PR TITLE
Increase default limit on the allowed number of future sequence numbered expressLane submissions

### DIFF
--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -107,7 +107,7 @@ var DefaultTimeboostConfig = TimeboostConfig{
 	ExpressLaneAdvantage:      time.Millisecond * 200,
 	SequencerHTTPEndpoint:     "http://localhost:8547",
 	EarlySubmissionGrace:      time.Second * 2,
-	MaxQueuedTxCount:          10,
+	MaxQueuedTxCount:          50,
 	MaxFutureSequenceDistance: 100,
 	RedisUrl:                  "unset",
 }


### PR DESCRIPTION
This PR increases the default limit on allowed count of expressLane submissions with future sequence number from 10 to 50, because a busy timeboost user might want to send a lot of txs all at once and since there's isn't any order of arrival it this limit may cause cascading errors. We do need this limit to prevent dos.