### PR TITLE
[Backport] ExpressLane submissions are returned results immediately after they are queued and use channels in redisCoordinator to accept push-updates to redis instead of launching goroutines

### DIFF
--- a/execution/gethexec/express_lane_service.go
+++ b/execution/gethexec/express_lane_service.go
@@ -35,17 +35,12 @@ var (
 )
 
 type transactionPublisher interface {
-	PublishTimeboostedTransaction(context.Context, *types.Transaction, *arbitrum_types.ConditionalOptions, chan error)
-}
-
-type msgAndResult struct {
-	msg        *timeboost.ExpressLaneSubmission
-	resultChan chan error
+	PublishTimeboostedTransaction(context.Context, *types.Transaction, *arbitrum_types.ConditionalOptions) error
 }
 
 type expressLaneRoundInfo struct {
-	sequence                     uint64
-	msgAndResultBySequenceNumber map[uint64]*msgAndResult
+	sequence            uint64
+	msgBySequenceNumber map[uint64]*timeboost.ExpressLaneSubmission
 }
 
 type expressLaneService struct {
@@ -105,7 +100,7 @@ pending:
 
 	var redisCoordinator *timeboost.RedisCoordinator
 	if seqConfig().Dangerous.Timeboost.RedisUrl != "" {
-		redisCoordinator, err = timeboost.NewRedisCoordinator(seqConfig().Dangerous.Timeboost.RedisUrl, roundTimingInfo.Round)
+		redisCoordinator, err = timeboost.NewRedisCoordinator(seqConfig().Dangerous.Timeboost.RedisUrl, roundTimingInfo, seqConfig().Dangerous.Timeboost.RedisUpdateEventsChannelSize)
 		if err != nil {
 			return nil, fmt.Errorf("error initializing expressLaneService redis: %w", err)
 		}
@@ -310,18 +305,10 @@ func (es *expressLaneService) currentRoundHasController() bool {
 }
 
 // sequenceExpressLaneSubmission with the roundInfo lock held, validates sequence number and sender address fields of the message
-// adds the message to the transaction queue and waits for the response
-func (es *expressLaneService) sequenceExpressLaneSubmission(
-	ctx context.Context,
-	msg *timeboost.ExpressLaneSubmission,
-) error {
-	unlockByDefer := true
+// adds the message to the sequencer transaction queue
+func (es *expressLaneService) sequenceExpressLaneSubmission(msg *timeboost.ExpressLaneSubmission) error {
 	es.roundInfoMutex.Lock()
-	defer func() {
-		if unlockByDefer {
-			es.roundInfoMutex.Unlock()
-		}
-	}()
+	defer es.roundInfoMutex.Unlock()
 
 	// Below code block isn't a repetition, it prevents stale messages to be accepted during control transfer within or after the round ends!
 	controller, ok := es.roundControl.Load(msg.Round)
@@ -340,16 +327,16 @@ func (es *expressLaneService) sequenceExpressLaneSubmission(
 	if !es.roundInfo.Contains(msg.Round) {
 		es.roundInfo.Add(msg.Round, &expressLaneRoundInfo{
 			0,
-			make(map[uint64]*msgAndResult),
+			make(map[uint64]*timeboost.ExpressLaneSubmission),
 		})
 	}
 	roundInfo, _ := es.roundInfo.Get(msg.Round)
 
-	prev, exists := roundInfo.msgAndResultBySequenceNumber[msg.SequenceNumber]
+	prev, exists := roundInfo.msgBySequenceNumber[msg.SequenceNumber]
 
 	// Check if the submission nonce is too low.
 	if msg.SequenceNumber < roundInfo.sequence {
-		if exists && bytes.Equal(prev.msg.Signature, msg.Signature) {
+		if exists && bytes.Equal(prev.Signature, msg.Signature) {
 			return nil
 		}
 		return timeboost.ErrSequenceNumberTooLow
@@ -357,7 +344,7 @@ func (es *expressLaneService) sequenceExpressLaneSubmission(
 
 	// Check if a duplicate submission exists already, and reject if so.
 	if exists {
-		if bytes.Equal(prev.msg.Signature, msg.Signature) {
+		if bytes.Equal(prev.Signature, msg.Signature) {
 			return nil
 		}
 		return timeboost.ErrDuplicateSequenceNumber
@@ -368,78 +355,50 @@ func (es *expressLaneService) sequenceExpressLaneSubmission(
 	// Log an informational warning if the message's sequence number is in the future.
 	if msg.SequenceNumber > roundInfo.sequence {
 		if msg.SequenceNumber > roundInfo.sequence+seqConfig.Dangerous.Timeboost.MaxFutureSequenceDistance {
-			return fmt.Errorf("message sequence number has reached max allowed limit. SequenceNumber: %d, Limit: %d", msg.SequenceNumber, roundInfo.sequence+seqConfig.Dangerous.Timeboost.MaxFutureSequenceDistance)
+			return fmt.Errorf("message sequence number has reached max allowed limit. SequenceNumber: %d, ExpectedSequenceNumber: %d, Limit: %d", msg.SequenceNumber, roundInfo.sequence, roundInfo.sequence+seqConfig.Dangerous.Timeboost.MaxFutureSequenceDistance)
 		}
 		log.Info("Received express lane submission with future sequence number", "SequenceNumber", msg.SequenceNumber)
 	}
 
 	// Put into the sequence number map.
-	resultChan := make(chan error, 1)
-	roundInfo.msgAndResultBySequenceNumber[msg.SequenceNumber] = &msgAndResult{msg, resultChan}
+	roundInfo.msgBySequenceNumber[msg.SequenceNumber] = msg
 
 	if es.redisCoordinator != nil {
-		es.LaunchThread(func(context.Context) {
-			// Persist accepted expressLane txs to redis
-			if err := es.redisCoordinator.AddAcceptedTx(msg); err != nil {
-				log.Error("Error adding accepted ExpressLaneSubmission to redis. Loss of msg possible if sequencer switch happens", "seqNum", msg.SequenceNumber, "txHash", msg.Transaction.Hash(), "err", err)
-			}
-		})
+		// Persist accepted expressLane txs to redis
+		if err := es.redisCoordinator.AddAcceptedTx(msg); err != nil {
+			log.Error("Error adding accepted ExpressLaneSubmission to redis. Loss of msg possible if sequencer switch happens", "seqNum", msg.SequenceNumber, "txHash", msg.Transaction.Hash(), "err", err)
+		}
 	}
 
-	now := time.Now()
+	var retErr error
 	queueTimeout := seqConfig.QueueTimeout
-	for es.roundTimingInfo.RoundNumber() == msg.Round { // This check ensures that the controller for this round is not allowed to send transactions from msgAndResultBySequenceNumber map once the next round starts
+	for es.roundTimingInfo.RoundNumber() == msg.Round { // This check ensures that the controller for this round is not allowed to send transactions from msgBySequenceNumber map once the next round starts
 		// Get the next message in the sequence.
-		nextMsgAndResult, exists := roundInfo.msgAndResultBySequenceNumber[roundInfo.sequence]
+		nextMsg, exists := roundInfo.msgBySequenceNumber[roundInfo.sequence]
 		if !exists {
 			break
 		}
-		// Queued txs cannot use this message's context as it would lead to context canceled error once the result for this message is available and returned
-		// Hence using es.GetContext() allows unblocking of queued up txs even if current tx's context has errored out
-		var queueCtx context.Context
-		var cancel context.CancelFunc
-		queueCtx, _ = ctxWithTimeout(es.GetContext(), queueTimeout)
-		if nextMsgAndResult.msg.SequenceNumber == msg.SequenceNumber {
-			queueCtx, cancel = ctxWithTimeout(ctx, queueTimeout)
-			defer cancel()
+		// Txs (current or queued) cannot use this function's context as it would lead to context canceled error later on, once the tx is queued and this function returns, hence we use es.GetContext()
+		queueCtx, _ := ctxWithTimeout(es.GetContext(), queueTimeout)
+		if err := es.transactionPublisher.PublishTimeboostedTransaction(queueCtx, nextMsg.Transaction, nextMsg.Options); err != nil {
+			log.Error("Error queuing expressLane transaction", "seqNum", nextMsg.SequenceNumber, "txHash", nextMsg.Transaction.Hash(), "err", err)
+			if nextMsg.SequenceNumber == msg.SequenceNumber {
+				retErr = err
+			}
 		}
-		es.transactionPublisher.PublishTimeboostedTransaction(queueCtx, nextMsgAndResult.msg.Transaction, nextMsgAndResult.msg.Options, nextMsgAndResult.resultChan)
 		// Increase the global round sequence number.
 		roundInfo.sequence += 1
 	}
-
-	seqCount := roundInfo.sequence
 	es.roundInfo.Add(msg.Round, roundInfo)
-	unlockByDefer = false
-	es.roundInfoMutex.Unlock() // Release lock so that other timeboost txs can be processed
-
-	abortCtx, cancel := ctxWithTimeout(ctx, queueTimeout*2) // We use the same timeout value that sequencer imposes
-	defer cancel()
-	select {
-	case err = <-resultChan:
-	case <-abortCtx.Done():
-		if ctx.Err() == nil {
-			log.Warn("Transaction sequencing hit abort deadline", "err", abortCtx.Err(), "submittedAt", now, "TxProcessingTimeout", queueTimeout*2, "txHash", msg.Transaction.Hash())
-		}
-		err = fmt.Errorf("Transaction sequencing hit timeout, result for the submitted transaction is not yet available: %w", abortCtx.Err())
-	}
 
 	if es.redisCoordinator != nil {
-		es.LaunchThread(func(context.Context) {
-			// We update the sequence count in redis only after receiving a result for sequencing this message, instead of updating while holding roundInfoMutex,
-			// because this prevents any loss of transactions when the prev chosen sequencer updates the count but some how fails to forward txs to the current chosen.
-			// If the prev chosen ends up forwarding the tx, it is ok as the duplicate txs will be discarded
-			if redisErr := es.redisCoordinator.UpdateSequenceCount(msg.Round, seqCount); redisErr != nil {
-				log.Error("Error updating round's sequence count in redis", "err", redisErr) // this shouldn't be a problem if future msgs succeed in updating the count
-			}
-		})
+		// We update the sequence count in redis after we were able to queue the txs up until roundInfo.sequence
+		if redisErr := es.redisCoordinator.UpdateSequenceCount(msg.Round, roundInfo.sequence); redisErr != nil {
+			log.Error("Error updating round's sequence count in redis", "err", redisErr) // this shouldn't be a problem if future msgs succeed in updating the count
+		}
 	}
 
-	if err != nil {
-		// If the tx fails we return an error with all the necessary info for the controller
-		return fmt.Errorf("%w: Sequence number: %d (consumed), Transaction hash: %v, Error: %w", timeboost.ErrAcceptedTxFailed, msg.SequenceNumber, msg.Transaction.Hash(), err)
-	}
-	return nil
+	return retErr
 }
 
 // validateExpressLaneTx checks for the correctness of all fields of msg
@@ -496,7 +455,7 @@ func (es *expressLaneService) syncFromRedis() {
 	roundInfo, exists := es.roundInfo.Get(currentRound)
 	if !exists {
 		// If expressLaneRoundInfo for current round doesn't exist yet, we'll add it to the cache
-		roundInfo = &expressLaneRoundInfo{0, make(map[uint64]*msgAndResult)}
+		roundInfo = &expressLaneRoundInfo{0, make(map[uint64]*timeboost.ExpressLaneSubmission)}
 	}
 	if redisSeqCount > roundInfo.sequence {
 		roundInfo.sequence = redisSeqCount
@@ -508,10 +467,8 @@ func (es *expressLaneService) syncFromRedis() {
 	pendingMsgs := es.redisCoordinator.GetAcceptedTxs(currentRound, sequenceCount, sequenceCount+es.seqConfig().Dangerous.Timeboost.MaxFutureSequenceDistance)
 	log.Info("Attempting to sequence pending expressLane transactions from redis", "count", len(pendingMsgs))
 	for _, msg := range pendingMsgs {
-		es.LaunchThread(func(ctx context.Context) {
-			if err := es.sequenceExpressLaneSubmission(ctx, msg); err != nil {
-				log.Error("Untracked expressLaneSubmission returned an error", "round", msg.Round, "seqNum", msg.SequenceNumber, "txHash", msg.Transaction.Hash(), "err", err)
-			}
-		})
+		if err := es.sequenceExpressLaneSubmission(msg); err != nil {
+			log.Error("Untracked expressLaneSubmission returned an error while sequencing", "round", msg.Round, "seqNum", msg.SequenceNumber, "txHash", msg.Transaction.Hash(), "err", err)
+		}
 	}
 }

--- a/execution/gethexec/express_lane_service_test.go
+++ b/execution/gethexec/express_lane_service_test.go
@@ -367,6 +367,7 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_outOfOrder(t *testing
 	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher := makeStubPublisher(els)
 	els.transactionPublisher = stubPublisher
+
 	messages := []*timeboost.ExpressLaneSubmission{
 		buildValidSubmissionWithSeqAndTx(t, 0, 10, types.NewTransaction(0, common.MaxAddress, big.NewInt(0), 0, big.NewInt(0), []byte{1})),
 		buildValidSubmissionWithSeqAndTx(t, 0, 5, emptyTx),
@@ -425,6 +426,7 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_erroredTx(t *testing.
 	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher := makeStubPublisher(els)
 	els.transactionPublisher = stubPublisher
+
 	messages := []*timeboost.ExpressLaneSubmission{
 		buildValidSubmissionWithSeqAndTx(t, 0, 1, emptyTx),
 		buildValidSubmissionWithSeqAndTx(t, 0, 2, types.NewTransaction(0, common.MaxAddress, big.NewInt(0), 0, big.NewInt(0), []byte{1})),
@@ -440,6 +442,7 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_erroredTx(t *testing.
 			require.NoError(t, err)
 		}
 	}
+
 	// One tx out of the four should have failed, so we should have only published 3.
 	// Since sequence number 2 failed after submission stage, that nonce is used up
 	require.Equal(t, 3, len(stubPublisher.publishedTxOrder))
@@ -465,6 +468,7 @@ func Test_expressLaneService_syncFromRedis(t *testing.T) {
 	els1.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher1 := makeStubPublisher(els1)
 	els1.transactionPublisher = stubPublisher1
+
 	messages := []*timeboost.ExpressLaneSubmission{
 		buildValidSubmissionWithSeqAndTx(t, 0, 1, emptyTx),
 		buildValidSubmissionWithSeqAndTx(t, 0, 3, emptyTx),

--- a/execution/gethexec/express_lane_service_test.go
+++ b/execution/gethexec/express_lane_service_test.go
@@ -278,13 +278,12 @@ func makeStubPublisher(els *expressLaneService) *stubPublisher {
 
 var emptyTx = types.NewTransaction(0, common.MaxAddress, big.NewInt(0), 0, big.NewInt(0), nil)
 
-func (s *stubPublisher) PublishTimeboostedTransaction(parentCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions, resultChan chan error) {
+func (s *stubPublisher) PublishTimeboostedTransaction(parentCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions) error {
 	if tx.Hash() != emptyTx.Hash() {
-		resultChan <- errors.New("oops, bad tx")
-		return
+		return errors.New("oops, bad tx")
 	}
 	s.publishedTxOrder = append(s.publishedTxOrder, 0)
-	resultChan <- nil
+	return nil
 }
 
 func Test_expressLaneService_sequenceExpressLaneSubmission_nonceTooLow(t *testing.T) {
@@ -293,14 +292,14 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_nonceTooLow(t *testin
 	els := &expressLaneService{
 		roundInfo: containers.NewLruCache[uint64, *expressLaneRoundInfo](8),
 	}
-	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
+	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*timeboost.ExpressLaneSubmission)})
 	els.StopWaiter.Start(ctx, els)
 	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher := makeStubPublisher(els)
 	els.transactionPublisher = stubPublisher
 
 	msg := buildValidSubmissionWithSeqAndTx(t, 0, 0, emptyTx)
-	err := els.sequenceExpressLaneSubmission(ctx, msg)
+	err := els.sequenceExpressLaneSubmission(msg)
 	require.ErrorIs(t, err, timeboost.ErrSequenceNumberTooLow)
 }
 
@@ -308,16 +307,17 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_duplicateNonce(t *tes
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	redisUrl := redisutil.CreateTestRedis(ctx, t)
+	timingInfo := defaultTestRoundTimingInfo(time.Now())
 	els := &expressLaneService{
 		roundInfo:       containers.NewLruCache[uint64, *expressLaneRoundInfo](8),
-		roundTimingInfo: defaultTestRoundTimingInfo(time.Now()),
+		roundTimingInfo: timingInfo,
 		seqConfig:       func() *SequencerConfig { return &DefaultSequencerConfig },
 	}
 	var err error
-	els.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, els.roundTimingInfo.Round)
+	els.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, &timingInfo, 50)
 	require.NoError(t, err)
 	els.redisCoordinator.Start(ctx)
-	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
+	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*timeboost.ExpressLaneSubmission)})
 	els.StopWaiter.Start(ctx, els)
 	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher := makeStubPublisher(els)
@@ -326,16 +326,14 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_duplicateNonce(t *tes
 	msg1 := buildValidSubmissionWithSeqAndTx(t, 0, 2, types.NewTx(&types.DynamicFeeTx{Data: []byte{1}}))
 	msg2 := buildValidSubmissionWithSeqAndTx(t, 0, 2, types.NewTx(&types.DynamicFeeTx{Data: []byte{2}}))
 	var wg sync.WaitGroup
-	wg.Add(3) // We expect only of the below two to return with an error here
+	wg.Add(2) // We expect only one of the two txs below to return with an error here
 	var err1, err2 error
 	go func(w *sync.WaitGroup) {
-		w.Done()
-		err1 = els.sequenceExpressLaneSubmission(ctx, msg1)
+		err1 = els.sequenceExpressLaneSubmission(msg1)
 		wg.Done()
 	}(&wg)
 	go func(w *sync.WaitGroup) {
-		w.Done()
-		err2 = els.sequenceExpressLaneSubmission(ctx, msg2)
+		err2 = els.sequenceExpressLaneSubmission(msg2)
 		wg.Done()
 	}(&wg)
 	wg.Wait()
@@ -354,21 +352,21 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_outOfOrder(t *testing
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	redisUrl := redisutil.CreateTestRedis(ctx, t)
+	timingInfo := defaultTestRoundTimingInfo(time.Now())
 	els := &expressLaneService{
 		roundInfo:       containers.NewLruCache[uint64, *expressLaneRoundInfo](8),
-		roundTimingInfo: defaultTestRoundTimingInfo(time.Now()),
+		roundTimingInfo: timingInfo,
 		seqConfig:       func() *SequencerConfig { return &DefaultSequencerConfig },
 	}
 	var err error
-	els.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, els.roundTimingInfo.Round)
+	els.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, &timingInfo, 50)
 	require.NoError(t, err)
 	els.redisCoordinator.Start(ctx)
-	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
+	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*timeboost.ExpressLaneSubmission)})
 	els.StopWaiter.Start(ctx, els)
 	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher := makeStubPublisher(els)
 	els.transactionPublisher = stubPublisher
-
 	messages := []*timeboost.ExpressLaneSubmission{
 		buildValidSubmissionWithSeqAndTx(t, 0, 10, types.NewTransaction(0, common.MaxAddress, big.NewInt(0), 0, big.NewInt(0), []byte{1})),
 		buildValidSubmissionWithSeqAndTx(t, 0, 5, emptyTx),
@@ -377,55 +375,56 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_outOfOrder(t *testing
 		buildValidSubmissionWithSeqAndTx(t, 0, 2, emptyTx),
 	}
 
-	// We launch 5 goroutines out of which 2 would return with a result hence we initially add a delta of 7
+	// We launch 5 goroutines and all would return with a result upon queuing or buffering
 	var wg sync.WaitGroup
-	wg.Add(7)
+	wg.Add(5)
 	for _, msg := range messages {
 		go func(w *sync.WaitGroup) {
+			err := els.sequenceExpressLaneSubmission(msg)
+			require.NoError(t, err)
 			w.Done()
-			err := els.sequenceExpressLaneSubmission(ctx, msg)
-			if msg.SequenceNumber != 10 { // Because this go-routine will be interrupted after the test itself ends and 10 will still be waiting for result
-				require.NoError(t, err)
-				w.Done()
-			}
 		}(&wg)
 	}
 	wg.Wait()
 
-	// We should have only published 2, as we are missing sequence number 3.
-	time.Sleep(2 * time.Second)
+	// We should have only published 1 and 2, as we are missing sequence number 3.
 	require.Equal(t, 2, len(stubPublisher.publishedTxOrder))
 	els.roundInfoMutex.Lock()
 	roundInfo, _ := els.roundInfo.Get(0)
-	require.Equal(t, 5, len(roundInfo.msgAndResultBySequenceNumber))
+	require.Equal(t, uint64(3), roundInfo.sequence)
+	require.Equal(t, 5, len(roundInfo.msgBySequenceNumber))
 	els.roundInfoMutex.Unlock()
 
-	wg.Add(2) // 4 & 5 should be able to get in after 3 so we add a delta of 2
-	err = els.sequenceExpressLaneSubmission(ctx, buildValidSubmissionWithSeqAndTx(t, 0, 3, emptyTx))
+	// 4 & 5 should be able to get in after 3 so we add a delta of 2
+	err = els.sequenceExpressLaneSubmission(buildValidSubmissionWithSeqAndTx(t, 0, 3, emptyTx))
 	require.NoError(t, err)
-	wg.Wait()
 	require.Equal(t, 5, len(stubPublisher.publishedTxOrder))
+	els.roundInfoMutex.Lock()
+	roundInfo, _ = els.roundInfo.Get(0)
+	require.Equal(t, uint64(6), roundInfo.sequence)
+	require.Equal(t, 6, len(roundInfo.msgBySequenceNumber))
+	els.roundInfoMutex.Unlock()
 }
 
 func Test_expressLaneService_sequenceExpressLaneSubmission_erroredTx(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	redisUrl := redisutil.CreateTestRedis(ctx, t)
+	timingInfo := defaultTestRoundTimingInfo(time.Now())
 	els := &expressLaneService{
 		roundInfo:       containers.NewLruCache[uint64, *expressLaneRoundInfo](8),
-		roundTimingInfo: defaultTestRoundTimingInfo(time.Now()),
+		roundTimingInfo: timingInfo,
 		seqConfig:       func() *SequencerConfig { return &SequencerConfig{} },
 	}
 	var err error
-	els.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, els.roundTimingInfo.Round)
+	els.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, &timingInfo, 50)
 	require.NoError(t, err)
 	els.redisCoordinator.Start(ctx)
-	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
+	els.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*timeboost.ExpressLaneSubmission)})
 	els.StopWaiter.Start(ctx, els)
 	els.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher := makeStubPublisher(els)
 	els.transactionPublisher = stubPublisher
-
 	messages := []*timeboost.ExpressLaneSubmission{
 		buildValidSubmissionWithSeqAndTx(t, 0, 1, emptyTx),
 		buildValidSubmissionWithSeqAndTx(t, 0, 2, types.NewTransaction(0, common.MaxAddress, big.NewInt(0), 0, big.NewInt(0), []byte{1})),
@@ -434,14 +433,13 @@ func Test_expressLaneService_sequenceExpressLaneSubmission_erroredTx(t *testing.
 	}
 	for _, msg := range messages {
 		if msg.Transaction.Hash() != emptyTx.Hash() {
-			err := els.sequenceExpressLaneSubmission(ctx, msg)
+			err := els.sequenceExpressLaneSubmission(msg)
 			require.ErrorContains(t, err, "oops, bad tx")
 		} else {
-			err := els.sequenceExpressLaneSubmission(ctx, msg)
+			err := els.sequenceExpressLaneSubmission(msg)
 			require.NoError(t, err)
 		}
 	}
-
 	// One tx out of the four should have failed, so we should have only published 3.
 	// Since sequence number 2 failed after submission stage, that nonce is used up
 	require.Equal(t, 3, len(stubPublisher.publishedTxOrder))
@@ -451,22 +449,22 @@ func Test_expressLaneService_syncFromRedis(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	redisUrl := redisutil.CreateTestRedis(ctx, t)
+	timingInfo := defaultTestRoundTimingInfo(time.Now())
 	els1 := &expressLaneService{
 		roundInfo:       containers.NewLruCache[uint64, *expressLaneRoundInfo](8),
-		roundTimingInfo: defaultTestRoundTimingInfo(time.Now()),
+		roundTimingInfo: timingInfo,
 		seqConfig:       func() *SequencerConfig { return &DefaultSequencerConfig },
 	}
 	var err error
-	els1.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, els1.roundTimingInfo.Round)
+	els1.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, &timingInfo, 50)
 	require.NoError(t, err)
 	els1.redisCoordinator.Start(ctx)
 
-	els1.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
+	els1.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*timeboost.ExpressLaneSubmission)})
 	els1.StopWaiter.Start(ctx, els1)
 	els1.roundControl.Store(0, crypto.PubkeyToAddress(testPriv.PublicKey))
 	stubPublisher1 := makeStubPublisher(els1)
 	els1.transactionPublisher = stubPublisher1
-
 	messages := []*timeboost.ExpressLaneSubmission{
 		buildValidSubmissionWithSeqAndTx(t, 0, 1, emptyTx),
 		buildValidSubmissionWithSeqAndTx(t, 0, 3, emptyTx),
@@ -474,16 +472,13 @@ func Test_expressLaneService_syncFromRedis(t *testing.T) {
 		buildValidSubmissionWithSeqAndTx(t, 0, 5, emptyTx),
 	}
 
-	// We launch 4 goroutines out of which 1 would return with a result hence we add a delta of 5
+	// We launch 4 goroutines and all would return with a result upon queuing or buffering
 	var wg sync.WaitGroup
-	wg.Add(5)
+	wg.Add(4)
 	for _, msg := range messages {
 		go func(w *sync.WaitGroup) {
+			_ = els1.sequenceExpressLaneSubmission(msg)
 			w.Done()
-			_ = els1.sequenceExpressLaneSubmission(ctx, msg)
-			if msg.SequenceNumber == 1 {
-				w.Done()
-			}
 		}(&wg)
 	}
 	wg.Wait()
@@ -495,10 +490,10 @@ func Test_expressLaneService_syncFromRedis(t *testing.T) {
 
 	els2 := &expressLaneService{
 		roundInfo:       containers.NewLruCache[uint64, *expressLaneRoundInfo](8),
-		roundTimingInfo: defaultTestRoundTimingInfo(time.Now()),
+		roundTimingInfo: timingInfo,
 		seqConfig:       func() *SequencerConfig { return &DefaultSequencerConfig },
 	}
-	els2.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, els2.roundTimingInfo.Round)
+	els2.redisCoordinator, err = timeboost.NewRedisCoordinator(redisUrl, &timingInfo, 50)
 	require.NoError(t, err)
 	els2.redisCoordinator.Start(ctx)
 
@@ -509,7 +504,6 @@ func Test_expressLaneService_syncFromRedis(t *testing.T) {
 
 	// As els2 becomes an active sequencer, syncFromRedis would be called when Activate() function of sequencer is invoked
 	els2.syncFromRedis()
-	time.Sleep(time.Second) // wait for parallel sequencing of redis txs to complete
 
 	els2.roundInfoMutex.Lock()
 	roundInfo, exists := els2.roundInfo.Get(0)
@@ -519,12 +513,12 @@ func Test_expressLaneService_syncFromRedis(t *testing.T) {
 	if roundInfo.sequence != 2 {
 		t.Fatalf("round sequence count mismatch. Want: 2, Got: %d", roundInfo.sequence)
 	}
-	if len(roundInfo.msgAndResultBySequenceNumber) != 3 { // There should be three pending txs in msgAndResult map
-		t.Fatalf("number of future sequence txs mismatch. Want: 3, Got: %d", len(roundInfo.msgAndResultBySequenceNumber))
+	if len(roundInfo.msgBySequenceNumber) != 3 { // There should be three pending txs in msgAndResult map
+		t.Fatalf("number of future sequence txs mismatch. Want: 3, Got: %d", len(roundInfo.msgBySequenceNumber))
 	}
 	els2.roundInfoMutex.Unlock()
 
-	err = els2.sequenceExpressLaneSubmission(ctx, buildValidSubmissionWithSeqAndTx(t, 0, 2, emptyTx)) // Send an unblocking tx
+	err = els2.sequenceExpressLaneSubmission(buildValidSubmissionWithSeqAndTx(t, 0, 2, emptyTx)) // Send an unblocking tx
 	require.NoError(t, err)
 
 	time.Sleep(time.Second) // wait for future seq num txs to be processed
@@ -602,7 +596,7 @@ func Benchmark_expressLaneService_validateExpressLaneTx(b *testing.B) {
 		},
 	}
 	es.roundControl.Store(0, addr)
-	es.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*msgAndResult)})
+	es.roundInfo.Add(0, &expressLaneRoundInfo{1, make(map[uint64]*timeboost.ExpressLaneSubmission)})
 
 	sub := buildValidSubmission(b, common.HexToAddress("0x2Aef36410182881a4b13664a1E079762D7F716e6"), testPriv, 0)
 	b.StartTimer()

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -89,25 +89,27 @@ type DangerousConfig struct {
 }
 
 type TimeboostConfig struct {
-	Enable                    bool          `koanf:"enable"`
-	AuctionContractAddress    string        `koanf:"auction-contract-address"`
-	AuctioneerAddress         string        `koanf:"auctioneer-address"`
-	ExpressLaneAdvantage      time.Duration `koanf:"express-lane-advantage"`
-	SequencerHTTPEndpoint     string        `koanf:"sequencer-http-endpoint"`
-	EarlySubmissionGrace      time.Duration `koanf:"early-submission-grace"`
-	MaxFutureSequenceDistance uint64        `koanf:"max-future-sequence-distance"`
-	RedisUrl                  string        `koanf:"redis-url"`
+	Enable                       bool          `koanf:"enable"`
+	AuctionContractAddress       string        `koanf:"auction-contract-address"`
+	AuctioneerAddress            string        `koanf:"auctioneer-address"`
+	ExpressLaneAdvantage         time.Duration `koanf:"express-lane-advantage"`
+	SequencerHTTPEndpoint        string        `koanf:"sequencer-http-endpoint"`
+	EarlySubmissionGrace         time.Duration `koanf:"early-submission-grace"`
+	MaxFutureSequenceDistance    uint64        `koanf:"max-future-sequence-distance"`
+	RedisUrl                     string        `koanf:"redis-url"`
+	RedisUpdateEventsChannelSize uint64        `koanf:"redis-update-events-channel-size"`
 }
 
 var DefaultTimeboostConfig = TimeboostConfig{
-	Enable:                    false,
-	AuctionContractAddress:    "",
-	AuctioneerAddress:         "",
-	ExpressLaneAdvantage:      time.Millisecond * 200,
-	SequencerHTTPEndpoint:     "http://localhost:8547",
-	EarlySubmissionGrace:      time.Second * 2,
-	MaxFutureSequenceDistance: 25,
-	RedisUrl:                  "unset",
+	Enable:                       false,
+	AuctionContractAddress:       "",
+	AuctioneerAddress:            "",
+	ExpressLaneAdvantage:         time.Millisecond * 200,
+	SequencerHTTPEndpoint:        "http://localhost:8547",
+	EarlySubmissionGrace:         time.Second * 2,
+	MaxFutureSequenceDistance:    25,
+	RedisUrl:                     "unset",
+	RedisUpdateEventsChannelSize: 500,
 }
 
 func (c *SequencerConfig) Validate() error {
@@ -214,6 +216,7 @@ func TimeboostAddOptions(prefix string, f *flag.FlagSet) {
 	f.Duration(prefix+".early-submission-grace", DefaultTimeboostConfig.EarlySubmissionGrace, "period of time before the next round where submissions for the next round will be queued")
 	f.Uint64(prefix+".max-future-sequence-distance", DefaultTimeboostConfig.MaxFutureSequenceDistance, "maximum allowed difference (in terms of sequence numbers) between a future express lane tx and the current sequence count of a round")
 	f.String(prefix+".redis-url", DefaultTimeboostConfig.RedisUrl, "the Redis URL for expressLaneService to coordinate via")
+	f.Uint64(prefix+".redis-update-events-channel-size", DefaultTimeboostConfig.RedisUpdateEventsChannelSize, "size of update events' buffered channels in timeboost redis coordinator")
 }
 
 func DangerousAddOptions(prefix string, f *flag.FlagSet) {
@@ -609,13 +612,12 @@ func (s *Sequencer) PublishExpressLaneTransaction(ctx context.Context, msg *time
 		return forwarder.PublishExpressLaneTransaction(ctx, msg)
 	}
 
-	return s.expressLaneService.sequenceExpressLaneSubmission(ctx, msg)
+	return s.expressLaneService.sequenceExpressLaneSubmission(msg)
 }
 
-func (s *Sequencer) PublishTimeboostedTransaction(queueCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions, resultChan chan error) {
-	if err := s.publishTransactionToQueue(queueCtx, tx, options, resultChan, true); err != nil {
-		resultChan <- err
-	}
+func (s *Sequencer) PublishTimeboostedTransaction(queueCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions) error {
+	resultChan := make(chan error, 1)
+	return s.publishTransactionToQueue(queueCtx, tx, options, resultChan, true)
 }
 
 func (s *Sequencer) publishTransactionToQueue(queueCtx context.Context, tx *types.Transaction, options *arbitrum_types.ConditionalOptions, resultChan chan error, isExpressLaneController bool) error {
@@ -1412,6 +1414,24 @@ func (s *Sequencer) Start(ctxIn context.Context) error {
 	return nil
 }
 
+type TxSource int
+
+const (
+	RetryQueue TxSource = iota + 1
+	NonceFailures
+	TxQueue
+	TimeboostAuctionResolutionTxQueue
+)
+
+var txSources = []string{"unknown", "retryQueue", "nonceFailures", "txQueue", "timeboostAuctionResolutionTxQueue"}
+
+func (s TxSource) String() string {
+	if int(s) > len(txSources) || s < 0 {
+		return txSources[0]
+	}
+	return txSources[s]
+}
+
 func (s *Sequencer) StopAndWait() {
 	s.StopWaiter.StopAndWait()
 	if s.config().Dangerous.Timeboost.Enable && s.expressLaneService != nil {
@@ -1435,22 +1455,22 @@ func (s *Sequencer) StopAndWait() {
 	emptyqueues:
 		for {
 			var item txQueueItem
-			source := ""
+			var source TxSource
 			if s.txRetryQueue.Len() > 0 {
 				item = s.txRetryQueue.Pop()
-				source = "retryQueue"
+				source = RetryQueue
 			} else if s.nonceFailures.Len() > 0 {
 				_, failure, _ := s.nonceFailures.GetOldest()
 				failure.revived = true
 				item = failure.queueItem
-				source = "nonceFailures"
+				source = NonceFailures
 				s.nonceFailures.RemoveOldest()
 			} else {
 				select {
 				case item = <-s.txQueue:
-					source = "txQueue"
+					source = TxQueue
 				case item = <-s.timeboostAuctionResolutionTxQueue:
-					source = "timeboostAuctionResolutionTxQueue"
+					source = TimeboostAuctionResolutionTxQueue
 				default:
 					break emptyqueues
 				}
@@ -1458,9 +1478,14 @@ func (s *Sequencer) StopAndWait() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				err := forwarder.PublishTransaction(item.ctx, item.tx, item.options)
+				var err error
+				if source == TimeboostAuctionResolutionTxQueue {
+					err = forwarder.PublishAuctionResolutionTransaction(item.ctx, item.tx)
+				} else {
+					err = forwarder.PublishTransaction(item.ctx, item.tx, item.options)
+				}
 				if err != nil {
-					log.Warn("failed to forward transaction while shutting down", "source", source, "err", err)
+					log.Warn("failed to forward transaction while shutting down", "source", source.String(), "err", err)
 				}
 			}()
 		}

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
@@ -574,12 +573,11 @@ func TestExpressLaneTransactionHandling(t *testing.T) {
 		if failErr == nil {
 			t.Fatal("incorrect express lane tx didn't fail upon submission")
 		}
-		if !strings.Contains(failErr.Error(), timeboost.ErrAcceptedTxFailed.Error()) || // Should be an ErrAcceptedTxFailed error that would consume sequence number
-			!strings.Contains(failErr.Error(), reason) {
+		if !strings.Contains(failErr.Error(), reason) {
 			t.Fatalf("unexpected error string returned: %s", failErr.Error())
 		}
 	}
-	checkFailErr(core.ErrNonceTooHigh.Error())
+	checkFailErr("context deadline exceeded") // tx will be rejected with nonce too high error so wont appear in a block
 
 	wg.Add(1)
 	go func(w *sync.WaitGroup) {
@@ -588,7 +586,7 @@ func TestExpressLaneTransactionHandling(t *testing.T) {
 	}(&wg)
 	wg.Wait()
 
-	checkFailErr("Transaction sequencing hit timeout")
+	checkFailErr("context deadline exceeded")
 }
 
 func dbKey(prefix []byte, pos uint64) []byte {
@@ -1189,11 +1187,11 @@ func TestSequencerFeed_ExpressLaneAuction_InnerPayloadNoncesAreRespected_Timeboo
 		To:        &ownerAddr,
 		Gas:       seqInfo.TransferGas,
 		Value:     big.NewInt(1e12),
-		Nonce:     1,
+		Nonce:     2,
 		GasFeeCap: aliceTx.GasFeeCap(),
 		Data:      nil,
 	}
-	charlie1 := seqInfo.SignTxAs("Charlie", txData)
+	charlie2 := seqInfo.SignTxAs("Charlie", txData)
 	txData = &types.DynamicFeeTx{
 		To:        &ownerAddr,
 		Gas:       seqInfo.TransferGas,
@@ -1203,21 +1201,23 @@ func TestSequencerFeed_ExpressLaneAuction_InnerPayloadNoncesAreRespected_Timeboo
 		Data:      nil,
 	}
 	charlie0 := seqInfo.SignTxAs("Charlie", txData)
+
+	// Send the express lane txs with nonces out of order, 0 and 2 so that nonce reordering logic in sequencer doesn't resequence them correctly
 	var err2 error
 	go func(w *sync.WaitGroup) {
 		defer w.Done()
 		time.Sleep(time.Millisecond * 10)
-		// Send the express lane txs with nonces out of order
-		err2 = expressLaneClient.SendTransaction(ctx, charlie1)
-		err = expressLaneClient.SendTransaction(ctx, charlie0)
-		Require(t, err)
+		err2 = expressLaneClient.SendTransactionWithSequence(ctx, charlie2, 0)
 	}(&wg)
+	time.Sleep(time.Millisecond * 50)
+	err = expressLaneClient.SendTransactionWithSequence(ctx, charlie0, 1)
+	Require(t, err)
 	wg.Wait()
 	if err2 == nil {
-		t.Fatal("Charlie should not be able to send tx with nonce 1")
+		t.Fatal("Charlie should not be able to send tx with nonce 2")
 	}
-	if !strings.Contains(err2.Error(), timeboost.ErrAcceptedTxFailed.Error()) {
-		t.Fatal("Charlie's first tx should've consumed a sequence number as it was initially accepted")
+	if !strings.Contains(err2.Error(), "context deadline exceeded") {
+		t.Fatal("Charlie's first tx should've consumed a sequence number and rejected thus not appear in a block leading to context deadline exceeded from EnsureTxSucceeded")
 	}
 	// After round is done, verify that Charlie beats Alice in the final sequence, and that the emitted txs
 	// for Charlie are correct.
@@ -1423,10 +1423,11 @@ func setupExpressLaneAuction(
 	builderSeq.nodeConfig.SeqCoordinator.DeleteFinalizedMsgs = false
 	builderSeq.execConfig.Sequencer.Enable = true
 	builderSeq.execConfig.Sequencer.Dangerous.Timeboost = gethexec.TimeboostConfig{
-		Enable:                    false, // We need to start without timeboost initially to create the auction contract
-		ExpressLaneAdvantage:      time.Second * 5,
-		RedisUrl:                  expressLaneRedisURL,
-		MaxFutureSequenceDistance: 1500, // Required for TestExpressLaneTransactionHandlingComplex
+		Enable:                       false, // We need to start without timeboost initially to create the auction contract
+		ExpressLaneAdvantage:         time.Second * 5,
+		RedisUrl:                     expressLaneRedisURL,
+		MaxFutureSequenceDistance:    1500, // Required for TestExpressLaneTransactionHandlingComplex
+		RedisUpdateEventsChannelSize: 50,
 	}
 	builderSeq.nodeConfig.TransactionStreamer.TrackBlockMetadataFrom = 1
 	cleanupSeq := builderSeq.Build(t)
@@ -1790,6 +1791,7 @@ type expressLaneClient struct {
 	roundTimingInfo     timeboost.RoundTimingInfo
 	auctionContractAddr common.Address
 	client              *rpc.Client
+	ethClient           *ethclient.Client
 	sequence            uint64
 }
 
@@ -1806,6 +1808,7 @@ func newExpressLaneClient(
 		roundTimingInfo:     roundTimingInfo,
 		auctionContractAddr: auctionContractAddr,
 		client:              client,
+		ethClient:           ethclient.NewClient(client),
 		sequence:            0,
 	}
 }
@@ -1844,14 +1847,15 @@ func (elc *expressLaneClient) SendTransactionWithSequence(ctx context.Context, t
 	if _, err := promise.Await(ctx); err != nil {
 		return err
 	}
-	return nil
+	_, err = EnsureTxSucceeded(ctx, elc.ethClient, transaction)
+	return err
 }
 
 func (elc *expressLaneClient) SendTransaction(ctx context.Context, transaction *types.Transaction) error {
 	elc.Lock()
 	defer elc.Unlock()
 	err := elc.SendTransactionWithSequence(ctx, transaction, elc.sequence)
-	if err == nil || strings.Contains(err.Error(), timeboost.ErrAcceptedTxFailed.Error()) {
+	if err == nil {
 		elc.sequence += 1
 	}
 	return err

--- a/timeboost/errors.go
+++ b/timeboost/errors.go
@@ -16,5 +16,4 @@ var (
 	ErrDuplicateSequenceNumber  = errors.New("SUBMISSION_NONCE_ALREADY_SEEN")
 	ErrSequenceNumberTooLow     = errors.New("SUBMISSION_NONCE_TOO_LOW")
 	ErrTooManyBids              = errors.New("PER_ROUND_BID_LIMIT_REACHED")
-	ErrAcceptedTxFailed         = errors.New("Accepted timeboost tx failed")
 )


### PR DESCRIPTION
Backports https://github.com/OffchainLabs/nitro/pull/2966