### PR TITLE
Improve comments and fix formatting in `bin.rs` and `reader.go`

### DIFF
--- a/arbitrator/bench/src/bin.rs
+++ b/arbitrator/bench/src/bin.rs
@@ -22,7 +22,7 @@ struct Args {
     #[arg(short, long)]
     json_inputs: PathBuf,
 
-    /// Path to a machine.wavm.br
+    /// Path to a machine .wavm.br
     #[arg(short, long)]
     binary: PathBuf,
 }
@@ -101,7 +101,7 @@ fn main() -> eyre::Result<()> {
             average(&step_times),
             step_size,
             num_iters,
-            total_end_time,
+            total_end_time
         );
         #[cfg(feature = "counters")]
         {

--- a/arbstate/daprovider/reader.go
+++ b/arbstate/daprovider/reader.go
@@ -29,8 +29,8 @@ type Reader interface {
 	) ([]byte, error)
 }
 
-// NewReaderForDAS is generally meant to be only used by nitro.
-// DA Providers should implement methods in the Reader interface independently
+// NewReaderForDAS creates a readerForDAS instance,
+// which provides data availability services (DAS) for Nitro.
 func NewReaderForDAS(dasReader DASReader, keysetFetcher DASKeysetFetcher) *readerForDAS {
 	return &readerForDAS{
 		dasReader:     dasReader,
@@ -58,8 +58,8 @@ func (d *readerForDAS) RecoverPayloadFromBatch(
 	return RecoverPayloadFromDasBatch(ctx, batchNum, sequencerMsg, d.dasReader, d.keysetFetcher, preimageRecorder, validateSeqMsg)
 }
 
-// NewReaderForBlobReader is generally meant to be only used by nitro.
-// DA Providers should implement methods in the Reader interface independently
+// NewReaderForBlobReader creates a readerForBlobReader instance,
+// which fetches data availability payloads using a BlobReader.
 func NewReaderForBlobReader(blobReader BlobReader) *readerForBlobReader {
 	return &readerForBlobReader{blobReader: blobReader}
 }


### PR DESCRIPTION
1. arbitrator/bench/src/bin.rs:
- Fixed comment formatting for `binary` argument description.
- Removed an extra trailing comma in a print statement.

2. arbstate/daprovider/reader.go:
- Updated the comment for `NewReaderForDAS` to explain that it provides data availability services for Nitro.
- Updated the comment for `NewReaderForBlobReader` to clarify that it fetches data availability payloads using a `BlobReader`.
