### PR TITLE
Additional documentation for usage of StateDB object in preTxFilters

### DIFF
--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -117,7 +117,7 @@ type ConditionalOptionsForTx []*arbitrum_types.ConditionalOptions
 type SequencingHooks struct {
 	TxErrors                []error                                                                                                                                                                 // This can be unset
 	DiscardInvalidTxsEarly  bool                                                                                                                                                                    // This can be unset
-	PreTxFilter             func(*params.ChainConfig, *types.Header, *state.StateDB, *arbosState.ArbosState, *types.Transaction, *arbitrum_types.ConditionalOptions, common.Address, *L1Info) error // This has to be set
+	PreTxFilter             func(*params.ChainConfig, *types.Header, *state.StateDB, *arbosState.ArbosState, *types.Transaction, *arbitrum_types.ConditionalOptions, common.Address, *L1Info) error // This has to be set. Writes to *state.StateDB object should be avoided to prevent invalid state from permeating
 	PostTxFilter            func(*types.Header, *state.StateDB, *arbosState.ArbosState, *types.Transaction, common.Address, uint64, *core.ExecutionResult) error                                    // This has to be set
 	BlockFilter             func(*types.Header, *state.StateDB, types.Transactions, types.Receipts) error                                                                                           // This can be unset
 	ConditionalOptionsForTx []*arbitrum_types.ConditionalOptions                                                                                                                                    // This can be unset
@@ -266,11 +266,13 @@ func ProduceBlockAdvanced(
 				return nil, nil, err
 			}
 
+			// Writes to statedb object should be avoided to prevent invalid state from permeating as statedb snapshot is not taken
 			if err = hooks.PreTxFilter(chainConfig, header, statedb, arbState, tx, options, sender, l1Info); err != nil {
 				return nil, nil, err
 			}
 
 			// Additional pre-transaction validity check
+			// Writes to statedb object should be avoided to prevent invalid state from permeating as statedb snapshot is not taken
 			if err = extraPreTxFilter(chainConfig, header, statedb, arbState, tx, options, sender, l1Info); err != nil {
 				return nil, nil, err
 			}

--- a/arbos/extra_transaction_checks.go
+++ b/arbos/extra_transaction_checks.go
@@ -11,7 +11,8 @@ import (
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 )
 
-// extraPreTxFilter should be modified by chain operators to enforce additional pre-transaction validity rules
+// extraPreTxFilter should be modified by chain operators to enforce additional pre-transaction validity rules.
+// Writes to *state.StateDB object should be avoided to prevent invalid state from permeating
 func extraPreTxFilter(
 	chainConfig *params.ChainConfig,
 	currentBlockHeader *types.Header,


### PR DESCRIPTION
This PR adds documentation around usage of StateDB object inside preTxFilters i.e writing to StateDB inside these hooks can lead to invalid state persisting as snapshot of this stateDB is not taken and not reverted to in case of a tx failure.

Resolves NIT-3252