### PR TITLE
Log an error when unable to forward transaction to any of the targets

### DIFF
--- a/execution/gethexec/forwarder.go
+++ b/execution/gethexec/forwarder.go
@@ -148,6 +148,7 @@ func (f *TxForwarder) PublishTransaction(inctx context.Context, tx *types.Transa
 			return err
 		}
 	}
+	log.Error("Failed to publish transaction to any of the forwarding targets", "numTargets", len(f.rpcClients))
 	return errors.New("failed to publish transaction to any of the forwarding targets")
 }
 
@@ -166,6 +167,7 @@ func (f *TxForwarder) PublishExpressLaneTransaction(inctx context.Context, msg *
 			return err
 		}
 	}
+	log.Error("Failed to publish transaction to any of the forwarding targets", "numTargets", len(f.rpcClients))
 	return errors.New("failed to publish transaction to any of the forwarding targets")
 }
 
@@ -192,6 +194,7 @@ func (f *TxForwarder) PublishAuctionResolutionTransaction(inctx context.Context,
 			return err
 		}
 	}
+	log.Error("Failed to publish transaction to any of the forwarding targets", "numTargets", len(f.rpcClients))
 	return errors.New("failed to publish transaction to any of the forwarding targets")
 }
 


### PR DESCRIPTION
This PR makes it that if `TxForwarder` is unable to forward the tx to any of its target will log an error of the form 
```
("Failed to publish transaction to any of the forwarding targets", "numTargets", <Number of targets>)
```

Resolves NIT-3215