### PR TITLE
Error when discard-after-timeout is set for DAS S3 storage service

### DIFF
--- a/das/s3_storage_service.go
+++ b/das/s3_storage_service.go
@@ -6,9 +6,8 @@ package das
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
-	"math"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -43,7 +42,7 @@ func S3ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".object-prefix", DefaultS3StorageServiceConfig.ObjectPrefix, "prefix to add to S3 objects")
 	f.String(prefix+".region", DefaultS3StorageServiceConfig.Region, "S3 region")
 	f.String(prefix+".secret-key", DefaultS3StorageServiceConfig.SecretKey, "S3 secret key")
-	f.Bool(prefix+".discard-after-timeout", DefaultS3StorageServiceConfig.DiscardAfterTimeout, "discard data after its expiry timeout")
+	f.Bool(prefix+".discard-after-timeout", DefaultS3StorageServiceConfig.DiscardAfterTimeout, "this config option is deprecated")
 }
 
 type S3StorageService struct {
@@ -57,6 +56,9 @@ func NewS3StorageService(config S3StorageServiceConfig) (StorageService, error) 
 	client, err := s3client.NewS3FullClient(config.AccessKey, config.SecretKey, config.Region)
 	if err != nil {
 		return nil, err
+	}
+	if config.DiscardAfterTimeout {
+		return nil, errors.New("s3-storage.discard-after-timeout is depreciated and no longer accepted. Expiration for objects uploaded to S3 bucket can be set by adding lifecycle configuration rule to a bucket")
 	}
 	return &S3StorageService{
 		client:              client,
@@ -77,17 +79,12 @@ func (s3s *S3StorageService) GetByHash(ctx context.Context, key common.Hash) ([]
 	return buf.Bytes(), err
 }
 
-func (s3s *S3StorageService) Put(ctx context.Context, value []byte, timeout uint64) error {
-	logPut("das.S3StorageService.Store", value, timeout, s3s)
+func (s3s *S3StorageService) Put(ctx context.Context, value []byte, _ uint64) error {
+	logPut("das.S3StorageService.Store", value, 0, s3s)
 	putObjectInput := s3.PutObjectInput{
 		Bucket: aws.String(s3s.bucket),
 		Key:    aws.String(s3s.objectPrefix + EncodeStorageServiceKey(dastree.Hash(value))),
 		Body:   bytes.NewReader(value)}
-	if s3s.discardAfterTimeout && timeout <= math.MaxInt64 {
-		// #nosec G115
-		expires := time.Unix(int64(timeout), 0)
-		putObjectInput.Expires = &expires
-	}
 	_, err := s3s.client.Upload(ctx, &putObjectInput)
 	if err != nil {
 		log.Error("das.S3StorageService.Store", "err", err)
@@ -104,9 +101,9 @@ func (s3s *S3StorageService) Close(ctx context.Context) error {
 }
 
 func (s3s *S3StorageService) ExpirationPolicy(ctx context.Context) (daprovider.ExpirationPolicy, error) {
-	if s3s.discardAfterTimeout {
-		return daprovider.DiscardAfterDataTimeout, nil
-	}
+	// Expiration of data uploaded to S3 bucket is handled directly via LifeCycle configuration of the bucket. Users can choose to add a
+	// Lifecycle configuration rule with an expiration action that causes objects with a specific prefix to expire certain days after creation.
+	// ref=https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-expire-general-considerations.html
 	return daprovider.KeepForever, nil
 }
 


### PR DESCRIPTION
This PR ensure that `s3-storage.discard-after-timeout` config option cannot be set, returns a detailed error on startup if attempted. 

Currently the only way to set expiration for data uploaded to S3 bucket is by adding a `Lifecycle configuration rule` with an expiration action that causes objects with a specific prefix to expire certain days after creation, [reference](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-expire-general-considerations.html). 

As there isn't a way to append a rule to the lifecycle configuration, nitro can't achieve this action. Hence we recommend users to directly set `Expiration` as a rule to the Lifecycle configuration of their S3 bucket to achieve pruning in S3 storage.

timeout argument from daprovider's `Writer` interface will simply be ignored if the underlying DAS writer is an `S3StorageService`

Resolves NIT-3169