### PR TITLE
Make config options required for navigating pectra header issues default

### DIFF
--- a/arbnode/delayed_sequencer.go
+++ b/arbnode/delayed_sequencer.go
@@ -58,7 +58,7 @@ var DefaultDelayedSequencerConfig = DelayedSequencerConfig{
 	Enable:              false,
 	FinalizeDistance:    20,
 	RequireFullFinality: false,
-	UseMergeFinality:    true,
+	UseMergeFinality:    false,
 	RescanInterval:      time.Second,
 }
 


### PR DESCRIPTION
This PR makes it that sequencer node runners need not explicitly set config parameters to navigate pectra header issue wrt delayed sequencing.