### PR TITLE
Stop backfilling block metadata when syncTillBlock reached

### DIFF
--- a/arbnode/blockmetadata.go
+++ b/arbnode/blockmetadata.go
@@ -134,7 +134,7 @@ func (b *BlockMetadataFetcher) persistBlockMetadata(ctx context.Context, query [
 	batch := b.db.NewBatch()
 	queryMap := util.ArrayToSet(query)
 	for _, elem := range result {
-		if elem.BlockNumber > b.syncUntilBlock {
+		if (b.syncUntilBlock != 0) && (elem.BlockNumber > b.syncUntilBlock) {
 			b.StopWaiterSafe.StopOnly()
 			return true, nil
 		}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -518,7 +518,7 @@ func getBlockMetadataFetcher(
 	var blockMetadataFetcher *BlockMetadataFetcher
 	if config.BlockMetadataFetcher.Enable {
 		var err error
-		blockMetadataFetcher, err = NewBlockMetadataFetcher(ctx, config.BlockMetadataFetcher, arbDb, exec, config.TransactionStreamer.TrackBlockMetadataFrom, expectedChainId)
+		blockMetadataFetcher, err = NewBlockMetadataFetcher(ctx, config.BlockMetadataFetcher, arbDb, exec, config.TransactionStreamer.TrackBlockMetadataFrom, config.TransactionStreamer.SyncTillBlock, expectedChainId)
 		if err != nil {
 			return nil, err
 		}

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -763,7 +763,7 @@ func TestTimeboostBulkBlockMetadataFetcher(t *testing.T) {
 
 	// Rebuild blockMetadata and cleanup trackers from ArbDB
 	rebuildStartPos := uint64(5)
-	blockMetadataFetcher, err := arbnode.NewBlockMetadataFetcher(ctx, arbnode.BlockMetadataFetcherConfig{Source: rpcclient.ClientConfig{URL: builder.L2.Stack.HTTPEndpoint()}}, arbDb, newNode.ExecNode, rebuildStartPos, builder.chainConfig.ChainID.Uint64())
+	blockMetadataFetcher, err := arbnode.NewBlockMetadataFetcher(ctx, arbnode.BlockMetadataFetcherConfig{Source: rpcclient.ClientConfig{URL: builder.L2.Stack.HTTPEndpoint()}}, arbDb, newNode.ExecNode, rebuildStartPos, 0, builder.chainConfig.ChainID.Uint64())
 	Require(t, err)
 	blockMetadataFetcher.Update(ctx)
 


### PR DESCRIPTION
The parameter `--node.transaction-streamer.sync-till-block` stops all node syncing when the specified block is reached.  It also needs to stop block metadata from getting synced.
