### PR TITLE
Change timeboost_auctionresolution metric to Gauge

### DIFF
--- a/execution/gethexec/express_lane_service.go
+++ b/execution/gethexec/express_lane_service.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	auctionResolutionLatency = metrics.NewRegisteredHistogram("arb/sequencer/timeboost/auctionresolution", nil, metrics.NewBoundedHistogramSample())
+	auctionResolutionLatency = metrics.NewRegisteredGauge("arb/sequencer/timeboost/auctionresolution", nil)
 )
 
 type transactionPublisher interface {


### PR DESCRIPTION
Auction resolution events happen only once per minute so using a histogram metric for arb_sequencer_timeboost_auction does not really make sense. Use a gauge intead so we can always see the last resolution duration.