### PR TITLE
Correctly identify "already known" transaction error in DataPoster

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -946,7 +946,12 @@ func (p *DataPoster) sendTx(ctx context.Context, prevTx *storage.QueuedTransacti
 	}
 
 	if err := p.client.SendTransaction(ctx, newTx.FullTx); err != nil {
-		if !rpcclient.IsAlreadyKnownError(err) && !strings.Contains(err.Error(), "nonce too low") {
+		isAlreadyKnown := rpcclient.IsAlreadyKnownError(err)
+		isAlreadyKnown = isAlreadyKnown || strings.Contains(err.Error(), "nonce too low")
+		// If we previously sent this nonce and the same tx, some L1 clients may return ReplacementNotAllowed instead of
+		// an already known error (might be due to their cache size constraints) so we dont return an error in such a case
+		isAlreadyKnown = isAlreadyKnown || (previouslySent && strings.Contains(err.Error(), "ReplacementNotAllowed") && prevTx != nil && prevTx.FullTx.Hash() == newTx.FullTx.Hash())
+		if !isAlreadyKnown {
 			log.Warn("DataPoster failed to send transaction", "err", err, "nonce", newTx.FullTx.Nonce(), "feeCap", newTx.FullTx.GasFeeCap(), "tipCap", newTx.FullTx.GasTipCap(), "blobFeeCap", newTx.FullTx.BlobGasFeeCap(), "gas", newTx.FullTx.Gas())
 			return err
 		}

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -950,7 +950,8 @@ func (p *DataPoster) sendTx(ctx context.Context, prevTx *storage.QueuedTransacti
 		isAlreadyKnown = isAlreadyKnown || strings.Contains(err.Error(), "nonce too low")
 		// If we previously sent this nonce and the same tx, some L1 clients may return ReplacementNotAllowed instead of
 		// an already known error (might be due to their cache size constraints) so we dont return an error in such a case
-		isAlreadyKnown = isAlreadyKnown || (previouslySent && strings.Contains(err.Error(), "ReplacementNotAllowed") && prevTx != nil && prevTx.FullTx.Hash() == newTx.FullTx.Hash())
+		_, _, err := p.client.TransactionByHash(ctx, newTx.FullTx.Hash())
+		isAlreadyKnown = isAlreadyKnown || (strings.Contains(err.Error(), "ReplacementNotAllowed") && err == nil)
 		if !isAlreadyKnown {
 			log.Warn("DataPoster failed to send transaction", "err", err, "nonce", newTx.FullTx.Nonce(), "feeCap", newTx.FullTx.GasFeeCap(), "tipCap", newTx.FullTx.GasTipCap(), "blobFeeCap", newTx.FullTx.BlobGasFeeCap(), "gas", newTx.FullTx.Gas())
 			return err

--- a/util/rpcclient/rpcclient.go
+++ b/util/rpcclient/rpcclient.go
@@ -13,6 +13,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -144,7 +145,7 @@ func (m limitedArgumentsMarshal) String() string {
 // This check is based on the error's string form and is not precise.
 func IsAlreadyKnownError(err error) bool {
 	s := err.Error()
-	if strings.Contains(s, "already known") || strings.Contains(s, "AlreadyKnown") {
+	if strings.Contains(s, txpool.ErrAlreadyKnown.Error()) || strings.Contains(s, "AlreadyKnown") {
 		return true
 	}
 	return false

--- a/util/rpcclient/rpcclient.go
+++ b/util/rpcclient/rpcclient.go
@@ -140,21 +140,12 @@ func (m limitedArgumentsMarshal) String() string {
 	return res
 }
 
-var blobTxUnderpricedRegexp = regexp.MustCompile(`replacement transaction underpriced: new tx gas fee cap (\d*) <= (\d*) queued`)
-
-// IsAlreadyKnownError returns true if the error appears to be an "already known" error.
+// IsAlreadyKnownError returns true if the error appears to be an "already known" (GETH) error or "AlreadyKnown" (Nethermind) error.
 // This check is based on the error's string form and is not precise.
 func IsAlreadyKnownError(err error) bool {
 	s := err.Error()
-	if strings.Contains(s, "already known") {
+	if strings.Contains(s, "already known") || strings.Contains(s, "AlreadyKnown") {
 		return true
-	}
-	// go-ethereum returns "replacement transaction underpriced" instead of "already known" for blob txs.
-	// This is fixed in https://github.com/ethereum/go-ethereum/pull/29210
-	// TODO: Once a new geth release is out with this fix, we can remove this check.
-	matches := blobTxUnderpricedRegexp.FindSubmatch([]byte(s))
-	if len(matches) == 3 {
-		return string(matches[1]) == string(matches[2])
 	}
 	return false
 }

--- a/util/rpcclient/rpcclient_test.go
+++ b/util/rpcclient/rpcclient_test.go
@@ -199,9 +199,6 @@ func TestIsAlreadyKnownError(t *testing.T) {
 		{"already known", true},
 		{"insufficient balance", false},
 		{"foo already known\nbar", true},
-		{"replacement transaction underpriced: new tx gas fee cap 3824396284 \u003c= 3824396284 queued", true},
-		{"replacement transaction underpriced: new tx gas fee cap 1234 \u003c= 5678 queued", false},
-		{"foo replacement transaction underpriced: new tx gas fee cap 3824396284 \u003c= 3824396284 queued bar", true},
 	} {
 		got := IsAlreadyKnownError(errors.New(testCase.input))
 		if got != testCase.expected {


### PR DESCRIPTION
When dataposter resubmits the same tx to an L1 client there is a chance that the L1 client might miss that the tx is already in its mempool- maybe due to cache size constraints so it might instead give out the `ReplacementNotAllowed` error although the tx is not a replace-by-fee one. In this PR we correctly identify such scenarios and log accordingly.

Resolves NIT-3226
Resolves NIT-3206