### PR TITLE
Allow to build brotli locally with recent versions of cmake

### DIFF
--- a/scripts/build-brotli.sh
+++ b/scripts/build-brotli.sh
@@ -99,7 +99,7 @@ if $BUILD_WASM; then
     mkdir -p buildfiles/install-wasm
     TEMP_INSTALL_DIR_ABS=$(cd -P buildfiles/install-wasm; pwd)
     cd buildfiles/build-wasm
-    cmake ../../ -DCMAKE_C_COMPILER=emcc -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fPIC -DCMAKE_INSTALL_PREFIX="$TEMP_INSTALL_DIR_ABS" -DCMAKE_AR="$(which emar)" -DCMAKE_RANLIB="$(which touch)"
+    cmake ../../ -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_C_COMPILER=emcc -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fPIC -DCMAKE_INSTALL_PREFIX="$TEMP_INSTALL_DIR_ABS" -DCMAKE_AR="$(which emar)" -DCMAKE_RANLIB="$(which touch)"
     make -j
     make install
     cp -rv "$TEMP_INSTALL_DIR_ABS/lib" "$TARGET_DIR_ABS/lib-wasm"
@@ -109,7 +109,7 @@ fi
 if $BUILD_LOCAL; then
     mkdir -p buildfiles/build-local
     cd buildfiles/build-local
-    cmake ../../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$TARGET_DIR_ABS"
+    cmake ../../ -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$TARGET_DIR_ABS"
     make -j
     make install
     cd ..


### PR DESCRIPTION
As suggested by the cmake documentation, `DCMAKE_POLICY_VERSION_MINIMUM=3.5` was added to the brotli cmake call to make sure it builds in recent cmake releases.