### PR TITLE
backport shutdown deadlock fixed in #2991

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1081,9 +1081,6 @@ func (n *Node) StopAndWait() {
 	if n.MessagePruner != nil && n.MessagePruner.Started() {
 		n.MessagePruner.StopAndWait()
 	}
-	if n.BroadcastServer != nil && n.BroadcastServer.Started() {
-		n.BroadcastServer.StopAndWait()
-	}
 	if n.BroadcastClients != nil {
 		n.BroadcastClients.StopAndWait()
 	}
@@ -1104,6 +1101,9 @@ func (n *Node) StopAndWait() {
 	}
 	if n.TxStreamer.Started() {
 		n.TxStreamer.StopAndWait()
+	}
+	if n.BroadcastServer != nil && n.BroadcastServer.Started() {
+		n.BroadcastServer.StopAndWait()
 	}
 	if n.SeqCoordinator != nil && n.SeqCoordinator.Started() {
 		// Just stops the redis client (most other stuff was stopped earlier)

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1102,6 +1102,8 @@ func (n *Node) StopAndWait() {
 	if n.TxStreamer.Started() {
 		n.TxStreamer.StopAndWait()
 	}
+	// n.BroadcastServer is stopped after txStreamer and inboxReader because if done before it would lead to a deadlock, as the threads from these two components
+	// attempt to Broadcast i.e send feedMessage to clientManager's broadcastChan when there wont be any reader to read it as n.BroadcastServer would've been stopped
 	if n.BroadcastServer != nil && n.BroadcastServer.Started() {
 		n.BroadcastServer.StopAndWait()
 	}

--- a/wsbroadcastserver/clientmanager.go
+++ b/wsbroadcastserver/clientmanager.go
@@ -305,16 +305,7 @@ func (cm *ClientManager) Start(parentCtx context.Context) {
 		for {
 			select {
 			case <-ctx.Done():
-				// We need to drain cm.broadcastChan to make sure no threads are waiting indefinitely to send messages to it post shutdown (context cancellation)
-				// Its certain that draining shouldn't take indefinite time as the only function feeding to cm.broadcastChan checks first if cm.Stopped() is true
-				cm.StopOnly() // Lets be sure that cm.broadcastChan won't receive anything after context cancellation
-				for {
-					select {
-					case <-cm.broadcastChan:
-					default:
-						return
-					}
-				}
+				return
 			case clientAction := <-cm.clientAction:
 				if clientAction.create {
 					err := cm.registerClient(ctx, clientAction.cc)

--- a/wsbroadcastserver/clientmanager.go
+++ b/wsbroadcastserver/clientmanager.go
@@ -150,6 +150,7 @@ func (cm *ClientManager) Broadcast(bm *m.BroadcastMessage) {
 	}
 	cm.broadcastChan <- bm
 }
+
 func (cm *ClientManager) doBroadcast(bm *m.BroadcastMessage) ([]*ClientConnection, error) {
 	if err := cm.backlog.Append(bm); err != nil {
 		return nil, err


### PR DESCRIPTION
Backport of #2991 

During StopAndWait() invocation of txStreamer there's a case of deadlock where ExecuteNextMsg function tries to broadcast the corresponding message, which eventually calls Broadcast function of clientManager of wsbroadcaster. This function is blocking if the single-capacity buffered channel cm.broadcastChan is full, thus causing a deadlock that wont allow the txStreamer to cleanly shutdown.

This PR fixes this issue by draining the cm.broadcastChan upon context cancellation.

Part of NIT-3152