### PR TITLE
Add a timer metric for tx inclusion

### DIFF
--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -52,8 +52,8 @@ var (
 	nonceFailureCacheOverflowCounter        = metrics.NewRegisteredGauge("arb/sequencer/noncefailurecache/overflow", nil)
 	blockCreationTimer                      = metrics.NewRegisteredTimer("arb/sequencer/block/creation", nil)
 	successfulBlocksCounter                 = metrics.NewRegisteredCounter("arb/sequencer/block/successful", nil)
-	nonTimeboostedTxInclusionTimer          = metrics.NewRegisteredTimer("arb/sequencer/tx/nontimeboosted/inclusion", nil)
-	timeboostedTxInclusionTimer             = metrics.NewRegisteredTimer("arb/sequencer/tx/timeboosted/inclusion", nil)
+	nonTimeboostedTxTimer                   = metrics.NewRegisteredTimer("arb/sequencer/tx/nontimeboosted", nil)
+	timeboostedTxTimer                      = metrics.NewRegisteredTimer("arb/sequencer/tx/timeboosted", nil)
 	conditionalTxRejectedBySequencerCounter = metrics.NewRegisteredCounter("arb/sequencer/conditionaltx/rejected", nil)
 	conditionalTxAcceptedBySequencerCounter = metrics.NewRegisteredCounter("arb/sequencer/conditionaltx/accepted", nil)
 	l1GasPriceGauge                         = metrics.NewRegisteredGauge("arb/sequencer/l1gasprice", nil)
@@ -246,9 +246,9 @@ func (i *txQueueItem) returnResult(err error) {
 	}
 	if err == nil && !i.isAuctionResolution {
 		if i.isTimeboosted {
-			timeboostedTxInclusionTimer.UpdateSince(i.firstAppearance)
+			timeboostedTxTimer.UpdateSince(i.firstAppearance)
 		} else {
-			nonTimeboostedTxInclusionTimer.UpdateSince(i.firstAppearance)
+			nonTimeboostedTxTimer.UpdateSince(i.firstAppearance)
 		}
 	}
 	i.resultChan <- err


### PR DESCRIPTION
This change adds the following metrics:
- arb_sequencer_tx_nontimeboosted_inclusion
- arb_sequencer_tx_timeboosted_inclusion

They measure the time from a tx being published to the sequencer with PublishTransaction or PublishTimeboostedTransaction, until when it is successfully included in a block. In the Timeboosted case, this does not include the time spent in the sequence number reordering buffer.

We don't want to record auction resolution transactions since they are not technically Timeboosted but they bypass the delay, which would skew the non-Timeboosted metric.

Note: The firstAppearance for a tx is moved forward to before the Timeboost delay starts. The only thing that firstAppearance was used for previously was how long the request could stay in the nonceFailureCache. This effectively lowers that time by 200ms; if we think that's a problem we can correct for it or use a different timestamp.