### PR TITLE
Better storage destination for temporary file downloads while downloading init file

### DIFF
--- a/cmd/conf/init.go
+++ b/cmd/conf/init.go
@@ -48,7 +48,7 @@ var InitConfigDefault = InitConfig{
 	Latest:                        "",
 	LatestBase:                    "https://snapshot.arbitrum.foundation/",
 	ValidateChecksum:              true,
-	DownloadPath:                  "/tmp/",
+	DownloadPath:                  "",
 	DownloadPoll:                  time.Minute,
 	DevInit:                       false,
 	DevInitAddress:                "",

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -51,6 +51,34 @@ import (
 
 var notFoundError = errors.New("file not found")
 
+func initializeAndDownloadInit(ctx context.Context, initConfig *conf.InitConfig, stack *node.Node) (string, func(), error) {
+	cleanUpTmp := func() {}
+	if initConfig.DownloadPath == "" {
+		tmpPath := filepath.Join(stack.InstanceDir(), "tmp")
+		_, err := os.Stat(tmpPath)
+		if err == nil {
+			return "", cleanUpTmp, fmt.Errorf("tmp directory for downloading init file already exists")
+		}
+		if !os.IsNotExist(err) {
+			return "", cleanUpTmp, fmt.Errorf("error checking if tmp directory for downloading init file already exists: %w", err)
+		}
+		if err := os.MkdirAll(tmpPath, os.ModePerm); err != nil {
+			return "", cleanUpTmp, fmt.Errorf("failed to create tmp directory for downloading init file: %w", err)
+		}
+		initConfig.DownloadPath = tmpPath
+		cleanUpTmp = func() {
+			if err := os.RemoveAll(tmpPath); err != nil {
+				log.Error("Failed to clean up tmp directory after downloading init file", "err", err)
+			}
+		}
+	}
+	initFile, err := downloadInit(ctx, initConfig)
+	if err != nil {
+		return "", cleanUpTmp, err
+	}
+	return initFile, cleanUpTmp, nil
+}
+
 func downloadInit(ctx context.Context, initConfig *conf.InitConfig) (string, error) {
 	if initConfig.Url == "" {
 		return "", nil
@@ -617,7 +645,8 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 		return nil, nil, err
 	}
 
-	initFile, err := downloadInit(ctx, &config.Init)
+	initFile, cleanUpTmp, err := initializeAndDownloadInit(ctx, &config.Init, stack)
+	defer cleanUpTmp()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/nitro/init_test.go
+++ b/cmd/nitro/init_test.go
@@ -47,6 +47,55 @@ const (
 	dirPerm     = 0700
 )
 
+func TestInitializeAndDownloadInit(t *testing.T) {
+	// Create archive with random data
+	serverDir := t.TempDir()
+	data := testhelpers.RandomSlice(dataSize)
+
+	// Write archive file
+	archiveFile := fmt.Sprintf("%s/%s", serverDir, archiveName)
+	err := os.WriteFile(archiveFile, data, filePerm)
+	Require(t, err, "failed to write archive")
+
+	// Start HTTP server
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr := startFileServer(t, ctx, serverDir)
+
+	stackConfig := testhelpers.CreateStackConfigForTest(t.TempDir())
+	stack, err := node.New(stackConfig)
+	Require(t, err)
+	defer stack.Close()
+
+	// Download file
+	initConfig := conf.InitConfigDefault
+	initConfig.Url = fmt.Sprintf("http://%s/%s", addr, archiveName)
+	initConfig.ValidateChecksum = false
+	initConfig.DownloadPath = ""
+	receivedArchive, cleanUpTmp, err := initializeAndDownloadInit(ctx, &initConfig, stack)
+	Require(t, err, "failed to download")
+
+	// Check archive contents
+	receivedData, err := os.ReadFile(receivedArchive)
+	Require(t, err, "failed to read received archive")
+	if !bytes.Equal(receivedData, data) {
+		t.Error("downloaded archive is different from generated one")
+	}
+
+	// Check if initConfig.DownloadPath is as expected and that the cleanup function deletes temporary directory (tmp) inside chain directory
+	expectedDownloadPath := filepath.Join(stack.InstanceDir(), "tmp")
+	if initConfig.DownloadPath != expectedDownloadPath {
+		t.Errorf("unexpected default download path. Want: %s Got: %s", expectedDownloadPath, initConfig.DownloadPath)
+	}
+	_, err = os.Stat(initConfig.DownloadPath)
+	Require(t, err)
+	cleanUpTmp()
+	_, err = os.Stat(initConfig.DownloadPath)
+	if !os.IsNotExist(err) {
+		t.Errorf("expecting os.stat to return os.ErrNotExist error after tmp directory cleanup, found: %s", err.Error())
+	}
+}
+
 func TestDownloadInitWithoutChecksum(t *testing.T) {
 	// Create archive with random data
 	serverDir := t.TempDir()


### PR DESCRIPTION
Temporary file downloads during download of init file should be saved under chain directory by default instead of `/tmp/` as chain dir is expected to be a large mounted volume in comparison to `/tmp/`. 

Files will be stored under `chain_directory/tmp` and the tmp sub directory will be removed as a part of cleanup after the initFile is downloaded and snapshot is extracted.

Resolves NIT-3255