### PR TITLE
Hide eip7623 behind an ArbOwner contract call

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -615,7 +615,7 @@ func (b *BatchPoster) ParentChainIsUsingEIP7623(ctx context.Context, latestHeade
 	if diffIsClose(gas1, gas2, 14, 18) {
 		// targetDiff is 16
 		parentChainIsUsingEIP7623 = false
-	} else if diffIsClose(gas1, gas2, 36, 44) {
+	} else if diffIsClose(gas1, gas2, 36, 200) {
 		// targetDiff is 40
 		parentChainIsUsingEIP7623 = true
 	} else {

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -615,7 +615,7 @@ func (b *BatchPoster) ParentChainIsUsingEIP7623(ctx context.Context, latestHeade
 	if diffIsClose(gas1, gas2, 14, 18) {
 		// targetDiff is 16
 		parentChainIsUsingEIP7623 = false
-	} else if diffIsClose(gas1, gas2, 36, 200) {
+	} else if diffIsClose(gas1, gas2, 36, 40) {
 		// targetDiff is 40
 		parentChainIsUsingEIP7623 = true
 	} else {

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -615,7 +615,7 @@ func (b *BatchPoster) ParentChainIsUsingEIP7623(ctx context.Context, latestHeade
 	if diffIsClose(gas1, gas2, 14, 18) {
 		// targetDiff is 16
 		parentChainIsUsingEIP7623 = false
-	} else if diffIsClose(gas1, gas2, 36, 40) {
+	} else if diffIsClose(gas1, gas2, 36, 44) {
 		// targetDiff is 40
 		parentChainIsUsingEIP7623 = true
 	} else {

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -24,6 +24,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbos/blockhash"
 	"github.com/offchainlabs/nitro/arbos/burn"
+	"github.com/offchainlabs/nitro/arbos/features"
 	"github.com/offchainlabs/nitro/arbos/l1pricing"
 	"github.com/offchainlabs/nitro/arbos/l2pricing"
 	"github.com/offchainlabs/nitro/arbos/merkleAccumulator"
@@ -52,6 +53,7 @@ type ArbosState struct {
 	chainOwners            *addressSet.AddressSet
 	sendMerkle             *merkleAccumulator.MerkleAccumulator
 	programs               *programs.Programs
+	features               *features.Features
 	blockhashes            *blockhash.Blockhashes
 	chainId                storage.StorageBackedBigInt
 	chainConfig            storage.StorageBackedBytes
@@ -86,6 +88,7 @@ func OpenArbosState(stateDB vm.StateDB, burner burn.Burner) (*ArbosState, error)
 		addressSet.OpenAddressSet(backingStorage.OpenCachedSubStorage(chainOwnerSubspace)),
 		merkleAccumulator.OpenMerkleAccumulator(backingStorage.OpenCachedSubStorage(sendMerkleSubspace)),
 		programs.Open(backingStorage.OpenSubStorage(programsSubspace)),
+		features.Open(backingStorage.OpenSubStorage(featuresSubspace)),
 		blockhash.OpenBlockhashes(backingStorage.OpenCachedSubStorage(blockhashesSubspace)),
 		backingStorage.OpenStorageBackedBigInt(uint64(chainIdOffset)),
 		backingStorage.OpenStorageBackedBytes(chainConfigSubspace),
@@ -168,6 +171,7 @@ var (
 	blockhashesSubspace  SubspaceID = []byte{6}
 	chainConfigSubspace  SubspaceID = []byte{7}
 	programsSubspace     SubspaceID = []byte{8}
+	featuresSubspace     SubspaceID = []byte{9}
 )
 
 var PrecompileMinArbOSVersions = make(map[common.Address]uint64)
@@ -440,6 +444,10 @@ func (state *ArbosState) SendMerkleAccumulator() *merkleAccumulator.MerkleAccumu
 
 func (state *ArbosState) Programs() *programs.Programs {
 	return state.programs
+}
+
+func (state *ArbosState) Features() *features.Features {
+	return state.features
 }
 
 func (state *ArbosState) Blockhashes() *blockhash.Blockhashes {

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -335,6 +335,12 @@ func (state *ArbosState) UpgradeArbosVersion(
 		case params.ArbosVersion_32:
 			// no change state needed
 
+		case 33, 34, 35, 36, 37, 38, 39:
+			// these versions are left to Orbit chains for custom upgrades.
+
+		case params.ArbosVersion_40:
+			// no change state needed
+
 		default:
 			return fmt.Errorf(
 				"the chain is upgrading to unsupported ArbOS version %v, %w",

--- a/arbos/arbosState/initialization_test.go
+++ b/arbos/arbosState/initialization_test.go
@@ -77,6 +77,28 @@ func tryMarshalUnmarshal(input *statetransfer.ArbosInitializationInfo, t *testin
 	checkAddressTable(arbState, input.AddressTableContents, t)
 	checkRetryables(arbState, input.RetryableData, t)
 	checkAccounts(stateDb, arbState, input.Accounts, t)
+	checkFeatures(t, arbState)
+}
+
+func checkFeatures(t *testing.T, arbState *ArbosState) {
+	t.Helper()
+	want := false
+	got := arbState.Features().IsIncreasedCalldataPriceEnabled()
+	if got != want {
+		t.Error("IsIncreasedCalldataPriceEnabled got:", got, " want:", want)
+	}
+	arbState.Features().SetCalldataPriceIncrease(true)
+	want = true
+	got = arbState.Features().IsIncreasedCalldataPriceEnabled()
+	if got != want {
+		t.Error("IsIncreasedCalldataPriceEnabled got:", got, " want:", want)
+	}
+	arbState.Features().SetCalldataPriceIncrease(false)
+	want = false
+	got = arbState.Features().IsIncreasedCalldataPriceEnabled()
+	if got != want {
+		t.Error("IsIncreasedCalldataPriceEnabled got:", got, " want:", want)
+	}
 }
 
 func pseudorandomRetryableInitForTesting(prand *testhelpers.PseudoRandomDataSource) statetransfer.InitializationDataForRetryable {

--- a/arbos/arbosState/initialization_test.go
+++ b/arbos/arbosState/initialization_test.go
@@ -83,19 +83,30 @@ func tryMarshalUnmarshal(input *statetransfer.ArbosInitializationInfo, t *testin
 func checkFeatures(t *testing.T, arbState *ArbosState) {
 	t.Helper()
 	want := false
-	got := arbState.Features().IsIncreasedCalldataPriceEnabled()
+	got, err := arbState.Features().IsIncreasedCalldataPriceEnabled()
+	if err != nil {
+		t.Error(err)
+	}
 	if got != want {
 		t.Error("IsIncreasedCalldataPriceEnabled got:", got, " want:", want)
 	}
 	arbState.Features().SetCalldataPriceIncrease(true)
 	want = true
-	got = arbState.Features().IsIncreasedCalldataPriceEnabled()
+	got, err = arbState.Features().IsIncreasedCalldataPriceEnabled()
+	if err != nil {
+		t.Error(err)
+	}
 	if got != want {
 		t.Error("IsIncreasedCalldataPriceEnabled got:", got, " want:", want)
 	}
-	arbState.Features().SetCalldataPriceIncrease(false)
+	if err = arbState.Features().SetCalldataPriceIncrease(false); err != nil {
+		t.Error(err)
+	}
 	want = false
-	got = arbState.Features().IsIncreasedCalldataPriceEnabled()
+	got, err = arbState.Features().IsIncreasedCalldataPriceEnabled()
+	if err != nil {
+		t.Error(err)
+	}
 	if got != want {
 		t.Error("IsIncreasedCalldataPriceEnabled got:", got, " want:", want)
 	}

--- a/arbos/arbosState/initialization_test.go
+++ b/arbos/arbosState/initialization_test.go
@@ -90,7 +90,9 @@ func checkFeatures(t *testing.T, arbState *ArbosState) {
 	if got != want {
 		t.Error("IsIncreasedCalldataPriceEnabled got:", got, " want:", want)
 	}
-	arbState.Features().SetCalldataPriceIncrease(true)
+	if err = arbState.Features().SetCalldataPriceIncrease(true); err != nil {
+		t.Error(err)
+	}
 	want = true
 	got, err = arbState.Features().IsIncreasedCalldataPriceEnabled()
 	if err != nil {

--- a/arbos/features/features.go
+++ b/arbos/features/features.go
@@ -1,0 +1,57 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see
+// https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package features
+
+import (
+	"github.com/offchainlabs/nitro/arbos/storage"
+)
+
+const (
+	// This should work for the first 256 features. After that, either add
+	// another member to the Features struct, or switch to StorageBackedBytes.
+	increasedCalldata int = iota
+)
+
+// Features is a thin wrapper around a storage.StorageBackedBigUint that
+// provides accessors for various feature toggles.
+type Features struct {
+	features storage.StorageBackedBigUint
+}
+
+// SetIncreasedCalldataPriceIncrease sets the increased calldata price feature
+// on or off depending on the value of enabled.
+func (f *Features) SetCalldataPriceIncrease(enabled bool) {
+	f.setBit(increasedCalldata, enabled)
+}
+
+// IsIncreasedCalldataPriceEnabled returns true if the increased calldata price
+// feature is enabled.
+func (f *Features) IsIncreasedCalldataPriceEnabled() bool {
+	return f.isSet(increasedCalldata)
+}
+
+func (f *Features) setBit(index int, enabled bool) {
+	bit := uint(1)
+	if !enabled {
+		bit = 0
+	}
+	// Features cannot be uninitialized.
+	bi, _ := f.features.Get()
+	bi.SetBit(bi, index, bit)
+	// This won't underflow or overflow. Not checking error.
+	f.features.SetChecked(bi)
+}
+
+func (f *Features) isSet(index int) bool {
+	// Features cannot be uninitialized.
+	bi, _ := f.features.Get()
+	return bi.Bit(index) == 1
+}
+
+func Open(sto *storage.Storage) *Features {
+	return &Features{
+		features: sto.OpenStorageBackedBigUint(0),
+	}
+}

--- a/arbos/features/features.go
+++ b/arbos/features/features.go
@@ -22,34 +22,36 @@ type Features struct {
 
 // SetIncreasedCalldataPriceIncrease sets the increased calldata price feature
 // on or off depending on the value of enabled.
-func (f *Features) SetCalldataPriceIncrease(enabled bool) {
-	f.setBit(increasedCalldata, enabled)
+func (f *Features) SetCalldataPriceIncrease(enabled bool) error {
+	return f.setBit(increasedCalldata, enabled)
 }
 
 // IsIncreasedCalldataPriceEnabled returns true if the increased calldata price
 // feature is enabled.
-func (f *Features) IsIncreasedCalldataPriceEnabled() bool {
+func (f *Features) IsIncreasedCalldataPriceEnabled() (bool, error) {
 	return f.isSet(increasedCalldata)
 }
 
-func (f *Features) setBit(index int, enabled bool) {
+func (f *Features) setBit(index int, enabled bool) error {
 	bit := uint(1)
 	if !enabled {
 		bit = 0
 	}
 	// Features cannot be uninitialized.
-	bi, _ := f.features.Get()
-	bi.SetBit(bi, index, bit)
-	// This won't underflow or overflow. Panic if it does.
-	if err := f.features.SetChecked(bi); err != nil {
-		panic(err)
+	bi, err := f.features.Get()
+	if err != nil {
+		return err
 	}
+	bi.SetBit(bi, index, bit)
+	return f.features.SetChecked(bi)
 }
 
-func (f *Features) isSet(index int) bool {
-	// Features cannot be uninitialized.
-	bi, _ := f.features.Get()
-	return bi.Bit(index) == 1
+func (f *Features) isSet(index int) (bool, error) {
+	bi, err := f.features.Get()
+	if err != nil {
+		return false, err
+	}
+	return bi.Bit(index) == 1, nil
 }
 
 func Open(sto *storage.Storage) *Features {

--- a/arbos/features/features.go
+++ b/arbos/features/features.go
@@ -40,8 +40,10 @@ func (f *Features) setBit(index int, enabled bool) {
 	// Features cannot be uninitialized.
 	bi, _ := f.features.Get()
 	bi.SetBit(bi, index, bit)
-	// This won't underflow or overflow. Not checking error.
-	f.features.SetChecked(bi)
+	// This won't underflow or overflow. Panic if it does.
+	if err := f.features.SetChecked(bi); err != nil {
+		panic(err)
+	}
 }
 
 func (f *Features) isSet(index int) bool {

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -781,5 +781,13 @@ func (p *TxProcessor) MsgIsNonMutating() bool {
 }
 
 func (p *TxProcessor) IsCalldataPricingIncreaseEnabled() bool {
-	return p.state.ArbOSVersion() >= params.ArbosVersion_40 && p.state.Features().IsIncreasedCalldataPriceEnabled()
+	if p.state.ArbOSVersion() < params.ArbosVersion_40 {
+		return false
+	}
+	enabled, err := p.state.Features().IsIncreasedCalldataPriceEnabled()
+	if err != nil {
+		log.Error("failed to check if increased calldata pricing is enabled", "err", err)
+		return false
+	}
+	return enabled
 }

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -779,3 +779,7 @@ func (p *TxProcessor) MsgIsNonMutating() bool {
 	mode := p.msg.TxRunMode
 	return mode == core.MessageGasEstimationMode || mode == core.MessageEthcallMode
 }
+
+func (p *TxProcessor) IsCalldataPricingIncreaseEnabled() bool {
+	return p.state.ArbOSVersion() >= params.ArbosVersion_40 && p.state.Features().IsIncreasedCalldataPriceEnabled()
+}

--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -166,7 +166,7 @@
         "EnableArbOS": true,
         "AllowDebugPrecompiles": true,
         "DataAvailabilityCommittee": false,
-        "InitialArbOSVersion": 32,
+        "InitialArbOSVersion": 40,
         "InitialChainOwner": "0x0000000000000000000000000000000000000000",
         "GenesisBlockNum": 0
       }

--- a/precompiles/ArbOwner.go
+++ b/precompiles/ArbOwner.go
@@ -353,3 +353,16 @@ func (con ArbOwner) SetChainConfig(c ctx, evm mech, serializedChainConfig []byte
 	}
 	return c.State.SetChainConfig(serializedChainConfig)
 }
+
+// SetCalldataPriceIncrease sets the increased calldata price feature on or off
+// (EIP-7623)
+func (con ArbOwner) SetCalldataPriceIncrease(c ctx, _ mech, enable bool) error {
+	c.State.Features().SetCalldataPriceIncrease(enable)
+	return nil
+}
+
+// IsCalldataPriceIncreaseEnabled checks if the increased calldata price feature
+// (EIP-7623) is enabled
+func (con ArbOwner) IsCalldataPriceIncreaseEnabled(c ctx, _ mech) (bool, error) {
+	return c.State.Features().IsIncreasedCalldataPriceEnabled(), nil
+}

--- a/precompiles/ArbOwner.go
+++ b/precompiles/ArbOwner.go
@@ -357,6 +357,5 @@ func (con ArbOwner) SetChainConfig(c ctx, evm mech, serializedChainConfig []byte
 // SetCalldataPriceIncrease sets the increased calldata price feature on or off
 // (EIP-7623)
 func (con ArbOwner) SetCalldataPriceIncrease(c ctx, _ mech, enable bool) error {
-	c.State.Features().SetCalldataPriceIncrease(enable)
-	return nil
+	return c.State.Features().SetCalldataPriceIncrease(enable)
 }

--- a/precompiles/ArbOwner.go
+++ b/precompiles/ArbOwner.go
@@ -360,9 +360,3 @@ func (con ArbOwner) SetCalldataPriceIncrease(c ctx, _ mech, enable bool) error {
 	c.State.Features().SetCalldataPriceIncrease(enable)
 	return nil
 }
-
-// IsCalldataPriceIncreaseEnabled checks if the increased calldata price feature
-// (EIP-7623) is enabled
-func (con ArbOwner) IsCalldataPriceIncreaseEnabled(c ctx, _ mech) (bool, error) {
-	return c.State.Features().IsIncreasedCalldataPriceEnabled(), nil
-}

--- a/precompiles/ArbOwnerPublic.go
+++ b/precompiles/ArbOwnerPublic.go
@@ -70,5 +70,5 @@ func (con ArbOwnerPublic) GetScheduledUpgrade(c ctx, evm mech) (uint64, uint64, 
 // IsCalldataPriceIncreaseEnabled checks if the increased calldata price feature
 // (EIP-7623) is enabled
 func (con ArbOwnerPublic) IsCalldataPriceIncreaseEnabled(c ctx, _ mech) (bool, error) {
-	return c.State.Features().IsIncreasedCalldataPriceEnabled(), nil
+	return c.State.Features().IsIncreasedCalldataPriceEnabled()
 }

--- a/precompiles/ArbOwnerPublic.go
+++ b/precompiles/ArbOwnerPublic.go
@@ -66,3 +66,9 @@ func (con ArbOwnerPublic) GetScheduledUpgrade(c ctx, evm mech) (uint64, uint64, 
 	}
 	return version, timestamp, nil
 }
+
+// IsCalldataPriceIncreaseEnabled checks if the increased calldata price feature
+// (EIP-7623) is enabled
+func (con ArbOwnerPublic) IsCalldataPriceIncreaseEnabled(c ctx, _ mech) (bool, error) {
+	return c.State.Features().IsIncreasedCalldataPriceEnabled(), nil
+}

--- a/precompiles/ArbOwner_test.go
+++ b/precompiles/ArbOwner_test.go
@@ -171,6 +171,19 @@ func TestArbOwner(t *testing.T) {
 	if l2BaseFee.Cmp(retrievedL2BaseFee) != 0 {
 		Fail(t, "Expected", l2BaseFee, "got", retrievedL2BaseFee)
 	}
+
+	cdpi, err := prec.IsCalldataPriceIncreaseEnabled(callCtx, evm)
+	Require(t, err)
+	if cdpi {
+		Fail(t)
+	}
+	err = prec.SetCalldataPriceIncrease(callCtx, evm, true)
+	Require(t, err)
+	cdpi, err = prec.IsCalldataPriceIncreaseEnabled(callCtx, evm)
+	Require(t, err)
+	if !cdpi {
+		Fail(t)
+	}
 }
 
 func TestArbOwnerSetChainConfig(t *testing.T) {

--- a/precompiles/ArbOwner_test.go
+++ b/precompiles/ArbOwner_test.go
@@ -172,14 +172,16 @@ func TestArbOwner(t *testing.T) {
 		Fail(t, "Expected", l2BaseFee, "got", retrievedL2BaseFee)
 	}
 
-	cdpi, err := prec.IsCalldataPriceIncreaseEnabled(callCtx, evm)
+	pubPrec := &ArbOwnerPublic{}
+
+	cdpi, err := pubPrec.IsCalldataPriceIncreaseEnabled(callCtx, evm)
 	Require(t, err)
 	if cdpi {
 		Fail(t)
 	}
 	err = prec.SetCalldataPriceIncrease(callCtx, evm, true)
 	Require(t, err)
-	cdpi, err = prec.IsCalldataPriceIncreaseEnabled(callCtx, evm)
+	cdpi, err = pubPrec.IsCalldataPriceIncreaseEnabled(callCtx, evm)
 	Require(t, err)
 	if !cdpi {
 		Fail(t)

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	glog "github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbos"
@@ -338,7 +337,7 @@ func MakePrecompile(metadata *bind.MetaData, implementer interface{}) (addr, *Pr
 
 			data, err := dataInputs.PackValues(dataValues)
 			if err != nil {
-				glog.Error(fmt.Sprintf(
+				log.Error(fmt.Sprintf(
 					"Could not pack values for event %s's GasCost\nerror %s", name, err,
 				))
 				return []reflect.Value{reflect.ValueOf(0), reflect.ValueOf(err)}
@@ -387,7 +386,7 @@ func MakePrecompile(metadata *bind.MetaData, implementer interface{}) (addr, *Pr
 
 			data, err := dataInputs.PackValues(dataValues)
 			if err != nil {
-				glog.Error(fmt.Sprintf(
+				log.Error(fmt.Sprintf(
 					"Couldn't pack values for event %s\nnargs %s\nvalues %s\ntopics %s\nerror %s",
 					name, args, dataValues, topicValues, err,
 				))
@@ -403,7 +402,7 @@ func MakePrecompile(metadata *bind.MetaData, implementer interface{}) (addr, *Pr
 				packable := []interface{}{topicValues[i]}
 				bytes, err := abi.Arguments{input}.PackValues(packable)
 				if err != nil {
-					glog.Error(fmt.Sprintf(
+					log.Error(fmt.Sprintf(
 						"Packing error for event %s\nargs %s\nvalues %s\ntopics %s\nerror %s",
 						name, args, dataValues, topicValues, err,
 					))
@@ -480,7 +479,7 @@ func MakePrecompile(metadata *bind.MetaData, implementer interface{}) (addr, *Pr
 
 			data, err := capturedSolErr.Inputs.PackValues(dataValues)
 			if err != nil {
-				glog.Error(fmt.Sprintf(
+				log.Error(fmt.Sprintf(
 					"Couldn't pack values for error %s\nnargs %s\nvalues %s\nerror %s",
 					name, args, dataValues, err,
 				))
@@ -539,7 +538,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 
 	eventCtx := func(gasLimit uint64, err error) *Context {
 		if err != nil {
-			glog.Error("call to event's GasCost field failed", "err", err)
+			log.Error("call to event's GasCost field failed", "err", err)
 		}
 		return &Context{
 			gasSupplied: gasLimit,
@@ -732,10 +731,10 @@ func (p *Precompile) Call(
 	case *arbos.TxProcessor:
 		callerCtx.txProcessor = txProcessor
 	case *vm.DefaultTxProcessor:
-		glog.Error("processing hook not set")
+		log.Error("processing hook not set")
 		return nil, 0, vm.ErrExecutionReverted
 	default:
-		glog.Error("unknown processing hook")
+		log.Error("unknown processing hook")
 		return nil, 0, vm.ErrExecutionReverted
 	}
 

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -635,6 +635,9 @@ func Precompiles() map[addr]ArbosPrecompile {
 		arbosState.PrecompileMinArbOSVersions[precompile.address] = precompile.arbosVersion
 	}
 
+	ArbOwner.methodsByName["SetCalldataPriceIncrease"].arbosVersion = params.ArbosVersion_40
+	ArbOwner.methodsByName["IsCalldataPriceIncreaseEnabled"].arbosVersion = params.ArbosVersion_40
+
 	return contracts
 }
 

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -636,7 +636,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 	}
 
 	ArbOwner.methodsByName["SetCalldataPriceIncrease"].arbosVersion = params.ArbosVersion_40
-	ArbOwner.methodsByName["IsCalldataPriceIncreaseEnabled"].arbosVersion = params.ArbosVersion_40
+	ArbOwnerPublic.methodsByName["IsCalldataPriceIncreaseEnabled"].arbosVersion = params.ArbosVersion_40
 
 	return contracts
 }

--- a/precompiles/precompile_test.go
+++ b/precompiles/precompile_test.go
@@ -188,6 +188,7 @@ func TestPrecompilesPerArbosVersion(t *testing.T) {
 		params.ArbosVersion_20: 8,
 		params.ArbosVersion_30: 38,
 		params.ArbosVersion_31: 1,
+		params.ArbosVersion_40: 2,
 	}
 
 	precompiles := Precompiles()

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -480,9 +480,7 @@ func TestParentChainNonEIP7623(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder := NewNodeBuilder(ctx).
-		DefaultConfig(t, true).
-		WithArbOSVersion(11) // ArbOS 11 doesn't use EIP-7623
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
 
 	// Build L1 and L2
 	cleanupL1AndL2 := builder.Build(t)
@@ -501,7 +499,7 @@ func TestParentChainNonEIP7623(t *testing.T) {
 	cleanupL3FirstNode := builder.BuildL3OnL2(t)
 	defer cleanupL3FirstNode()
 
-	// Check if L3's parent chain is using EIP-7623
+	// Check if L3's parent chain is not using EIP-7623
 	latestHeader, err = builder.L3.ConsensusNode.L1Reader.LastHeader(ctx)
 	Require(t, err)
 	isUsingEIP7623, err = builder.L3.ConsensusNode.BatchPoster.ParentChainIsUsingEIP7623(ctx, latestHeader)

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -21,10 +21,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/offchainlabs/bold/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbnode/dataposter"
 	"github.com/offchainlabs/nitro/arbnode/dataposter/externalsignertest"
-	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/solgen/go/upgrade_executorgen"
 	"github.com/offchainlabs/nitro/util/redisutil"
 )


### PR DESCRIPTION
Pulls in PR https://github.com/OffchainLabs/nitro-contracts/pull/315

This PR introduces an ArbOwner contract call `SetCalldataPriceIncrease` which can be used to enable and disable the EIP-7623 calldata increase on Arbitrum chains. By default, the ArbosState won't have the feature set to true. So, it will be disabled.