### PR TITLE
Check chainid before starting BlockMetadataFetcher

### DIFF
--- a/arbnode/blockmetadata.go
+++ b/arbnode/blockmetadata.go
@@ -79,7 +79,8 @@ func NewBlockMetadataFetcher(
 	ethClient := ethclient.NewClient(client)
 	chainId, err := ethClient.ChainID(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("BlockMetadataFetcher error when getting ChainId from %s (configured with --node.block-metadata-fetcher.source.url) %w", c.Source.URL, err)
+		log.Error("error when getting ChainId from backend configured with --node.block-metadata-fetcher.source.url, continuing to start the node without the BlockMetadataFetcher", "url", c.Source.URL, "err", err)
+		return nil, nil
 	}
 	if chainId.Uint64() != expectedChainId {
 		return nil, fmt.Errorf("BlockMetadataFetcher error, ChainId %d from %s (configured with --node.block-metadata-fetcher.source.url) does not match expected ChainId %d", chainId.Uint64(), c.Source.URL, expectedChainId)

--- a/arbnode/blockmetadata.go
+++ b/arbnode/blockmetadata.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -43,6 +44,25 @@ func BlockMetadataFetcherConfigAddOptions(prefix string, f *pflag.FlagSet) {
 		"This should be set lesser than or equal to the limit on the api provider side")
 }
 
+var wrongChainIdErr = errors.New("WRONG_CHAINID")
+
+func (b *BlockMetadataFetcher) checkMetadataBackendChainId(ctx context.Context) error {
+	if !b.chainIdChecked {
+		ethClient := ethclient.NewClient(b.client)
+		chainId, err := ethClient.ChainID(ctx)
+		if err != nil {
+			log.Error("error when getting ChainId from backend configured with --node.block-metadata-fetcher.source.url", "url", b.config.Source.URL, "err", err)
+			return nil
+		}
+		if chainId.Uint64() != b.expectedChainId {
+			log.Error("ChainId from backend configured with --node.block-metadata-fetcher.source.url does not match expected ChainId", "backendChainId", chainId.Uint64(), "expectedChainId", b.expectedChainId, "url", b.config.Source.URL)
+			return wrongChainIdErr
+		}
+		b.chainIdChecked = true
+	}
+	return nil
+}
+
 // BlockMetadataFetcher looks for missing blockMetadata of block numbers starting from trackBlockMetadataFrom (config option of tx streamer)
 // and adds them to arbDB. BlockMetadata is fetched by querying the source's bulk blockMetadata fetching API "arb_getRawBlockMetadata".
 // Missing trackers are removed after their corresponding blockMetadata are added to the arbDB
@@ -78,14 +98,19 @@ func NewBlockMetadataFetcher(
 	if err = client.Start(ctx); err != nil {
 		return nil, err
 	}
-	return &BlockMetadataFetcher{
+	fetcher := &BlockMetadataFetcher{
 		config:                 c,
 		db:                     db,
 		client:                 client,
 		exec:                   exec,
 		trackBlockMetadataFrom: trackBlockMetadataFrom,
 		expectedChainId:        expectedChainId,
-	}, nil
+	}
+
+	if err = fetcher.checkMetadataBackendChainId(ctx); errors.Is(err, wrongChainIdErr) {
+		return nil, err
+	}
+	return fetcher, nil
 }
 
 func (b *BlockMetadataFetcher) fetch(ctx context.Context, fromBlock, toBlock uint64) ([]gethexec.NumberAndBlockMetadata, error) {
@@ -126,18 +151,9 @@ func (b *BlockMetadataFetcher) persistBlockMetadata(ctx context.Context, query [
 }
 
 func (b *BlockMetadataFetcher) Update(ctx context.Context) time.Duration {
-	if !b.chainIdChecked {
-		ethClient := ethclient.NewClient(b.client)
-		chainId, err := ethClient.ChainID(ctx)
-		if err != nil {
-			log.Error("error when getting ChainId from backend configured with --node.block-metadata-fetcher.source.url, retrying in 10 minutes", "url", b.config.Source.URL, "err", err)
-			return time.Minute * 10
-		}
-		if chainId.Uint64() != b.expectedChainId {
-			log.Error("ChainId from backend configured with --node.block-metadata-fetcher.source.url does not match expected ChainId, retrying in 10 minutes", "backendChainId", chainId.Uint64(), "expectedChainId", b.expectedChainId, "url", b.config.Source.URL)
-			return time.Minute * 10
-		}
-		b.chainIdChecked = true
+	if err := b.checkMetadataBackendChainId(ctx); err != nil {
+		log.Error("Error running the BlockMetadataFetcher, trying again in 10 minutes", "err", err)
+		return time.Minute * 10
 	}
 
 	handleQuery := func(query []uint64) bool {

--- a/arbnode/blockmetadata.go
+++ b/arbnode/blockmetadata.go
@@ -44,15 +44,14 @@ func BlockMetadataFetcherConfigAddOptions(prefix string, f *pflag.FlagSet) {
 		"This should be set lesser than or equal to the limit on the api provider side")
 }
 
-var wrongChainIdErr = errors.New("WRONG_CHAINID")
-var failedToGetChainIdErr = errors.New("FAILED_TO_GET_CHAINID")
+var wrongChainIdErr = errors.New("wrong chain id")
 
 func checkMetadataBackendChainId(ctx context.Context, client *rpcclient.RpcClient, sourceUrl string, expectedChainId uint64) error {
 	ethClient := ethclient.NewClient(client)
 	chainId, err := ethClient.ChainID(ctx)
 	if err != nil {
 		log.Error("error when getting ChainId from backend configured with --node.block-metadata-fetcher.source.url", "url", sourceUrl, "err", err)
-		return failedToGetChainIdErr
+		return errors.New("failed to get chainid")
 	}
 	if chainId.Uint64() != expectedChainId {
 		log.Error("ChainId from backend configured with --node.block-metadata-fetcher.source.url does not match expected ChainId", "backendChainId", chainId.Uint64(), "expectedChainId", expectedChainId, "url", sourceUrl)
@@ -158,7 +157,7 @@ func (b *BlockMetadataFetcher) persistBlockMetadata(ctx context.Context, query [
 func (b *BlockMetadataFetcher) Update(ctx context.Context) time.Duration {
 	if !b.chainIdChecked {
 		if err := checkMetadataBackendChainId(ctx, b.client, b.config.Source.URL, b.expectedChainId); err != nil {
-			log.Error("Error running the BlockMetadataFetcher, trying again in 10 minutes", "err", err)
+			log.Error("Error running the BlockMetadataFetcher", "err", err)
 			return time.Minute * 10
 		}
 		b.chainIdChecked = true

--- a/arbnode/blockmetadata.go
+++ b/arbnode/blockmetadata.go
@@ -45,20 +45,18 @@ func BlockMetadataFetcherConfigAddOptions(prefix string, f *pflag.FlagSet) {
 }
 
 var wrongChainIdErr = errors.New("WRONG_CHAINID")
+var failedToGetChainIdErr = errors.New("FAILED_TO_GET_CHAINID")
 
-func (b *BlockMetadataFetcher) checkMetadataBackendChainId(ctx context.Context) error {
-	if !b.chainIdChecked {
-		ethClient := ethclient.NewClient(b.client)
-		chainId, err := ethClient.ChainID(ctx)
-		if err != nil {
-			log.Error("error when getting ChainId from backend configured with --node.block-metadata-fetcher.source.url", "url", b.config.Source.URL, "err", err)
-			return nil
-		}
-		if chainId.Uint64() != b.expectedChainId {
-			log.Error("ChainId from backend configured with --node.block-metadata-fetcher.source.url does not match expected ChainId", "backendChainId", chainId.Uint64(), "expectedChainId", b.expectedChainId, "url", b.config.Source.URL)
-			return wrongChainIdErr
-		}
-		b.chainIdChecked = true
+func checkMetadataBackendChainId(ctx context.Context, client *rpcclient.RpcClient, sourceUrl string, expectedChainId uint64) error {
+	ethClient := ethclient.NewClient(client)
+	chainId, err := ethClient.ChainID(ctx)
+	if err != nil {
+		log.Error("error when getting ChainId from backend configured with --node.block-metadata-fetcher.source.url", "url", sourceUrl, "err", err)
+		return failedToGetChainIdErr
+	}
+	if chainId.Uint64() != expectedChainId {
+		log.Error("ChainId from backend configured with --node.block-metadata-fetcher.source.url does not match expected ChainId", "backendChainId", chainId.Uint64(), "expectedChainId", expectedChainId, "url", sourceUrl)
+		return wrongChainIdErr
 	}
 	return nil
 }
@@ -98,6 +96,16 @@ func NewBlockMetadataFetcher(
 	if err = client.Start(ctx); err != nil {
 		return nil, err
 	}
+
+	chainIdChecked := false
+	if err = checkMetadataBackendChainId(ctx, client, c.Source.URL, expectedChainId); err != nil {
+		if errors.Is(err, wrongChainIdErr) {
+			return nil, err
+		}
+	} else {
+		chainIdChecked = true
+	}
+
 	fetcher := &BlockMetadataFetcher{
 		config:                 c,
 		db:                     db,
@@ -105,10 +113,7 @@ func NewBlockMetadataFetcher(
 		exec:                   exec,
 		trackBlockMetadataFrom: trackBlockMetadataFrom,
 		expectedChainId:        expectedChainId,
-	}
-
-	if err = fetcher.checkMetadataBackendChainId(ctx); errors.Is(err, wrongChainIdErr) {
-		return nil, err
+		chainIdChecked:         chainIdChecked,
 	}
 	return fetcher, nil
 }
@@ -151,9 +156,12 @@ func (b *BlockMetadataFetcher) persistBlockMetadata(ctx context.Context, query [
 }
 
 func (b *BlockMetadataFetcher) Update(ctx context.Context) time.Duration {
-	if err := b.checkMetadataBackendChainId(ctx); err != nil {
-		log.Error("Error running the BlockMetadataFetcher, trying again in 10 minutes", "err", err)
-		return time.Minute * 10
+	if !b.chainIdChecked {
+		if err := checkMetadataBackendChainId(ctx, b.client, b.config.Source.URL, b.expectedChainId); err != nil {
+			log.Error("Error running the BlockMetadataFetcher, trying again in 10 minutes", "err", err)
+			return time.Minute * 10
+		}
+		b.chainIdChecked = true
 	}
 
 	handleQuery := func(query []uint64) bool {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -511,13 +511,14 @@ func getBlockMetadataFetcher(
 	configFetcher ConfigFetcher,
 	arbDb ethdb.Database,
 	exec execution.ExecutionClient,
+	expectedChainId uint64,
 ) (*BlockMetadataFetcher, error) {
 	config := configFetcher.Get()
 
 	var blockMetadataFetcher *BlockMetadataFetcher
 	if config.BlockMetadataFetcher.Enable {
 		var err error
-		blockMetadataFetcher, err = NewBlockMetadataFetcher(ctx, config.BlockMetadataFetcher, arbDb, exec, config.TransactionStreamer.TrackBlockMetadataFrom)
+		blockMetadataFetcher, err = NewBlockMetadataFetcher(ctx, config.BlockMetadataFetcher, arbDb, exec, config.TransactionStreamer.TrackBlockMetadataFrom, expectedChainId)
 		if err != nil {
 			return nil, err
 		}
@@ -1036,7 +1037,7 @@ func createNodeImpl(
 		return nil, err
 	}
 
-	blockMetadataFetcher, err := getBlockMetadataFetcher(ctx, configFetcher, arbDb, executionClient)
+	blockMetadataFetcher, err := getBlockMetadataFetcher(ctx, configFetcher, arbDb, executionClient, l2Config.ChainID.Uint64())
 	if err != nil {
 		return nil, err
 	}

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -763,7 +763,7 @@ func TestTimeboostBulkBlockMetadataFetcher(t *testing.T) {
 
 	// Rebuild blockMetadata and cleanup trackers from ArbDB
 	rebuildStartPos := uint64(5)
-	blockMetadataFetcher, err := arbnode.NewBlockMetadataFetcher(ctx, arbnode.BlockMetadataFetcherConfig{Source: rpcclient.ClientConfig{URL: builder.L2.Stack.HTTPEndpoint()}}, arbDb, newNode.ExecNode, rebuildStartPos)
+	blockMetadataFetcher, err := arbnode.NewBlockMetadataFetcher(ctx, arbnode.BlockMetadataFetcherConfig{Source: rpcclient.ClientConfig{URL: builder.L2.Stack.HTTPEndpoint()}}, arbDb, newNode.ExecNode, rebuildStartPos, builder.chainConfig.ChainID.Uint64())
 	Require(t, err)
 	blockMetadataFetcher.Update(ctx)
 


### PR DESCRIPTION
Fixes NIT-3258

This change adds a sanity check so that on nitro startup, the RPC node pointed to by `--node.block-metadata-fetcher.source.url` is for the same chain ID that nitro is using.

# Testing done

Ran TestTimeboostBulkBlockMetadataFetcher with the chainid check inverted (== instead of !=), BlockMetadataFetcher fails to be constructed and returns an error as expected:
```
=== NAME  TestTimeboostBulkBlockMetadataFetcher
    timeboost_test.go:767: goroutine 51 [running]:
        runtime/debug.Stack()
                /usr/local/go1.23.2/src/runtime/debug/stack.go:26 +0x5e
        github.com/offchainlabs/nitro/util/testhelpers.RequireImpl({0x3e71aa0, 0xc0003e1860}, {0x3e34e20, 0xc001176fa0}, {0x0, 0x0, 0x0})
                /home/tristan/offchain/nitro/util/testhelpers/testhelpers.go:29 +0x55
        github.com/offchainlabs/nitro/system_tests.Require(0xc0003e1860, {0x3e34e20, 0xc001176fa0}, {0x0, 0x0, 0x0})
                /home/tristan/offchain/nitro/system_tests/common_test.go:1498 +0x5d
        github.com/offchainlabs/nitro/system_tests.TestTimeboostBulkBlockMetadataFetcher(0xc0003e1860)
                /home/tristan/offchain/nitro/system_tests/timeboost_test.go:767 +0x140e
        testing.tRunner(0xc0003e1860, 0x3b16458)
                /usr/local/go1.23.2/src/testing/testing.go:1690 +0xf4
        created by testing.(*T).Run in goroutine 1
                /usr/local/go1.23.2/src/testing/testing.go:1743 +0x390
        
    timeboost_test.go:767: ESC[31;1m [] BlockMetadataFetcher error, ChainId 412346 from http://127.0.0.1:44433 (configured with --node.block-metadata-fetcher.source.url) does not match expected ChainId 412346 ESC[0;0m
```