### PR TITLE
Fail on gas estimation when trying to redeem a duplicate retryable

### DIFF
--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -384,6 +384,13 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, gasUsed uint64, err error, r
 
 		return true, usergas, nil, ticketId.Bytes()
 	case *types.ArbitrumRetryTx:
+		retryable, err := p.state.RetryableState().OpenRetryable(tx.TicketId, p.evm.Context.Time)
+		if err != nil {
+			return true, 0, err, nil
+		}
+		if retryable == nil {
+			return true, 0, fmt.Errorf("retryable with tickerId: %v not found", tx.TicketId), nil
+		}
 
 		// Transfer callvalue from escrow
 		escrow := retryables.RetryableEscrowAddress(tx.TicketId)

--- a/system_tests/retryable_test.go
+++ b/system_tests/retryable_test.go
@@ -406,6 +406,19 @@ func TestSubmitRetryableFailThenRetry(t *testing.T) {
 		Fatal(t, receipt.GasUsed)
 	}
 
+	l2FaucetTxOpts := builder.L2Info.GetDefaultTransactOpts("Faucet", ctx)
+	l2FaucetTxOpts.GasLimit = 0 // gas estimation
+	l2FaucetTxOpts.Value = big.NewInt(2)
+	l2FaucetTxOpts.NoSend = true
+	expectedErr := fmt.Errorf("retryable with tickerId: %v not found", ticketId)
+	_, err = simple.RedeemAllAndCreateAddresses(&l2FaucetTxOpts, [][32]byte{ticketId, ticketId}, []common.Address{testhelpers.RandomAddress(), testhelpers.RandomAddress()})
+	if err == nil {
+		t.Fatal("expected non-nil error for gas estimation of duplicate retryable redeems")
+	}
+	if err.Error() != expectedErr.Error() {
+		t.Fatalf("unexpected error for gas estimation of duplicate retryable redeems. Want: %v, Got: %v", expectedErr, err)
+	}
+
 	arbRetryableTx, err := precompilesgen.NewArbRetryableTx(common.HexToAddress("6e"), builder.L2.Client)
 	Require(t, err)
 	tx, err := arbRetryableTx.Redeem(&ownerTxOpts, ticketId)


### PR DESCRIPTION
Previously during gas estimation mode one could successfully execute a tx that redeems a retryable more than once, but of course the tx would itself would fail when submitted! This PR fixes this by throwing an error `retryable with tickerId: %v not found` if there's a duplicate redeem attempt.

Resolves NIT-3080