### PR TITLE
[Backport] Increase default value for timeboost.max-future-sequence-distance to 1000

### DIFF
--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -108,7 +108,7 @@ var DefaultTimeboostConfig = TimeboostConfig{
 	ExpressLaneAdvantage:         time.Millisecond * 200,
 	SequencerHTTPEndpoint:        "http://localhost:8547",
 	EarlySubmissionGrace:         time.Second * 2,
-	MaxFutureSequenceDistance:    25,
+	MaxFutureSequenceDistance:    1000,
 	RedisUrl:                     "unset",
 	RedisUpdateEventsChannelSize: 500,
 	QueueTimeoutInBlocks:         5,


### PR DESCRIPTION
backports https://github.com/OffchainLabs/nitro/pull/3035