### PR TITLE
Revert "Make config options required for navigating pectra header issues default"

### DIFF
--- a/arbnode/delayed_sequencer.go
+++ b/arbnode/delayed_sequencer.go
@@ -58,7 +58,7 @@ var DefaultDelayedSequencerConfig = DelayedSequencerConfig{
 	Enable:              false,
 	FinalizeDistance:    20,
 	RequireFullFinality: false,
-	UseMergeFinality:    false,
+	UseMergeFinality:    true,
 	RescanInterval:      time.Second,
 }
 


### PR DESCRIPTION
This reverts commit 5439d26dbf4f5e93d4c3cd359ed7cdd73493f07d.

This should not be used for chains with mainnet as parent because it does reduce safety a bit