### PR TITLE
Fix Broken Challenge Test CI

### DIFF
--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -99,6 +99,7 @@ func testChallengeProtocolBOLD(t *testing.T, spawnerOpts ...server_arb.SpawnerOp
 	ownerBal.Mul(ownerBal, big.NewInt(1_000_000))
 	l2info.GenerateGenesisAccount("Owner", ownerBal)
 	sconf := setup.RollupStackConfig{
+		UseBlobs:               true,
 		UseMockBridge:          false,
 		UseMockOneStepProver:   false,
 		MinimumAssertionPeriod: 0,


### PR DESCRIPTION
This PR https://github.com/OffchainLabs/nitro/pull/3088 broke challenge test CI because of a new parameter that is required for BoLD tests. The PR was merged because challenge tests are not a requirement for merges to master