### PR TITLE
feat: Live tracing

### DIFF
--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -124,7 +124,7 @@ func NewTransactionStreamerForTest(t *testing.T, ctx context.Context, ownerAddre
 	initReader := statetransfer.NewMemoryInitDataReader(&initData)
 
 	cacheConfig := core.DefaultCacheConfigWithScheme(env.GetTestStateScheme())
-	bc, err := gethexec.WriteOrTestBlockChain(chainDb, cacheConfig, initReader, chainConfig, arbostypes.TestInitMessage, gethexec.ConfigDefault.TxLookupLimit, 0)
+	bc, err := gethexec.WriteOrTestBlockChain(chainDb, cacheConfig, initReader, chainConfig, nil, arbostypes.TestInitMessage, gethexec.ConfigDefault.TxLookupLimit, 0)
 
 	if err != nil {
 		Fail(t, err)

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -74,6 +74,7 @@ type Config struct {
 	ResourceMgmt             resourcemanager.Config         `koanf:"resource-mgmt" reload:"hot"`
 	BlockMetadataFetcher     BlockMetadataFetcherConfig     `koanf:"block-metadata-fetcher" reload:"hot"`
 	ConsensusExecutionSyncer ConsensusExecutionSyncerConfig `koanf:"consensus-execution-syncer"`
+	VMTrace                  arbostypes.VMTraceConfig       `koanf:"vmtrace" reload:"hot"`
 	// SnapSyncConfig is only used for testing purposes, these should not be configured in production.
 	SnapSyncTest SnapSyncConfig
 }
@@ -145,6 +146,7 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet, feedInputEnable bool, feed
 	MaintenanceConfigAddOptions(prefix+".maintenance", f)
 	BlockMetadataFetcherConfigAddOptions(prefix+".block-metadata-fetcher", f)
 	ConsensusExecutionSyncerConfigAddOptions(prefix+".consensus-execution-syncer", f)
+	VMTraceConfigAddOptions(prefix+".vmtrace", f)
 }
 
 var ConfigDefault = Config{
@@ -167,6 +169,7 @@ var ConfigDefault = Config{
 	BlockMetadataFetcher:     DefaultBlockMetadataFetcherConfig,
 	Maintenance:              DefaultMaintenanceConfig,
 	ConsensusExecutionSyncer: DefaultConsensusExecutionSyncerConfig,
+	VMTrace:                  DefaultVMTraceConfig,
 	SnapSyncTest:             DefaultSnapSyncConfig,
 }
 
@@ -216,6 +219,21 @@ func ConfigDefaultL2Test() *Config {
 	config.Bold.MinimumGapToParentAssertion = 0
 
 	return &config
+}
+
+var DefaultVMTraceConfig = arbostypes.VMTraceConfig{
+	TracerName: "",
+	JSONConfig: "{}",
+}
+
+var TestVMTraceConfig = arbostypes.VMTraceConfig{
+	TracerName: "",
+	JSONConfig: "{}",
+}
+
+func VMTraceConfigAddOptions(prefix string, f *flag.FlagSet) {
+	f.String(prefix+".tracername", DefaultVMTraceConfig.TracerName, "Name of tracer which should record internal VM operations (costly)")
+	f.String(prefix+".jsonconfig", DefaultVMTraceConfig.JSONConfig, "Tracer configuration (JSON)")
 }
 
 type DangerousConfig struct {
@@ -1274,6 +1292,7 @@ func (n *Node) Start(ctx context.Context) error {
 			return fmt.Errorf("error initializing exec client: %w", err)
 		}
 	}
+
 	n.SyncMonitor.Initialize(n.InboxReader, n.TxStreamer, n.SeqCoordinator)
 	err := n.Stack.Start()
 	if err != nil {

--- a/arbos/arbostypes/vmtraceconfig.go
+++ b/arbos/arbostypes/vmtraceconfig.go
@@ -1,0 +1,7 @@
+// To activate live tracer with flags --node.vmtrace.tracername and --node.vmtrace.jsonconfig
+package arbostypes
+
+type VMTraceConfig struct {
+	TracerName string
+	JSONConfig string
+}

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
@@ -146,6 +147,7 @@ func ProduceBlock(
 	chainContext core.ChainContext,
 	isMsgForPrefetch bool,
 	runMode core.MessageRunMode,
+	liveTracingHooks *tracing.Hooks,
 ) (*types.Block, types.Receipts, error) {
 	chainConfig := chainContext.Config()
 	txes, err := ParseL2Transactions(message, chainConfig.ChainID)
@@ -156,11 +158,19 @@ func ProduceBlock(
 
 	hooks := NoopSequencingHooks()
 	return ProduceBlockAdvanced(
-		message.Header, txes, delayedMessagesRead, lastBlockHeader, statedb, chainContext, hooks, isMsgForPrefetch, runMode,
+		message.Header,
+		txes,
+		delayedMessagesRead,
+		lastBlockHeader,
+		statedb,
+		chainContext,
+		hooks,
+		isMsgForPrefetch,
+		runMode,
+		liveTracingHooks,
 	)
 }
 
-// A bit more flexible than ProduceBlock for use in the sequencer.
 func ProduceBlockAdvanced(
 	l1Header *arbostypes.L1IncomingMessageHeader,
 	txes types.Transactions,
@@ -171,6 +181,7 @@ func ProduceBlockAdvanced(
 	sequencingHooks *SequencingHooks,
 	isMsgForPrefetch bool,
 	runMode core.MessageRunMode,
+	liveTracingHooks *tracing.Hooks,
 ) (*types.Block, types.Receipts, error) {
 
 	arbState, err := arbosState.OpenSystemArbosState(statedb, nil, true)
@@ -314,7 +325,18 @@ func ProduceBlockAdvanced(
 
 			gasPool := gethGas
 			blockContext := core.NewEVMBlockContext(header, chainContext, &header.Coinbase)
-			evm := vm.NewEVM(blockContext, statedb, chainConfig, vm.Config{})
+
+			var evm *vm.EVM
+
+			if isMsgForPrefetch || liveTracingHooks == nil {
+				evm = vm.NewEVM(blockContext, statedb, chainConfig, vm.Config{})
+			} else {
+				// Enable tracing
+				tracingStateDB := state.NewHookedState(statedb, liveTracingHooks)
+				evm = vm.NewEVM(blockContext, tracingStateDB, chainConfig, vm.Config{
+					Tracer: liveTracingHooks,
+				})
+			}
 			receipt, result, err := core.ApplyTransactionWithResultFilter(
 				evm,
 				&gasPool,

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -575,7 +575,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 				if err != nil {
 					return chainDb, nil, fmt.Errorf("error pruning: %w", err)
 				}
-				l2BlockChain, err := gethexec.GetBlockChain(chainDb, cacheConfig, chainConfig, config.Execution.TxLookupLimit)
+				l2BlockChain, err := gethexec.GetBlockChain(chainDb, cacheConfig, chainConfig, &config.Node.VMTrace, config.Execution.TxLookupLimit)
 				if err != nil {
 					return chainDb, nil, err
 				}
@@ -726,7 +726,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 		if chainConfig == nil {
 			return chainDb, nil, errors.New("no --init.* mode supplied and chain data not in expected directory")
 		}
-		l2BlockChain, err = gethexec.GetBlockChain(chainDb, cacheConfig, chainConfig, config.Execution.TxLookupLimit)
+		l2BlockChain, err = gethexec.GetBlockChain(chainDb, cacheConfig, chainConfig, &config.Node.VMTrace, config.Execution.TxLookupLimit)
 		if err != nil {
 			return chainDb, nil, err
 		}
@@ -825,7 +825,8 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 		if !emptyBlockChain && (cacheConfig.StateScheme == rawdb.PathScheme) && config.Init.Force {
 			return chainDb, nil, errors.New("It is not possible to force init with non-empty blockchain when using path scheme")
 		}
-		l2BlockChain, err = gethexec.WriteOrTestBlockChain(chainDb, cacheConfig, initDataReader, chainConfig, parsedInitMessage, config.Execution.TxLookupLimit, config.Init.AccountsPerSync)
+
+		l2BlockChain, err = gethexec.WriteOrTestBlockChain(chainDb, cacheConfig, initDataReader, chainConfig, &config.Node.VMTrace, parsedInitMessage, config.Execution.TxLookupLimit, config.Init.AccountsPerSync)
 		if err != nil {
 			return chainDb, nil, err
 		}

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	_ "github.com/ethereum/go-ethereum/eth/tracers/js"
+	_ "github.com/ethereum/go-ethereum/eth/tracers/live"
 	_ "github.com/ethereum/go-ethereum/eth/tracers/native"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/graphql"

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -299,7 +299,7 @@ func main() {
 		message := readMessage(chainConfig.ArbitrumChainParams.DataAvailabilityCommittee)
 
 		chainContext := WavmChainContext{chainConfig: chainConfig}
-		newBlock, _, err = arbos.ProduceBlock(message.Message, message.DelayedMessagesRead, lastBlockHeader, statedb, chainContext, false, core.MessageReplayMode)
+		newBlock, _, err = arbos.ProduceBlock(message.Message, message.DelayedMessagesRead, lastBlockHeader, statedb, chainContext, false, core.MessageReplayMode, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/execution/gethexec/block_recorder.go
+++ b/execution/gethexec/block_recorder.go
@@ -159,6 +159,7 @@ func (r *BlockRecorder) RecordBlockCreation(
 			chaincontext,
 			false,
 			core.MessageReplayMode,
+			nil,
 		)
 		if err != nil {
 			return nil, err

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -550,7 +550,6 @@ func (s *ExecutionEngine) sequenceTransactionsWithBlockMutex(header *arbostypes.
 	}
 	statedb.StartPrefetcher("Sequencer", witness)
 	defer statedb.StopPrefetcher()
-
 	delayedMessagesRead := lastBlockHeader.Nonce.Uint64()
 
 	startTime := time.Now()
@@ -564,6 +563,7 @@ func (s *ExecutionEngine) sequenceTransactionsWithBlockMutex(header *arbostypes.
 		hooks,
 		false,
 		core.MessageCommitMode,
+		s.bc.GetVMConfig().Tracer,
 	)
 	if err != nil {
 		return nil, err
@@ -760,6 +760,7 @@ func (s *ExecutionEngine) createBlockFromNextMessage(msg *arbostypes.MessageWith
 		s.bc,
 		isMsgForPrefetch,
 		runMode,
+		s.bc.GetVMConfig().Tracer,
 	)
 
 	return block, statedb, receipts, err

--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -818,7 +818,7 @@ func create2ndNodeWithConfigForBoldProtocol(
 	Require(t, execConfig.Validate())
 	execConfig.Caching.StateScheme = rawdb.HashScheme
 	coreCacheConfig := gethexec.DefaultCacheConfigFor(l2stack, &execConfig.Caching)
-	l2blockchain, err := gethexec.WriteOrTestBlockChain(l2chainDb, coreCacheConfig, initReader, chainConfig, initMessage, execConfig.TxLookupLimit, 0)
+	l2blockchain, err := gethexec.WriteOrTestBlockChain(l2chainDb, coreCacheConfig, initReader, chainConfig, nil, initMessage, execConfig.TxLookupLimit, 0)
 	Require(t, err)
 
 	execConfigFetcher := func() *gethexec.Config { return execConfig }

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -1473,7 +1473,7 @@ func createNonL1BlockChainWithStackConfig(
 		}
 	}
 	coreCacheConfig := gethexec.DefaultCacheConfigFor(stack, &execConfig.Caching)
-	blockchain, err := gethexec.WriteOrTestBlockChain(chainDb, coreCacheConfig, initReader, chainConfig, initMessage, ExecConfigDefaultTest(t).TxLookupLimit, 0)
+	blockchain, err := gethexec.WriteOrTestBlockChain(chainDb, coreCacheConfig, initReader, chainConfig, nil, initMessage, ExecConfigDefaultTest(t).TxLookupLimit, 0)
 	Require(t, err)
 
 	return info, stack, chainDb, arbDb, blockchain
@@ -1567,7 +1567,7 @@ func Create2ndNodeWithConfig(
 	chainConfig := firstExec.ArbInterface.BlockChain().Config()
 
 	coreCacheConfig := gethexec.DefaultCacheConfigFor(chainStack, &execConfig.Caching)
-	blockchain, err := gethexec.WriteOrTestBlockChain(chainDb, coreCacheConfig, initReader, chainConfig, initMessage, ExecConfigDefaultTest(t).TxLookupLimit, 0)
+	blockchain, err := gethexec.WriteOrTestBlockChain(chainDb, coreCacheConfig, initReader, chainConfig, nil, initMessage, ExecConfigDefaultTest(t).TxLookupLimit, 0)
 	Require(t, err)
 
 	AddValNodeIfNeeded(t, ctx, nodeConfig, true, "", valnodeConfig.Wasm.RootPath)

--- a/system_tests/state_fuzz_test.go
+++ b/system_tests/state_fuzz_test.go
@@ -69,7 +69,7 @@ func BuildBlock(
 	}
 
 	block, _, err := arbos.ProduceBlock(
-		l1Message, delayedMessagesRead, lastBlockHeader, statedb, chainContext, false, runMode,
+		l1Message, delayedMessagesRead, lastBlockHeader, statedb, chainContext, false, runMode, nil,
 	)
 	return block, err
 }

--- a/system_tests/staterecovery_test.go
+++ b/system_tests/staterecovery_test.go
@@ -61,7 +61,7 @@ func TestRectreateMissingStates(t *testing.T) {
 		// For now Archive node should use HashScheme
 		cachingConfig.StateScheme = rawdb.HashScheme
 		cacheConfig := gethexec.DefaultCacheConfigFor(stack, &cachingConfig)
-		bc, err := gethexec.GetBlockChain(chainDb, cacheConfig, builder.chainConfig, builder.execConfig.TxLookupLimit)
+		bc, err := gethexec.GetBlockChain(chainDb, cacheConfig, builder.chainConfig, nil, builder.execConfig.TxLookupLimit)
 		Require(t, err)
 		err = staterecovery.RecreateMissingStates(chainDb, bc, cacheConfig, 1)
 		Require(t, err)


### PR DESCRIPTION
This PR improves upon [Tenderly's PR](https://github.com/OffchainLabs/nitro/pull/2934/files) on experimental live tracing support.

- No need to fork go-ethereum to export hooks.
- Activate tracer on demand with `--node.vmconfig.tracername` and `--node.vmconfig.jsonconfig`
- Avoids the prefetchBlock edge case where a block is re-executed multiple times. Instead of updating `digestMEssageWithBlockMutex` I updated `sequenceTransactionsWithBlockMutex` in executionengine.go


# How to test

Add log messages in each hook in [go-ethereum's noop tracer](https://github.com/OffchainLabs/go-ethereum/blob/master/eth/tracers/live/noop.go), then run

```sh
./target/bin/nitro --dev --log-level DEBUG --node.vmtrace.tracername "noop"
```

# Changes made

1. Import the `tracers/live` directory in `cmd/nitro.go` to call init() functions on tracers

2. Add config params to the nitro binary to activate a tracer from bash

3. Call `tracers.LiveDirectory.New()` in `func GetBlockchain()` in `gethexec/blockchain.go` to activate the tracer based on config. The tracer is attached to vmconfig

4. Read the tracer in `executionengine.go`. Pass it to statedb and block_processor.go

5. Add missing hook calls `OnBlockStart` and `OnBlockEnd` in block_processor.go. Remaining hooks function correctly without any change.

# Known quirks

- Apparently we cannot set `genesis.alloc` in `--dev` mode. Avoid `OnGenesisBlock` hook when running in dev mode, otherwise the node will give an error.