### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/das/aggregator_test.go
+++ b/das/aggregator_test.go
@@ -144,20 +144,6 @@ func (w *WrapStore) Store(ctx context.Context, message []byte, timeout uint64) (
 	return nil, nil
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func enableLogging() {
 	glogger := log.NewGlogHandler(
 		log.NewTerminalHandler(io.Writer(os.Stderr), false))

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -57,10 +57,7 @@ type Number interface {
 
 // MinInt the minimum of two ints
 func MinInt[T Number](value, ceiling T) T {
-	if value > ceiling {
-		return ceiling
-	}
-	return value
+	return min(value, ceiling)
 }
 
 // MaxInt the maximum of one or more ints


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.