### PR TITLE
Enable TestSequencerInboxReader system test

### DIFF
--- a/system_tests/seqinbox_test.go
+++ b/system_tests/seqinbox_test.go
@@ -186,7 +186,7 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 		return fmt.Sprintf("Account%v", x)
 	}
 
-	accounts := []string{"ReorgPadding"}
+	var accounts []string
 	for i := 1; i <= (seqInboxTestIters-1)/10; i++ {
 		accounts = append(accounts, fmt.Sprintf("ReorgSacrifice%v", i))
 	}
@@ -212,21 +212,20 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 			// The miner usually collects transactions from deleted blocks and puts them in the mempool.
 			// However, this code doesn't run on reorgs larger than 64 blocks for performance reasons.
 			// Therefore, we make a bunch of small blocks to prevent the code from running.
-			padAddr := builder.L1Info.GetAddress("ReorgPadding")
-			for j := uint64(0); j < 70; j++ {
-				rawTx := &types.DynamicFeeTx{
-					To:        &padAddr,
-					Gas:       21000,
-					GasFeeCap: big.NewInt(params.GWei * 100),
-					Value:     new(big.Int),
-					Nonce:     j,
-				}
-				tx := builder.L1Info.SignTxAs("ReorgPadding", rawTx)
+			reorgTargetNumber := blockStates[reorgTo].l1BlockNumber
+			currentHeader, err := builder.L1.Client.HeaderByNumber(ctx, nil)
+			Require(t, err)
+			blocksToPad := 65 - (currentHeader.Number.Uint64() - reorgTargetNumber)
+
+			currNonce, err := builder.L1.Client.PendingNonceAt(ctx, builder.L1Info.GetAddress("Faucet"))
+			Require(t, err)
+			builder.L1Info.GetInfoWithPrivKey("Faucet").Nonce.Store(currNonce)
+			for j := uint64(0); j < blocksToPad; j++ {
+				tx := builder.L1Info.PrepareTx("Faucet", "User", 30000, big.NewInt(1e12), nil)
 				Require(t, builder.L1.Client.SendTransaction(ctx, tx))
 				_, _ = builder.L1.EnsureTxSucceeded(tx)
 			}
-			reorgTargetNumber := blockStates[reorgTo].l1BlockNumber
-			currentHeader, err := builder.L1.Client.HeaderByNumber(ctx, nil)
+			currentHeader, err = builder.L1.Client.HeaderByNumber(ctx, nil)
 			Require(t, err)
 			// #nosec G115
 			if currentHeader.Number.Int64()-int64(reorgTargetNumber) < 65 {
@@ -265,7 +264,7 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 				sourceNum := rand.Int() % len(state.accounts)
 				source := state.accounts[sourceNum]
 				// #nosec G115
-				amount := new(big.Int).SetUint64(uint64(rand.Int()) % state.balances[source].Uint64())
+				amount := new(big.Int).SetUint64((uint64(rand.Int()%10000) % state.balances[source].Uint64()))
 				reserveAmount := new(big.Int).SetUint64(l2pricing.InitialBaseFeeWei * 100000000)
 				if state.balances[source].Cmp(new(big.Int).Add(amount, reserveAmount)) < 0 {
 					// Leave enough funds for gas
@@ -405,7 +404,7 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 		expectedBlockNumber := blockStates[len(blockStates)-1].l2BlockNumber
 		for i := 0; ; i++ {
 			blockNumber := l2Backend.APIBackend().CurrentHeader().Number.Uint64()
-			if blockNumber == expectedBlockNumber {
+			if blockNumber >= expectedBlockNumber {
 				break
 			} else if i >= 1000 {
 				Fatal(t, "timed out waiting for l2 block update; have", blockNumber, "want", expectedBlockNumber)
@@ -448,6 +447,5 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 }
 
 func TestSequencerInboxReader(t *testing.T) {
-	t.Skip("diagnose after Stylus merge")
 	testSequencerInboxReaderImpl(t, false)
 }

--- a/system_tests/seqinbox_test.go
+++ b/system_tests/seqinbox_test.go
@@ -264,8 +264,8 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 				sourceNum := rand.Int() % len(state.accounts)
 				source := state.accounts[sourceNum]
 				// #nosec G115
-				amount := new(big.Int).SetUint64((uint64(rand.Int()%10000) % state.balances[source].Uint64()))
-				reserveAmount := new(big.Int).SetUint64(l2pricing.InitialBaseFeeWei * 100000000)
+				amount := new(big.Int).SetUint64(uint64(rand.Int()) % state.balances[source].Uint64())
+				reserveAmount := new(big.Int).SetUint64(l2pricing.InitialBaseFeeWei * 100000000000)
 				if state.balances[source].Cmp(new(big.Int).Add(amount, reserveAmount)) < 0 {
 					// Leave enough funds for gas
 					amount = big.NewInt(1)


### PR DESCRIPTION
This PR reenables `TestSequencerInboxReader` which was previously skipped. The test is updated with a couple of simplifications to run it.

Resolves NIT-3241