### PR TITLE
Fix race in TestTimeboostExpressLaneTransactionHandlingComplex

### DIFF
--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -479,20 +479,30 @@ func TestTimeboostExpressLaneTransactionHandlingComplex(t *testing.T) {
 
 	// Send bunch of future txs so that they are queued up waiting for the unblocking seq num tx
 	var bobExpressLaneTxs types.Transactions
-	for i := currSeq + 1; i < 1000; i++ {
-		futureSeqTx := seqInfo.PrepareTx("Alice", "Owner", seqInfo.TransferGas, big.NewInt(1), nil)
-		bobExpressLaneTxs = append(bobExpressLaneTxs, futureSeqTx)
-		Require(t, bobExpressLaneClient.QueueTransactionWithSequence(ctx, futureSeqTx, i))
-	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(w *sync.WaitGroup) {
+		for i := currSeq + 1; i < 1000; i++ {
+			if roundTimingInfo.TimeTilNextRound() < time.Second {
+				break
+			}
+			futureSeqTx := seqInfo.PrepareTx("Alice", "Owner", seqInfo.TransferGas, big.NewInt(1), nil)
+			bobExpressLaneTxs = append(bobExpressLaneTxs, futureSeqTx)
+			Require(t, bobExpressLaneClient.QueueTransactionWithSequence(ctx, futureSeqTx, i))
+		}
+		w.Done()
+	}(&wg)
 
 	// Alice will win the auction for next round = x+1
 	placeBidsAndDecideWinner(t, ctx, seqClient, seqInfo, auctionContract, "Alice", "Bob", aliceBidderClient, bobBidderClient, roundDuration)
 
-	time.Sleep(roundTimingInfo.TimeTilNextRound() - 500*time.Millisecond) // we'll wait till the 1/2 second mark to the next round and then send the unblocking tx
+	time.Sleep(roundTimingInfo.TimeTilNextRound() - 500*time.Millisecond) // we'll wait till the 500 millisecond mark to the next round and then send the unblocking tx
+	wg.Wait()
 
 	Require(t, bobExpressLaneClient.SendTransactionWithSequence(ctx, unblockingTx, currSeq)) // the unblockingTx itself should ideally pass, but the released 1000 txs shouldn't affect the round for which alice has won the bid for
 
-	time.Sleep(roundTimingInfo.TimeTilNextRound()) // Wait for controller change after the current round's end
+	time.Sleep(500 * time.Millisecond) // Wait for controller change after the current round's end
 
 	// Check that Alice's tx gets priority since she's the controller
 	verifyControllerAdvantage(t, ctx, seqClient, aliceExpressLaneClient, seqInfo, "Alice", "Bob")

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -498,7 +498,7 @@ func TestTimeboostExpressLaneTransactionHandlingComplex(t *testing.T) {
 	// Alice will win the auction for next round = x+1
 	placeBidsAndDecideWinner(t, ctx, seqClient, seqInfo, auctionContract, "Alice", "Bob", aliceBidderClient, bobBidderClient, roundDuration)
 
-	time.Sleep(roundTimingInfo.TimeTilNextRound() - endFloodingDuration/2) // we'll wait till the endFloodingBeforeThisDurationToNextRound/2 duration to the next round and then send the unblocking tx
+	time.Sleep(roundTimingInfo.TimeTilNextRound() - endFloodingDuration/2) // we'll wait till the endFloodingDuration/2 duration to the next round and then send the unblocking tx
 	wg.Wait()
 
 	Require(t, bobExpressLaneClient.SendTransactionWithSequence(ctx, unblockingTx, currSeq)) // the unblockingTx itself should ideally pass, but the released 1000 txs shouldn't affect the round for which alice has won the bid for

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -478,13 +478,14 @@ func TestTimeboostExpressLaneTransactionHandlingComplex(t *testing.T) {
 	bobExpressLaneClient.Unlock()
 
 	// Send bunch of future txs so that they are queued up waiting for the unblocking seq num tx
-	endFloodingBeforeThisDurationToNextRound := time.Second
+	// endFloodingDuration represents the duration before which at the end of this round that we would like to stop flooding with txs
+	endFloodingDuration := time.Second
 	var bobExpressLaneTxs types.Transactions
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func(w *sync.WaitGroup) {
 		for i := currSeq + 1; i < 1000; i++ {
-			if roundTimingInfo.TimeTilNextRound() < endFloodingBeforeThisDurationToNextRound {
+			if roundTimingInfo.TimeTilNextRound() < endFloodingDuration {
 				break
 			}
 			futureSeqTx := seqInfo.PrepareTx("Alice", "Owner", seqInfo.TransferGas, big.NewInt(1), nil)
@@ -497,12 +498,12 @@ func TestTimeboostExpressLaneTransactionHandlingComplex(t *testing.T) {
 	// Alice will win the auction for next round = x+1
 	placeBidsAndDecideWinner(t, ctx, seqClient, seqInfo, auctionContract, "Alice", "Bob", aliceBidderClient, bobBidderClient, roundDuration)
 
-	time.Sleep(roundTimingInfo.TimeTilNextRound() - endFloodingBeforeThisDurationToNextRound/2) // we'll wait till the endFloodingBeforeThisDurationToNextRound/2 duration to the next round and then send the unblocking tx
+	time.Sleep(roundTimingInfo.TimeTilNextRound() - endFloodingDuration/2) // we'll wait till the endFloodingBeforeThisDurationToNextRound/2 duration to the next round and then send the unblocking tx
 	wg.Wait()
 
 	Require(t, bobExpressLaneClient.SendTransactionWithSequence(ctx, unblockingTx, currSeq)) // the unblockingTx itself should ideally pass, but the released 1000 txs shouldn't affect the round for which alice has won the bid for
 
-	time.Sleep(endFloodingBeforeThisDurationToNextRound / 2) // Wait for controller change after the current round's end
+	time.Sleep(endFloodingDuration / 2) // Wait for controller change after the current round's end
 
 	// Check that Alice's tx gets priority since she's the controller
 	verifyControllerAdvantage(t, ctx, seqClient, aliceExpressLaneClient, seqInfo, "Alice", "Bob")


### PR DESCRIPTION
This PR fixes the race issue missed in https://github.com/OffchainLabs/nitro/pull/3106.
Passes `go test -race -run ^TestTimeboostExpressLaneTransactionHandlingComplex$` locally

Resolves NIT-3222