### PR TITLE
Check chainid before starting BlockMetadataFetcher

### DIFF
--- a/arbnode/blockmetadata.go
+++ b/arbnode/blockmetadata.go
@@ -44,15 +44,14 @@ func BlockMetadataFetcherConfigAddOptions(prefix string, f *pflag.FlagSet) {
 		"This should be set lesser than or equal to the limit on the api provider side")
 }
 
-var wrongChainIdErr = errors.New("WRONG_CHAINID")
-var failedToGetChainIdErr = errors.New("FAILED_TO_GET_CHAINID")
+var wrongChainIdErr = errors.New("wrong chain id")
 
 func checkMetadataBackendChainId(ctx context.Context, client *rpcclient.RpcClient, sourceUrl string, expectedChainId uint64) error {
 	ethClient := ethclient.NewClient(client)
 	chainId, err := ethClient.ChainID(ctx)
 	if err != nil {
 		log.Error("error when getting ChainId from backend configured with --node.block-metadata-fetcher.source.url", "url", sourceUrl, "err", err)
-		return failedToGetChainIdErr
+		return errors.New("failed to get chainid")
 	}
 	if chainId.Uint64() != expectedChainId {
 		log.Error("ChainId from backend configured with --node.block-metadata-fetcher.source.url does not match expected ChainId", "backendChainId", chainId.Uint64(), "expectedChainId", expectedChainId, "url", sourceUrl)
@@ -158,7 +157,7 @@ func (b *BlockMetadataFetcher) persistBlockMetadata(query []uint64, result []get
 func (b *BlockMetadataFetcher) Update(ctx context.Context) time.Duration {
 	if !b.chainIdChecked {
 		if err := checkMetadataBackendChainId(ctx, b.client, b.config.Source.URL, b.expectedChainId); err != nil {
-			log.Error("Error running the BlockMetadataFetcher, trying again in 10 minutes", "err", err)
+			log.Error("Error running the BlockMetadataFetcher", "err", err)
 			return time.Minute * 10
 		}
 		b.chainIdChecked = true

--- a/arbnode/blockmetadata.go
+++ b/arbnode/blockmetadata.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"fmt"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -51,6 +50,9 @@ type BlockMetadataFetcher struct {
 	client                 *rpcclient.RpcClient
 	exec                   execution.ExecutionClient
 	trackBlockMetadataFrom arbutil.MessageIndex
+	expectedChainId        uint64
+
+	chainIdChecked bool
 }
 
 func NewBlockMetadataFetcher(
@@ -73,21 +75,13 @@ func NewBlockMetadataFetcher(
 	if err = client.Start(ctx); err != nil {
 		return nil, err
 	}
-	ethClient := ethclient.NewClient(client)
-	chainId, err := ethClient.ChainID(ctx)
-	if err != nil {
-		log.Error("error when getting ChainId from backend configured with --node.block-metadata-fetcher.source.url, continuing to start the node without the BlockMetadataFetcher", "url", c.Source.URL, "err", err)
-		return nil, nil
-	}
-	if chainId.Uint64() != expectedChainId {
-		return nil, fmt.Errorf("BlockMetadataFetcher error, ChainId %d from %s (configured with --node.block-metadata-fetcher.source.url) does not match expected ChainId %d", chainId.Uint64(), c.Source.URL, expectedChainId)
-	}
 	return &BlockMetadataFetcher{
 		config:                 c,
 		db:                     db,
 		client:                 client,
 		exec:                   exec,
 		trackBlockMetadataFrom: trackBlockMetadataFrom,
+		expectedChainId:        expectedChainId,
 	}, nil
 }
 
@@ -129,6 +123,20 @@ func (b *BlockMetadataFetcher) persistBlockMetadata(query []uint64, result []get
 }
 
 func (b *BlockMetadataFetcher) Update(ctx context.Context) time.Duration {
+	if !b.chainIdChecked {
+		ethClient := ethclient.NewClient(b.client)
+		chainId, err := ethClient.ChainID(ctx)
+		if err != nil {
+			log.Error("error when getting ChainId from backend configured with --node.block-metadata-fetcher.source.url, retrying in 10 minutes", "url", b.config.Source.URL, "err", err)
+			return time.Minute * 10
+		}
+		if chainId.Uint64() != b.expectedChainId {
+			log.Error("ChainId from backend configured with --node.block-metadata-fetcher.source.url does not match expected ChainId, retrying in 10 minutes", "backendChainId", chainId.Uint64(), "expectedChainId", b.expectedChainId, "url", b.config.Source.URL)
+			return time.Minute * 10
+		}
+		b.chainIdChecked = true
+	}
+
 	handleQuery := func(query []uint64) bool {
 		result, err := b.fetch(
 			ctx,

--- a/arbnode/blockmetadata.go
+++ b/arbnode/blockmetadata.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"time"
 
 	"github.com/spf13/pflag"
 
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -51,7 +53,14 @@ type BlockMetadataFetcher struct {
 	trackBlockMetadataFrom arbutil.MessageIndex
 }
 
-func NewBlockMetadataFetcher(ctx context.Context, c BlockMetadataFetcherConfig, db ethdb.Database, exec execution.ExecutionClient, startPos uint64) (*BlockMetadataFetcher, error) {
+func NewBlockMetadataFetcher(
+	ctx context.Context,
+	c BlockMetadataFetcherConfig,
+	db ethdb.Database,
+	exec execution.ExecutionClient,
+	startPos uint64,
+	expectedChainId uint64,
+) (*BlockMetadataFetcher, error) {
 	var trackBlockMetadataFrom arbutil.MessageIndex
 	var err error
 	if startPos != 0 {
@@ -63,6 +72,14 @@ func NewBlockMetadataFetcher(ctx context.Context, c BlockMetadataFetcherConfig, 
 	client := rpcclient.NewRpcClient(func() *rpcclient.ClientConfig { return &c.Source }, nil)
 	if err = client.Start(ctx); err != nil {
 		return nil, err
+	}
+	ethClient := ethclient.NewClient(client)
+	chainId, err := ethClient.ChainID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("BlockMetadataFetcher error when getting ChainId from %s (configured with --node.block-metadata-fetcher.source.url) %w", c.Source.URL, err)
+	}
+	if chainId.Uint64() != expectedChainId {
+		return nil, fmt.Errorf("BlockMetadataFetcher error, ChainId %d from %s (configured with --node.block-metadata-fetcher.source.url) does not match expected ChainId %d", chainId.Uint64(), c.Source.URL, expectedChainId)
 	}
 	return &BlockMetadataFetcher{
 		config:                 c,

--- a/arbnode/blockmetadata.go
+++ b/arbnode/blockmetadata.go
@@ -76,7 +76,8 @@ func NewBlockMetadataFetcher(
 	ethClient := ethclient.NewClient(client)
 	chainId, err := ethClient.ChainID(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("BlockMetadataFetcher error when getting ChainId from %s (configured with --node.block-metadata-fetcher.source.url) %w", c.Source.URL, err)
+		log.Error("error when getting ChainId from backend configured with --node.block-metadata-fetcher.source.url, continuing to start the node without the BlockMetadataFetcher", "url", c.Source.URL, "err", err)
+		return nil, nil
 	}
 	if chainId.Uint64() != expectedChainId {
 		return nil, fmt.Errorf("BlockMetadataFetcher error, ChainId %d from %s (configured with --node.block-metadata-fetcher.source.url) does not match expected ChainId %d", chainId.Uint64(), c.Source.URL, expectedChainId)

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -782,7 +782,7 @@ func TestTimeboostBulkBlockMetadataFetcher(t *testing.T) {
 
 	// Rebuild blockMetadata and cleanup trackers from ArbDB
 	rebuildStartPos := uint64(5)
-	blockMetadataFetcher, err := arbnode.NewBlockMetadataFetcher(ctx, arbnode.BlockMetadataFetcherConfig{Source: rpcclient.ClientConfig{URL: builder.L2.Stack.HTTPEndpoint()}}, arbDb, newNode.ExecNode, rebuildStartPos)
+	blockMetadataFetcher, err := arbnode.NewBlockMetadataFetcher(ctx, arbnode.BlockMetadataFetcherConfig{Source: rpcclient.ClientConfig{URL: builder.L2.Stack.HTTPEndpoint()}}, arbDb, newNode.ExecNode, rebuildStartPos, builder.chainConfig.ChainID.Uint64())
 	Require(t, err)
 	blockMetadataFetcher.Update(ctx)
 


### PR DESCRIPTION
Backport #3149

This change adds a sanity check so that on nitro startup, the RPC node pointed to by `--node.block-metadata-fetcher.source.url` is for the same chain ID that nitro is using.