### PR TITLE
Fix timeboost signature checking

### DIFF
--- a/timeboost/bid_validator.go
+++ b/timeboost/bid_validator.go
@@ -327,9 +327,10 @@ func (bv *BidValidator) validateBid(
 	// Signature verification expects the last byte of the signature to have 27 subtracted,
 	// as it represents the recovery ID. If the last byte is greater than or equal to 27, it indicates a recovery ID that hasn't been adjusted yet,
 	// it's needed for internal signature verification logic.
-	if sigItem[len(sigItem)-1] >= 27 {
-		sigItem[len(sigItem)-1] -= 27
+	if sigItem[len(sigItem)-1] != 27 && sigItem[len(sigItem)-1] != 28 {
+		return nil, errors.New("invalid Ethereum signature (V is not 27 or 28)")
 	}
+	sigItem[len(sigItem)-1] -= 27
 
 	bidHash, err := bid.ToEIP712Hash(bv.auctionContractDomainSeparator)
 	if err != nil {
@@ -341,6 +342,9 @@ func (bv *BidValidator) validateBid(
 	}
 	// Check how many bids the bidder has sent in this round and cap according to a limit.
 	bidder := crypto.PubkeyToAddress(*pubkey)
+	if !crypto.VerifySignature(crypto.CompressPubkey(pubkey), bidHash[:], sigItem[:64]) {
+		return nil, errors.New("invalid signature")
+	}
 	bv.Lock()
 	numBids, ok := bv.bidsPerSenderInRound[bidder]
 	if !ok {


### PR DESCRIPTION
Fixed the auctioneer to do the exact same signature checks as the smart contract
