### PR TITLE
Make Consensus interface async

### DIFF
--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -63,8 +63,10 @@ func (w *execClientWrapper) Maintenance() containers.PromiseInterface[struct{}] 
 	return containers.NewReadyPromise(struct{}{}, nil)
 }
 
-func (w *execClientWrapper) Synced() bool { w.t.Error("not supported"); return false }
-
+func (w *execClientWrapper) Synced(ctx context.Context) bool {
+	w.t.Error("not supported")
+	return false
+}
 func (w *execClientWrapper) FullSyncProgressMap() map[string]interface{} {
 	w.t.Error("not supported")
 	return nil

--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -67,7 +67,7 @@ func (w *execClientWrapper) Synced(ctx context.Context) bool {
 	w.t.Error("not supported")
 	return false
 }
-func (w *execClientWrapper) FullSyncProgressMap() map[string]interface{} {
+func (w *execClientWrapper) FullSyncProgressMap(ctx context.Context) map[string]interface{} {
 	w.t.Error("not supported")
 	return nil
 }

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1503,8 +1503,9 @@ func (n *Node) FindInboxBatchContainingMessage(message arbutil.MessageIndex) (ui
 	return n.InboxTracker.FindInboxBatchContainingMessage(message)
 }
 
-func (n *Node) GetBatchParentChainBlock(seqNum uint64) (uint64, error) {
-	return n.InboxTracker.GetBatchParentChainBlock(seqNum)
+func (n *Node) GetBatchParentChainBlock(seqNum uint64) containers.PromiseInterface[uint64] {
+	batchParentChainBlock, err := n.InboxTracker.GetBatchParentChainBlock(seqNum)
+	return containers.NewReadyPromise(batchParentChainBlock, err)
 }
 
 func (n *Node) FullSyncProgressMap() map[string]interface{} {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1501,11 +1501,11 @@ func (n *Node) StopAndWait() {
 
 func (n *Node) FindInboxBatchContainingMessage(message arbutil.MessageIndex) containers.PromiseInterface[execution.InboxBatch] {
 	batchNum, found, err := n.InboxTracker.FindInboxBatchContainingMessage(message)
-	inboxBatchRes := execution.InboxBatch{
+	inboxBatch := execution.InboxBatch{
 		BatchNum: batchNum,
 		Found:    found,
 	}
-	return containers.NewReadyPromise(inboxBatchRes, err)
+	return containers.NewReadyPromise(inboxBatch, err)
 }
 
 func (n *Node) GetBatchParentChainBlock(seqNum uint64) containers.PromiseInterface[uint64] {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1509,8 +1509,7 @@ func (n *Node) FindInboxBatchContainingMessage(message arbutil.MessageIndex) con
 }
 
 func (n *Node) GetBatchParentChainBlock(seqNum uint64) containers.PromiseInterface[uint64] {
-	batchParentChainBlock, err := n.InboxTracker.GetBatchParentChainBlock(seqNum)
-	return containers.NewReadyPromise(batchParentChainBlock, err)
+	return containers.NewReadyPromise(n.InboxTracker.GetBatchParentChainBlock(seqNum))
 }
 
 func (n *Node) FullSyncProgressMap() containers.PromiseInterface[map[string]interface{}] {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1517,8 +1517,8 @@ func (n *Node) FullSyncProgressMap() map[string]interface{} {
 	return n.SyncMonitor.FullSyncProgressMap()
 }
 
-func (n *Node) Synced() bool {
-	return n.SyncMonitor.Synced()
+func (n *Node) Synced() containers.PromiseInterface[bool] {
+	return containers.NewReadyPromise(n.SyncMonitor.Synced(), nil)
 }
 
 func (n *Node) SyncTargetMessageCount() arbutil.MessageIndex {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1499,8 +1499,13 @@ func (n *Node) StopAndWait() {
 	}
 }
 
-func (n *Node) FindInboxBatchContainingMessage(message arbutil.MessageIndex) (uint64, bool, error) {
-	return n.InboxTracker.FindInboxBatchContainingMessage(message)
+func (n *Node) FindInboxBatchContainingMessage(message arbutil.MessageIndex) containers.PromiseInterface[execution.InboxBatch] {
+	batchNum, found, err := n.InboxTracker.FindInboxBatchContainingMessage(message)
+	inboxBatchRes := execution.InboxBatch{
+		BatchNum: batchNum,
+		Found:    found,
+	}
+	return containers.NewReadyPromise(inboxBatchRes, err)
 }
 
 func (n *Node) GetBatchParentChainBlock(seqNum uint64) containers.PromiseInterface[uint64] {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1513,8 +1513,8 @@ func (n *Node) GetBatchParentChainBlock(seqNum uint64) containers.PromiseInterfa
 	return containers.NewReadyPromise(batchParentChainBlock, err)
 }
 
-func (n *Node) FullSyncProgressMap() map[string]interface{} {
-	return n.SyncMonitor.FullSyncProgressMap()
+func (n *Node) FullSyncProgressMap() containers.PromiseInterface[map[string]interface{}] {
+	return containers.NewReadyPromise(n.SyncMonitor.FullSyncProgressMap(), nil)
 }
 
 func (n *Node) Synced() containers.PromiseInterface[bool] {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1519,8 +1519,9 @@ func (n *Node) SyncTargetMessageCount() arbutil.MessageIndex {
 	return n.SyncMonitor.SyncTargetMessageCount()
 }
 
-func (n *Node) WriteMessageFromSequencer(pos arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult execution.MessageResult, blockMetadata common.BlockMetadata) error {
-	return n.TxStreamer.WriteMessageFromSequencer(pos, msgWithMeta, msgResult, blockMetadata)
+func (n *Node) WriteMessageFromSequencer(pos arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult execution.MessageResult, blockMetadata common.BlockMetadata) containers.PromiseInterface[struct{}] {
+	err := n.TxStreamer.WriteMessageFromSequencer(pos, msgWithMeta, msgResult, blockMetadata)
+	return containers.NewReadyPromise(struct{}{}, err)
 }
 
 func (n *Node) ExpectChosenSequencer() containers.PromiseInterface[struct{}] {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1521,8 +1521,8 @@ func (n *Node) Synced() containers.PromiseInterface[bool] {
 	return containers.NewReadyPromise(n.SyncMonitor.Synced(), nil)
 }
 
-func (n *Node) SyncTargetMessageCount() arbutil.MessageIndex {
-	return n.SyncMonitor.SyncTargetMessageCount()
+func (n *Node) SyncTargetMessageCount() containers.PromiseInterface[arbutil.MessageIndex] {
+	return containers.NewReadyPromise(n.SyncMonitor.SyncTargetMessageCount(), nil)
 }
 
 func (n *Node) WriteMessageFromSequencer(pos arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult execution.MessageResult, blockMetadata common.BlockMetadata) containers.PromiseInterface[struct{}] {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -46,6 +46,7 @@ import (
 	legacystaker "github.com/offchainlabs/nitro/staker/legacy"
 	multiprotocolstaker "github.com/offchainlabs/nitro/staker/multi_protocol"
 	"github.com/offchainlabs/nitro/staker/validatorwallet"
+	"github.com/offchainlabs/nitro/util/containers"
 	"github.com/offchainlabs/nitro/util/contracts"
 	"github.com/offchainlabs/nitro/util/headerreader"
 	"github.com/offchainlabs/nitro/util/redisutil"
@@ -1522,8 +1523,9 @@ func (n *Node) WriteMessageFromSequencer(pos arbutil.MessageIndex, msgWithMeta a
 	return n.TxStreamer.WriteMessageFromSequencer(pos, msgWithMeta, msgResult, blockMetadata)
 }
 
-func (n *Node) ExpectChosenSequencer() error {
-	return n.TxStreamer.ExpectChosenSequencer()
+func (n *Node) ExpectChosenSequencer() containers.PromiseInterface[struct{}] {
+	err := n.TxStreamer.ExpectChosenSequencer()
+	return containers.NewReadyPromise(struct{}{}, err)
 }
 
 func (n *Node) BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) (common.BlockMetadata, error) {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1535,6 +1535,6 @@ func (n *Node) ExpectChosenSequencer() containers.PromiseInterface[struct{}] {
 	return containers.NewReadyPromise(struct{}{}, err)
 }
 
-func (n *Node) BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) (common.BlockMetadata, error) {
-	return n.TxStreamer.BlockMetadataAtMessageIndex(msgIdx)
+func (n *Node) BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[common.BlockMetadata] {
+	return containers.NewReadyPromise(n.TxStreamer.BlockMetadataAtMessageIndex(msgIdx))
 }

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -762,7 +762,7 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 	// Sequencer should want lockout if and only if- its synced, not avoiding lockout and execution processed every message that consensus had 1 second ago
 	synced := c.sequencer.Synced(ctx)
 	if !synced {
-		syncProgress := c.sequencer.FullSyncProgressMap()
+		syncProgress := c.sequencer.FullSyncProgressMap(ctx)
 		var detailsList []interface{}
 		for key, value := range syncProgress {
 			detailsList = append(detailsList, key, value)

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -684,7 +684,7 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 	for msgToRead < readUntil && localMsgCount >= remoteFinalizedMsgCount {
 		var resString string
 		resString, msgReadErr = client.Get(ctx, redisutil.MessageKeyFor(msgToRead)).Result()
-		if msgReadErr != nil && c.sequencer.Synced() {
+		if msgReadErr != nil && c.sequencer.Synced(ctx) {
 			log.Warn("coordinator failed reading message", "pos", msgToRead, "err", msgReadErr)
 			break
 		}
@@ -760,7 +760,7 @@ func (c *SeqCoordinator) update(ctx context.Context) time.Duration {
 	}
 
 	// Sequencer should want lockout if and only if- its synced, not avoiding lockout and execution processed every message that consensus had 1 second ago
-	synced := c.sequencer.Synced()
+	synced := c.sequencer.Synced(ctx)
 	if !synced {
 		syncProgress := c.sequencer.FullSyncProgressMap()
 		var detailsList []interface{}
@@ -1077,7 +1077,7 @@ func (c *SeqCoordinator) SeekLockout(ctx context.Context) {
 	defer c.wantsLockoutMutex.Unlock()
 	c.avoidLockout--
 	log.Info("seeking lockout", "myUrl", c.config.Url())
-	if c.sequencer.Synced() {
+	if c.sequencer.Synced(ctx) {
 		// Even if this errors we still internally marked ourselves as wanting the lockout
 		err := c.wantsLockoutUpdateWithMutex(ctx, c.RedisCoordinator().Client)
 		if err != nil {

--- a/execution/gethexec/api.go
+++ b/execution/gethexec/api.go
@@ -52,7 +52,7 @@ func (a *ArbAPI) GetRawBlockMetadata(ctx context.Context, fromBlock, toBlock rpc
 	if a.bulkBlockMetadataFetcher == nil {
 		return nil, errors.New("arb_getRawBlockMetadata is not available")
 	}
-	return a.bulkBlockMetadataFetcher.Fetch(fromBlock, toBlock)
+	return a.bulkBlockMetadataFetcher.Fetch(ctx, fromBlock, toBlock)
 }
 
 type ArbTimeboostAuctioneerAPI struct {

--- a/execution/gethexec/blockmetadata.go
+++ b/execution/gethexec/blockmetadata.go
@@ -18,7 +18,7 @@ import (
 var ErrBlockMetadataApiBlocksLimitExceeded = errors.New("number of blocks requested for blockMetadata exceeded")
 
 type BlockMetadataFetcher interface {
-	BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) (common.BlockMetadata, error)
+	BlockMetadataAtMessageIndex(ctx context.Context, msgIdx arbutil.MessageIndex) (common.BlockMetadata, error)
 	BlockNumberToMessageIndex(blockNum uint64) (arbutil.MessageIndex, error)
 	MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) uint64
 	SetReorgEventsNotifier(reorgEventsNotifier chan struct{})
@@ -54,7 +54,7 @@ func NewBulkBlockMetadataFetcher(bc *core.BlockChain, fetcher BlockMetadataFetch
 
 // Fetch won't include block numbers for whom consensus (arbDB) doesn't have blockMetadata, it stores recently fetched blockMetadata into an LRU
 // which is cleared in the events of reorg in order to provide accurate blockMetadata
-func (b *BulkBlockMetadataFetcher) Fetch(fromBlock, toBlock rpc.BlockNumber) ([]NumberAndBlockMetadata, error) {
+func (b *BulkBlockMetadataFetcher) Fetch(ctx context.Context, fromBlock, toBlock rpc.BlockNumber) ([]NumberAndBlockMetadata, error) {
 	fromBlock, _ = b.bc.ClipToPostNitroGenesis(fromBlock)
 	toBlock, _ = b.bc.ClipToPostNitroGenesis(toBlock)
 	// #nosec G115
@@ -81,7 +81,7 @@ func (b *BulkBlockMetadataFetcher) Fetch(fromBlock, toBlock rpc.BlockNumber) ([]
 			data, found = b.cache.Get(i)
 		}
 		if !found {
-			data, err = b.fetcher.BlockMetadataAtMessageIndex(i)
+			data, err = b.fetcher.BlockMetadataAtMessageIndex(ctx, i)
 			if err != nil {
 				return nil, err
 			}

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -262,9 +262,9 @@ func (s *ExecutionEngine) SetConsensus(consensus execution.FullConsensusClient) 
 	s.consensus = consensus
 }
 
-func (s *ExecutionEngine) BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) (common.BlockMetadata, error) {
+func (s *ExecutionEngine) BlockMetadataAtMessageIndex(ctx context.Context, msgIdx arbutil.MessageIndex) (common.BlockMetadata, error) {
 	if s.consensus != nil {
-		return s.consensus.BlockMetadataAtMessageIndex(msgIdx)
+		return s.consensus.BlockMetadataAtMessageIndex(msgIdx).Await(ctx)
 	}
 	return nil, errors.New("FullConsensusClient is not accessible to execution")
 }

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -609,7 +609,7 @@ func (s *ExecutionEngine) sequenceTransactionsWithBlockMutex(header *arbostypes.
 	}
 
 	blockMetadata := s.blockMetadataFromBlock(block, timeboostedTxs)
-	err = s.consensus.WriteMessageFromSequencer(msgIdx, msgWithMeta, *msgResult, blockMetadata)
+	_, err = s.consensus.WriteMessageFromSequencer(msgIdx, msgWithMeta, *msgResult, blockMetadata).Await(s.GetContext())
 	if err != nil {
 		return nil, err
 	}
@@ -685,7 +685,7 @@ func (s *ExecutionEngine) sequenceDelayedMessageWithBlockMutex(message *arbostyp
 		return nil, err
 	}
 
-	err = s.consensus.WriteMessageFromSequencer(msgIdx, messageWithMeta, *msgResult, s.blockMetadataFromBlock(block, nil))
+	_, err = s.consensus.WriteMessageFromSequencer(msgIdx, messageWithMeta, *msgResult, s.blockMetadataFromBlock(block, nil)).Await(s.GetContext())
 	if err != nil {
 		return nil, err
 	}

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -464,7 +464,7 @@ func (s *ExecutionEngine) sequencerWrapper(sequencerFunc func() (*types.Block, e
 		}
 		// We got SequencerInsertLockTaken
 		// option 1: there was a race, we are no longer main sequencer
-		chosenErr := s.consensus.ExpectChosenSequencer()
+		_, chosenErr := s.consensus.ExpectChosenSequencer().Await(s.GetContext())
 		if chosenErr != nil {
 			return nil, chosenErr
 		}

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -500,8 +500,8 @@ func (n *ExecutionNode) Maintenance() containers.PromiseInterface[struct{}] {
 	return containers.NewReadyPromise(struct{}{}, err)
 }
 
-func (n *ExecutionNode) Synced() bool {
-	return n.SyncMonitor.Synced()
+func (n *ExecutionNode) Synced(ctx context.Context) bool {
+	return n.SyncMonitor.Synced(ctx)
 }
 
 func (n *ExecutionNode) FullSyncProgressMap() map[string]interface{} {

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -504,8 +504,8 @@ func (n *ExecutionNode) Synced(ctx context.Context) bool {
 	return n.SyncMonitor.Synced(ctx)
 }
 
-func (n *ExecutionNode) FullSyncProgressMap() map[string]interface{} {
-	return n.SyncMonitor.FullSyncProgressMap()
+func (n *ExecutionNode) FullSyncProgressMap(ctx context.Context) map[string]interface{} {
+	return n.SyncMonitor.FullSyncProgressMap(ctx)
 }
 
 func (n *ExecutionNode) SetFinalityData(ctx context.Context, finalityData *arbutil.FinalityData) containers.PromiseInterface[struct{}] {

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -744,7 +744,8 @@ func (s *Sequencer) CheckHealth(ctx context.Context) error {
 	if pauseChan != nil {
 		return nil
 	}
-	return s.execEngine.consensus.ExpectChosenSequencer()
+	_, err := s.execEngine.consensus.ExpectChosenSequencer().Await(ctx)
+	return err
 }
 
 func (s *Sequencer) ForwardTarget() string {

--- a/execution/gethexec/sync_monitor.go
+++ b/execution/gethexec/sync_monitor.go
@@ -42,8 +42,12 @@ func NewSyncMonitor(config *SyncMonitorConfig, exec *ExecutionEngine) *SyncMonit
 	}
 }
 
-func (s *SyncMonitor) FullSyncProgressMap() map[string]interface{} {
-	res := s.consensus.FullSyncProgressMap()
+func (s *SyncMonitor) FullSyncProgressMap(ctx context.Context) map[string]interface{} {
+	res, err := s.consensus.FullSyncProgressMap().Await(ctx)
+	if err != nil {
+		res = make(map[string]interface{})
+		res["fullSyncProgressMapError"] = err
+	}
 
 	res["consensusSyncTarget"] = s.consensus.SyncTargetMessageCount()
 
@@ -68,7 +72,7 @@ func (s *SyncMonitor) SyncProgressMap(ctx context.Context) map[string]interface{
 	if s.Synced(ctx) {
 		return make(map[string]interface{})
 	}
-	return s.FullSyncProgressMap()
+	return s.FullSyncProgressMap(ctx)
 }
 
 func (s *SyncMonitor) Synced(ctx context.Context) bool {

--- a/execution/gethexec/sync_monitor.go
+++ b/execution/gethexec/sync_monitor.go
@@ -86,14 +86,14 @@ func (s *SyncMonitor) SetConsensusInfo(consensus execution.ConsensusInfo) {
 	s.consensus = consensus
 }
 
-func (s *SyncMonitor) BlockMetadataByNumber(blockNum uint64) (common.BlockMetadata, error) {
+func (s *SyncMonitor) BlockMetadataByNumber(ctx context.Context, blockNum uint64) (common.BlockMetadata, error) {
 	genesis := s.exec.GetGenesisBlockNumber()
 	if blockNum < genesis { // Arbitrum classic block
 		return nil, nil
 	}
 	msgIdx := arbutil.MessageIndex(blockNum - genesis)
 	if s.consensus != nil {
-		return s.consensus.BlockMetadataAtMessageIndex(msgIdx)
+		return s.consensus.BlockMetadataAtMessageIndex(msgIdx).Await(ctx)
 	}
 	log.Debug("FullConsensusClient is not accessible to execution, BlockMetadataByNumber will return nil")
 	return nil, nil

--- a/execution/gethexec/sync_monitor.go
+++ b/execution/gethexec/sync_monitor.go
@@ -83,19 +83,19 @@ func (s *SyncMonitor) SyncProgressMap(ctx context.Context) map[string]interface{
 func (s *SyncMonitor) Synced(ctx context.Context) bool {
 	synced, err := s.consensus.Synced().Await(ctx)
 	if err != nil {
-		log.Warn("Error checking if consensus is synced", "err", err)
+		log.Error("Error checking if consensus is synced", "err", err)
 		return false
 	}
 	if synced {
 		built, err := s.exec.HeadMessageIndex()
 		if err != nil {
-			log.Warn("Error getting head message index", "err", err)
+			log.Error("Error getting head message index", "err", err)
 			return false
 		}
 
 		consensusSyncTarget, err := s.consensus.SyncTargetMessageCount().Await(ctx)
 		if err != nil {
-			log.Warn("Error getting consensus sync target", "err", err)
+			log.Error("Error getting consensus sync target", "err", err)
 			return false
 		}
 

--- a/execution/gethexec/sync_monitor.go
+++ b/execution/gethexec/sync_monitor.go
@@ -83,7 +83,7 @@ func (s *SyncMonitor) SyncProgressMap(ctx context.Context) map[string]interface{
 func (s *SyncMonitor) Synced(ctx context.Context) bool {
 	synced, err := s.consensus.Synced().Await(ctx)
 	if err != nil {
-		log.Warn("Error checking if execution is synced", "err", err)
+		log.Warn("Error checking if consensus is synced", "err", err)
 		return false
 	}
 	if synced {

--- a/execution/gethexec/sync_monitor.go
+++ b/execution/gethexec/sync_monitor.go
@@ -64,7 +64,7 @@ func (s *SyncMonitor) FullSyncProgressMap() map[string]interface{} {
 	return res
 }
 
-func (s *SyncMonitor) SyncProgressMap() map[string]interface{} {
+func (s *SyncMonitor) SyncProgressMap(ctx context.Context) map[string]interface{} {
 	if s.Synced() {
 		return make(map[string]interface{})
 	}

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -87,7 +87,7 @@ type BatchFetcher interface {
 type ConsensusInfo interface {
 	Synced() containers.PromiseInterface[bool]
 	FullSyncProgressMap() containers.PromiseInterface[map[string]interface{}]
-	SyncTargetMessageCount() arbutil.MessageIndex
+	SyncTargetMessageCount() containers.PromiseInterface[arbutil.MessageIndex]
 	BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[common.BlockMetadata]
 }
 

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -76,7 +76,7 @@ type ExecutionBatchPoster interface {
 // BatchFetcher is required for any execution node
 type BatchFetcher interface {
 	FindInboxBatchContainingMessage(message arbutil.MessageIndex) (uint64, bool, error)
-	GetBatchParentChainBlock(seqNum uint64) (uint64, error)
+	GetBatchParentChainBlock(seqNum uint64) containers.PromiseInterface[uint64]
 }
 
 type ConsensusInfo interface {

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -68,7 +68,7 @@ type ExecutionSequencer interface {
 	ForwardTo(url string) error
 	SequenceDelayedMessage(message *arbostypes.L1IncomingMessage, delayedSeqNum uint64) error
 	NextDelayedMessageNumber() (uint64, error)
-	Synced() bool
+	Synced(ctx context.Context) bool
 	FullSyncProgressMap() map[string]interface{}
 }
 
@@ -85,7 +85,7 @@ type BatchFetcher interface {
 }
 
 type ConsensusInfo interface {
-	Synced() bool
+	Synced() containers.PromiseInterface[bool]
 	FullSyncProgressMap() map[string]interface{}
 	SyncTargetMessageCount() arbutil.MessageIndex
 	BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[common.BlockMetadata]

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -24,6 +24,11 @@ type RecordResult struct {
 	UserWasms state.UserWasms
 }
 
+type InboxBatch struct {
+	BatchNum uint64
+	Found    bool
+}
+
 var ErrRetrySequencer = errors.New("please retry transaction")
 var ErrSequencerInsertLockTaken = errors.New("insert lock taken")
 
@@ -75,7 +80,7 @@ type ExecutionBatchPoster interface {
 // not implemented in execution, used as input
 // BatchFetcher is required for any execution node
 type BatchFetcher interface {
-	FindInboxBatchContainingMessage(message arbutil.MessageIndex) (uint64, bool, error)
+	FindInboxBatchContainingMessage(message arbutil.MessageIndex) containers.PromiseInterface[InboxBatch]
 	GetBatchParentChainBlock(seqNum uint64) containers.PromiseInterface[uint64]
 }
 

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -69,7 +69,7 @@ type ExecutionSequencer interface {
 	SequenceDelayedMessage(message *arbostypes.L1IncomingMessage, delayedSeqNum uint64) error
 	NextDelayedMessageNumber() (uint64, error)
 	Synced(ctx context.Context) bool
-	FullSyncProgressMap() map[string]interface{}
+	FullSyncProgressMap(ctx context.Context) map[string]interface{}
 }
 
 // needed for batch poster
@@ -86,7 +86,7 @@ type BatchFetcher interface {
 
 type ConsensusInfo interface {
 	Synced() containers.PromiseInterface[bool]
-	FullSyncProgressMap() map[string]interface{}
+	FullSyncProgressMap() containers.PromiseInterface[map[string]interface{}]
 	SyncTargetMessageCount() arbutil.MessageIndex
 	BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[common.BlockMetadata]
 }

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -88,7 +88,7 @@ type ConsensusInfo interface {
 
 type ConsensusSequencer interface {
 	WriteMessageFromSequencer(msgIdx arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult MessageResult, blockMetadata common.BlockMetadata) error
-	ExpectChosenSequencer() error
+	ExpectChosenSequencer() containers.PromiseInterface[struct{}]
 }
 
 type FullConsensusClient interface {

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -87,7 +87,7 @@ type ConsensusInfo interface {
 }
 
 type ConsensusSequencer interface {
-	WriteMessageFromSequencer(msgIdx arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult MessageResult, blockMetadata common.BlockMetadata) error
+	WriteMessageFromSequencer(msgIdx arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult MessageResult, blockMetadata common.BlockMetadata) containers.PromiseInterface[struct{}]
 	ExpectChosenSequencer() containers.PromiseInterface[struct{}]
 }
 

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -88,7 +88,7 @@ type ConsensusInfo interface {
 	Synced() bool
 	FullSyncProgressMap() map[string]interface{}
 	SyncTargetMessageCount() arbutil.MessageIndex
-	BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) (common.BlockMetadata, error)
+	BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[common.BlockMetadata]
 }
 
 type ConsensusSequencer interface {

--- a/execution/nodeInterface/NodeInterface.go
+++ b/execution/nodeInterface/NodeInterface.go
@@ -87,7 +87,8 @@ func (n NodeInterface) msgNumToInboxBatch(msgIndex arbutil.MessageIndex) (uint64
 	if fetcher == nil {
 		return 0, false, errors.New("batch fetcher not set")
 	}
-	return fetcher.FindInboxBatchContainingMessage(msgIndex)
+	inboxBatch, err := fetcher.FindInboxBatchContainingMessage(msgIndex).Await(n.context)
+	return inboxBatch.BatchNum, inboxBatch.Found, err
 }
 
 func (n NodeInterface) FindBatchContainingBlock(c ctx, evm mech, blockNum uint64) (uint64, error) {

--- a/execution/nodeInterface/NodeInterface.go
+++ b/execution/nodeInterface/NodeInterface.go
@@ -133,7 +133,7 @@ func (n NodeInterface) GetL1Confirmations(c ctx, evm mech, blockHash bytes32) (u
 	if !found {
 		return 0, nil
 	}
-	parentChainBlockNum, err := node.ExecEngine.GetBatchFetcher().GetBatchParentChainBlock(batchNum)
+	parentChainBlockNum, err := node.ExecEngine.GetBatchFetcher().GetBatchParentChainBlock(batchNum).Await(n.context)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Resolves NIT-3058

Make Consensus interface async.

Pulls https://github.com/OffchainLabs/go-ethereum/pull/421