### PR TITLE
Increase default value for timeboost.max-future-sequence-distance to 1000

### DIFF
--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -107,7 +107,7 @@ var DefaultTimeboostConfig = TimeboostConfig{
 	ExpressLaneAdvantage:         time.Millisecond * 200,
 	SequencerHTTPEndpoint:        "http://localhost:8547",
 	EarlySubmissionGrace:         time.Second * 2,
-	MaxFutureSequenceDistance:    25,
+	MaxFutureSequenceDistance:    1000,
 	RedisUrl:                     "unset",
 	RedisUpdateEventsChannelSize: 500,
 	QueueTimeoutInBlocks:         5,


### PR DESCRIPTION
This PR increases default value of `--execution.sequencer.dangerous.timeboost.max-future-sequence-distance` to 1000