### PR TITLE
Fix Broken Challenge Tests on Master

### DIFF
--- a/system_tests/bold_state_provider_test.go
+++ b/system_tests/bold_state_provider_test.go
@@ -156,7 +156,7 @@ func TestChallengeProtocolBOLD_Bisections(t *testing.T) {
 }
 
 func TestChallengeProtocolBOLD_StateProvider(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
 	maxNumBlocks := uint64(1 << 14)
@@ -358,6 +358,7 @@ func setupBoldStateProvider(t *testing.T, ctx context.Context, blockChallengeHei
 	sconf := setup.RollupStackConfig{
 		UseMockBridge:          false,
 		UseMockOneStepProver:   false,
+		UseBlobs:               true,
 		MinimumAssertionPeriod: 0,
 	}
 

--- a/system_tests/overflow_assertions_test.go
+++ b/system_tests/overflow_assertions_test.go
@@ -69,6 +69,7 @@ func TestOverflowAssertions(t *testing.T) {
 		UseMockBridge:          false,
 		UseMockOneStepProver:   false,
 		MinimumAssertionPeriod: minAssertionBlocks,
+		UseBlobs:               true,
 	}
 
 	_, l2node, _, _, l1info, _, l1client, l1stack, assertionChain, _ := createTestNodeOnL1ForBoldProtocol(t, ctx, true, nil, l2chainConfig, nil, sconf, l2info)


### PR DESCRIPTION
BoLD tests have a config value called `UseBlobs` which specifies if the parent chain supports blobs. This needs to be set to true if the parent chain is an L1. This was causing tests to fail because we had not added this option to a few tests. We should also make challenge tests required for merges to master