### PR TITLE
Validate timeboost config options correctly and make timeboost config not dangerous

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -238,7 +238,7 @@ func mainImpl() int {
 		log.Error("Sequencer coordinator must be enabled with parent chain reader, try starting node with --parent-chain.connection.url")
 		return 1
 	}
-	if nodeConfig.Execution.Sequencer.Enable && !nodeConfig.Execution.Sequencer.Dangerous.Timeboost.Enable && nodeConfig.Node.TransactionStreamer.TrackBlockMetadataFrom != 0 {
+	if nodeConfig.Execution.Sequencer.Enable && !nodeConfig.Execution.Sequencer.Timeboost.Enable && nodeConfig.Node.TransactionStreamer.TrackBlockMetadataFrom != 0 {
 		log.Warn("Sequencer node's track-block-metadata-from is set but timeboost is not enabled")
 	}
 

--- a/execution/gethexec/express_lane_service.go
+++ b/execution/gethexec/express_lane_service.go
@@ -99,8 +99,8 @@ func newExpressLaneService(
 ) (*expressLaneService, error) {
 	var err error
 	var redisCoordinator *timeboost.RedisCoordinator
-	if seqConfig().Dangerous.Timeboost.RedisUrl != "" {
-		redisCoordinator, err = timeboost.NewRedisCoordinator(seqConfig().Dangerous.Timeboost.RedisUrl, roundTimingInfo, seqConfig().Dangerous.Timeboost.RedisUpdateEventsChannelSize)
+	if seqConfig().Timeboost.RedisUrl != "" {
+		redisCoordinator, err = timeboost.NewRedisCoordinator(seqConfig().Timeboost.RedisUrl, roundTimingInfo, seqConfig().Timeboost.RedisUpdateEventsChannelSize)
 		if err != nil {
 			return nil, fmt.Errorf("error initializing expressLaneService redis: %w", err)
 		}
@@ -184,8 +184,8 @@ func (es *expressLaneService) sequenceExpressLaneSubmission(msg *timeboost.Expre
 
 	// Log an informational warning if the message's sequence number is in the future.
 	if msg.SequenceNumber > roundInfo.sequence {
-		if msg.SequenceNumber > roundInfo.sequence+seqConfig.Dangerous.Timeboost.MaxFutureSequenceDistance {
-			return fmt.Errorf("message sequence number has reached max allowed limit. SequenceNumber: %d, ExpectedSequenceNumber: %d, Limit: %d", msg.SequenceNumber, roundInfo.sequence, roundInfo.sequence+seqConfig.Dangerous.Timeboost.MaxFutureSequenceDistance)
+		if msg.SequenceNumber > roundInfo.sequence+seqConfig.Timeboost.MaxFutureSequenceDistance {
+			return fmt.Errorf("message sequence number has reached max allowed limit. SequenceNumber: %d, ExpectedSequenceNumber: %d, Limit: %d", msg.SequenceNumber, roundInfo.sequence, roundInfo.sequence+seqConfig.Timeboost.MaxFutureSequenceDistance)
 		}
 		log.Info("Received express lane submission with future sequence number", "SequenceNumber", msg.SequenceNumber)
 	}
@@ -257,7 +257,7 @@ func (es *expressLaneService) syncFromRedis() {
 	sequenceCount := roundInfo.sequence
 	es.roundInfoMutex.Unlock()
 
-	pendingMsgs := es.redisCoordinator.GetAcceptedTxs(currentRound, sequenceCount, sequenceCount+es.seqConfig().Dangerous.Timeboost.MaxFutureSequenceDistance)
+	pendingMsgs := es.redisCoordinator.GetAcceptedTxs(currentRound, sequenceCount, sequenceCount+es.seqConfig().Timeboost.MaxFutureSequenceDistance)
 	log.Info("Attempting to sequence pending expressLane transactions from redis", "count", len(pendingMsgs))
 	for _, msg := range pendingMsgs {
 		if err := es.sequenceExpressLaneSubmission(msg); err != nil {

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -516,8 +516,8 @@ func (n *ExecutionNode) SetFinalityData(ctx context.Context, finalityData *arbut
 
 func (n *ExecutionNode) InitializeTimeboost(ctx context.Context, chainConfig *params.ChainConfig) error {
 	execNodeConfig := n.ConfigFetcher()
-	if execNodeConfig.Sequencer.Dangerous.Timeboost.Enable {
-		auctionContractAddr := common.HexToAddress(execNodeConfig.Sequencer.Dangerous.Timeboost.AuctionContractAddress)
+	if execNodeConfig.Sequencer.Timeboost.Enable {
+		auctionContractAddr := common.HexToAddress(execNodeConfig.Sequencer.Timeboost.AuctionContractAddress)
 
 		auctionContract, err := NewExpressLaneAuctionFromInternalAPI(
 			n.Backend.APIBackend(),
@@ -539,14 +539,14 @@ func (n *ExecutionNode) InitializeTimeboost(ctx context.Context, chainConfig *pa
 			auctionContract,
 			auctionContractAddr,
 			chainConfig,
-			execNodeConfig.Sequencer.Dangerous.Timeboost.EarlySubmissionGrace,
+			execNodeConfig.Sequencer.Timeboost.EarlySubmissionGrace,
 		)
 
 		n.TxPreChecker.SetExpressLaneTracker(expressLaneTracker)
 
 		if execNodeConfig.Sequencer.Enable {
 			err := n.Sequencer.InitializeExpressLaneService(
-				common.HexToAddress(execNodeConfig.Sequencer.Dangerous.Timeboost.AuctioneerAddress),
+				common.HexToAddress(execNodeConfig.Sequencer.Timeboost.AuctioneerAddress),
 				roundTimingInfo,
 				expressLaneTracker,
 			)

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -183,7 +183,7 @@ func SequencerConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Duration(prefix+".max-acceptable-timestamp-delta", DefaultSequencerConfig.MaxAcceptableTimestampDelta, "maximum acceptable time difference between the local time and the latest L1 block's timestamp")
 	f.StringSlice(prefix+".sender-whitelist", DefaultSequencerConfig.SenderWhitelist, "comma separated whitelist of authorized senders (if empty, everyone is allowed)")
 	AddOptionsForSequencerForwarderConfig(prefix+".forwarder", f)
-	DangerousAddOptions(prefix+".dangerous", f)
+	TimeboostAddOptions(prefix+".timeboost", f)
 
 	f.Int(prefix+".queue-size", DefaultSequencerConfig.QueueSize, "size of the pending tx queue")
 	f.Duration(prefix+".queue-timeout", DefaultSequencerConfig.QueueTimeout, "maximum amount of time transaction can wait in queue")
@@ -207,10 +207,6 @@ func TimeboostAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".redis-url", DefaultTimeboostConfig.RedisUrl, "the Redis URL for expressLaneService to coordinate via")
 	f.Uint64(prefix+".redis-update-events-channel-size", DefaultTimeboostConfig.RedisUpdateEventsChannelSize, "size of update events' buffered channels in timeboost redis coordinator")
 	f.Uint64(prefix+".queue-timeout-in-blocks", DefaultTimeboostConfig.QueueTimeoutInBlocks, "maximum amount of time (measured in blocks) that Express Lane transactions can wait in the sequencer's queue")
-}
-
-func DangerousAddOptions(prefix string, f *flag.FlagSet) {
-	TimeboostAddOptions(prefix+".timeboost", f)
 }
 
 type txQueueItem struct {

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -77,13 +77,9 @@ type SequencerConfig struct {
 	ExpectedSurplusSoftThreshold string          `koanf:"expected-surplus-soft-threshold" reload:"hot"`
 	ExpectedSurplusHardThreshold string          `koanf:"expected-surplus-hard-threshold" reload:"hot"`
 	EnableProfiling              bool            `koanf:"enable-profiling" reload:"hot"`
-	Dangerous                    DangerousConfig `koanf:"dangerous"`
+	Timeboost                    TimeboostConfig `koanf:"timeboost"`
 	expectedSurplusSoftThreshold int
 	expectedSurplusHardThreshold int
-}
-
-type DangerousConfig struct {
-	Timeboost TimeboostConfig `koanf:"timeboost"`
 }
 
 type TimeboostConfig struct {
@@ -138,20 +134,20 @@ func (c *SequencerConfig) Validate() error {
 	if c.MaxTxDataSize > arbostypes.MaxL2MessageSize-50000 {
 		return errors.New("max-tx-data-size too large for MaxL2MessageSize")
 	}
-	if c.Dangerous.Timeboost.Enable {
+	if c.Timeboost.Enable {
+		if len(c.Timeboost.AuctionContractAddress) > 0 && !common.IsHexAddress(c.Timeboost.AuctionContractAddress) {
+			return fmt.Errorf("invalid timeboost.auction-contract-address \"%v\"", c.Timeboost.AuctionContractAddress)
+		}
 		if c.Enable {
-			if c.Dangerous.Timeboost.RedisUrl == DefaultTimeboostConfig.RedisUrl {
+			if c.Timeboost.RedisUrl == DefaultTimeboostConfig.RedisUrl {
 				return errors.New("timeboost is enabled but no redis-url was set")
 			}
-			if c.Dangerous.Timeboost.MaxFutureSequenceDistance == 0 {
+			if c.Timeboost.MaxFutureSequenceDistance == 0 {
 				return errors.New("timeboost max-future-sequence-distance option cannot be zero, it should be set to a positive value")
 			}
-		}
-		if len(c.Dangerous.Timeboost.AuctionContractAddress) > 0 && !common.IsHexAddress(c.Dangerous.Timeboost.AuctionContractAddress) {
-			return fmt.Errorf("invalid timeboost.auction-contract-address \"%v\"", c.Dangerous.Timeboost.AuctionContractAddress)
-		}
-		if len(c.Dangerous.Timeboost.AuctioneerAddress) > 0 && !common.IsHexAddress(c.Dangerous.Timeboost.AuctioneerAddress) {
-			return fmt.Errorf("invalid timeboost.auctioneer-address \"%v\"", c.Dangerous.Timeboost.AuctioneerAddress)
+			if len(c.Timeboost.AuctioneerAddress) > 0 && !common.IsHexAddress(c.Timeboost.AuctioneerAddress) {
+				return fmt.Errorf("invalid timeboost.auctioneer-address \"%v\"", c.Timeboost.AuctioneerAddress)
+			}
 		}
 	}
 	return nil
@@ -177,11 +173,7 @@ var DefaultSequencerConfig = SequencerConfig{
 	ExpectedSurplusSoftThreshold: "default",
 	ExpectedSurplusHardThreshold: "default",
 	EnableProfiling:              false,
-	Dangerous:                    DefaultDangerousConfig,
-}
-
-var DefaultDangerousConfig = DangerousConfig{
-	Timeboost: DefaultTimeboostConfig,
+	Timeboost:                    DefaultTimeboostConfig,
 }
 
 func SequencerConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -498,7 +490,7 @@ func (s *Sequencer) PublishTransaction(parentCtx context.Context, tx *types.Tran
 
 	config := s.config()
 	queueTimeout := config.QueueTimeout
-	queueCtx, cancelFunc := ctxWithTimeout(parentCtx, queueTimeout+config.Dangerous.Timeboost.ExpressLaneAdvantage) // Include timeboost delay in ctx timeout
+	queueCtx, cancelFunc := ctxWithTimeout(parentCtx, queueTimeout+config.Timeboost.ExpressLaneAdvantage) // Include timeboost delay in ctx timeout
 	defer cancelFunc()
 
 	resultChan := make(chan error, 1)
@@ -528,7 +520,7 @@ func (s *Sequencer) PublishTransaction(parentCtx context.Context, tx *types.Tran
 }
 
 func (s *Sequencer) PublishAuctionResolutionTransaction(ctx context.Context, tx *types.Transaction) error {
-	if !s.config().Dangerous.Timeboost.Enable {
+	if !s.config().Timeboost.Enable {
 		return errors.New("timeboost not enabled")
 	}
 
@@ -584,7 +576,7 @@ func (s *Sequencer) PublishAuctionResolutionTransaction(ctx context.Context, tx 
 }
 
 func (s *Sequencer) PublishExpressLaneTransaction(ctx context.Context, msg *timeboost.ExpressLaneSubmission) error {
-	if !s.config().Dangerous.Timeboost.Enable {
+	if !s.config().Timeboost.Enable {
 		return errors.New("timeboost not enabled")
 	}
 
@@ -656,14 +648,14 @@ func (s *Sequencer) publishTransactionToQueue(queueCtx context.Context, tx *type
 		return err
 	}
 
-	if s.config().Dangerous.Timeboost.Enable && s.expressLaneService != nil {
+	if s.config().Timeboost.Enable && s.expressLaneService != nil {
 		if !isExpressLaneController && s.expressLaneService.currentRoundHasController() {
-			time.Sleep(s.config().Dangerous.Timeboost.ExpressLaneAdvantage)
+			time.Sleep(s.config().Timeboost.ExpressLaneAdvantage)
 		}
 	}
 
 	var blockStamp uint64
-	if isExpressLaneController && config.Dangerous.Timeboost.QueueTimeoutInBlocks > 0 {
+	if isExpressLaneController && config.Timeboost.QueueTimeoutInBlocks > 0 {
 		blockStamp = s.execEngine.bc.CurrentBlock().Number.Uint64()
 	}
 
@@ -1101,12 +1093,12 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 		}
 		if queueItem.isTimeboosted &&
 			queueItem.blockStamp != 0 &&
-			lastBlock.Number.Uint64() >= queueItem.blockStamp+config.Dangerous.Timeboost.QueueTimeoutInBlocks {
+			lastBlock.Number.Uint64() >= queueItem.blockStamp+config.Timeboost.QueueTimeoutInBlocks {
 			err := fmt.Errorf("timeboosted tx: %s has hit block based timeout. currentBlockNum: %d, blockStamp: %d, blockExpiry: %d",
 				queueItem.tx.Hash(),
 				lastBlock.Number.Uint64()+1,
 				queueItem.blockStamp,
-				queueItem.blockStamp+config.Dangerous.Timeboost.QueueTimeoutInBlocks,
+				queueItem.blockStamp+config.Timeboost.QueueTimeoutInBlocks,
 			)
 			queueItem.returnResult(err) // this isnt read by anyone, so we log a debug line
 			log.Debug("Error sequencing timeboost tx", "err", err)
@@ -1458,7 +1450,7 @@ func (s TxSource) String() string {
 
 func (s *Sequencer) StopAndWait() {
 	s.StopWaiter.StopAndWait()
-	if s.config().Dangerous.Timeboost.Enable && s.expressLaneService != nil {
+	if s.config().Timeboost.Enable && s.expressLaneService != nil {
 		s.expressLaneService.StopAndWait()
 	}
 	if s.txRetryQueue.Len() == 0 &&

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -138,24 +138,21 @@ func (c *SequencerConfig) Validate() error {
 	if c.MaxTxDataSize > arbostypes.MaxL2MessageSize-50000 {
 		return errors.New("max-tx-data-size too large for MaxL2MessageSize")
 	}
-	return c.Dangerous.Timeboost.Validate()
-}
-
-func (c *TimeboostConfig) Validate() error {
-	if !c.Enable {
-		return nil
-	}
-	if c.RedisUrl == DefaultTimeboostConfig.RedisUrl {
-		return errors.New("timeboost is enabled but no redis-url was set")
-	}
-	if len(c.AuctionContractAddress) > 0 && !common.IsHexAddress(c.AuctionContractAddress) {
-		return fmt.Errorf("invalid timeboost.auction-contract-address \"%v\"", c.AuctionContractAddress)
-	}
-	if len(c.AuctioneerAddress) > 0 && !common.IsHexAddress(c.AuctioneerAddress) {
-		return fmt.Errorf("invalid timeboost.auctioneer-address \"%v\"", c.AuctioneerAddress)
-	}
-	if c.MaxFutureSequenceDistance == 0 {
-		return errors.New("timeboost max-future-sequence-distance option cannot be zero, it should be set to a positive value")
+	if c.Dangerous.Timeboost.Enable {
+		if c.Enable {
+			if c.Dangerous.Timeboost.RedisUrl == DefaultTimeboostConfig.RedisUrl {
+				return errors.New("timeboost is enabled but no redis-url was set")
+			}
+			if c.Dangerous.Timeboost.MaxFutureSequenceDistance == 0 {
+				return errors.New("timeboost max-future-sequence-distance option cannot be zero, it should be set to a positive value")
+			}
+		}
+		if len(c.Dangerous.Timeboost.AuctionContractAddress) > 0 && !common.IsHexAddress(c.Dangerous.Timeboost.AuctionContractAddress) {
+			return fmt.Errorf("invalid timeboost.auction-contract-address \"%v\"", c.Dangerous.Timeboost.AuctionContractAddress)
+		}
+		if len(c.Dangerous.Timeboost.AuctioneerAddress) > 0 && !common.IsHexAddress(c.Dangerous.Timeboost.AuctioneerAddress) {
+			return fmt.Errorf("invalid timeboost.auctioneer-address \"%v\"", c.Dangerous.Timeboost.AuctioneerAddress)
+		}
 	}
 	return nil
 }

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -1477,7 +1477,7 @@ func setupExpressLaneAuction(
 	builderSeq.nodeConfig.SeqCoordinator.MyUrl = nodeNames[0]
 	builderSeq.nodeConfig.SeqCoordinator.DeleteFinalizedMsgs = false
 	builderSeq.execConfig.Sequencer.Enable = true
-	builderSeq.execConfig.Sequencer.Dangerous.Timeboost = gethexec.TimeboostConfig{
+	builderSeq.execConfig.Sequencer.Timeboost = gethexec.TimeboostConfig{
 		Enable:                       false, // We need to start without timeboost initially to create the auction contract
 		ExpressLaneAdvantage:         time.Second * 5,
 		RedisUrl:                     expressLaneRedisURL,
@@ -1673,7 +1673,7 @@ func setupExpressLaneAuction(
 		auctionContract,
 		proxyAddr,
 		builderSeq.chainConfig,
-		builderSeq.execConfig.Sequencer.Dangerous.Timeboost.EarlySubmissionGrace,
+		builderSeq.execConfig.Sequencer.Timeboost.EarlySubmissionGrace,
 	)
 
 	err = builderSeq.L2.ExecNode.Sequencer.InitializeExpressLaneService(
@@ -1697,7 +1697,7 @@ func setupExpressLaneAuction(
 	}
 
 	expressLaneTracker.Start(ctx)
-	builderSeq.execConfig.Sequencer.Dangerous.Timeboost.Enable = true // Prevents race in sequencer where expressLaneService is read inside publishTransactionToQueue
+	builderSeq.execConfig.Sequencer.Timeboost.Enable = true // Prevents race in sequencer where expressLaneService is read inside publishTransactionToQueue
 
 	// Set up an autonomous auction contract service that runs in the background in this test.
 	redisURL := redisutil.CreateTestRedis(ctx, t)


### PR DESCRIPTION
This PR makes sure timeboost config options are validated only when they are being used.

Resolves NIT-3214