### PR TITLE
minimal pruning mode

### DIFF
--- a/cmd/pruning/pruning.go
+++ b/cmd/pruning/pruning.go
@@ -158,9 +158,9 @@ func findImportantRoots(ctx context.Context, chainDb ethdb.Database, stack *node
 				log.Warn("missing latest validated block", "hash", lastValidated.GlobalState.BlockHash)
 			}
 		}
-	} else if initConfig.Prune == "full" {
+	} else if initConfig.Prune == "full" || initConfig.Prune == "minimal" {
 		if validatorRequired {
-			return nil, errors.New("refusing to prune to full-node level when validator is enabled (you should prune in validator mode)")
+			return nil, fmt.Errorf("refusing to prune in %s mode when validator is enabled (you should prune in validator mode)", initConfig.Prune)
 		}
 	} else if hashListRegex.MatchString(initConfig.Prune) {
 		parts := strings.Split(initConfig.Prune, ",")
@@ -177,8 +177,8 @@ func findImportantRoots(ctx context.Context, chainDb ethdb.Database, stack *node
 	} else {
 		return nil, fmt.Errorf("unknown pruning mode: \"%v\"", initConfig.Prune)
 	}
-	if l1Client != nil {
-		// Find the latest finalized block and add it as a pruning target
+	if initConfig.Prune != "minimal" && l1Client != nil {
+		// in pruning modes other then "minimal", find the latest finalized block and add it as a pruning target
 		l1Block, err := l1Client.BlockByNumber(ctx, big.NewInt(int64(rpc.FinalizedBlockNumber)))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get finalized block: %w", err)

--- a/system_tests/pruning_test.go
+++ b/system_tests/pruning_test.go
@@ -2,6 +2,7 @@ package arbtest
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -32,14 +33,15 @@ func countStateEntries(db ethdb.Iteratee) int {
 }
 
 func TestPruning(t *testing.T) {
-	testPruning(t, false)
+	// TODO test "validator" pruning mode - requires latest confirmed
+	for _, mode := range []string{"full", "minimal"} {
+		t.Run(fmt.Sprintf("-%s-mode-without-parallel-storage-traversal", mode), func(t *testing.T) { testPruning(t, mode, false) })
+		t.Run(fmt.Sprintf("-%s-mode-with-parallel-storage-traversal", mode), func(t *testing.T) { testPruning(t, mode, true) })
+	}
 }
 
-func TestPruningPruneParallelStorageTraversal(t *testing.T) {
-	testPruning(t, true)
-}
-
-func testPruning(t *testing.T, pruneParallelStorageTraversal bool) {
+func testPruning(t *testing.T, mode string, pruneParallelStorageTraversal bool) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -98,7 +100,7 @@ func testPruning(t *testing.T, pruneParallelStorageTraversal bool) {
 		}
 
 		initConfig := conf.InitConfigDefault
-		initConfig.Prune = "full"
+		initConfig.Prune = mode
 		initConfig.PruneParallelStorageTraversal = pruneParallelStorageTraversal
 		coreCacheConfig := gethexec.DefaultCacheConfigFor(stack, &builder.execConfig.Caching)
 		persistentConfig := conf.PersistentConfigDefault


### PR DESCRIPTION
Resolves NIT-3243

This PR adds new "minimal" pruning mode. In this mode pruning will keep only genesis state root and snapshot state root. 

In comparison to "full" pruning mode, "minimal" mode does not keep state for latest finalized block, so the pruning should be much quicker (see details below). However, the resulting database won't support reorgs past the latest state preserved - it can be mitigated by keeping older database snapshots that with time will become finalized and can be rolled back to.

### Motivation

Currently, the most time consuming operation during pruning is traversing triedb for given state root to add the trie nodes to bloom filter. 

Creating bloom filter for state root "covered" by bottom most layer of Snapshot Tree is much faster (35 min versus 47 hours of triedb traversing) , as it doesn't involve reading intermediary trie nodes from disk. Instead only trie leaves are read from disk and the rest is recomputed (see: https://github.com/OffchainLabs/go-ethereum/blob/e6c8bea35d519098cf7cc9c0d3765aef9ab72cbb/core/state/snapshot/conversion.go#L53-L56).

Current "full" mode of pruning preserves tries for following state roots:

* genesis state root -> requires traversing triedb, but the state is relatively small, traversing takes under 1 hour

* latest finalized state root -> requires traversing triedb and this state is much bigger, traversing takes ~47 hours

* state root of bottommost snapshot tree layer  -> requires just iterating snapshot tree (intermediate trie nodes are recomputed instead of reading them from disk), takes ~35 min