### PR TITLE
Fix Slack Notify on Nightly CI Failure With Correct Yaml Args

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -356,14 +356,16 @@ jobs:
 
   notify-on-failure:
     name: Notify Slack on failure
-    needs: [tests-scheduled, tests-pr]
+    needs: [tests-scheduled]
     runs-on: ubuntu-latest
-    if: ${{ failure() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    if: ${{ failure() }}
     steps:
       - name: Send Slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          slack-message: "⚠️ Nightly CI job failed! ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          errors: true
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
+            "text": "⚠️ CI job failed! ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",


### PR DESCRIPTION
Our Nightly workflow was not working properly due to incorrect args passed to our Slack notification action. This has now been fixed and tested