### PR TITLE
ci: bump actions/cache to v4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -99,7 +99,7 @@ jobs:
       run: cargo install --force cbindgen
 
     - name: Cache Build Products
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/go-build
@@ -108,13 +108,13 @@ jobs:
 
     - name: Cache wabt build
       id: cache-wabt
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/wabt-prefix
         key: ${{ runner.os }}-wabt-codeql-${{ matrix.language }}-${{ env.WABT_VERSION }}
 
     - name: Cache cbrotli
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-cbrotli
       with:
         path: |
@@ -127,7 +127,7 @@ jobs:
         restore-keys: ${{ runner.os }}-brotli-${{ matrix.language }}-${{ hashFiles('scripts/build-brotli.sh') }}-${{ hashFiles('.github/workflows/arbitrator-ci.yaml') }}
 
     - name: Cache Rust Build Products
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           driver-opts: network=host
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: cargo install --force cbindgen
 
       - name: Cache Build Products
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -97,7 +97,7 @@ jobs:
           restore-keys: ${{ runner.os }}-go-
 
       - name: Cache Rust Build Products
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/
@@ -110,7 +110,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-${{ steps.rust-version.outputs.version }}-
 
       - name: Cache cbrotli
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-cbrotli
         with:
           path: |
@@ -279,7 +279,7 @@ jobs:
 
       - name: Cache Build Products
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -288,7 +288,7 @@ jobs:
 
       - name: Cache Rust Build Products
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/
@@ -304,7 +304,7 @@ jobs:
 
       - name: Cache cbrotli
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-cbrotli
         with:
           path: |

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -20,7 +20,7 @@ jobs:
         driver-opts: network=host
 
     - name: Cache Docker layers
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}


### PR DESCRIPTION
Node 20 compatibility: switch all jobs to actions/cache@v4. Pure maintenance update, behaviour unchanged.