### PR TITLE
ExpressLane submissions are returned results immediately after they are queued

### DIFF
--- a/execution/gethexec/express_lane_service_test.go
+++ b/execution/gethexec/express_lane_service_test.go
@@ -278,13 +278,12 @@ func makeStubPublisher(els *expressLaneService) *stubPublisher {
 
 var emptyTx = types.NewTransaction(0, common.MaxAddress, big.NewInt(0), 0, big.NewInt(0), nil)
 
-func (s *stubPublisher) PublishTimeboostedTransaction(parentCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions, resultChan chan error) {
+func (s *stubPublisher) PublishTimeboostedTransaction(parentCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions) error {
 	if tx.Hash() != emptyTx.Hash() {
-		resultChan <- errors.New("oops, bad tx")
-		return
+		return errors.New("oops, bad tx")
 	}
 	s.publishedTxOrder = append(s.publishedTxOrder, 0)
-	resultChan <- nil
+	return nil
 }
 
 func Test_expressLaneService_sequenceExpressLaneSubmission_nonceTooLow(t *testing.T) {
@@ -293,14 +292,14 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_nonceTooLow(t *testin
 	els := &expressLaneService{
 		roundInfo: containers.NewLruCache[uint64, *expressLaneRoundInfo](8),
 	}
-	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
+	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*timeboost.ExpressLaneSubmission)})
 	els.StopWaiter.Start(ctx, els)
 	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher := makeStubPublisher(els)
 	els.transactionPublisher = stubPublisher
 
 	msg := buildValidSubmissionWithSeqAndTx(t, 0, 0, emptyTx)
-	err := els.sequenceExpressLaneSubmission(ctx, msg, false)
+	err := els.sequenceExpressLaneSubmission(ctx, msg)
 	require.ErrorIs(t, err, timeboost.ErrSequenceNumberTooLow)
 }
 
@@ -318,7 +317,7 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_duplicateNonce(t *tes
 	els.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, &timingInfo)
 	require.NoError(t, err)
 	els.redisCoordinator.Start(ctx)
-	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
+	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*timeboost.ExpressLaneSubmission)})
 	els.StopWaiter.Start(ctx, els)
 	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher := makeStubPublisher(els)
@@ -327,16 +326,14 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_duplicateNonce(t *tes
 	msg1 := buildValidSubmissionWithSeqAndTx(t, 0, 2, types.NewTx(&types.DynamicFeeTx{Data: []byte{1}}))
 	msg2 := buildValidSubmissionWithSeqAndTx(t, 0, 2, types.NewTx(&types.DynamicFeeTx{Data: []byte{2}}))
 	var wg sync.WaitGroup
-	wg.Add(3) // We expect only of the below two to return with an error here
+	wg.Add(2) // We expect only one of the two txs below to return with an error here
 	var err1, err2 error
 	go func(w *sync.WaitGroup) {
-		w.Done()
-		err1 = els.sequenceExpressLaneSubmission(ctx, msg1, false)
+		err1 = els.sequenceExpressLaneSubmission(ctx, msg1)
 		wg.Done()
 	}(&wg)
 	go func(w *sync.WaitGroup) {
-		w.Done()
-		err2 = els.sequenceExpressLaneSubmission(ctx, msg2, false)
+		err2 = els.sequenceExpressLaneSubmission(ctx, msg2)
 		wg.Done()
 	}(&wg)
 	wg.Wait()
@@ -365,7 +362,7 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_outOfOrder(t *testing
 	els.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, &timingInfo)
 	require.NoError(t, err)
 	els.redisCoordinator.Start(ctx)
-	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
+	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*timeboost.ExpressLaneSubmission)})
 	els.StopWaiter.Start(ctx, els)
 	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher := makeStubPublisher(els)
@@ -379,34 +376,35 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_outOfOrder(t *testing
 		buildValidSubmissionWithSeqAndTx(t, 0, 2, emptyTx),
 	}
 
-	// We launch 5 goroutines out of which 2 would return with a result hence we initially add a delta of 7
+	// We launch 5 goroutines and all would return with a result upon queuing or buffering
 	var wg sync.WaitGroup
-	wg.Add(7)
+	wg.Add(5)
 	for _, msg := range messages {
 		go func(w *sync.WaitGroup) {
+			err := els.sequenceExpressLaneSubmission(ctx, msg)
+			require.NoError(t, err)
 			w.Done()
-			err := els.sequenceExpressLaneSubmission(ctx, msg, false)
-			if msg.SequenceNumber != 10 { // Because this go-routine will be interrupted after the test itself ends and 10 will still be waiting for result
-				require.NoError(t, err)
-				w.Done()
-			}
 		}(&wg)
 	}
 	wg.Wait()
 
-	// We should have only published 2, as we are missing sequence number 3.
-	time.Sleep(2 * time.Second)
+	// We should have only published 1 and 2, as we are missing sequence number 3.
 	require.Equal(t, 2, len(stubPublisher.publishedTxOrder))
 	els.roundInfoMutex.Lock()
 	roundInfo, _ := els.roundInfo.Get(0)
-	require.Equal(t, 5, len(roundInfo.msgAndResultBySequenceNumber))
+	require.Equal(t, uint64(3), roundInfo.sequence)
+	require.Equal(t, 5, len(roundInfo.msgBySequenceNumber))
 	els.roundInfoMutex.Unlock()
 
-	wg.Add(2) // 4 & 5 should be able to get in after 3 so we add a delta of 2
-	err = els.sequenceExpressLaneSubmission(ctx, buildValidSubmissionWithSeqAndTx(t, 0, 3, emptyTx), false)
+	// 4 & 5 should be able to get in after 3 so we add a delta of 2
+	err = els.sequenceExpressLaneSubmission(ctx, buildValidSubmissionWithSeqAndTx(t, 0, 3, emptyTx))
 	require.NoError(t, err)
-	wg.Wait()
 	require.Equal(t, 5, len(stubPublisher.publishedTxOrder))
+	els.roundInfoMutex.Lock()
+	roundInfo, _ = els.roundInfo.Get(0)
+	require.Equal(t, uint64(6), roundInfo.sequence)
+	require.Equal(t, 6, len(roundInfo.msgBySequenceNumber))
+	els.roundInfoMutex.Unlock()
 }
 
 func Test_expressLaneService_sequenceExpressLaneSubmission_erroredTx(t *testing.T) {
@@ -423,7 +421,7 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_erroredTx(t *testing.
 	els.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, &timingInfo)
 	require.NoError(t, err)
 	els.redisCoordinator.Start(ctx)
-	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
+	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*timeboost.ExpressLaneSubmission)})
 	els.StopWaiter.Start(ctx, els)
 	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher := makeStubPublisher(els)
@@ -437,10 +435,10 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_erroredTx(t *testing.
 	}
 	for _, msg := range messages {
 		if msg.Transaction.Hash() != emptyTx.Hash() {
-			err := els.sequenceExpressLaneSubmission(ctx, msg, false)
+			err := els.sequenceExpressLaneSubmission(ctx, msg)
 			require.ErrorContains(t, err, "oops, bad tx")
 		} else {
-			err := els.sequenceExpressLaneSubmission(ctx, msg, false)
+			err := els.sequenceExpressLaneSubmission(ctx, msg)
 			require.NoError(t, err)
 		}
 	}
@@ -465,7 +463,7 @@ func Test_expressLaneService_syncFromRedis(t *testing.T) {
 	require.NoError(t, err)
 	els1.redisCoordinator.Start(ctx)
 
-	els1.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
+	els1.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*timeboost.ExpressLaneSubmission)})
 	els1.StopWaiter.Start(ctx, els1)
 	els1.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher1 := makeStubPublisher(els1)
@@ -478,16 +476,13 @@ func Test_expressLaneService_syncFromRedis(t *testing.T) {
 		buildValidSubmissionWithSeqAndTx(t, 0, 5, emptyTx),
 	}
 
-	// We launch 4 goroutines out of which 1 would return with a result hence we add a delta of 5
+	// We launch 4 goroutines and all would return with a result upon queuing or buffering
 	var wg sync.WaitGroup
-	wg.Add(5)
+	wg.Add(4)
 	for _, msg := range messages {
 		go func(w *sync.WaitGroup) {
+			_ = els1.sequenceExpressLaneSubmission(ctx, msg)
 			w.Done()
-			_ = els1.sequenceExpressLaneSubmission(ctx, msg, false)
-			if msg.SequenceNumber == 1 {
-				w.Done()
-			}
 		}(&wg)
 	}
 	wg.Wait()
@@ -522,12 +517,12 @@ func Test_expressLaneService_syncFromRedis(t *testing.T) {
 	if roundInfo.sequence != 2 {
 		t.Fatalf("round sequence count mismatch. Want: 2, Got: %d", roundInfo.sequence)
 	}
-	if len(roundInfo.msgAndResultBySequenceNumber) != 3 { // There should be three pending txs in msgAndResult map
-		t.Fatalf("number of future sequence txs mismatch. Want: 3, Got: %d", len(roundInfo.msgAndResultBySequenceNumber))
+	if len(roundInfo.msgBySequenceNumber) != 3 { // There should be three pending txs in msgAndResult map
+		t.Fatalf("number of future sequence txs mismatch. Want: 3, Got: %d", len(roundInfo.msgBySequenceNumber))
 	}
 	els2.roundInfoMutex.Unlock()
 
-	err = els2.sequenceExpressLaneSubmission(ctx, buildValidSubmissionWithSeqAndTx(t, 0, 2, emptyTx), false) // Send an unblocking tx
+	err = els2.sequenceExpressLaneSubmission(ctx, buildValidSubmissionWithSeqAndTx(t, 0, 2, emptyTx)) // Send an unblocking tx
 	require.NoError(t, err)
 
 	time.Sleep(time.Second) // wait for future seq num txs to be processed
@@ -605,7 +600,7 @@ func Benchmark_expressLaneService_validateExpressLaneTx(b *testing.B) {
 		},
 	}
 	es.roundControl.Store(0, addr)
-	es.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
+	es.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*timeboost.ExpressLaneSubmission)})
 
 	sub := buildValidSubmission(b, common.HexToAddress("0x2Aef36410182881a4b13664a1E079762D7F716e6"), testPriv, 0)
 	b.StartTimer()

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -609,13 +609,12 @@ func (s *Sequencer) PublishExpressLaneTransaction(ctx context.Context, msg *time
 		return forwarder.PublishExpressLaneTransaction(ctx, msg)
 	}
 
-	return s.expressLaneService.sequenceExpressLaneSubmission(ctx, msg, false)
+	return s.expressLaneService.sequenceExpressLaneSubmission(ctx, msg)
 }
 
-func (s *Sequencer) PublishTimeboostedTransaction(queueCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions, resultChan chan error) {
-	if err := s.publishTransactionToQueue(queueCtx, tx, options, resultChan, true); err != nil {
-		resultChan <- err
-	}
+func (s *Sequencer) PublishTimeboostedTransaction(queueCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions) error {
+	resultChan := make(chan error, 1)
+	return s.publishTransactionToQueue(queueCtx, tx, options, resultChan, true)
 }
 
 func (s *Sequencer) publishTransactionToQueue(queueCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions, resultChan chan error, isExpressLaneController bool) error {

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
@@ -553,12 +552,11 @@ func TestExpressLaneTransactionHandling(t *testing.T) {
 		if failErr == nil {
 			t.Fatal("incorrect express lane tx didn't fail upon submission")
 		}
-		if !strings.Contains(failErr.Error(), timeboost.ErrAcceptedTxFailed.Error()) || // Should be an ErrAcceptedTxFailed error that would consume sequence number
-			!strings.Contains(failErr.Error(), reason) {
+		if !strings.Contains(failErr.Error(), reason) {
 			t.Fatalf("unexpected error string returned: %s", failErr.Error())
 		}
 	}
-	checkFailErr(core.ErrNonceTooHigh.Error())
+	checkFailErr("context deadline exceeded") // tx will be rejected with nonce too high error so wont appear in a block
 
 	wg.Add(1)
 	go func(w *sync.WaitGroup) {
@@ -567,7 +565,7 @@ func TestExpressLaneTransactionHandling(t *testing.T) {
 	}(&wg)
 	wg.Wait()
 
-	checkFailErr("Transaction sequencing hit timeout")
+	checkFailErr("context deadline exceeded")
 }
 
 func dbKey(prefix []byte, pos uint64) []byte {
@@ -1160,11 +1158,11 @@ func TestSequencerFeed_ExpressLaneAuction_InnerPayloadNoncesAreRespected_Timeboo
 		To:        &ownerAddr,
 		Gas:       seqInfo.TransferGas,
 		Value:     big.NewInt(1e12),
-		Nonce:     1,
+		Nonce:     2,
 		GasFeeCap: aliceTx.GasFeeCap(),
 		Data:      nil,
 	}
-	charlie1 := seqInfo.SignTxAs("Charlie", txData)
+	charlie2 := seqInfo.SignTxAs("Charlie", txData)
 	txData = &types.DynamicFeeTx{
 		To:        &ownerAddr,
 		Gas:       seqInfo.TransferGas,
@@ -1174,21 +1172,23 @@ func TestSequencerFeed_ExpressLaneAuction_InnerPayloadNoncesAreRespected_Timeboo
 		Data:      nil,
 	}
 	charlie0 := seqInfo.SignTxAs("Charlie", txData)
+
+	// Send the express lane txs with nonces out of order, 0 and 2 so that nonce reordering logic in sequencer doesn't resequence them correctly
 	var err2 error
 	go func(w *sync.WaitGroup) {
 		defer w.Done()
 		time.Sleep(time.Millisecond * 10)
-		// Send the express lane txs with nonces out of order
-		err2 = expressLaneClient.SendTransaction(ctx, charlie1)
-		err = expressLaneClient.SendTransaction(ctx, charlie0)
-		Require(t, err)
+		err2 = expressLaneClient.SendTransactionWithSequence(ctx, charlie2, 0)
 	}(&wg)
+	time.Sleep(time.Millisecond * 50)
+	err = expressLaneClient.SendTransactionWithSequence(ctx, charlie0, 1)
+	Require(t, err)
 	wg.Wait()
 	if err2 == nil {
-		t.Fatal("Charlie should not be able to send tx with nonce 1")
+		t.Fatal("Charlie should not be able to send tx with nonce 2")
 	}
-	if !strings.Contains(err2.Error(), timeboost.ErrAcceptedTxFailed.Error()) {
-		t.Fatal("Charlie's first tx should've consumed a sequence number as it was initially accepted")
+	if !strings.Contains(err2.Error(), "context deadline exceeded") {
+		t.Fatal("Charlie's first tx should've consumed a sequence number and rejected thus not appear in a block leading to context deadline exceeded from EnsureTxSucceeded")
 	}
 	// After round is done, verify that Charlie beats Alice in the final sequence, and that the emitted txs
 	// for Charlie are correct.
@@ -1761,6 +1761,7 @@ type expressLaneClient struct {
 	roundTimingInfo     timeboost.RoundTimingInfo
 	auctionContractAddr common.Address
 	client              *rpc.Client
+	ethClient           *ethclient.Client
 	sequence            uint64
 }
 
@@ -1777,6 +1778,7 @@ func newExpressLaneClient(
 		roundTimingInfo:     roundTimingInfo,
 		auctionContractAddr: auctionContractAddr,
 		client:              client,
+		ethClient:           ethclient.NewClient(client),
 		sequence:            0,
 	}
 }
@@ -1815,14 +1817,15 @@ func (elc *expressLaneClient) SendTransactionWithSequence(ctx context.Context, t
 	if _, err := promise.Await(ctx); err != nil {
 		return err
 	}
-	return nil
+	_, err = EnsureTxSucceeded(ctx, elc.ethClient, transaction)
+	return err
 }
 
 func (elc *expressLaneClient) SendTransaction(ctx context.Context, transaction *types.Transaction) error {
 	elc.Lock()
 	defer elc.Unlock()
 	err := elc.SendTransactionWithSequence(ctx, transaction, elc.sequence)
-	if err == nil || strings.Contains(err.Error(), timeboost.ErrAcceptedTxFailed.Error()) {
+	if err == nil {
 		elc.sequence += 1
 	}
 	return err

--- a/timeboost/errors.go
+++ b/timeboost/errors.go
@@ -16,5 +16,4 @@ var (
 	ErrDuplicateSequenceNumber  = errors.New("SEQUENCE_NUMBER_ALREADY_SEEN")
 	ErrSequenceNumberTooLow     = errors.New("SEQUENCE_NUMBER_TOO_LOW")
 	ErrTooManyBids              = errors.New("PER_ROUND_BID_LIMIT_REACHED")
-	ErrAcceptedTxFailed         = errors.New("Accepted timeboost tx failed")
 )


### PR DESCRIPTION
Currently timeboost txs submitted by the expressLane controller are handled similarly to how normal txs are handled by the sequencer i.e it waits until the tx is processed and either makes into a block or not, before returning the result to a user. 

This PR, for timeboost txs, changes this behavior to instead return right after successfully queuing the tx and to not wait until the result (block is produced) is available. `timeboost_sendExpressLaneTransaction` will now return as soon as the transaction gets queued and the controller/user will need to check the tx's status by querying for its receipt.

`Accepted timeboost tx failed` error is removed and instead if an expressLaneSubmission returns a `null` error then that sequence number is consumed, if not, the sequence number is not consumed and can be retried. Sometimes submissions may encounter the below error if an earlier sequence numbered tx is missing to correctly process all the upcoming txs, in which case controller should submit/resubmit tx with the correct sequence number given in `ExpectedSequenceNumber` field of the error string.
```
"message sequence number has reached max allowed limit. SequenceNumber: %d, ExpectedSequenceNumber: %d, Limit: %d"
```

Resolves NIT-3155