### PR TITLE
Add a node.batch-poster.dangerous.fixed-gas-limit flag

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -138,7 +138,8 @@ const (
 )
 
 type BatchPosterDangerousConfig struct {
-	AllowPostingFirstBatchWhenSequencerMessageCountMismatch bool `koanf:"allow-posting-first-batch-when-sequencer-message-count-mismatch"`
+	AllowPostingFirstBatchWhenSequencerMessageCountMismatch bool   `koanf:"allow-posting-first-batch-when-sequencer-message-count-mismatch"`
+	FixedGasLimit                                           uint64 `koanf:"fixed-gas-limit"`
 }
 
 type BatchPosterConfig struct {
@@ -208,6 +209,7 @@ type BatchPosterConfigFetcher func() *BatchPosterConfig
 
 func DangerousBatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".allow-posting-first-batch-when-sequencer-message-count-mismatch", DefaultBatchPosterConfig.Dangerous.AllowPostingFirstBatchWhenSequencerMessageCountMismatch, "allow posting the first batch even if sequence number doesn't match chain (useful after force-inclusion)")
+	f.Uint64(prefix+".fixed-gas-limit", DefaultBatchPosterConfig.Dangerous.FixedGasLimit, "use this gas limit for batch posting instead of estimating it")
 }
 
 func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
@@ -1494,9 +1496,14 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 	// In theory, this might reduce gas usage, but only by a factor that's already
 	// accounted for in `config.ExtraBatchGas`, as that same factor can appear if a user
 	// posts a new delayed message that we didn't see while gas estimating.
-	gasLimit, err := b.estimateGas(ctx, sequencerMsg, lastPotentialMsg.DelayedMessagesRead, data, kzgBlobs, nonce, accessList, delayProof)
-	if err != nil {
-		return false, err
+	var gasLimit uint64
+	if b.config().Dangerous.FixedGasLimit != 0 {
+		gasLimit = b.config().Dangerous.FixedGasLimit
+	} else {
+		gasLimit, err = b.estimateGas(ctx, sequencerMsg, lastPotentialMsg.DelayedMessagesRead, data, kzgBlobs, nonce, accessList, delayProof)
+		if err != nil {
+			return false, err
+		}
 	}
 	newMeta, err := rlp.EncodeToBytes(batchPosterPosition{
 		MessageCount:        b.building.msgCount,


### PR DESCRIPTION
There are rare cases where problems with gas estimation could be malfunctioning and we want the ability to override it from a config flag. When --node.batch-poster.dangerous.fixed-gas-limit is non-zero, the value will be used as a the gas limit when posting batches and will completely bypass gas estimation.

Resolves: NIT-3225