### PR TITLE
refactor: use map.Copy for cleaner map handling

### DIFF
--- a/cmd/util/confighelpers/configuration.go
+++ b/cmd/util/confighelpers/configuration.go
@@ -6,6 +6,7 @@ package confighelpers
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
 	"strings"
@@ -299,9 +300,7 @@ func DumpConfig(k *koanf.Koanf, extraOverrideFields map[string]interface{}) erro
 	overrideFields := map[string]interface{}{"conf.dump": false}
 
 	// Don't keep printing configuration file
-	for k, v := range extraOverrideFields {
-		overrideFields[k] = v
-	}
+	maps.Copy(overrideFields, extraOverrideFields)
 
 	err := k.Load(confmap.Provider(overrideFields, "."), nil)
 	if err != nil {

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -354,9 +355,7 @@ func copyPreimagesInto(dest, source map[arbutil.PreimageType]map[common.Hash][]b
 		if dest[piType] == nil {
 			dest[piType] = make(map[common.Hash][]byte, len(piMap))
 		}
-		for hash, preimage := range piMap {
-			dest[piType][hash] = preimage
-		}
+		maps.Copy(dest[piType], piMap)
 	}
 }
 


### PR DESCRIPTION
Use the built-in methods from the standard library to simplify the code, while also conducting a global check for replaceable cases.