### PR TITLE
Correctly start and stop validation node

### DIFF
--- a/cmd/nitro-val/nitro_val.go
+++ b/cmd/nitro-val/nitro_val.go
@@ -146,6 +146,7 @@ func mainImpl() int {
 		log.Error("error starting validator node", "err", err)
 		return 1
 	}
+	defer valNode.Stop()
 	err = stack.Start()
 	if err != nil {
 		fatalErrChan <- fmt.Errorf("error starting stack: %w", err)

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -672,6 +672,7 @@ func mainImpl() int {
 			fatalErrChan <- fmt.Errorf("error starting validator node: %w", err)
 		} else {
 			log.Info("validation node started")
+			defer valNode.Stop()
 		}
 	}
 	if err == nil {

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -1140,10 +1140,10 @@ func createTestValidationNode(t *testing.T, ctx context.Context, config *valnode
 	err = valnode.Start(ctx)
 	Require(t, err)
 
-	go func() {
-		<-ctx.Done()
+	t.Cleanup(func() {
 		stack.Close()
-	}()
+		valnode.Stop()
+	})
 
 	return valnode, stack
 }

--- a/validator/valnode/validation_api.go
+++ b/validator/valnode/validation_api.go
@@ -81,6 +81,9 @@ func NewExecutionServerAPI(valSpawner validator.ValidationSpawner, execution val
 }
 
 func (a *ExecServerAPI) CreateExecutionRun(ctx context.Context, wasmModuleRoot common.Hash, jsonInput *server_api.InputJSON, useBoldMachineOptional *bool) (uint64, error) {
+	if a.Stopped() {
+		return 0, errors.New("ExecServerAPI is stopped")
+	}
 	input, err := server_api.ValidationInputFromJson(jsonInput)
 	if err != nil {
 		return 0, err
@@ -111,6 +114,7 @@ func (a *ExecServerAPI) removeOldRuns(ctx context.Context) time.Duration {
 	defer a.runIdLock.Unlock()
 	for id, entry := range a.runs {
 		if entry.accessed.Before(oldestKept) {
+			entry.run.Close()
 			delete(a.runs, id)
 		}
 	}
@@ -122,9 +126,21 @@ func (a *ExecServerAPI) Start(ctx_in context.Context) {
 	a.CallIteratively(a.removeOldRuns)
 }
 
+func (a *ExecServerAPI) StopAndWait() {
+	a.StopWaiter.StopAndWait()
+	a.runIdLock.Lock()
+	defer a.runIdLock.Unlock()
+	for _, entry := range a.runs {
+		entry.run.Close()
+	}
+}
+
 var errRunNotFound error = errors.New("run not found")
 
 func (a *ExecServerAPI) getRun(id uint64) (validator.ExecutionRun, error) {
+	if a.Stopped() {
+		return nil, errRunNotFound
+	}
 	a.runIdLock.Lock()
 	defer a.runIdLock.Unlock()
 	entry := a.runs[id]
@@ -200,12 +216,10 @@ func (a *ExecServerAPI) CheckAlive(ctx context.Context, execid uint64) error {
 }
 
 func (a *ExecServerAPI) CloseExec(execid uint64) {
-	a.runIdLock.Lock()
-	defer a.runIdLock.Unlock()
-	run, found := a.runs[execid]
-	if !found {
-		return
+	run, err := a.getRun(execid)
+	if err != nil {
+		return // means not found
 	}
-	run.run.Close()
+	run.Close()
 	delete(a.runs, execid)
 }


### PR DESCRIPTION
This PR fixes implementation of `ValidationNode` to correctly start and stop threads relating to handling of `execution runs` by `ExecServerAPI`- which in turn calls `ArbitratorSpawner`. This ensures we clear machine caches correctly on node shutdown and that stale execution runs are cleared promptly in regular intervals.

Resolves NIT-2661