### PR TITLE
Use the new nolint directive

### DIFF
--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -822,10 +822,12 @@ func (c *SeqCoordinator) update(ctx context.Context) (time.Duration, error) {
 	// update wanting the lockout
 	var wantsLockoutErr error
 	if synced && !c.AvoidingLockout() {
-		//lint:ignore nilerr we want to retry after redis error
+		//nolint:nilerr
+		// we want to retry after redis error
 		wantsLockoutErr = c.wantsLockoutUpdate(ctx, c.RedisCoordinator().Client)
 	} else {
-		//lint:ignore nilerr we want to retry after redis error
+		//nolint:nilerr
+		// we want to retry after redis error
 		wantsLockoutErr = c.wantsLockoutRelease(ctx)
 	}
 	if wantsLockoutErr != nil {
@@ -833,7 +835,8 @@ func (c *SeqCoordinator) update(ctx context.Context) (time.Duration, error) {
 	}
 
 	if (wantsLockoutErr != nil) || (msgReadErr != nil) {
-		//lint:ignore nilerr we want to retry after redis error
+		//nolint:nilerr
+		// we want to retry after redis error
 		return c.retryAfterRedisError(), nil
 	}
 	return c.noRedisError(), nil

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -822,12 +822,10 @@ func (c *SeqCoordinator) update(ctx context.Context) (time.Duration, error) {
 	// update wanting the lockout
 	var wantsLockoutErr error
 	if synced && !c.AvoidingLockout() {
-		//nolint:nilerr
-		// we want to retry after redis error
+		//nolint:nilerr	// we want to retry after redis error
 		wantsLockoutErr = c.wantsLockoutUpdate(ctx, c.RedisCoordinator().Client)
 	} else {
-		//nolint:nilerr
-		// we want to retry after redis error
+		//nolint:nilerr	// we want to retry after redis error
 		wantsLockoutErr = c.wantsLockoutRelease(ctx)
 	}
 	if wantsLockoutErr != nil {
@@ -835,8 +833,7 @@ func (c *SeqCoordinator) update(ctx context.Context) (time.Duration, error) {
 	}
 
 	if (wantsLockoutErr != nil) || (msgReadErr != nil) {
-		//nolint:nilerr
-		// we want to retry after redis error
+		//nolint:nilerr	// we want to retry after redis error
 		return c.retryAfterRedisError(), nil
 	}
 	return c.noRedisError(), nil


### PR DESCRIPTION
The old style is not supported well in newer versions of the golangci-lint
binary.  The new syntax is also clearer about the separation between the
directive arguments and comments explaining the directives.