### PR TITLE
feat: Implement optional pre/post transaction checks

### DIFF
--- a/arbos/extra_transaction_checks.go
+++ b/arbos/extra_transaction_checks.go
@@ -1,6 +1,8 @@
 package arbos
 
 import (
+	"errors"
+
 	"github.com/ethereum/go-ethereum/arbitrum_types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -10,6 +12,16 @@ import (
 
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 )
+
+// senderBlacklist contains addresses that are blocked from sending transactions.
+// Chain operators can populate this list.
+var senderBlacklist = map[common.Address]struct{}{
+	// Example: common.HexToAddress("0x123..."): {},
+}
+
+// maxTxGasLimit defines the maximum gas a single transaction is allowed to consume.
+// Chain operators can adjust this value.
+const maxTxGasLimit uint64 = 50_000_000 // Example limit, adjust as needed
 
 // extraPreTxFilter should be modified by chain operators to enforce additional pre-transaction validity rules
 func extraPreTxFilter(
@@ -22,7 +34,11 @@ func extraPreTxFilter(
 	sender common.Address,
 	l1Info *L1Info,
 ) error {
-	// TODO: implement additional pre-transaction checks
+	// Check if the sender is in the blacklist
+	if _, blocked := senderBlacklist[sender]; blocked {
+		return errors.New("sender is blocked")
+	}
+
 	return nil
 }
 
@@ -38,6 +54,10 @@ func extraPostTxFilter(
 	l1Info *L1Info,
 	result *core.ExecutionResult,
 ) error {
-	// TODO: implement additional post-transaction checks
+	// Check if the transaction exceeded the gas limit
+	if result.UsedGas > maxTxGasLimit {
+		return errors.New("transaction exceeded gas limit")
+	}
+
 	return nil
 }

--- a/arbos/extra_transaction_checks_test.go
+++ b/arbos/extra_transaction_checks_test.go
@@ -1,0 +1,54 @@
+package arbos
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+)
+
+func TestExtraPreTxFilter(t *testing.T) {
+	testSender := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	// Test case 1: Sender not blacklisted
+	err := extraPreTxFilter(nil, nil, nil, nil, nil, nil, testSender, nil)
+	if err != nil {
+		t.Errorf("extraPreTxFilter() error = %v, want nil for non-blacklisted sender", err)
+	}
+
+	// Test case 2: Sender blacklisted
+	originalBlacklist := senderBlacklist // Backup original map (if needed for parallel tests)
+	senderBlacklist = map[common.Address]struct{}{ // Override for this test
+		testSender: {},
+	}
+	err = extraPreTxFilter(nil, nil, nil, nil, nil, nil, testSender, nil)
+	if err == nil {
+		t.Errorf("extraPreTxFilter() error = nil, want error for blacklisted sender")
+	}
+	senderBlacklist = originalBlacklist // Restore original map
+}
+
+func TestExtraPostTxFilter(t *testing.T) {
+	result := &core.ExecutionResult{}
+
+	// Test case 1: Gas used below limit
+	result.UsedGas = maxTxGasLimit - 1
+	err := extraPostTxFilter(nil, nil, nil, nil, nil, nil, common.Address{}, nil, result)
+	if err != nil {
+		t.Errorf("extraPostTxFilter() error = %v, want nil when gas is below limit", err)
+	}
+
+	// Test case 2: Gas used exactly at limit
+	result.UsedGas = maxTxGasLimit
+	err = extraPostTxFilter(nil, nil, nil, nil, nil, nil, common.Address{}, nil, result)
+	if err != nil {
+		t.Errorf("extraPostTxFilter() error = %v, want nil when gas is at the limit", err)
+	}
+
+	// Test case 3: Gas used above limit
+	result.UsedGas = maxTxGasLimit + 1
+	err = extraPostTxFilter(nil, nil, nil, nil, nil, nil, common.Address{}, nil, result)
+	if err == nil {
+		t.Errorf("extraPostTxFilter() error = nil, want error when gas is above limit")
+	}
+} 


### PR DESCRIPTION
This PR implements basic optional transaction checks in `arbos/extra_transaction_checks.go` that chain operators can enable and customize:

- **Sender Blacklist (`extraPreTxFilter`):** Added a mechanism to block transactions from specific sender addresses. Operators can populate the `senderBlacklist` map.
- **Max Gas Limit (`extraPostTxFilter`):** Added a check to limit the maximum gas allowed per transaction (`maxTxGasLimit`). Transactions exceeding this limit will be reverted.

These checks provide operators with more control over transaction processing and network resources.