### PR TITLE
Fix L3 Support for BoLD

### DIFF
--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -1,7 +1,7 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-//go:build challengetest && !race
+//g o:build challengetest && !race
 
 package arbtest
 
@@ -486,7 +486,7 @@ func testChallengeProtocolBOLD(t *testing.T, spawnerOpts ...server_arb.SpawnerOp
 }
 
 // Every 3 seconds, send an L1 transaction to keep the chain moving.
-func keepChainMoving(t *testing.T, ctx context.Context, l1Info *BlockchainTestInfo, l1Client *ethclient.Client) {
+func keepChainMoving(t *testing.T, ctx context.Context, l1Info *BlockchainTestInfo, client *ethclient.Client) {
 	delay := time.Second * 3
 	for {
 		select {
@@ -497,8 +497,8 @@ func keepChainMoving(t *testing.T, ctx context.Context, l1Info *BlockchainTestIn
 			if ctx.Err() != nil {
 				break
 			}
-			TransferBalance(t, "Faucet", "Faucet", common.Big0, l1Info, l1Client, ctx)
-			latestBlock, err := l1Client.BlockNumber(ctx)
+			TransferBalance(t, "Faucet", "Faucet", common.Big0, l1Info, client, ctx)
+			latestBlock, err := client.BlockNumber(ctx)
 			if ctx.Err() != nil {
 				break
 			}

--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -1,7 +1,7 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-//g o:build challengetest && !race
+//go:build challengetest && !race
 
 package arbtest
 

--- a/system_tests/bold_l3_support_test.go
+++ b/system_tests/bold_l3_support_test.go
@@ -1,0 +1,260 @@
+// Copyright 2024, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+//g o:build challengetest && !race
+
+package arbtest
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+	solimpl "github.com/offchainlabs/bold/chain-abstraction/sol-implementation"
+	challengemanager "github.com/offchainlabs/bold/challenge-manager"
+	modes "github.com/offchainlabs/bold/challenge-manager/types"
+	l2stateprovider "github.com/offchainlabs/bold/layer2-state-provider"
+	"github.com/offchainlabs/bold/solgen/go/rollupgen"
+	butil "github.com/offchainlabs/bold/util"
+	"github.com/offchainlabs/nitro/arbnode"
+	"github.com/offchainlabs/nitro/arbnode/dataposter/storage"
+	"github.com/offchainlabs/nitro/solgen/go/mocksgen"
+	"github.com/offchainlabs/nitro/staker/bold"
+)
+
+func TestChallengeProtocolBOLD_L3Support(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithBoldDeployment()
+
+	// Block validation requires db hash scheme.
+	builder.execConfig.Caching.StateScheme = rawdb.HashScheme
+	builder.nodeConfig.BlockValidator.Enable = true
+	builder.nodeConfig.Staker.Enable = true
+	builder.nodeConfig.Staker.Strategy = "MakeNodes"
+	builder.nodeConfig.Bold.Strategy = "MakeNodes"
+	builder.nodeConfig.Bold.RPCBlockNumber = "latest"
+	builder.valnodeConfig.UseJit = false
+
+	cleanupL1AndL2 := builder.Build(t)
+	defer cleanupL1AndL2()
+
+	cleanupL3FirstNode := builder.BuildL3OnL2(t)
+	defer cleanupL3FirstNode()
+	firstNodeTestClient := builder.L3
+
+	secondNodeNodeConfig := arbnode.ConfigDefaultL1NonSequencerTest()
+	secondNodeNodeConfig.BlockValidator.Enable = true
+	secondNodeNodeConfig.Staker.Enable = true
+	secondNodeNodeConfig.Staker.Strategy = "MakeNodes"
+	secondNodeNodeConfig.Bold.Strategy = "MakeNodes"
+	secondNodeNodeConfig.Bold.RPCBlockNumber = "latest"
+	secondNodeTestClient, cleanupL3SecondNode := builder.Build2ndNodeOnL3(t, &SecondNodeParams{nodeConfig: secondNodeNodeConfig})
+	defer cleanupL3SecondNode()
+
+	go keepChainMoving(t, ctx, builder.L1Info, builder.L1.Client) // Advance L1.
+	go keepChainMoving(t, ctx, builder.L2Info, builder.L2.Client) // Advance L2.
+
+	_ = firstNodeTestClient
+	_ = secondNodeTestClient
+
+	builder.L2Info.GenerateAccount("HonestAsserter")
+	fundL3Staker(t, ctx, builder, builder.L2.Client, "HonestAsserter")
+	builder.L2Info.GenerateAccount("EvilAsserter")
+	fundL3Staker(t, ctx, builder, builder.L2.Client, "EvilAsserter")
+
+	assertionChain, cleanupHonestChallengeManager := startL3BoldChallengeManager(t, ctx, builder, firstNodeTestClient, "HonestAsserter", nil)
+	defer cleanupHonestChallengeManager()
+
+	_ = assertionChain
+
+	time.Sleep(time.Hour)
+
+	// _, cleanupEvilChallengeManager := startL3BoldChallengeManager(t, ctx, builder, secondNodeTestClient, "EvilAsserter", func(stateManager BoldStateProviderInterface) BoldStateProviderInterface {
+	// 	return &incorrectBlockStateProvider{
+	// 		honest:              stateManager,
+	// 		chain:               assertionChain,
+	// 		wrongAtFirstVirtual: false,
+	// 		wrongAtBlockHeight:  blockChallengeLeafHeight - 2,
+	// 	}
+	// })
+	// defer cleanupEvilChallengeManager()
+
+	// TransferBalance(t, "Faucet", "Faucet", common.Big0, builder.L3Info, builder.L3.Client, ctx)
+
+	// // Everything's setup, now just wait for the challenge to complete and ensure the honest party won
+	// chalManager := assertionChain.SpecChallengeManager()
+	// filterer, err := challengeV2gen.NewEdgeChallengeManagerFilterer(chalManager.Address(), builder.L2.Client)
+	// Require(t, err)
+
+	// fromBlock := uint64(0)
+	// ticker := time.NewTicker(time.Second)
+	// defer ticker.Stop()
+	// for {
+	// 	select {
+	// 	case <-ticker.C:
+	// 		latestBlock, err := builder.L2.Client.HeaderByNumber(ctx, nil)
+	// 		Require(t, err)
+	// 		toBlock := latestBlock.Number.Uint64()
+	// 		if fromBlock == toBlock {
+	// 			continue
+	// 		}
+	// 		filterOpts := &bind.FilterOpts{
+	// 			Start:   fromBlock,
+	// 			End:     &toBlock,
+	// 			Context: ctx,
+	// 		}
+	// 		it, err := filterer.FilterEdgeConfirmedByOneStepProof(filterOpts, nil, nil)
+	// 		Require(t, err)
+	// 		for it.Next() {
+	// 			if it.Error() != nil {
+	// 				t.Fatalf("Error in filter iterator: %v", it.Error())
+	// 			}
+	// 			t.Log("Received event of OSP confirmation!")
+	// 			tx, _, err := builder.L2.Client.TransactionByHash(ctx, it.Event.Raw.TxHash)
+	// 			Require(t, err)
+	// 			signer := types.NewCancunSigner(tx.ChainId())
+	// 			address, err := signer.Sender(tx)
+	// 			Require(t, err)
+	// 			if address == builder.L2Info.GetAddress("HonestAsserter") {
+	// 				t.Log("Honest party won OSP, impossible for evil party to win if honest party continues")
+	// 				Require(t, it.Close())
+	// 				return
+	// 			}
+	// 		}
+	// 		fromBlock = toBlock
+	// 	case <-ctx.Done():
+	// 		return
+	// 	}
+	// }
+}
+
+func fundL3Staker(t *testing.T, ctx context.Context, builder *NodeBuilder, l2Client *ethclient.Client, name string) {
+	balance := big.NewInt(params.Ether)
+	balance.Mul(balance, big.NewInt(100))
+	TransferBalance(t, "Faucet", name, balance, builder.L2Info, l2Client, ctx)
+
+	rollupUserLogic, err := rollupgen.NewRollupUserLogic(builder.l3Addresses.Rollup, l2Client)
+	Require(t, err)
+	stakeToken, err := rollupUserLogic.StakeToken(&bind.CallOpts{Context: ctx})
+	Require(t, err)
+	stakeTokenWeth, err := mocksgen.NewTestWETH9(stakeToken, l2Client)
+	Require(t, err)
+
+	txOpts := builder.L2Info.GetDefaultTransactOpts(name, ctx)
+
+	txOpts.Value = big.NewInt(params.Ether)
+	tx, err := stakeTokenWeth.Deposit(&txOpts)
+	Require(t, err)
+	_, err = builder.L2.EnsureTxSucceeded(tx)
+	Require(t, err)
+	txOpts.Value = nil
+
+	tx, err = stakeTokenWeth.Approve(&txOpts, builder.l3Addresses.Rollup, balance)
+	Require(t, err)
+	_, err = builder.L2.EnsureTxSucceeded(tx)
+	Require(t, err)
+
+	challengeManager, err := rollupUserLogic.ChallengeManager(&bind.CallOpts{Context: ctx})
+	Require(t, err)
+	tx, err = stakeTokenWeth.Approve(&txOpts, challengeManager, balance)
+	Require(t, err)
+	_, err = builder.L2.EnsureTxSucceeded(tx)
+	Require(t, err)
+}
+
+func startL3BoldChallengeManager(t *testing.T, ctx context.Context, builder *NodeBuilder, node *TestClient, addressName string, mockStateProvider func(BoldStateProviderInterface) BoldStateProviderInterface) (*solimpl.AssertionChain, func()) {
+	if !builder.deployBold {
+		t.Fatal("bold deployment not enabled")
+	}
+
+	var stateManager BoldStateProviderInterface
+	var err error
+	cacheDir := t.TempDir()
+	stateManager, err = bold.NewBOLDStateProvider(
+		node.ConsensusNode.BlockValidator,
+		node.ConsensusNode.StatelessBlockValidator,
+		l2stateprovider.Height(blockChallengeLeafHeight),
+		&bold.StateProviderConfig{
+			ValidatorName:          addressName,
+			MachineLeavesCachePath: cacheDir,
+			CheckBatchFinality:     false,
+		},
+		cacheDir,
+	)
+	Require(t, err)
+
+	if mockStateProvider != nil {
+		stateManager = mockStateProvider(stateManager)
+	}
+
+	provider := l2stateprovider.NewHistoryCommitmentProvider(
+		stateManager,
+		stateManager,
+		stateManager,
+		[]l2stateprovider.Height{
+			l2stateprovider.Height(blockChallengeLeafHeight),
+			l2stateprovider.Height(bigStepChallengeLeafHeight),
+			l2stateprovider.Height(bigStepChallengeLeafHeight),
+			l2stateprovider.Height(bigStepChallengeLeafHeight),
+			l2stateprovider.Height(smallStepChallengeLeafHeight),
+		},
+		stateManager,
+		nil, // Api db
+	)
+
+	rollupUserLogic, err := rollupgen.NewRollupUserLogic(builder.l3Addresses.Rollup, builder.L2.Client)
+	Require(t, err)
+	chalManagerAddr, err := rollupUserLogic.ChallengeManager(&bind.CallOpts{})
+	Require(t, err)
+
+	txOpts := builder.L2Info.GetDefaultTransactOpts(addressName, ctx)
+
+	dp, err := arbnode.StakerDataposter(
+		ctx,
+		rawdb.NewTable(node.ConsensusNode.ArbDB, storage.StakerPrefix),
+		builder.L3.ConsensusNode.L1Reader,
+		&txOpts,
+		NewFetcherFromConfig(builder.nodeConfig),
+		node.ConsensusNode.SyncMonitor,
+		builder.L2Info.Signer.ChainID(),
+	)
+	Require(t, err)
+
+	assertionChain, err := solimpl.NewAssertionChain(
+		ctx,
+		builder.l3Addresses.Rollup,
+		chalManagerAddr,
+		&txOpts,
+		butil.NewBackendWrapper(builder.L2.Client, rpc.LatestBlockNumber),
+		bold.NewDataPosterTransactor(dp),
+		solimpl.WithRpcHeadBlockNumber(rpc.LatestBlockNumber),
+	)
+	Require(t, err)
+
+	stackOpts := []challengemanager.StackOpt{
+		challengemanager.StackWithName(addressName),
+		challengemanager.StackWithMode(modes.MakeMode),
+		challengemanager.StackWithPostingInterval(time.Second * 3),
+		challengemanager.StackWithPollingInterval(time.Second),
+		challengemanager.StackWithAverageBlockCreationTime(time.Second),
+		challengemanager.StackWithMinimumGapToParentAssertion(0),
+	}
+
+	challengeManager, err := challengemanager.NewChallengeStack(
+		assertionChain,
+		provider,
+		stackOpts...,
+	)
+	Require(t, err)
+
+	challengeManager.Start(ctx)
+	return assertionChain, challengeManager.StopAndWait
+}

--- a/system_tests/bold_l3_support_test.go
+++ b/system_tests/bold_l3_support_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-//g o:build challengetest && !race
+//go:build challengetest && !race
 
 package arbtest
 
@@ -32,6 +32,7 @@ import (
 )
 
 func TestChallengeProtocolBOLD_L3Support(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -77,9 +78,6 @@ func TestChallengeProtocolBOLD_L3Support(t *testing.T) {
 
 	go keepChainMoving(t, ctx, builder.L1Info, builder.L1.Client) // Advance L1.
 	go keepChainMoving(t, ctx, builder.L2Info, builder.L2.Client) // Advance L2.
-
-	_ = firstNodeTestClient
-	_ = secondNodeTestClient
 
 	builder.L2Info.GenerateAccount("HonestAsserter")
 	fundL3Staker(t, ctx, builder, builder.L2.Client, "HonestAsserter")

--- a/system_tests/bold_l3_support_test.go
+++ b/system_tests/bold_l3_support_test.go
@@ -46,6 +46,7 @@ func TestChallengeProtocolBOLD_L3Support(t *testing.T) {
 	cleanupL1AndL2 := builder.Build(t)
 	defer cleanupL1AndL2()
 
+	builder.l3Config.nodeConfig.Staker.Enable = true
 	cleanupL3FirstNode := builder.BuildL3OnL2(t)
 	defer cleanupL3FirstNode()
 	firstNodeTestClient := builder.L3

--- a/system_tests/bold_new_challenge_test.go
+++ b/system_tests/bold_new_challenge_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-//go:build challengetest && !race
+//g o:build challengetest && !race
 
 package arbtest
 

--- a/system_tests/bold_new_challenge_test.go
+++ b/system_tests/bold_new_challenge_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
-//g o:build challengetest && !race
+//go:build challengetest && !race
 
 package arbtest
 

--- a/system_tests/bold_state_provider_test.go
+++ b/system_tests/bold_state_provider_test.go
@@ -1,7 +1,7 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
 
-//g o:build challengetest && !race
+//go:build challengetest && !race
 
 package arbtest
 

--- a/system_tests/bold_state_provider_test.go
+++ b/system_tests/bold_state_provider_test.go
@@ -1,7 +1,7 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
 
-//go:build challengetest && !race
+//g o:build challengetest && !race
 
 package arbtest
 

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -1368,6 +1368,7 @@ func deployOnParentChain(
 			setup.RollupStackConfig{
 				UseMockBridge:          false,
 				UseMockOneStepProver:   false,
+				UseBlobs:               chainSupportsBlobs,
 				MinimumAssertionPeriod: 0,
 			},
 		)


### PR DESCRIPTION
# Background

Currently, L3 support for BoLD is broken because of some of the parent chain timing assumptions present in our code. The BoLD codebase does not allow setting a custom block time for the assertion chain struct it uses, meaning it is hardcoded to 12 seconds until changed in this [PR](https://github.com/OffchainLabs/bold/pull/738).

Next, we have to actually use the custom block time in the bold initialization within the staker/ folder of the Nitro repo.

Finally, this PR introduces a system test for verifying a BoLD challenge works using an L3.

## Notes
Requires https://github.com/OffchainLabs/bold/pull/739 merged in