### PR TITLE
Move Legacy Challenge, Race, and Stylus Long Tests to Nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-mode: [defaults, race, challenge, stylus, long]
+        test-mode: [defaults, challenge, stylus]
 
     steps:
       - name: Checkout
@@ -160,14 +160,6 @@ jobs:
           echo "Running tests with Hash Scheme" >> full.log
           ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags cionly --timeout 20m
 
-      - name: run tests with race detection and hash state scheme
-        if: matrix.test-mode == 'race'
-        env:
-          TEST_STATE_SCHEME: hash
-        run: |
-          echo "Running tests with Hash Scheme" >> full.log
-          ${{ github.workspace }}/.github/workflows/gotestsum.sh --race --timeout 30m
-
       - name: run redis tests
         if: matrix.test-mode == 'defaults'
         run: |
@@ -201,10 +193,6 @@ jobs:
       - name: run stylus tests
         if: matrix.test-mode == 'stylus'
         run: ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags stylustest --run TestProgramArbitrator --timeout 60m --cover
-
-      - name: run long stylus tests
-        if: matrix.test-mode == 'long'
-        run: ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags stylustest --run TestProgramLong --timeout 60m --cover
 
       - name: Archive detailed run log
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1,0 +1,317 @@
+name: Nightly CI
+run-name: Nightly CI tests triggered from @${{ github.actor }} of ${{ github.head_ref }}
+
+on:
+  workflow_dispatch:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    # Run at 00:00 AM UTC
+    - cron: '0 0 * * *'
+
+jobs:
+  # Only run on schedule AND main branch
+  challenge-tests-scheduled:
+    name: Challenge tests (scheduled)
+    runs-on: ubuntu-8
+
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+
+    strategy:
+      fail-fast: false
+
+    if: github.event_name == 'schedule' && github.ref == 'refs/heads/master'
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install -y wabt gotestsum
+
+      - name: Setup nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
+
+      - name: Install go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.23.x
+
+      - name: Install wasm-ld
+        run: |
+          sudo apt-get update && sudo apt-get install -y lld-14
+          sudo ln -s /usr/bin/wasm-ld-14 /usr/local/bin/wasm-ld
+
+      - name: Install rust stable
+        uses: dtolnay/rust-toolchain@stable
+        id: install-rust
+        with:
+          toolchain: '1.84.1'
+          targets: 'wasm32-wasip1, wasm32-unknown-unknown'
+          components: 'llvm-tools-preview, rustfmt, clippy'
+
+      - name: Install rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        id: install-rust-nightly
+        with:
+          toolchain: 'nightly-2025-02-14'
+          targets: 'wasm32-wasip1, wasm32-unknown-unknown'
+          components: 'rust-src, rustfmt, clippy'
+
+      - name: Set STYLUS_NIGHTLY_VER environment variable
+        run: echo "STYLUS_NIGHTLY_VER=+$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        
+      - name: Install cbindgen
+        run: cargo install --force cbindgen
+
+      - name: Cache Build Products
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.test-mode }}
+          restore-keys: ${{ runner.os }}-go-
+
+      - name: Cache Rust Build Products
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/
+            arbitrator/target/
+            arbitrator/wasm-libraries/target/
+            arbitrator/wasm-libraries/soft-float/
+            target/etc/initial-machine-cache/
+            /home/runner/.rustup/toolchains/
+          key: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-min-${{ hashFiles('arbitrator/Cargo.lock') }}-${{ matrix.test-mode }}
+          restore-keys: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-
+
+      - name: Cache cbrotli
+        uses: actions/cache@v3
+        id: cache-cbrotli
+        with:
+          path: |
+            target/include/brotli/
+            target/lib-wasm/
+            target/lib/libbrotlicommon-static.a
+            target/lib/libbrotlienc-static.a
+            target/lib/libbrotlidec-static.a
+          key: ${{ runner.os }}-brotli-${{ hashFiles('scripts/build-brotli.sh') }}-${{ hashFiles('.github/workflows/arbitrator-ci.yaml') }}-${{ matrix.test-mode }}
+          restore-keys: ${{ runner.os }}-brotli-
+
+      - name: Build cbrotli-local
+        if: steps.cache-cbrotli.outputs.cache-hit != 'true'
+        run: ./scripts/build-brotli.sh -l
+
+      - name: Build cbrotli-wasm in docker
+        if: steps.cache-cbrotli.outputs.cache-hit != 'true'
+        run: ./scripts/build-brotli.sh -w -d
+
+      - name: Build
+        run: make build test-go-deps -j
+
+      - name: Build all lint dependencies
+        run: make -j build-node-deps
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          skip-pkg-cache: true
+      - name: Custom Lint
+        run: |
+          go run ./linters ./...
+
+      - name: Set environment variables
+        run: |
+          mkdir -p target/tmp/deadbeefbee
+          echo "TMPDIR=$(pwd)/target/tmp/deadbeefbee" >> "$GITHUB_ENV"
+          echo "GOMEMLIMIT=6GiB" >> "$GITHUB_ENV"
+          echo "GOGC=80" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_ENV"
+
+      - name: run challenge tests
+        if: matrix.test-mode == 'challenge'
+        run: ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags legacychallengetest --run TestChallenge --timeout 60m --cover
+
+      - name: Archive detailed run log
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.test-mode }}-full.log
+          path: full.log
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        if: matrix.test-mode == 'defaults'
+        with:
+          fail_ci_if_error: false
+          files: ./coverage.txt,./coverage-redis.txt
+          verbose: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Only run this job if files in staker/legacy/ are modified
+  challenge-tests-pr:
+    name: Challenge tests (PR modified files)
+    runs-on: ubuntu-8
+    if: github.event_name == 'pull_request'
+    
+    permissions:
+      pull-requests: read
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          
+      - name: Check changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: bold/legacy/**
+          
+      - name: Install dependencies if files changed
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: sudo apt update && sudo apt install -y wabt gotestsum
+
+      - name: Setup nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
+
+      - name: Install go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.23.x
+
+      - name: Install wasm-ld
+        run: |
+          sudo apt-get update && sudo apt-get install -y lld-14
+          sudo ln -s /usr/bin/wasm-ld-14 /usr/local/bin/wasm-ld
+
+      - name: Install rust stable
+        uses: dtolnay/rust-toolchain@stable
+        id: install-rust
+        with:
+          toolchain: '1.84.1'
+          targets: 'wasm32-wasip1, wasm32-unknown-unknown'
+          components: 'llvm-tools-preview, rustfmt, clippy'
+
+      - name: Install rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        id: install-rust-nightly
+        with:
+          toolchain: 'nightly-2025-02-14'
+          targets: 'wasm32-wasip1, wasm32-unknown-unknown'
+          components: 'rust-src, rustfmt, clippy'
+
+      - name: Set STYLUS_NIGHTLY_VER environment variable
+        run: echo "STYLUS_NIGHTLY_VER=+$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        
+      - name: Install cbindgen
+        run: cargo install --force cbindgen
+
+      - name: Cache Build Products
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.test-mode }}
+          restore-keys: ${{ runner.os }}-go-
+
+      - name: Cache Rust Build Products
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/
+            arbitrator/target/
+            arbitrator/wasm-libraries/target/
+            arbitrator/wasm-libraries/soft-float/
+            target/etc/initial-machine-cache/
+            /home/runner/.rustup/toolchains/
+          key: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-min-${{ hashFiles('arbitrator/Cargo.lock') }}-${{ matrix.test-mode }}
+          restore-keys: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-
+
+      - name: Cache cbrotli
+        uses: actions/cache@v3
+        id: cache-cbrotli
+        with:
+          path: |
+            target/include/brotli/
+            target/lib-wasm/
+            target/lib/libbrotlicommon-static.a
+            target/lib/libbrotlienc-static.a
+            target/lib/libbrotlidec-static.a
+          key: ${{ runner.os }}-brotli-${{ hashFiles('scripts/build-brotli.sh') }}-${{ hashFiles('.github/workflows/arbitrator-ci.yaml') }}-${{ matrix.test-mode }}
+          restore-keys: ${{ runner.os }}-brotli-
+
+      - name: Build cbrotli-local
+        if: steps.cache-cbrotli.outputs.cache-hit != 'true'
+        run: ./scripts/build-brotli.sh -l
+
+      - name: Build cbrotli-wasm in docker
+        if: steps.cache-cbrotli.outputs.cache-hit != 'true'
+        run: ./scripts/build-brotli.sh -w -d
+
+      - name: Build
+        run: make build test-go-deps -j
+
+      - name: Build all lint dependencies
+        run: make -j build-node-deps
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          skip-pkg-cache: true
+      - name: Custom Lint
+        run: |
+          go run ./linters ./...
+
+      - name: Set environment variables
+        run: |
+          mkdir -p target/tmp/deadbeefbee
+          echo "TMPDIR=$(pwd)/target/tmp/deadbeefbee" >> "$GITHUB_ENV"
+          echo "GOMEMLIMIT=6GiB" >> "$GITHUB_ENV"
+          echo "GOGC=80" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_ENV"
+
+      - name: run challenge tests
+        run: ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags legacychallengetest --run TestChallenge --timeout 60m --cover
+
+      - name: Archive detailed run log
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.test-mode }}-full.log
+          path: full.log
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        if: matrix.test-mode == 'defaults'
+        with:
+          fail_ci_if_error: false
+          files: ./coverage.txt,./coverage-redis.txt
+          verbose: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -38,134 +38,9 @@ jobs:
       - name: Install dependencies
         run: sudo apt update && sudo apt install -y wabt gotestsum
 
-      - name: Setup nodejs
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-          cache: 'yarn'
-          cache-dependency-path: '**/yarn.lock'
+      # Rest of steps remain unchanged...
 
-      - name: Install go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.23.x
-
-      - name: Install wasm-ld
-        run: |
-          sudo apt-get update && sudo apt-get install -y lld-14
-          sudo ln -s /usr/bin/wasm-ld-14 /usr/local/bin/wasm-ld
-
-      - name: Install rust stable
-        uses: dtolnay/rust-toolchain@stable
-        id: install-rust
-        with:
-          toolchain: '1.84.1'
-          targets: 'wasm32-wasip1, wasm32-unknown-unknown'
-          components: 'llvm-tools-preview, rustfmt, clippy'
-
-      - name: Install rust nightly
-        uses: dtolnay/rust-toolchain@nightly
-        id: install-rust-nightly
-        with:
-          toolchain: 'nightly-2025-02-14'
-          targets: 'wasm32-wasip1, wasm32-unknown-unknown'
-          components: 'rust-src, rustfmt, clippy'
-
-      - name: Set STYLUS_NIGHTLY_VER environment variable
-        run: echo "STYLUS_NIGHTLY_VER=+$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        
-      - name: Install cbindgen
-        run: cargo install --force cbindgen
-
-      - name: Cache Build Products
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.test-mode }}
-          restore-keys: ${{ runner.os }}-go-
-
-      - name: Cache Rust Build Products
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/
-            arbitrator/target/
-            arbitrator/wasm-libraries/target/
-            arbitrator/wasm-libraries/soft-float/
-            target/etc/initial-machine-cache/
-            /home/runner/.rustup/toolchains/
-          key: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-min-${{ hashFiles('arbitrator/Cargo.lock') }}-${{ matrix.test-mode }}
-          restore-keys: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-
-
-      - name: Cache cbrotli
-        uses: actions/cache@v3
-        id: cache-cbrotli
-        with:
-          path: |
-            target/include/brotli/
-            target/lib-wasm/
-            target/lib/libbrotlicommon-static.a
-            target/lib/libbrotlienc-static.a
-            target/lib/libbrotlidec-static.a
-          key: ${{ runner.os }}-brotli-${{ hashFiles('scripts/build-brotli.sh') }}-${{ hashFiles('.github/workflows/arbitrator-ci.yaml') }}-${{ matrix.test-mode }}
-          restore-keys: ${{ runner.os }}-brotli-
-
-      - name: Build cbrotli-local
-        if: steps.cache-cbrotli.outputs.cache-hit != 'true'
-        run: ./scripts/build-brotli.sh -l
-
-      - name: Build cbrotli-wasm in docker
-        if: steps.cache-cbrotli.outputs.cache-hit != 'true'
-        run: ./scripts/build-brotli.sh -w -d
-
-      - name: Build
-        run: make build test-go-deps -j
-
-      - name: Build all lint dependencies
-        run: make -j build-node-deps
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: latest
-          skip-pkg-cache: true
-      - name: Custom Lint
-        run: |
-          go run ./linters ./...
-
-      - name: Set environment variables
-        run: |
-          mkdir -p target/tmp/deadbeefbee
-          echo "TMPDIR=$(pwd)/target/tmp/deadbeefbee" >> "$GITHUB_ENV"
-          echo "GOMEMLIMIT=6GiB" >> "$GITHUB_ENV"
-          echo "GOGC=80" >> "$GITHUB_ENV"
-          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_ENV"
-
-      - name: run challenge tests
-        if: matrix.test-mode == 'challenge'
-        run: ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags legacychallengetest --run TestChallenge --timeout 60m --cover
-
-      - name: Archive detailed run log
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.test-mode }}-full.log
-          path: full.log
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
-        if: matrix.test-mode == 'defaults'
-        with:
-          fail_ci_if_error: false
-          files: ./coverage.txt,./coverage-redis.txt
-          verbose: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  # Only run this job if files in staker/legacy/ are modified
+  # Only run this job if files in bold/legacy/ are modified
   challenge-tests-pr:
     name: Challenge tests (PR modified files)
     runs-on: ubuntu-8
@@ -186,11 +61,23 @@ jobs:
         with:
           files: bold/legacy/**
           
-      - name: Install dependencies if files changed
+      # Add conditional execution for all subsequent steps
+      - name: Skip tests if no relevant files changed
+        id: check-skip
+        if: steps.changed-files.outputs.any_changed != 'true'
+        run: |
+          echo "No changes detected in bold/legacy/** - skipping challenge tests"
+          exit 0  # Success exit code to pass the job
+
+      # All remaining steps should have the condition 
+      # "if: steps.changed-files.outputs.any_changed == 'true'"
+      
+      - name: Install dependencies
         if: steps.changed-files.outputs.any_changed == 'true'
         run: sudo apt update && sudo apt install -y wabt gotestsum
 
       - name: Setup nodejs
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-node@v3
         with:
           node-version: '18'
@@ -198,16 +85,19 @@ jobs:
           cache-dependency-path: '**/yarn.lock'
 
       - name: Install go
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v4
         with:
           go-version: 1.23.x
 
       - name: Install wasm-ld
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           sudo apt-get update && sudo apt-get install -y lld-14
           sudo ln -s /usr/bin/wasm-ld-14 /usr/local/bin/wasm-ld
 
       - name: Install rust stable
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: dtolnay/rust-toolchain@stable
         id: install-rust
         with:
@@ -216,6 +106,7 @@ jobs:
           components: 'llvm-tools-preview, rustfmt, clippy'
 
       - name: Install rust nightly
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: dtolnay/rust-toolchain@nightly
         id: install-rust-nightly
         with:
@@ -224,15 +115,19 @@ jobs:
           components: 'rust-src, rustfmt, clippy'
 
       - name: Set STYLUS_NIGHTLY_VER environment variable
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: echo "STYLUS_NIGHTLY_VER=+$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
 
       - name: Install Foundry
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: foundry-rs/foundry-toolchain@v1
         
       - name: Install cbindgen
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: cargo install --force cbindgen
 
       - name: Cache Build Products
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/cache@v3
         with:
           path: |
@@ -242,6 +137,7 @@ jobs:
           restore-keys: ${{ runner.os }}-go-
 
       - name: Cache Rust Build Products
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/cache@v3
         with:
           path: |
@@ -255,6 +151,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-
 
       - name: Cache cbrotli
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/cache@v3
         id: cache-cbrotli
         with:
@@ -268,29 +165,35 @@ jobs:
           restore-keys: ${{ runner.os }}-brotli-
 
       - name: Build cbrotli-local
-        if: steps.cache-cbrotli.outputs.cache-hit != 'true'
+        if: steps.changed-files.outputs.any_changed == 'true' && steps.cache-cbrotli.outputs.cache-hit != 'true'
         run: ./scripts/build-brotli.sh -l
 
       - name: Build cbrotli-wasm in docker
-        if: steps.cache-cbrotli.outputs.cache-hit != 'true'
+        if: steps.changed-files.outputs.any_changed == 'true' && steps.cache-cbrotli.outputs.cache-hit != 'true'
         run: ./scripts/build-brotli.sh -w -d
 
       - name: Build
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: make build test-go-deps -j
 
       - name: Build all lint dependencies
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: make -j build-node-deps
 
       - name: Lint
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           skip-pkg-cache: true
+          
       - name: Custom Lint
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           go run ./linters ./...
 
       - name: Set environment variables
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           mkdir -p target/tmp/deadbeefbee
           echo "TMPDIR=$(pwd)/target/tmp/deadbeefbee" >> "$GITHUB_ENV"
@@ -299,17 +202,19 @@ jobs:
           echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_ENV"
 
       - name: run challenge tests
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags legacychallengetest --run TestChallenge --timeout 60m --cover
 
       - name: Archive detailed run log
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.test-mode }}-full.log
           path: full.log
 
       - name: Upload coverage to Codecov
+        if: steps.changed-files.outputs.any_changed == 'true' && matrix.test-mode == 'defaults'
         uses: codecov/codecov-action@v2
-        if: matrix.test-mode == 'defaults'
         with:
           fail_ci_if_error: false
           files: ./coverage.txt,./coverage-redis.txt

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -26,6 +26,8 @@ jobs:
 
     strategy:
       fail-fast: false
+      matrix:
+        test-mode: [race, legacychallenge, long]
 
     if: github.event_name == 'schedule' && github.ref == 'refs/heads/master'
     
@@ -38,7 +40,163 @@ jobs:
       - name: Install dependencies
         run: sudo apt update && sudo apt install -y wabt gotestsum
 
-      # Rest of steps remain unchanged...
+        - name: Setup nodejs
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
+
+      - name: Install go
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.23.x
+
+      - name: Install wasm-ld
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          sudo apt-get update && sudo apt-get install -y lld-14
+          sudo ln -s /usr/bin/wasm-ld-14 /usr/local/bin/wasm-ld
+
+      - name: Install rust stable
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: dtolnay/rust-toolchain@stable
+        id: install-rust
+        with:
+          toolchain: '1.84.1'
+          targets: 'wasm32-wasip1, wasm32-unknown-unknown'
+          components: 'llvm-tools-preview, rustfmt, clippy'
+
+      - name: Install rust nightly
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: dtolnay/rust-toolchain@nightly
+        id: install-rust-nightly
+        with:
+          toolchain: 'nightly-2025-02-14'
+          targets: 'wasm32-wasip1, wasm32-unknown-unknown'
+          components: 'rust-src, rustfmt, clippy'
+
+      - name: Set STYLUS_NIGHTLY_VER environment variable
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: echo "STYLUS_NIGHTLY_VER=+$(rustup toolchain list | grep '^nightly' | head -n1 | cut -d' ' -f1)" >> "$GITHUB_ENV"
+
+      - name: Install Foundry
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: foundry-rs/foundry-toolchain@v1
+        
+      - name: Install cbindgen
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: cargo install --force cbindgen
+
+      - name: Cache Build Products
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.test-mode }}
+          restore-keys: ${{ runner.os }}-go-
+
+      - name: Cache Rust Build Products
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/
+            arbitrator/target/
+            arbitrator/wasm-libraries/target/
+            arbitrator/wasm-libraries/soft-float/
+            target/etc/initial-machine-cache/
+            /home/runner/.rustup/toolchains/
+          key: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-min-${{ hashFiles('arbitrator/Cargo.lock') }}-${{ matrix.test-mode }}
+          restore-keys: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.rustc_hash }}-
+
+      - name: Cache cbrotli
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/cache@v3
+        id: cache-cbrotli
+        with:
+          path: |
+            target/include/brotli/
+            target/lib-wasm/
+            target/lib/libbrotlicommon-static.a
+            target/lib/libbrotlienc-static.a
+            target/lib/libbrotlidec-static.a
+          key: ${{ runner.os }}-brotli-${{ hashFiles('scripts/build-brotli.sh') }}-${{ hashFiles('.github/workflows/arbitrator-ci.yaml') }}-${{ matrix.test-mode }}
+          restore-keys: ${{ runner.os }}-brotli-
+
+      - name: Build cbrotli-local
+        if: steps.changed-files.outputs.any_changed == 'true' && steps.cache-cbrotli.outputs.cache-hit != 'true'
+        run: ./scripts/build-brotli.sh -l
+
+      - name: Build cbrotli-wasm in docker
+        if: steps.changed-files.outputs.any_changed == 'true' && steps.cache-cbrotli.outputs.cache-hit != 'true'
+        run: ./scripts/build-brotli.sh -w -d
+
+      - name: Build
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: make build test-go-deps -j
+
+      - name: Build all lint dependencies
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: make -j build-node-deps
+
+      - name: Lint
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          skip-pkg-cache: true
+          
+      - name: Custom Lint
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          go run ./linters ./...
+
+      - name: Set environment variables
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          mkdir -p target/tmp/deadbeefbee
+          echo "TMPDIR=$(pwd)/target/tmp/deadbeefbee" >> "$GITHUB_ENV"
+          echo "GOMEMLIMIT=6GiB" >> "$GITHUB_ENV"
+          echo "GOGC=80" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_ENV"
+
+      - name: run tests with race detection and hash state scheme
+        if: matrix.test-mode == 'race'
+        env:
+          TEST_STATE_SCHEME: hash
+        run: |
+          echo "Running tests with Hash Scheme" >> full.log
+          ${{ github.workspace }}/.github/workflows/gotestsum.sh --race --timeout 30m
+
+      - name: run challenge tests
+        if: matrix.test-mode == 'legacychallenge'
+        run: ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags legacychallengetest --run TestChallenge --timeout 60m --cover
+
+      - name: run long stylus tests
+        if: matrix.test-mode == 'long'
+        run: ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags stylustest --run TestProgramLong --timeout 60m --cover
+
+      - name: Archive detailed run log
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.test-mode }}-full.log
+          path: full.log
+
+      - name: Upload coverage to Codecov
+        if: steps.changed-files.outputs.any_changed == 'true' && matrix.test-mode == 'defaults'
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: false
+          files: ./coverage.txt,./coverage-redis.txt
+          verbose: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   # Only run this job if files in bold/legacy/ are modified
   challenge-tests-pr:

--- a/system_tests/full_challenge_test.go
+++ b/system_tests/full_challenge_test.go
@@ -1,8 +1,8 @@
 // Copyright 2021-2023, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
-//go:build challengetest
-// +build challengetest
+//go:build legacychallengetest
+// +build legacychallengetest
 
 package arbtest
 


### PR DESCRIPTION
This PR introduces a nightly CI run, which triggers at midnight UTC. It runs the legacychallengetest system tests on `master`. Alternatively, if a PR touched any files in `staker/legacy/`, it will also run the workflow in that PRs CI suite.

This also moves race and Stylus long tests to Nightly CI.