### PR TITLE
Remove need for --node.bold.enable

### DIFF
--- a/staker/bold/bold_staker.go
+++ b/staker/bold/bold_staker.go
@@ -51,7 +51,6 @@ func init() {
 }
 
 type BoldConfig struct {
-	Enable   bool   `koanf:"enable"`
 	Strategy string `koanf:"strategy"`
 	// How often to post assertions onchain.
 	AssertionPostingInterval time.Duration `koanf:"assertion-posting-interval"`
@@ -125,7 +124,6 @@ var DefaultStateProviderConfig = StateProviderConfig{
 }
 
 var DefaultBoldConfig = BoldConfig{
-	Enable:                              false,
 	Strategy:                            "Watchtower",
 	AssertionPostingInterval:            time.Minute * 15,
 	AssertionScanningInterval:           time.Minute,
@@ -155,7 +153,6 @@ var BoldModes = map[legacystaker.StakerStrategy]boldtypes.Mode{
 }
 
 func BoldConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Bool(prefix+".enable", DefaultBoldConfig.Enable, "enable bold challenge protocol")
 	f.String(prefix+".strategy", DefaultBoldConfig.Strategy, "define the bold validator staker strategy, either watchtower, defensive, stakeLatest, or makeNodes")
 	f.String(prefix+".rpc-block-number", DefaultBoldConfig.RPCBlockNumber, "define the block number to use for reading data onchain, either latest, safe, or finalized")
 	f.Int64(prefix+".max-get-log-blocks", DefaultBoldConfig.MaxGetLogBlocks, "maximum size for chunk of blocks when using get logs rpc")

--- a/staker/multi_protocol/multi_protocol_staker.go
+++ b/staker/multi_protocol/multi_protocol_staker.go
@@ -137,19 +137,22 @@ func (m *MultiProtocolStaker) Start(ctxIn context.Context) {
 		log.Info("Starting pre-BOLD staker")
 		m.oldStaker.Start(ctxIn)
 		stakerSwitchInterval := m.boldConfig.CheckStakerSwitchInterval
-		m.CallIteratively(func(ctx context.Context) time.Duration {
-			switchedToBoldProtocol, err := m.checkAndSwitchToBoldStaker(ctxIn)
-			if err != nil {
-				log.Warn("staker: error in checking switch to bold staker", "err", err)
-				return stakerSwitchInterval
+		m.LaunchThread(func(ctx context.Context) {
+			ticker := time.NewTicker(stakerSwitchInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+				}
+
+				if err := m.checkAndSwitchToBoldStaker(ctxIn); err != nil {
+					log.Warn("Staker: error in checking and switching to bold staker", "err", err)
+					continue
+				}
+				return
 			}
-			if switchedToBoldProtocol {
-				log.Info("Detected BOLD protocol upgrade, stopping old staker and starting BOLD staker")
-				// Ready to stop the old staker.
-				m.oldStaker.StopOnly()
-				m.StopOnly()
-			}
-			return stakerSwitchInterval
 		})
 	}
 }
@@ -166,9 +169,6 @@ func (m *MultiProtocolStaker) StopAndWait() {
 
 func (m *MultiProtocolStaker) isBoldActive(ctx context.Context) (bool, common.Address, error) {
 	var addr common.Address
-	if !m.boldConfig.Enable {
-		return false, addr, nil
-	}
 	callOpts := m.getCallOpts(ctx)
 	rollupAddress, err := m.bridge.Rollup(callOpts)
 	if err != nil {
@@ -187,22 +187,27 @@ func (m *MultiProtocolStaker) isBoldActive(ctx context.Context) (bool, common.Ad
 	return err == nil, rollupAddress, nil
 }
 
-func (m *MultiProtocolStaker) checkAndSwitchToBoldStaker(ctx context.Context) (bool, error) {
+func (m *MultiProtocolStaker) checkAndSwitchToBoldStaker(ctx context.Context) error {
 	shouldSwitch, rollupAddress, err := m.isBoldActive(ctx)
 	if err != nil {
-		return false, err
+		return err
 	}
 	if !shouldSwitch {
-		return false, nil
+		log.Info("Bold is not yet active on-chain, will retry switching later")
+		return nil
 	}
 	if err := m.setupBoldStaker(ctx, rollupAddress); err != nil {
-		return false, err
+		return err
 	}
 	if err = m.boldStaker.Initialize(ctx); err != nil {
-		return false, err
+		return err
 	}
+	log.Info("Detected BOLD protocol upgrade, stopping old staker and starting BOLD staker")
 	m.boldStaker.Start(ctx)
-	return true, nil
+	// Ready to stop the old staker.
+	m.oldStaker.StopOnly()
+	m.StopOnly()
+	return nil
 }
 
 func (m *MultiProtocolStaker) getCallOpts(ctx context.Context) *bind.CallOpts {


### PR DESCRIPTION
This PR removes the `--node.bold.enable` config option, and cleans up logic for switching over from legacy staker to Bold up on detecting bold activation on-chain.

Resolves NIT-3115