### PR TITLE
small fix in arbitrator profiling tool

### DIFF
--- a/arbitrator/prover/src/main.rs
+++ b/arbitrator/prover/src/main.rs
@@ -399,8 +399,6 @@ fn main() -> Result<()> {
                 }
             }
         }
-        let opts_binary = opts.binary;
-        let opts_libraries = opts.libraries;
         let format_pc = |module_num: usize, func_num: usize| -> (String, String) {
             let Some(names) = mach.get_module_names(module_num) else {
                 return (
@@ -408,18 +406,7 @@ fn main() -> Result<()> {
                     format!("[unknown {}]", func_num),
                 );
             };
-            let module_name = if module_num == 0 {
-                names.module.clone()
-            } else if module_num == &opts_libraries.len() + 1 {
-                opts_binary.file_name().unwrap().to_str().unwrap().into()
-            } else {
-                opts_libraries[module_num - 1]
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .into()
-            };
+            let module_name = names.module.clone();
             let func_idx = func_num as u32;
             let mut name = names
                 .functions

--- a/arbitrator/prover/src/main.rs
+++ b/arbitrator/prover/src/main.rs
@@ -436,7 +436,7 @@ fn main() -> Result<()> {
             func_vector.sort_by(|a, b| b.1.total_cycles.cmp(&a.1.total_cycles));
             let mut printed = 0;
             for (&(module_num, func), profile) in func_vector {
-                let (name, module_name) = format_pc(module_num, func);
+                let (module_name, name) = format_pc(module_num, func);
                 let percent =
                     (profile.total_cycles as f64) * 100.0 / (cycles_measured_total as f64);
                 println!(


### PR DESCRIPTION
This PR:
* fixes swapped function name with module name
* uses module names returned from machine instead of using names supplied by libraries option - useful when loading a machine from binary