### PR TITLE
Reduce the Noise of Sequencer Coordinator Logging

### DIFF
--- a/util/redisutil/redis_coordinator.go
+++ b/util/redisutil/redis_coordinator.go
@@ -78,7 +78,7 @@ func (c *RedisCoordinator) RecommendSequencerWantingLockout(ctx context.Context)
 
 	now := time.Now()
 	elapsedTime := time.Since(c.firstSequencerWantingLockoutErrorTime)
-	if elapsedTime > time.Minute {
+	if elapsedTime > time.Hour {
 		c.firstSequencerWantingLockoutErrorTime = now
 		logMessage(log.Debug)
 	} else {

--- a/util/redisutil/redis_coordinator.go
+++ b/util/redisutil/redis_coordinator.go
@@ -77,12 +77,11 @@ func (c *RedisCoordinator) RecommendSequencerWantingLockout(ctx context.Context)
 	}
 
 	now := time.Now()
-	if firstSequencerWantingLockoutErrorTime.IsZero() || now.Sub(firstSequencerWantingLockoutErrorTime) > time.Minute {
+	elapsedTime := time.Since(firstSequencerWantingLockoutErrorTime)
+	if firstSequencerWantingLockoutErrorTime.IsZero() || elapsedTime > time.Minute {
 		firstSequencerWantingLockoutErrorTime = now
 		logMessage(log.Debug)
 	} else {
-		elapsedTime := now.Sub(firstSequencerWantingLockoutErrorTime)
-
 		if elapsedTime > 20*time.Second {
 			logMessage(log.Error)
 		} else if elapsedTime > 10*time.Second {

--- a/util/redisutil/redis_coordinator.go
+++ b/util/redisutil/redis_coordinator.go
@@ -63,6 +63,9 @@ func (c *RedisCoordinator) RecommendSequencerWantingLockout(ctx context.Context)
 		if err != nil {
 			return "", err
 		}
+		// We found a sequencer that wants the lockout, so we reset the last time we observed the error
+		// to a value of zero for logging purposes below.
+		c.firstSequencerWantingLockoutErrorTime = time.Time{}
 		return url, nil
 	}
 

--- a/util/redisutil/redis_coordinator.go
+++ b/util/redisutil/redis_coordinator.go
@@ -41,8 +41,7 @@ func NewRedisCoordinator(redisUrl string) (*RedisCoordinator, error) {
 	}
 
 	return &RedisCoordinator{
-		Client:                                redisClient,
-		firstSequencerWantingLockoutErrorTime: time.Now(),
+		Client: redisClient,
 	}, nil
 }
 
@@ -76,12 +75,11 @@ func (c *RedisCoordinator) RecommendSequencerWantingLockout(ctx context.Context)
 		level("no sequencer appears to want the lockout on redis", args...)
 	}
 
-	now := time.Now()
-	elapsedTime := time.Since(c.firstSequencerWantingLockoutErrorTime)
-	if elapsedTime > time.Hour {
-		c.firstSequencerWantingLockoutErrorTime = now
+	if c.firstSequencerWantingLockoutErrorTime.IsZero() {
+		c.firstSequencerWantingLockoutErrorTime = time.Now()
 		logMessage(log.Debug)
 	} else {
+		elapsedTime := time.Since(c.firstSequencerWantingLockoutErrorTime)
 		if elapsedTime > 20*time.Second {
 			logMessage(log.Error)
 		} else if elapsedTime > 10*time.Second {


### PR DESCRIPTION
During a recent sequencer upgrade, 70 error logs were generated with message no sequencer appears to want the lockout on Redis. Instead, we initially log this at DEBUG level, then move to WARN, and then log to ERROR if more than 20 seconds have passed and this error is still observed.

Resolves NIT-3260