### PR TITLE
Auction resolution tx should not be considered as timeboosted

### DIFF
--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -581,7 +581,7 @@ func (s *Sequencer) PublishAuctionResolutionTransaction(ctx context.Context, tx 
 		returnedResult:  &atomic.Bool{},
 		ctx:             s.GetContext(),
 		firstAppearance: time.Now(),
-		isTimeboosted:   true,
+		isTimeboosted:   false,
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fixes a small issue that mislabels the auction resolution tx as timeboosted.

Resolves NIT-3266