### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp in *_test.go

### DIFF
--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"io"
 	"math/big"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -78,14 +77,8 @@ func TestChallengeProtocolBOLDStartStepChallenge(t *testing.T) {
 }
 
 func testChallengeProtocolBOLD(t *testing.T, spawnerOpts ...server_arb.SpawnerOption) {
-	goodDir, err := os.MkdirTemp("", "good_*")
-	Require(t, err)
-	evilDir, err := os.MkdirTemp("", "evil_*")
-	Require(t, err)
-	t.Cleanup(func() {
-		Require(t, os.RemoveAll(goodDir))
-		Require(t, os.RemoveAll(evilDir))
-	})
+	goodDir := t.TempDir()
+	evilDir := t.TempDir()
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
 	var transferGas = util.NormalizeL2GasForL1GasInitial(800_000, params.GWei) // include room for aggregator L1 costs

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -134,16 +133,7 @@ func createSequencer(t *testing.T, builder *NodeBuilder, ipcPath string, redisUr
 // tmpPath returns file path with specified filename from temporary directory of the test.
 func tmpPath(t *testing.T, filename string) string {
 	t.Helper()
-	// create a unique, maximum 10 characters-long temporary directory {name} with path as $TMPDIR/{name}
-	tmpDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	t.Cleanup(func() {
-		if err = os.RemoveAll(tmpDir); err != nil {
-			t.Errorf("Failed to cleanup temp dir: %v", err)
-		}
-	})
+	tmpDir := t.TempDir()
 	return filepath.Join(tmpDir, filename)
 }
 


### PR DESCRIPTION
similar to: https://github.com/OffchainLabs/nitro/pull/3002
checked whole code space


