### PR TITLE
Feed disconnect error should be logged at level error if it happens more than once per minute

### DIFF
--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -373,7 +373,7 @@ func (bc *BroadcastClient) startBackgroundReader(earlyFrameData io.Reader) {
 		sourcesDisconnectedGauge.Inc(1)
 		backoffDuration := bc.config().ReconnectInitialBackoff
 		flateReader := wsbroadcastserver.NewFlateReader()
-		// We set lastConnectionResetByPeerErrorTime to 2 minutes in the past to bypass initial time.Since(lastConnectionResetByPeerErrorTime) <= time.Minute check
+		// Log should be error instead of debug if first attempt fails
 		lastConnectionResetByPeerErrorTime := time.Now().Add(-2 * time.Minute)
 		for {
 			select {

--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -373,6 +373,8 @@ func (bc *BroadcastClient) startBackgroundReader(earlyFrameData io.Reader) {
 		sourcesDisconnectedGauge.Inc(1)
 		backoffDuration := bc.config().ReconnectInitialBackoff
 		flateReader := wsbroadcastserver.NewFlateReader()
+		// We set lastConnectionResetByPeerErrorTime to 2 minutes in the past to bypass initial time.Since(lastConnectionResetByPeerErrorTime) <= time.Minute check
+		lastConnectionResetByPeerErrorTime := time.Now().Add(-2 * time.Minute)
 		for {
 			select {
 			case <-ctx.Done():
@@ -393,6 +395,13 @@ func (bc *BroadcastClient) startBackgroundReader(earlyFrameData io.Reader) {
 					log.Error("Server connection timed out without receiving data", "url", bc.websocketUrl, "err", err)
 				} else if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 					log.Warn("readData returned EOF", "url", bc.websocketUrl, "opcode", int(op), "err", err)
+				} else if strings.Contains(err.Error(), "connection reset by peer") {
+					logLevel := log.Warn
+					if time.Since(lastConnectionResetByPeerErrorTime) <= time.Minute {
+						logLevel = log.Error
+					}
+					lastConnectionResetByPeerErrorTime = time.Now()
+					logLevel("error calling readData", "url", bc.websocketUrl, "opcode", int(op), "err", err)
 				} else {
 					log.Error("error calling readData", "url", bc.websocketUrl, "opcode", int(op), "err", err)
 				}


### PR DESCRIPTION
This PR makes the feed disconnect error of the form `*connection reset by peer` ephemeral. It's logged as a warning unless it happens more than once per minute, in which case, it will be logged as an error.

Resolves NIT-3205