### PR TITLE
Run Docker Build on Design Approval and send CI Slack Notification on Failure

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,44 +1,58 @@
 name: Docker build CI
 run-name: Docker build CI triggered from @${{ github.actor }} of ${{ github.head_ref }}
-
 on:
   workflow_dispatch:
-  merge_group:
   pull_request:
-  push:
-    branches:
-      - master
-      - develop
-
+    types: [labeled]
 jobs:
+  # Only runs Docker build jobs if a PR has received a final "design approved" label as a final check
+  check-label:
+    name: Check for required label
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      should-run: ${{ steps.check-label.outputs.has-label }}
+    steps:
+      - id: check-label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const hasLabel = labels.some(label => label.name === 'design-approved');
+            core.setOutput('has-label', hasLabel);
+            console.log(`PR has 'design-approved' label: ${hasLabel}`);
+
   docker:
     name: Docker build
+    needs: check-label
+    # Run if it's not a PR or if it's a PR with the required label
+    if: github.event_name != 'pull_request' || needs.check-label.outputs.should-run == 'true'
     runs-on: ubuntu-8
     services:
-      # local registery
+      # local registry
       registry:
         image: registry:2
         ports:
           - 5000:5000
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
-
       - name: Cache Docker layers
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
           restore-keys: ${{ runner.os }}-buildx-
-
       - name: Build nitro-node docker
         uses: docker/build-push-action@v5
         with:
@@ -48,7 +62,6 @@ jobs:
           tags: localhost:5000/nitro-node:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
       - name: Build nitro-node-dev docker
         uses: docker/build-push-action@v5
         with:
@@ -58,18 +71,15 @@ jobs:
           tags: localhost:5000/nitro-node-dev:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
       - name: Start background nitro-testnode
         shell: bash
         run: |
           cd nitro-testnode
           ./test-node.bash --init --dev &
-
       - name: Wait for rpc to come up
         shell: bash
         run: |
           ${{ github.workspace }}/.github/workflows/waitForNitro.sh
-
       - name: Print WAVM module root
         id: module-root
         run: |
@@ -79,14 +89,12 @@ jobs:
           module_root="$(cat "target/machines/latest/module-root.txt")"
           echo "module-root=$module_root" >> "$GITHUB_OUTPUT"
           echo -e "\x1b[1;34mWAVM module root:\x1b[0m $module_root"
-
       - name: Upload WAVM machine as artifact
         uses: actions/upload-artifact@v4
         with:
           name: wavm-machine-${{ steps.module-root.outputs.module-root }}
           path: target/machines/latest/*
           if-no-files-found: error
-
       - name: Move cache
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252
@@ -94,7 +102,6 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
       - name: Clear cache on failure
         if: failure()
         run: |

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -14,8 +14,8 @@ on:
 
 jobs:
   # Only run on schedule AND main branch
-  challenge-tests-scheduled:
-    name: Challenge tests (scheduled)
+  tests-scheduled:
+    name: Scheduled tests
     runs-on: ubuntu-8
 
     services:
@@ -199,8 +199,8 @@ jobs:
 
 
   # Only run this job if files in bold/legacy/ are modified
-  challenge-tests-pr:
-    name: Challenge tests (PR modified files)
+  tests-pr:
+    name: PR modified files tests
     runs-on: ubuntu-8
     if: github.event_name == 'pull_request'
     
@@ -375,3 +375,17 @@ jobs:
           files: ./coverage.txt,./coverage-redis.txt
           verbose: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  notify-on-failure:
+    name: Notify Slack on failure
+    needs: [tests-scheduled, tests-pr]
+    runs-on: ubuntu-latest
+    if: ${{ failure() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "⚠️ Nightly CI job failed! ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
This PR runs the docker build pipeline step on design approval, and sends a slack notification to a channel on Nightly CI failure for team to investigate. The docker build pipeline is helpful to run on every PR, but it takes around 40 minutes to complete. Running it only once a PR is fully ready to go to master and has a design approved label would be a nice compromise thanks to @ganeshvanahalli for the suggestion