### PR TITLE
Skip Flakey Challenge Test to Unclog CI While It is Investigated

### DIFF
--- a/system_tests/bold_new_challenge_test.go
+++ b/system_tests/bold_new_challenge_test.go
@@ -258,6 +258,7 @@ func fundBoldStaker(t *testing.T, ctx context.Context, builder *NodeBuilder, nam
 }
 
 func TestChallengeProtocolBOLDNearLastVirtualBlock(t *testing.T) {
+	t.Skip("This test is flaky and needs to be fixed")
 	testChallengeProtocolBOLDVirtualBlocks(t, false)
 }
 


### PR DESCRIPTION
`TestChallengeProtocolBOLDNearLastVirtualBlock` is currently flakey, blocking a large list of PRs. To temporarily unblock progress, it is being skipped while it is investigated. Normally, skipping tests is not a good idea, but under the time constraints and priority list we have, this seems to be the best option. The test will be investigated this week