### PR TITLE
ExpressLane txs erroring due to context timing out at the end of a round shouldn't be logged as an error

### DIFF
--- a/execution/gethexec/express_lane_service.go
+++ b/execution/gethexec/express_lane_service.go
@@ -213,7 +213,12 @@ func (es *expressLaneService) sequenceExpressLaneSubmission(msg *timeboost.Expre
 		timeout := min(es.roundTimingInfo.TimeTilNextRound(), queueTimeout)
 		queueCtx, _ := ctxWithTimeout(es.GetContext(), timeout)
 		if err := es.transactionPublisher.PublishTimeboostedTransaction(queueCtx, nextMsg.Transaction, nextMsg.Options); err != nil {
-			log.Error("Error queuing expressLane transaction", "seqNum", nextMsg.SequenceNumber, "txHash", nextMsg.Transaction.Hash(), "err", err)
+			logLevel := log.Error
+			// If tx sequencing was attempted right around the edge of a round then an error due to context timing out is expected, so we log a warning in such a case
+			if err == queueCtx.Err() && timeout < time.Second {
+				logLevel = log.Warn
+			}
+			logLevel("Error queuing expressLane transaction", "seqNum", nextMsg.SequenceNumber, "txHash", nextMsg.Transaction.Hash(), "err", err)
 			if nextMsg.SequenceNumber == msg.SequenceNumber {
 				retErr = err
 			}

--- a/execution/gethexec/express_lane_service.go
+++ b/execution/gethexec/express_lane_service.go
@@ -215,7 +215,7 @@ func (es *expressLaneService) sequenceExpressLaneSubmission(msg *timeboost.Expre
 		if err := es.transactionPublisher.PublishTimeboostedTransaction(queueCtx, nextMsg.Transaction, nextMsg.Options); err != nil {
 			logLevel := log.Error
 			// If tx sequencing was attempted right around the edge of a round then an error due to context timing out is expected, so we log a warning in such a case
-			if err == queueCtx.Err() && timeout < time.Second {
+			if errors.Is(err, queueCtx.Err()) && timeout < time.Second {
 				logLevel = log.Warn
 			}
 			logLevel("Error queuing expressLane transaction", "seqNum", nextMsg.SequenceNumber, "txHash", nextMsg.Transaction.Hash(), "err", err)


### PR DESCRIPTION
When expressLane txs are attempted sequencing at the end of round, it is expected that they error due to context timing out in which case we dont need to log an error but instead log a warning here.

Resolves NIT-3270