### PR TITLE
Test batch poster with delay proofs and backlog

### DIFF
--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -508,3 +508,55 @@ func TestParentChainNonEIP7623(t *testing.T) {
 		t.Fatal("L3's parent chain should not be using EIP-7623")
 	}
 }
+
+func TestBatchPosterWithDelayProofsAndBacklog(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const threshold = 10
+	builder := NewNodeBuilder(ctx).
+		DefaultConfig(t, true).
+		WithBoldDeployment().
+		WithDelayBuffer(threshold).
+		WithL1ClientWrapper(t)
+	cleanup := builder.Build(t)
+	defer cleanup()
+
+	initialBatchCount := GetBatchCount(t, builder)
+
+	// Filter batch poster transactions using the L1 client wrapper
+	batchPosterAddress := builder.L1Info.GetAddress("Sequencer")
+	batchPosterTxsChan := make(chan *types.Transaction, 100)
+	batchPosterTxs := []*types.Transaction{}
+	builder.L1.ClientWrapper.EnableRawTransactionFilter(batchPosterAddress, batchPosterTxsChan)
+
+	builder.L2Info.GenerateAccount("User2")
+	delayedTx := builder.L2Info.PrepareTx("Owner", "User2", builder.L2Info.TransferGas, common.Big1, nil)
+
+	const numBatches = 3
+	for i := 0; i < numBatches; i++ {
+		// Send transactions using the bridge to generate delay proofs
+		SendSignedTxViaL1(t, ctx, builder.L1Info, builder.L1.Client, builder.L2.Client, delayedTx)
+		// Capture the batch poster transaction, ensuring the batch was closed. If it was not
+		// closed, the select will time out and the test will fail.
+		select {
+		case tx := <-batchPosterTxsChan:
+			batchPosterTxs = append(batchPosterTxs, tx)
+		case <-time.After(1 * time.Second):
+			Fatal(t, "Timed out waiting for batch poster tx")
+		}
+	}
+	select {
+	case <-batchPosterTxsChan:
+		Fatal(t, "Unexpected batch poster transaction")
+	default:
+	}
+
+	// Check that the batch poster txs didn't arrive in L1
+	CheckBatchCount(t, builder, initialBatchCount)
+
+	// Disable the filter and send the batch poster transactions
+	builder.L1.ClientWrapper.DisableRawTransactionFilter()
+	builder.L1.SendWaitTestTransactions(t, batchPosterTxs)
+	CheckBatchCount(t, builder, initialBatchCount+numBatches)
+}

--- a/system_tests/client_wrapper.go
+++ b/system_tests/client_wrapper.go
@@ -1,0 +1,102 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package arbtest
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// ClientWrapper wraps a RPC client to manipulate inbound requests.
+type ClientWrapper struct {
+	mutex                *sync.Mutex
+	innerClient          rpc.ClientInterface
+	chainInfo            *BlockchainTestInfo
+	rawTransactionFilter common.Address
+	rawTransactionChan   chan<- *types.Transaction
+}
+
+func NewClientWrapper(innerClient rpc.ClientInterface, chainInfo *BlockchainTestInfo) *ClientWrapper {
+	return &ClientWrapper{
+		mutex:       new(sync.Mutex),
+		innerClient: innerClient,
+		chainInfo:   chainInfo,
+	}
+}
+
+func (w *ClientWrapper) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	if method == "eth_sendRawTransaction" && w.filterRawTransaction(result, args...) {
+		return nil
+	}
+	return w.innerClient.CallContext(ctx, result, method, args...)
+}
+
+func (w *ClientWrapper) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	return w.innerClient.EthSubscribe(ctx, channel, args...)
+}
+
+func (w *ClientWrapper) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	return w.innerClient.BatchCallContext(ctx, b)
+}
+
+func (w *ClientWrapper) Close() {
+	w.innerClient.Close()
+}
+
+// EnableRawTransactionFilter will filter sendRawTransaction requests with the given sender.
+// The filtered requests will return OK and will be sent to the given channel instead of going through.
+func (w *ClientWrapper) EnableRawTransactionFilter(sender common.Address, rawTransactionChan chan<- *types.Transaction) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	w.rawTransactionFilter = sender
+	w.rawTransactionChan = rawTransactionChan
+}
+
+func (w *ClientWrapper) DisableRawTransactionFilter() {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	w.rawTransactionFilter = common.Address{}
+}
+
+func (w *ClientWrapper) filterRawTransaction(result interface{}, args ...interface{}) bool {
+	if w.rawTransactionFilter == (common.Address{}) {
+		return false
+	}
+	if len(args) < 1 {
+		return false
+	}
+	rawTx, ok := args[0].(string)
+	if !ok {
+		return false
+	}
+	rawTxBytes, err := hexutil.Decode(rawTx)
+	if err != nil {
+		return false
+	}
+	var tx types.Transaction
+	err = tx.UnmarshalBinary(rawTxBytes)
+	if err != nil {
+		return false
+	}
+	from, err := types.Sender(w.chainInfo.Signer, &tx)
+	if err != nil {
+		return false
+	}
+	if from == w.rawTransactionFilter {
+		w.rawTransactionChan <- &tx
+		return true
+	}
+	return false
+}

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -110,6 +110,7 @@ type TestClient struct {
 	Stack         *node.Node
 	ConsensusNode *arbnode.Node
 	ExecNode      *gethexec.ExecutionNode
+	ClientWrapper *ClientWrapper
 
 	// having cleanup() field makes cleanup customizable from default cleanup methods after calling build
 	cleanup func()
@@ -249,6 +250,7 @@ type NodeBuilder struct {
 	wasmCacheTag                uint32
 	delayBufferThreshold        uint64
 	useFreezer                  bool
+	withL1ClientWrapper         bool
 
 	// Created nodes
 	L1 *TestClient
@@ -375,6 +377,15 @@ func (b *NodeBuilder) WithDelayBuffer(threshold uint64) *NodeBuilder {
 	return b
 }
 
+// WithL1ClientWrapper creates a ClientWrapper for the L1 RPC client before passing it to the L2 node.
+func (b *NodeBuilder) WithL1ClientWrapper(t *testing.T) *NodeBuilder {
+	if !b.withL1 {
+		Fatal(t, "WithL1ClientWrapper only works when L1 is enabled")
+	}
+	b.withL1ClientWrapper = true
+	return b
+}
+
 func (b *NodeBuilder) Build(t *testing.T) func() {
 	b.CheckConfig(t)
 	if b.withL1 {
@@ -411,7 +422,7 @@ func (b *NodeBuilder) CheckConfig(t *testing.T) {
 
 func (b *NodeBuilder) BuildL1(t *testing.T) {
 	b.L1 = NewTestClient(b.ctx)
-	b.L1Info, b.L1.Client, b.L1.L1Backend, b.L1.Stack = createTestL1BlockChain(t, b.L1Info)
+	b.L1Info, b.L1.Client, b.L1.L1Backend, b.L1.Stack, b.L1.ClientWrapper = createTestL1BlockChain(t, b.L1Info, b.withL1ClientWrapper)
 	locator, err := server_common.NewMachineLocator(b.valnodeConfig.Wasm.RootPath)
 	Require(t, err)
 	b.addresses, b.initMessage = deployOnParentChain(
@@ -1191,7 +1202,7 @@ func AddValNode(t *testing.T, ctx context.Context, nodeConfig *arbnode.Config, u
 	configByValidationNode(nodeConfig, valStack)
 }
 
-func createTestL1BlockChain(t *testing.T, l1info info) (info, *ethclient.Client, *eth.Ethereum, *node.Node) {
+func createTestL1BlockChain(t *testing.T, l1info info, withClientWrapper bool) (info, *ethclient.Client, *eth.Ethereum, *node.Node, *ClientWrapper) {
 	if l1info == nil {
 		l1info = NewL1TestInfo(t)
 	}
@@ -1244,11 +1255,16 @@ func createTestL1BlockChain(t *testing.T, l1info info) (info, *ethclient.Client,
 
 	Require(t, stack.Start())
 
-	rpcClient := stack.Attach()
+	var rpcClient rpc.ClientInterface = stack.Attach()
+	var clientWrapper *ClientWrapper
+	if withClientWrapper {
+		clientWrapper = NewClientWrapper(rpcClient, l1info)
+		rpcClient = clientWrapper
+	}
 
 	l1Client := ethclient.NewClient(rpcClient)
 
-	return l1info, l1Client, l1backend, stack
+	return l1info, l1Client, l1backend, stack, clientWrapper
 }
 
 func getInitMessage(ctx context.Context, t *testing.T, parentChainClient *ethclient.Client, addresses *chaininfo.RollupAddresses) *arbostypes.ParsedInitMessage {


### PR DESCRIPTION
There was a bug in the batch poster when it created batches with delay proofs and there were already batches in the backlog. This bug was fixed in https://github.com/OffchainLabs/nitro/pull/3100. This commit brings a system test to ensure that the bug is fixed.

Close NIT-3228