### PR TITLE
Replace TODOs with meaningful messages and valid documentation link

### DIFF
--- a/arbitrator/wasm-libraries/user-host-trait/src/lib.rs
+++ b/arbitrator/wasm-libraries/user-host-trait/src/lib.rs
@@ -392,7 +392,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
     /// `read_return_data` hostio. The semantics are equivalent to that of the EVM's [`CREATE`]
     /// opcode, which notably includes the exact address returned.
     ///
-    /// [`Deploying Stylus Programs`]: https://developer.arbitrum.io/TODO
+    /// [`Deploying Stylus Programs`]: https://docs.arbitrum.io/stylus/quickstart#deploy-your-program
     /// [`CREATE`]: https://www.evm.codes/#f0
     fn create1(
         &mut self,

--- a/execution/gethexec/api.go
+++ b/execution/gethexec/api.go
@@ -371,7 +371,7 @@ func (api *ArbTraceForwarderAPI) forward(ctx context.Context, method string, arg
 		return nil, err
 	}
 	if fallbackClient == nil {
-		return nil, errors.New("arbtrace calls forwarding not configured") // TODO(magic)
+		return nil, fmt.Errorf("arbtrace forwarding is not configured: fallback client is nil; check fallbackClientUrl and initialization logic")
 	}
 	var resp *json.RawMessage
 	err = fallbackClient.CallContext(ctx, &resp, method, args...)


### PR DESCRIPTION
- Instead of leaving that `TODO(magic)` hanging there, I added a proper error message to make it clearer when `fallbackClient` isn't set up.

- Fixed the outdated link for "Deploying Stylus Programs" — now it points to the right spot in the docs:
    [`https://docs.arbitrum.io/stylus/quickstart#deploy-your-program`](https://docs.arbitrum.io/stylus/quickstart#deploy-your-program)
