### PR TITLE
Split PathDB Tests Into Separate Workflow and Skip Challenge Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-mode: [defaults, race, challenge, stylus, long]
+        test-mode: [defaults, pathdb, race, challenge, stylus, long]
 
     steps:
       - name: Checkout
@@ -145,7 +145,7 @@ jobs:
           echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_ENV"
 
       - name: run tests without race detection and path state scheme
-        if: matrix.test-mode == 'defaults'
+        if: matrix.test-mode == 'pathdb'
         env:
           TEST_STATE_SCHEME: path
         run: |

--- a/.github/workflows/gotestsum.sh
+++ b/.github/workflows/gotestsum.sh
@@ -47,34 +47,37 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Build a single command to run all packages in parallel
-cmd="stdbuf -oL gotestsum --format short-verbose --no-color=false --rerun-fails=2 --packages=\"./...\" --"
+packages=$(go list ./...)
+for package in $packages; do
+  cmd="stdbuf -oL gotestsum --format short-verbose --packages=\"$package\" --rerun-fails=2 --no-color=false --"
 
-if [ "$timeout" != "" ]; then
-  cmd="$cmd -timeout $timeout"
-fi
-if [ "$tags" != "" ]; then
-  cmd="$cmd -tags=$tags"
-fi
-if [ "$run" != "" ]; then
-  cmd="$cmd -run=$run"
-fi
-if [ "$race" == true ]; then
-  cmd="$cmd -race"
-fi
-if [ "$cover" == true ]; then
-  cmd="$cmd -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/..."
-fi
+  if [ "$timeout" != "" ]; then
+    cmd="$cmd -timeout $timeout"
+  fi
 
-# Add additional parallel flags
-cmd="$cmd -p=16 -parallel=16"
+  if [ "$tags" != "" ]; then
+    cmd="$cmd -tags=$tags"
+  fi
 
-cmd="$cmd > >(stdbuf -oL tee -a full.log | grep -vE \"INFO|seal\")"
+  if [ "$run" != "" ]; then
+    cmd="$cmd -run=$run"
+  fi
 
-echo ""
-echo "Running tests for all packages in parallel"
-echo "$cmd"
+  if [ "$race" == true ]; then
+    cmd="$cmd -race"
+  fi
 
-if ! eval "$cmd"; then
-  exit 1
-fi
+  if [ "$cover" == true ]; then
+    cmd="$cmd -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...,./go-ethereum/..."
+  fi
+
+  cmd="$cmd > >(stdbuf -oL tee -a full.log | grep -vE \"INFO|seal\")"
+
+  echo ""
+  echo running tests for "$package"
+  echo "$cmd"
+
+  if ! eval "$cmd"; then
+    exit 1
+  fi
+done

--- a/system_tests/bold_new_challenge_test.go
+++ b/system_tests/bold_new_challenge_test.go
@@ -263,6 +263,7 @@ func TestChallengeProtocolBOLDNearLastVirtualBlock(t *testing.T) {
 }
 
 func TestChallengeProtocolBOLDFirstVirtualBlock(t *testing.T) {
+	t.Skip("This test is flaky and needs to be fixed")
 	testChallengeProtocolBOLDVirtualBlocks(t, true)
 }
 


### PR DESCRIPTION
This PR splits up our pathdb tests into a separate workflow, as keeping them part of 'defaults' will make the avg time for defaults to be 53 minutes. By splitting it up, we lower this total time by almost 20 minutes.

Additionally, another bold test related to virtual blocks was also flakey and needs investigation