### PR TITLE
[config change] Extend blocks re-executor to support multiple block ranges

### DIFF
--- a/blocks_reexecutor/blocks_reexecutor.go
+++ b/blocks_reexecutor/blocks_reexecutor.go
@@ -2,10 +2,12 @@ package blocksreexecutor
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 
@@ -29,11 +31,12 @@ import (
 type Config struct {
 	Enable             bool   `koanf:"enable"`
 	Mode               string `koanf:"mode"`
-	StartBlock         uint64 `koanf:"start-block"`
-	EndBlock           uint64 `koanf:"end-block"`
+	Blocks             string `koanf:"blocks"` // Range of blocks to be executed in json format
 	Room               int    `koanf:"room"`
 	MinBlocksPerThread uint64 `koanf:"min-blocks-per-thread"`
 	TrieCleanLimit     int    `koanf:"trie-clean-limit"`
+
+	blocks [][2]uint64
 }
 
 func (c *Config) Validate() error {
@@ -41,8 +44,18 @@ func (c *Config) Validate() error {
 	if c.Enable && c.Mode != "random" && c.Mode != "full" {
 		return errors.New("invalid mode for blocks re-execution")
 	}
-	if c.EndBlock < c.StartBlock {
-		return errors.New("invalid block range for blocks re-execution")
+	if c.Blocks == "" {
+		return errors.New("list of block ranges to be re-executed cannot be empty")
+	}
+	var blocks [][2]uint64
+	if err := json.Unmarshal([]byte(c.Blocks), &blocks); err != nil {
+		return fmt.Errorf("failed to parse blocks re-execution's blocks string: %w", err)
+	}
+	c.blocks = blocks
+	for _, blockRange := range c.blocks {
+		if blockRange[1] < blockRange[0] {
+			return errors.New("invalid block range for blocks re-execution")
+		}
 	}
 	if c.Room <= 0 {
 		return errors.New("room for blocks re-execution should be greater than 0")
@@ -54,21 +67,21 @@ var DefaultConfig = Config{
 	Enable: false,
 	Mode:   "random",
 	Room:   runtime.NumCPU(),
+	Blocks: `[[0,0]]`, // execute from chain start to chain end
 }
 
 var TestConfig = Config{
-	Enable:             true,
-	Mode:               "full",
-	Room:               runtime.NumCPU(),
-	MinBlocksPerThread: 10,
-	TrieCleanLimit:     600,
+	Enable:         true,
+	Mode:           "full",
+	Blocks:         `[[0,0]]`, // execute from chain start to chain end
+	Room:           runtime.NumCPU(),
+	TrieCleanLimit: 600,
 }
 
 func ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultConfig.Enable, "enables re-execution of a range of blocks against historic state")
 	f.String(prefix+".mode", DefaultConfig.Mode, "mode to run the blocks-reexecutor on. Valid modes full and random. full - execute all the blocks in the given range. random - execute a random sample range of blocks with in a given range")
-	f.Uint64(prefix+".start-block", DefaultConfig.StartBlock, "first block number of the block range for re-execution")
-	f.Uint64(prefix+".end-block", DefaultConfig.EndBlock, "last block number of the block range for re-execution")
+	f.String(prefix+".blocks", DefaultConfig.Blocks, "json encoded list of block ranges in the form of start and end block numbers in a list of size 2")
 	f.Int(prefix+".room", DefaultConfig.Room, "number of threads to parallelize blocks re-execution")
 	f.Uint64(prefix+".min-blocks-per-thread", DefaultConfig.MinBlocksPerThread, "minimum number of blocks to execute per thread. When mode is random this acts as the size of random block range sample")
 	f.Int(prefix+".trie-clean-limit", DefaultConfig.TrieCleanLimit, "memory allowance (MB) to use for caching trie nodes in memory")
@@ -76,65 +89,73 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet) {
 
 type BlocksReExecutor struct {
 	stopwaiter.StopWaiter
-	config             *Config
-	db                 state.Database
-	blockchain         *core.BlockChain
-	stateFor           arbitrum.StateForHeaderFunction
-	done               chan struct{}
-	fatalErrChan       chan error
-	startBlock         uint64
-	currentBlock       uint64
-	minBlocksPerThread uint64
-	mutex              sync.Mutex
+	config       *Config
+	db           state.Database
+	blockchain   *core.BlockChain
+	stateFor     arbitrum.StateForHeaderFunction
+	done         chan struct{}
+	fatalErrChan chan error
+	blocks       [][3]uint64 // start, end and minBlocksPerThread of block ranges
+	mutex        sync.Mutex
 }
 
 func New(c *Config, blockchain *core.BlockChain, ethDb ethdb.Database, fatalErrChan chan error) (*BlocksReExecutor, error) {
 	if blockchain.TrieDB().Scheme() == rawdb.PathScheme {
 		return nil, errors.New("blocksReExecutor not supported on pathdb")
 	}
-	start := c.StartBlock
-	end := c.EndBlock
 	chainStart := blockchain.Config().ArbitrumChainParams.GenesisBlockNum
 	chainEnd := blockchain.CurrentBlock().Number.Uint64()
-	if start == 0 && end == 0 {
-		start = chainStart
-		end = chainEnd
-	}
-	if start < chainStart || start > chainEnd {
-		log.Warn("invalid state reexecutor's start block number, resetting to genesis", "start", start, "genesis", chainStart)
-		start = chainStart
-	}
-	if end > chainEnd || end < chainStart {
-		log.Warn("invalid state reexecutor's end block number, resetting to latest", "end", end, "latest", chainEnd)
-		end = chainEnd
-	}
 	minBlocksPerThread := uint64(10000)
 	if c.MinBlocksPerThread != 0 {
 		minBlocksPerThread = c.MinBlocksPerThread
 	}
-	if c.Mode == "random" && end != start {
-		// Reexecute a range of 10000 or (non-zero) c.MinBlocksPerThread number of blocks between start to end picked randomly
-		rng := minBlocksPerThread
-		if rng > end-start {
-			rng = end - start
+	var blocks [][3]uint64
+	for _, blockRange := range c.blocks {
+		start := blockRange[0]
+		end := blockRange[1]
+		if start == 0 && end == 0 {
+			start = chainStart
+			end = chainEnd
 		}
-		// #nosec G115
-		start += uint64(rand.Int63n(int64(end - start - rng + 1)))
-		end = start + rng
-	}
-	// Inclusive of block reexecution [start, end]
-	// Do not reexecute genesis block i,e chainStart
-	if start > 0 && start != chainStart {
-		start--
-	}
-	// Divide work equally among available threads when MinBlocksPerThread is zero
-	if c.MinBlocksPerThread == 0 {
-		// #nosec G115
-		work := (end - start) / uint64(c.Room*2)
+		if start < chainStart || start > chainEnd {
+			log.Warn("invalid state reexecutor's start block number, resetting to genesis", "start", start, "genesis", chainStart)
+			start = chainStart
+		}
+		if end > chainEnd || end < chainStart {
+			log.Warn("invalid state reexecutor's end block number, resetting to latest", "end", end, "latest", chainEnd)
+			end = chainEnd
+		}
+		if c.Mode == "random" && end != start {
+			// Reexecute a range of 10000 or (non-zero) c.MinBlocksPerThread number of blocks between start to end picked randomly
+			rng := minBlocksPerThread
+			if rng > end-start {
+				rng = end - start
+			}
+			// #nosec G115
+			start += uint64(rand.Int63n(int64(end - start - rng + 1)))
+			end = start + rng
+		}
+		// Inclusive of block reexecution [start, end]
+		// Do not reexecute genesis block i,e chainStart
+		if start > 0 && start != chainStart {
+			start--
+		}
+		// Divide work equally among available threads when MinBlocksPerThread is zero
+		var work uint64
+		if c.MinBlocksPerThread == 0 {
+			// #nosec G115
+			work = (end - start) / uint64(c.Room*2)
+		}
 		if work > 0 {
-			minBlocksPerThread = work
+			blocks = append(blocks, [3]uint64{start, end, work})
+		} else {
+			blocks = append(blocks, [3]uint64{start, end, minBlocksPerThread})
 		}
 	}
+	// We sort the block ranges in descending order of their endBlocks to avoid duplicate reexecution of blocks
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i][1] > blocks[j][1]
+	})
 	hashConfig := *hashdb.Defaults
 	hashConfig.CleanCacheSize = c.TrieCleanLimit * 1024 * 1024
 	trieConfig := triedb.Config{
@@ -142,14 +163,12 @@ func New(c *Config, blockchain *core.BlockChain, ethDb ethdb.Database, fatalErrC
 		HashDB:    &hashConfig,
 	}
 	blocksReExecutor := &BlocksReExecutor{
-		config:             c,
-		db:                 state.NewDatabase(triedb.NewDatabase(ethDb, &trieConfig), nil),
-		blockchain:         blockchain,
-		currentBlock:       end,
-		startBlock:         start,
-		minBlocksPerThread: minBlocksPerThread,
-		done:               make(chan struct{}, c.Room),
-		fatalErrChan:       fatalErrChan,
+		config:       c,
+		db:           state.NewDatabase(triedb.NewDatabase(ethDb, &trieConfig), nil),
+		blockchain:   blockchain,
+		blocks:       blocks,
+		done:         make(chan struct{}, c.Room),
+		fatalErrChan: fatalErrChan,
 	}
 	blocksReExecutor.stateFor = func(header *types.Header) (*state.StateDB, arbitrum.StateReleaseFunc, error) {
 		blocksReExecutor.mutex.Lock()
@@ -165,15 +184,15 @@ func New(c *Config, blockchain *core.BlockChain, ethDb ethdb.Database, fatalErrC
 }
 
 // LaunchBlocksReExecution launches the thread to apply blocks of range [currentBlock-s.config.MinBlocksPerThread, currentBlock] to the last available valid state
-func (s *BlocksReExecutor) LaunchBlocksReExecution(ctx context.Context, currentBlock uint64) uint64 {
-	start := arbmath.SaturatingUSub(currentBlock, s.minBlocksPerThread)
-	if start < s.startBlock {
-		start = s.startBlock
+func (s *BlocksReExecutor) LaunchBlocksReExecution(ctx context.Context, startBlock, currentBlock, minBlocksPerThread uint64) uint64 {
+	start := arbmath.SaturatingUSub(currentBlock, minBlocksPerThread)
+	if start < startBlock {
+		start = startBlock
 	}
 	startState, startHeader, release, err := arbitrum.FindLastAvailableState(ctx, s.blockchain, s.stateFor, s.blockchain.GetHeaderByNumber(start), nil, -1)
 	if err != nil {
 		s.fatalErrChan <- fmt.Errorf("blocksReExecutor failed to get last available state while searching for state at %d, err: %w", start, err)
-		return s.startBlock
+		return startBlock
 	}
 	start = startHeader.Number.Uint64()
 	s.LaunchThread(func(ctx context.Context) {
@@ -188,36 +207,46 @@ func (s *BlocksReExecutor) LaunchBlocksReExecution(ctx context.Context, currentB
 	return start
 }
 
-func (s *BlocksReExecutor) Impl(ctx context.Context) {
+func (s *BlocksReExecutor) Impl(ctx context.Context, startBlock, currentBlock, minBlocksPerThread uint64) uint64 {
 	var threadsLaunched uint64
-	end := s.currentBlock
-	for i := 0; i < s.config.Room && s.currentBlock > s.startBlock; i++ {
+	end := currentBlock
+	for i := 0; i < s.config.Room && currentBlock > startBlock; i++ {
 		threadsLaunched++
-		s.currentBlock = s.LaunchBlocksReExecution(ctx, s.currentBlock)
+		currentBlock = s.LaunchBlocksReExecution(ctx, startBlock, currentBlock, minBlocksPerThread)
 	}
 	for {
 		select {
 		case <-s.done:
-			if s.currentBlock > s.startBlock {
-				s.currentBlock = s.LaunchBlocksReExecution(ctx, s.currentBlock)
+			if currentBlock > startBlock {
+				currentBlock = s.LaunchBlocksReExecution(ctx, startBlock, currentBlock, minBlocksPerThread)
 			} else {
 				threadsLaunched--
 			}
 
 		case <-ctx.Done():
-			return
+			return 0
 		}
 		if threadsLaunched == 0 {
 			break
 		}
 	}
-	log.Info("BlocksReExecutor successfully completed re-execution of blocks against historic state", "stateAt", s.startBlock, "startBlock", s.startBlock+1, "endBlock", end)
+	log.Info("BlocksReExecutor successfully completed re-execution of blocks against historic state", "stateAt", startBlock, "startBlock", startBlock+1, "endBlock", end)
+	return currentBlock
 }
 
 func (s *BlocksReExecutor) Start(ctx context.Context, done chan struct{}) {
 	s.StopWaiter.Start(ctx, s)
 	s.LaunchThread(func(ctx context.Context) {
-		s.Impl(ctx)
+		// Using returned value from Impl we can avoid duplicate reexecution of blocks
+		// lowestBlockNotReExecuted represents the block after which either all the blocks have already been reexecuted or not in scope of reexecution
+		lowestBlockNotReExecuted := s.blocks[0][1] + 1
+		for _, blocks := range s.blocks {
+			if lowestBlockNotReExecuted > blocks[0] {
+				lowestBlockNotReExecuted = s.Impl(ctx, blocks[0], min(lowestBlockNotReExecuted, blocks[1]), blocks[2])
+			} else {
+				log.Info("BlocksReExecutor successfully completed re-execution of blocks against historic state", "stateAt", blocks[0], "startBlock", blocks[0]+1, "endBlock", blocks[1])
+			}
+		}
 		if done != nil {
 			close(done)
 		}


### PR DESCRIPTION
This PR changes the blocks re-executor to support multiple block ranges, i.e `--blocks-reexecutor.start-block` and `--blocks-reexecutor.end-block` config options have been replaced with just `--blocks-reexecutor.blocks` option which is a string that should hold the array of block ranges. For example the below option would re-execute blocks from each range inclusively (like before with start and end blocks)-
```
--blocks-reexecutor.blocks="[[10, 1000], [2002, 30000]]"
```

The impl is optimized to avoid duplicate re-executions in case of overlap in block ranges and for full nodes where state at a block number isnt always available.

Resolves NIT-3018