### PR TITLE
Fix path concatenation and GCS data write logic; improve cross-platform compatibility

### DIFF
--- a/das/fallback_storage_service.go
+++ b/das/fallback_storage_service.go
@@ -98,7 +98,7 @@ func (f *FallbackStorageService) GetByHash(ctx context.Context, key common.Hash)
 }
 
 func (f *FallbackStorageService) String() string {
-	return "FallbackStorageService(stoargeService:" + f.StorageService.String() + ")"
+	return "FallbackStorageService(storageService:" + f.StorageService.String() + ")"
 }
 
 func (f *FallbackStorageService) HealthCheck(ctx context.Context) error {

--- a/das/google_cloud_storage_service.go
+++ b/das/google_cloud_storage_service.go
@@ -47,7 +47,7 @@ func (g *GoogleCloudStorageClient) Upload(ctx context.Context, bucket, objectPre
 		}
 	}
 
-	if _, err := fmt.Fprintln(w, value); err != nil {
+	if _, err := w.Write(value); err != nil {
 		return err
 	}
 	return w.Close()
@@ -78,7 +78,7 @@ type GoogleCloudStorageServiceConfig struct {
 var DefaultGoogleCloudStorageServiceConfig = GoogleCloudStorageServiceConfig{}
 
 func GoogleCloudConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Bool(prefix+".enable", DefaultGoogleCloudStorageServiceConfig.Enable, "EXPERIMENTAL/unsupported - enable storage/retrieval of sequencer batch data from an Google Cloud Storage bucket")
+	f.Bool(prefix+".enable", DefaultGoogleCloudStorageServiceConfig.Enable, "EXPERIMENTAL/unsupported - enable storage/retrieval of sequencer batch data from a Google Cloud Storage bucket")
 	f.String(prefix+".access-token", DefaultGoogleCloudStorageServiceConfig.AccessToken, "Google Cloud Storage access token (JSON string)")
 	f.String(prefix+".access-token-file", DefaultGoogleCloudStorageServiceConfig.AccessTokenFile, "Google Cloud Storage access token (JSON file path)")
 	f.String(prefix+".bucket", DefaultGoogleCloudStorageServiceConfig.Bucket, "Google Cloud Storage bucket")

--- a/das/key_utils.go
+++ b/das/key_utils.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/crypto"
 
@@ -53,7 +54,7 @@ func GenerateAndStoreKeys(keyDir string) (*blsSignatures.PublicKey, *blsSignatur
 	if err != nil {
 		return nil, nil, err
 	}
-	pubKeyPath := keyDir + "/" + DefaultPubKeyFilename
+	pubKeyPath := filepath.Join(keyDir, DefaultPubKeyFilename)
 	pubKeyBytes := blsSignatures.PublicKeyToBytes(pubKey)
 	encodedPubKey := make([]byte, base64.StdEncoding.EncodedLen(len(pubKeyBytes)))
 	base64.StdEncoding.Encode(encodedPubKey, pubKeyBytes)
@@ -62,7 +63,7 @@ func GenerateAndStoreKeys(keyDir string) (*blsSignatures.PublicKey, *blsSignatur
 		return nil, nil, err
 	}
 
-	privKeyPath := keyDir + "/" + DefaultPrivKeyFilename
+	privKeyPath := filepath.Join(keyDir, DefaultPrivKeyFilename)
 	privKeyBytes := blsSignatures.PrivateKeyToBytes(privKey)
 	encodedPrivKey := make([]byte, base64.StdEncoding.EncodedLen(len(privKeyBytes)))
 	base64.StdEncoding.Encode(encodedPrivKey, privKeyBytes)
@@ -74,12 +75,12 @@ func GenerateAndStoreKeys(keyDir string) (*blsSignatures.PublicKey, *blsSignatur
 }
 
 func ReadKeysFromFile(keyDir string) (*blsSignatures.PublicKey, blsSignatures.PrivateKey, error) {
-	pubKey, err := ReadPubKeyFromFile(keyDir + "/" + DefaultPubKeyFilename)
+	pubKey, err := ReadPubKeyFromFile(filepath.Join(keyDir, DefaultPubKeyFilename))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	privKey, err := ReadPrivKeyFromFile(keyDir + "/" + DefaultPrivKeyFilename)
+	privKey, err := ReadPrivKeyFromFile(filepath.Join(keyDir, DefaultPrivKeyFilename))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -116,10 +117,10 @@ func GenerateAndStoreECDSAKeys(dir string) error {
 		return err
 	}
 
-	err = crypto.SaveECDSA(dir+"/ecdsa", privateKey)
+	err = crypto.SaveECDSA(filepath.Join(dir, "ecdsa"), privateKey)
 	if err != nil {
 		return err
 	}
 	encodedPubKey := hex.EncodeToString(crypto.FromECDSAPub(&privateKey.PublicKey))
-	return os.WriteFile(dir+"/ecdsa.pub", []byte(encodedPubKey), 0o600)
+	return os.WriteFile(filepath.Join(dir, "ecdsa.pub"), []byte(encodedPubKey), 0o600)
 }


### PR DESCRIPTION
1. Incorrect file path concatenation
- Replaced hardcoded `+ "/" +` string concatenations with `filepath.Join` to ensure cross-platform compatibility (e.g. Windows vs Unix).
- Affected file: `key_utils.go`
- Functions updated:
  - `GenerateAndStoreKeys`
  - `ReadKeysFromFile`
  - `GenerateAndStoreECDSAKeys`

2. Incorrect byte writing in Google Cloud Storage client
- Replaced `fmt.Fprintln(w, value)` with `w.Write(value)` to ensure the exact byte array is written without an added newline (`\n`).
- This fixes a critical issue where the written content didn't match the hash, breaking `GetByHash`.
- Affected file: `google_cloud_storage_service.go`
- Function updated: `GoogleCloudStorageClient.Upload`

3. Minor grammar fix in CLI flag description
- Corrected article in a comment: `"an Google Cloud"` → `"a Google Cloud"`

4. Typo fix
- Corrected `"stoargeService"` to `"storageService"` in `FallbackStorageService.String()`.
