### PR TITLE
fix: handle empty bids table in timeboost auctioneer

### DIFF
--- a/timeboost/db_test.go
+++ b/timeboost/db_test.go
@@ -127,3 +127,75 @@ func TestDeleteBidsLowerThanRound(t *testing.T) {
 	err = mock.ExpectationsWereMet()
 	assert.NoError(t, err)
 }
+
+func TestGetBidsEmptyDatabase(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	d := &SqliteDatabase{
+		sqlDB:               sqlxDB,
+		currentTableVersion: -1,
+	}
+
+	// Set up mock for empty database
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM Bids").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	// Call the function
+	bids, round, err := d.GetBids(0)
+
+	// Verify results
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), round)
+	assert.Empty(t, bids)
+	assert.NotNil(t, bids) // Should be an empty slice, not nil
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+func TestGetBidsWithData(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	d := &SqliteDatabase{
+		sqlDB:               sqlxDB,
+		currentTableVersion: -1,
+	}
+
+	// Set up mock for database with data
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM Bids").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
+
+	mock.ExpectQuery("SELECT MAX\\(Round\\) FROM Bids").
+		WillReturnRows(sqlmock.NewRows([]string{"MAX(Round)"}).AddRow(5))
+
+	// Create rows for the select query
+	rows := sqlmock.NewRows([]string{"Id", "ChainId", "Bidder", "ExpressLaneController", "AuctionContractAddress", "Round", "Amount", "Signature"}).
+		AddRow(1, "1", "0x123", "0x456", "0x789", 3, "100", "sig1").
+		AddRow(2, "1", "0x123", "0x456", "0x789", 3, "200", "sig2").
+		AddRow(3, "1", "0x123", "0x456", "0x789", 4, "300", "sig3")
+
+	mock.ExpectQuery("SELECT \\* FROM Bids WHERE Round < \\? ORDER BY Round ASC").
+		WithArgs(5).
+		WillReturnRows(rows)
+
+	// Call the function
+	bids, round, err := d.GetBids(0)
+
+	// Verify results
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(5), round)
+	assert.Equal(t, 3, len(bids))
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Fixes an error in the timeboost auctioneer when no bids exist in the database. The error occurs because SQL's MAX() function returns NULL when there are no rows, and scanning NULL into a uint64 is unsupported.

This change adds a check for empty bids table before attempting to get the maximum round, preventing the error message from appearing when the auctioneer hasn't seen any bids yet. Also adds unit tests to verify the functionality with empty and populated databases.

Resolves error: 'failed to fetch maxRound from bids: sql: Scan error on
column index 0, name "MAX(Round)": converting NULL to uint64 is unsupported'