### PR TITLE
Add cargo fmt check for rust

### DIFF
--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -170,6 +170,12 @@ jobs:
       - name: Check stylus_bechmark
         run: cargo check --manifest-path arbitrator/tools/stylus_benchmark/Cargo.toml
 
+      - name: Rustfmt
+        run: cargo fmt -p arbutil -p prover -p jit -p stylus --manifest-path arbitrator/Cargo.toml -- --check
+
+      - name: Rustfmt - tools/stylus_benchmark
+        run: cargo fmt --all --manifest-path arbitrator/tools/stylus_benchmark/Cargo.toml -- --check
+
       - name: Make proofs from test cases
         run: make -j test-gen-proofs
 

--- a/Makefile
+++ b/Makefile
@@ -574,6 +574,8 @@ contracts/test/prover/proofs/%.json: $(arbitrator_cases)/%.wasm $(prover_bin)
 
 .make/fmt: $(DEP_PREDICATE) build-node-deps .make/yarndeps $(ORDER_ONLY_PREDICATE) .make
 	golangci-lint run --disable-all -E gofmt --fix
+	cargo fmt -p arbutil -p prover -p jit -p stylus --manifest-path arbitrator/Cargo.toml -- --check
+	cargo fmt --all --manifest-path arbitrator/wasm-testsuite/Cargo.toml -- --check
 	yarn --cwd contracts prettier:solidity
 	@touch $@
 

--- a/arbitrator/arbutil/src/evm/req.rs
+++ b/arbitrator/arbutil/src/evm/req.rs
@@ -276,7 +276,9 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         req.extend(gas_left.to_be_bytes());
 
         let (_, data, cost) = self.request(EvmApiMethod::AccountCode, req);
-        if !data.slice().is_empty() || arbos_version < super::ARBOS_VERSION_STYLUS_LAST_CODE_CACHE_FIX {
+        if !data.slice().is_empty()
+            || arbos_version < super::ARBOS_VERSION_STYLUS_LAST_CODE_CACHE_FIX
+        {
             self.last_code = Some((address, data.clone()));
         }
         (data, cost)

--- a/arbitrator/stylus/src/test/api.rs
+++ b/arbitrator/stylus/src/test/api.rs
@@ -180,7 +180,12 @@ impl EvmApi<VecReader> for TestEvmApi {
         unimplemented!()
     }
 
-    fn account_code(&mut self, _arbos_version: u64, _address: Bytes20, _gas_left: Gas) -> (VecReader, Gas) {
+    fn account_code(
+        &mut self,
+        _arbos_version: u64,
+        _address: Bytes20,
+        _gas_left: Gas,
+    ) -> (VecReader, Gas) {
         unimplemented!()
     }
 


### PR DESCRIPTION
It was already part of the codebase, but https://github.com/OffchainLabs/nitro/pull/2972 mistakenly removed all the checks when it was only supposed to remove the check for stylus sdk.