### PR TITLE
Move Challenge Tests to Nightly Ensuring They Still Build in Each PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
       - name: build challenge tests
         if: matrix.test-mode == 'challenge'
         run: |
-            go test -tags challengetest ./... -run=^$ -v
+          go test -tags challengetest ./... -run=^$ -v
 
       - name: run stylus tests
         if: matrix.test-mode == 'stylus'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,9 +182,10 @@ jobs:
             exit 1
           fi
 
-      - name: run challenge tests
+      - name: build challenge tests
         if: matrix.test-mode == 'challenge'
-        run: ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags challengetest --run TestChallenge --timeout 60m --cover
+        run: |
+            go test -tags challengetest ./... -run=^$ -v
 
       - name: run stylus tests
         if: matrix.test-mode == 'stylus'

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-mode: [race, legacychallenge, long, challeneg]
+        test-mode: [race, legacychallenge, long, challenge]
 
     if: github.event_name == 'schedule' && github.ref == 'refs/heads/master'
     

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-mode: [race, legacychallenge, long]
+        test-mode: [race, legacychallenge, long, challeneg]
 
     if: github.event_name == 'schedule' && github.ref == 'refs/heads/master'
     
@@ -154,6 +154,10 @@ jobs:
           ${{ github.workspace }}/.github/workflows/gotestsum.sh --race --timeout 30m --test_state_scheme hash
 
       - name: run challenge tests
+        if: matrix.test-mode == 'challenge'
+        run: ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags challengetest --run TestChallenge --timeout 120m --cover
+
+      - name: run legacy challenge tests
         if: matrix.test-mode == 'legacychallenge'
         run: ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags legacychallengetest --run TestChallenge --timeout 60m --cover
 


### PR DESCRIPTION
This PR moves challenge tests to nightly, which take around an hour today, while still ensuring they build in a PR