### PR TITLE
chore: fix potential int64 overflow in block number conversion

### DIFF
--- a/arbutil/correspondingl1blocknumber.go
+++ b/arbutil/correspondingl1blocknumber.go
@@ -25,9 +25,10 @@ type ParentHeaderFetcher interface {
 
 func CorrespondingL1BlockNumber(ctx context.Context, client ParentHeaderFetcher, parentBlockNumber uint64) (uint64, error) {
 	// #nosec G115
-	header, err := client.HeaderByNumber(ctx, big.NewInt(int64(parentBlockNumber)))
+	bigNum := new(big.Int).SetUint64(parentBlockNumber)
+	header, err := client.HeaderByNumber(ctx, bigNum)
 	if err != nil {
-		return 0, fmt.Errorf("error getting L1 block number %d header : %w", parentBlockNumber, err)
+		return 0, fmt.Errorf("error getting L1 block number %d header: %w", parentBlockNumber, err)
 	}
 	return ParentHeaderToL1BlockNumber(header), nil
 }


### PR DESCRIPTION
`parentBlockNumber` is of type `uint64`, but before passing it to `big.NewInt()`, it was first cast to `int64`.  
If `parentBlockNumber > math.MaxInt64` (~9.2×10¹⁸), this cast would cause an overflow, resulting in an unexpected negative value.  

I replaced `big.NewInt(int64(parentBlockNumber))` with `big.NewInt(0).SetUint64(parentBlockNumber)`.  

Now, the code correctly handles `uint64` values without the risk of overflow.