### PR TITLE
[Backport] Implement block-based timeout and set timeboost queued transactions to timeout at the round endtime

### DIFF
--- a/execution/gethexec/express_lane_service.go
+++ b/execution/gethexec/express_lane_service.go
@@ -378,8 +378,10 @@ func (es *expressLaneService) sequenceExpressLaneSubmission(msg *timeboost.Expre
 		if !exists {
 			break
 		}
-		// Txs (current or queued) cannot use this function's context as it would lead to context canceled error later on, once the tx is queued and this function returns, hence we use es.GetContext()
-		queueCtx, _ := ctxWithTimeout(es.GetContext(), queueTimeout)
+		// Txs (current or buffered) cannot use this function's context as it would lead to context canceled error later on, once the tx is queued and this function returns, hence we
+		// use es.GetContext(). Txs sequenced this round shouldn't be processed by sequencer into next round, to enforce this, queueCtx has a timeout = min(TimeTilNextRound, queueTimeout)
+		timeout := min(es.roundTimingInfo.TimeTilNextRound(), queueTimeout)
+		queueCtx, _ := ctxWithTimeout(es.GetContext(), timeout)
 		if err := es.transactionPublisher.PublishTimeboostedTransaction(queueCtx, nextMsg.Transaction, nextMsg.Options); err != nil {
 			log.Error("Error queuing expressLane transaction", "seqNum", nextMsg.SequenceNumber, "txHash", nextMsg.Transaction.Hash(), "err", err)
 			if nextMsg.SequenceNumber == msg.SequenceNumber {

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -98,6 +98,7 @@ type TimeboostConfig struct {
 	MaxFutureSequenceDistance    uint64        `koanf:"max-future-sequence-distance"`
 	RedisUrl                     string        `koanf:"redis-url"`
 	RedisUpdateEventsChannelSize uint64        `koanf:"redis-update-events-channel-size"`
+	QueueTimeoutInBlocks         uint64        `koanf:"queue-timeout-in-blocks"`
 }
 
 var DefaultTimeboostConfig = TimeboostConfig{
@@ -110,6 +111,7 @@ var DefaultTimeboostConfig = TimeboostConfig{
 	MaxFutureSequenceDistance:    25,
 	RedisUrl:                     "unset",
 	RedisUpdateEventsChannelSize: 500,
+	QueueTimeoutInBlocks:         5,
 }
 
 func (c *SequencerConfig) Validate() error {
@@ -217,6 +219,7 @@ func TimeboostAddOptions(prefix string, f *flag.FlagSet) {
 	f.Uint64(prefix+".max-future-sequence-distance", DefaultTimeboostConfig.MaxFutureSequenceDistance, "maximum allowed difference (in terms of sequence numbers) between a future express lane tx and the current sequence count of a round")
 	f.String(prefix+".redis-url", DefaultTimeboostConfig.RedisUrl, "the Redis URL for expressLaneService to coordinate via")
 	f.Uint64(prefix+".redis-update-events-channel-size", DefaultTimeboostConfig.RedisUpdateEventsChannelSize, "size of update events' buffered channels in timeboost redis coordinator")
+	f.Uint64(prefix+".queue-timeout-in-blocks", DefaultTimeboostConfig.QueueTimeoutInBlocks, "maximum amount of time (measured in blocks) that Express Lane transactions can wait in the sequencer's queue")
 }
 
 func DangerousAddOptions(prefix string, f *flag.FlagSet) {
@@ -232,6 +235,7 @@ type txQueueItem struct {
 	ctx             context.Context
 	firstAppearance time.Time
 	isTimeboosted   bool
+	blockStamp      uint64 // block number at which timeboosted tx was added to the txQueue
 }
 
 func (i *txQueueItem) returnResult(err error) {
@@ -663,6 +667,11 @@ func (s *Sequencer) publishTransactionToQueue(queueCtx context.Context, tx *type
 		}
 	}
 
+	var blockStamp uint64
+	if isExpressLaneController && config.Dangerous.Timeboost.QueueTimeoutInBlocks > 0 {
+		blockStamp = s.execEngine.bc.CurrentBlock().Number.Uint64()
+	}
+
 	queueItem := txQueueItem{
 		tx,
 		len(txBytes),
@@ -672,6 +681,7 @@ func (s *Sequencer) publishTransactionToQueue(queueCtx context.Context, tx *type
 		queueCtx,
 		time.Now(),
 		isExpressLaneController,
+		blockStamp,
 	}
 	select {
 	case s.txQueue <- queueItem:
@@ -1010,6 +1020,7 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 	defer nonceFailureCacheSizeGauge.Update(int64(s.nonceFailures.Len()))
 
 	config := s.config()
+	lastBlock := s.execEngine.bc.CurrentBlock()
 
 	// Clear out old nonceFailures
 	s.nonceFailures.Resize(config.NonceFailureCacheSize)
@@ -1089,6 +1100,23 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 		if queueItem.txSize > config.MaxTxDataSize {
 			// This tx is too large
 			queueItem.returnResult(txpool.ErrOversizedData)
+			continue
+		}
+		if queueItem.isTimeboosted &&
+			queueItem.blockStamp != 0 &&
+			lastBlock.Number.Uint64() >= queueItem.blockStamp+config.Dangerous.Timeboost.QueueTimeoutInBlocks {
+			err := fmt.Errorf("timeboosted tx: %s has hit block based timeout. currentBlockNum: %d, blockStamp: %d, blockExpiry: %d",
+				queueItem.tx.Hash(),
+				lastBlock.Number.Uint64()+1,
+				queueItem.blockStamp,
+				queueItem.blockStamp+config.Dangerous.Timeboost.QueueTimeoutInBlocks,
+			)
+			queueItem.returnResult(err) // this isnt read by anyone, so we log a debug line
+			log.Debug("Error sequencing timeboost tx", "err", err)
+			continue
+		}
+		if arbmath.BigLessThan(queueItem.tx.GasFeeCap(), lastBlock.BaseFee) {
+			queueItem.returnResult(fmt.Errorf("%w: maxFeePerGas: %s baseFee: %s", core.ErrFeeCapTooLow, queueItem.tx.GasFeeCap(), lastBlock.BaseFee))
 			continue
 		}
 		if totalBlockSize+queueItem.txSize > config.MaxTxDataSize {


### PR DESCRIPTION
Backports https://github.com/OffchainLabs/nitro/pull/3013