### PR TITLE
fix: Consistent bash imports in scripts (new PR for collaboration)

### DIFF
--- a/scripts/build-brotli.sh
+++ b/scripts/build-brotli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/check-build.sh
+++ b/scripts/check-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script checks the prerequisites for building Arbitrum Nitro locally.
 
 # Color codes
@@ -138,4 +138,3 @@ else
 fi
 
 exit $EXIT_CODE
-

--- a/scripts/remove_reference_types.sh
+++ b/scripts/remove_reference_types.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script removes reference types from a wasm file
 

--- a/scripts/split-val-entry.sh
+++ b/scripts/split-val-entry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 xxd -l 32 -ps -c 40 /dev/urandom > /tmp/nitro-val.jwt
 


### PR DESCRIPTION
`#!/bin/bash` does not work in Nixos. Since some scripts already use `#!/usr/bin/env bash`, we should make imports consistent everywhere.

Duplicate of #3096, but made from non-organization Github to allow collaboration.