### PR TITLE
Comparing two gas estimations must be on same block

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -652,7 +652,10 @@ func (b *BatchPoster) ParentChainIsUsingEIP7623(ctx context.Context, latestHeade
 		return false, fmt.Errorf("unexpected gas difference, gas1: %d, gas2: %d", gas1, gas2)
 	}
 	b.useEip7623 = parentChainIsUsingEIP7623
-	b.checkEip7623 = false
+	if parentChainIsUsingEIP7623 {
+		// Once the parent chain is using EIP-7623, we don't need to check it again.
+		b.checkEip7623 = false
+	}
 	return parentChainIsUsingEIP7623, nil
 }
 


### PR DESCRIPTION
Fixes NIT-3278

`eth_estimateGas` is called twice with different data to figure out if parent chain is using EIP7623.  To get reliable comparisons, ensure that both calls are made against the same block.
