### PR TITLE
pin foundry to 1.0.0 for contracts builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=brotli-library-builder /workspace/install/ /
 FROM node:18-bookworm-slim AS contracts-builder
 RUN apt-get update && \
     apt-get install -y git python3 make g++ curl
-RUN curl -L https://foundry.paradigm.xyz | bash && . ~/.bashrc && ~/.foundry/bin/foundryup
+RUN curl -L https://foundry.paradigm.xyz | bash && . ~/.bashrc && ~/.foundry/bin/foundryup -i 1.0.0
 WORKDIR /workspace
 COPY contracts-legacy/package.json contracts-legacy/yarn.lock contracts-legacy/
 RUN cd contracts-legacy && yarn install


### PR DESCRIPTION
Currently the Dockerfile build fails on ARM.

```#36 [contracts-builder 14/14] RUN . ~/.bashrc && NITRO_BUILD_IGNORE_TIMESTAMPS=1 make build-solidity
#36 sha256:f5e3e84e334751c002a83fdeec4b038f8ca7beae4a9a648ebef32262ec5476c3
#36 89.39 Successfully generated 458 typings!
#36 89.40 Compiled 213 Solidity files successfully (evm targets: cancun, london).
#36 89.50 Done in 77.67s.
#36 89.51 yarn --cwd contracts build:forge:yul
#36 89.65 yarn run v1.22.22
#36 89.68 warning package.json: License should be a valid SPDX license expression
#36 89.69 $ FOUNDRY_PROFILE=yul forge build --skip *.sol
#36 89.72 Compiling 1 files with Solc 0.8.29
#36 89.72 installing solc version "0.8.29"
#36 90.63 Successfully installed solc 0.8.29
#36 90.63 Error: solc exited with exit status: 1
#36 90.63 /root/.local/share/svm/0.8.29/solc-0.8.29: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /root/.local/share/svm/0.8.29/solc-0.8.29)
#36 90.63 /root/.local/share/svm/0.8.29/solc-0.8.29: /lib/aarch64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /root/.local/share/svm/0.8.29/solc-0.8.29)
#36 90.63 /root/.local/share/svm/0.8.29/solc-0.8.29: /lib/aarch64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.31' not found (required by /root/.local/share/svm/0.8.29/solc-0.8.29)
#36 90.65 error Command failed with exit code 1.
#36 90.65 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
#36 90.66 make: *** [Makefile:598: .make/solidity] Error 1
#36 ERROR: executor failed running [/bin/sh -c . ~/.bashrc && NITRO_BUILD_IGNORE_TIMESTAMPS=1 make build-solidity]: exit code: 2
```

The change in this PR allows the contracts-legacy submodule to be built using the `node:18-bookworm-slim` image. Alternatively that submodule pin could be upgraded to support node 20 and then a newer docker base image could be used (`node:20-bookworm-slim`).