### PR TITLE
geth has removed `personal` command namespace

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -182,9 +182,6 @@ func mainImpl() int {
 	nodeConfig.Auth.Apply(&stackConf)
 	nodeConfig.IPC.Apply(&stackConf)
 	nodeConfig.GraphQL.Apply(&stackConf)
-	if nodeConfig.WS.ExposeAll {
-		stackConf.WSModules = append(stackConf.WSModules, "personal")
-	}
 	stackConf.P2P.ListenAddr = ""
 	stackConf.P2P.NoDial = true
 	stackConf.P2P.NoDiscovery = true

--- a/timeboost/setup_test.go
+++ b/timeboost/setup_test.go
@@ -233,7 +233,7 @@ func setupAccounts(t testing.TB, numAccounts uint64) ([]*testAccount, *simulated
 	withRPC := func(n *node.Config, _ *ethconfig.Config) {
 		n.HTTPHost = "localhost"
 		n.HTTPPort = randPort
-		n.HTTPModules = []string{"eth", "net", "web3", "debug", "personal"}
+		n.HTTPModules = []string{"eth", "net", "web3", "debug"}
 	}
 	backend := simulated.NewBackend(genesis, simulated.WithBlockGasLimit(gasLimit), withRPC)
 	return accs, backend, fmt.Sprintf("http://localhost:%d", randPort)


### PR DESCRIPTION
Remove references to `personal` namespace to avoid extraneous error messages