### PR TITLE
refactor: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/cmd/autonomous-auctioneer/main.go
+++ b/cmd/autonomous-auctioneer/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -36,7 +37,7 @@ func startMetrics(cfg *AutonomousAuctioneerConfig) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
 	if cfg.Metrics && !metrics.Enabled {
-		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+		return errors.New("metrics must be enabled via command line by adding --metrics, json config has no effect")
 	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)

--- a/cmd/conf/init.go
+++ b/cmd/conf/init.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"slices"
@@ -124,7 +125,7 @@ func (c *InitConfig) Validate() error {
 		if reorgOption >= 0 {
 			numReorgOptionsSpecified++
 			if numReorgOptionsSpecified > 1 {
-				return fmt.Errorf("at most one init reorg option can be specified")
+				return errors.New("at most one init reorg option can be specified")
 			}
 		}
 	}

--- a/cmd/daserver/daserver.go
+++ b/cmd/daserver/daserver.go
@@ -159,7 +159,7 @@ func startMetrics(cfg *DAServerConfig) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
 	if cfg.Metrics && !metrics.Enabled {
-		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+		return errors.New("metrics must be enabled via command line by adding --metrics, json config has no effect")
 	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)

--- a/cmd/nitro-val/nitro_val.go
+++ b/cmd/nitro-val/nitro_val.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	_ "net/http/pprof" // #nosec G108
@@ -40,7 +41,7 @@ func startMetrics(cfg *ValidationNodeConfig) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
 	if cfg.Metrics && !metrics.Enabled {
-		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+		return errors.New("metrics must be enabled via command line by adding --metrics, json config has no effect")
 	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -23,9 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cavaliergopher/grab/v3"
-	"github.com/codeclysm/extract/v3"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -75,7 +72,7 @@ func downloadInit(ctx context.Context, initConfig *conf.InitConfig) (string, err
 	}
 	file, err := downloadFile(ctx, initConfig, initConfig.Url, checksum)
 	if err != nil && errors.Is(err, notFoundError) {
-		return "", fmt.Errorf("file not found but checksum exists")
+		return "", errors.New("file not found but checksum exists")
 	}
 	return file, err
 }
@@ -177,7 +174,7 @@ func fetchChecksum(ctx context.Context, url string) ([]byte, error) {
 		return nil, fmt.Errorf("error decoding checksum: %w", err)
 	}
 	if len(checksum) != sha256.Size {
-		return nil, fmt.Errorf("invalid checksum length")
+		return nil, errors.New("invalid checksum length")
 	}
 	return checksum, nil
 }
@@ -204,7 +201,7 @@ func downloadInitInParts(ctx context.Context, initConfig *conf.InitConfig) (stri
 	for _, line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) != 2 {
-			return "", fmt.Errorf("manifest file in wrong format")
+			return "", errors.New("manifest file in wrong format")
 		}
 		checksum, err := hex.DecodeString(fields[0])
 		if err != nil {
@@ -246,7 +243,7 @@ func downloadInitInParts(ctx context.Context, initConfig *conf.InitConfig) (stri
 // joinArchive joins the archive parts into a single file and return its path.
 func joinArchive(parts []string, archivePath string) (string, error) {
 	if len(parts) == 0 {
-		return "", fmt.Errorf("no database parts found")
+		return "", errors.New("no database parts found")
 	}
 	archive, err := os.Create(archivePath)
 	if err != nil {
@@ -275,7 +272,7 @@ func setLatestSnapshotUrl(ctx context.Context, initConfig *conf.InitConfig, chai
 		return nil
 	}
 	if initConfig.Url != "" {
-		return fmt.Errorf("cannot set latest url if url is already set")
+		return errors.New("cannot set latest url if url is already set")
 	}
 	baseUrl, err := url.Parse(initConfig.LatestBase)
 	if err != nil {

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -149,7 +149,7 @@ func startMetrics(cfg *NodeConfig) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
 	if cfg.Metrics && !metrics.Enabled {
-		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+		return errors.New("metrics must be enabled via command line by adding --metrics, json config has no effect")
 	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -40,7 +41,7 @@ func startMetrics(cfg *relay.Config) error {
 	mAddr := fmt.Sprintf("%v:%v", cfg.MetricsServer.Addr, cfg.MetricsServer.Port)
 	pAddr := fmt.Sprintf("%v:%v", cfg.PprofCfg.Addr, cfg.PprofCfg.Port)
 	if cfg.Metrics && !metrics.Enabled {
-		return fmt.Errorf("metrics must be enabled via command line by adding --metrics, json config has no effect")
+		return errors.New("metrics must be enabled via command line by adding --metrics, json config has no effect")
 	}
 	if cfg.Metrics && cfg.PProf && mAddr == pAddr {
 		return fmt.Errorf("metrics and pprof cannot be enabled on the same address:port: %s", mAddr)

--- a/cmd/staterecovery/staterecovery.go
+++ b/cmd/staterecovery/staterecovery.go
@@ -1,6 +1,7 @@
 package staterecovery
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -18,7 +19,7 @@ func RecreateMissingStates(chainDb ethdb.Database, bc *core.BlockChain, cacheCon
 	start := time.Now()
 	currentHeader := bc.CurrentBlock()
 	if currentHeader == nil {
-		return fmt.Errorf("current header is nil")
+		return errors.New("current header is nil")
 	}
 	target := currentHeader.Number.Uint64()
 	current := startBlock

--- a/cmd/util/confighelpers/configuration.go
+++ b/cmd/util/confighelpers/configuration.go
@@ -315,5 +315,5 @@ func DumpConfig(k *koanf.Koanf, extraOverrideFields map[string]interface{}) erro
 
 	fmt.Println(string(c))
 	os.Exit(0)
-	return fmt.Errorf("Unreachable")
+	return errors.New("Unreachable")
 }

--- a/das/factory.go
+++ b/das/factory.go
@@ -6,8 +6,6 @@ package das
 import (
 	"context"
 	"errors"
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 
@@ -273,7 +271,7 @@ func CreateDAReaderForNode(
 	}
 
 	if !config.RestAggregator.Enable {
-		return nil, nil, nil, fmt.Errorf("--node.data-availability.enable was set but not --node.data-availability.rest-aggregator. When running a Nitro Anytrust node in non-Batch Poster mode, some way to get the batch data is required.")
+		return nil, nil, nil, errors.New("--node.data-availability.enable was set but not --node.data-availability.rest-aggregator. When running a Nitro Anytrust node in non-Batch Poster mode, some way to get the batch data is required.")
 	}
 	// Done checking config requirements
 


### PR DESCRIPTION
Replaced fmt.Errorf with errors.New in cases where formatting is not required. This reduces unnecessary function calls, leading to slightly improved performance and cleaner code.