### PR TITLE
Fix secondary feed start sequence starting from 0

### DIFF
--- a/broadcastclients/broadcastclients.go
+++ b/broadcastclients/broadcastclients.go
@@ -44,13 +44,14 @@ type BroadcastClients struct {
 	primaryClients   []*broadcastclient.BroadcastClient
 	secondaryClients []*broadcastclient.BroadcastClient
 	secondaryURL     []string
-	makeClient       func(string, *Router) (*broadcastclient.BroadcastClient, error)
+	makeClient       func(string, *Router, arbutil.MessageIndex) (*broadcastclient.BroadcastClient, error)
 
 	primaryRouter   *Router
 	secondaryRouter *Router
 
 	// Use atomic access
-	connected atomic.Int32
+	connected         atomic.Int32
+	latestSequenceNum atomic.Uint64
 }
 
 func NewBroadcastClients(
@@ -81,12 +82,13 @@ func NewBroadcastClients(
 		secondaryClients: make([]*broadcastclient.BroadcastClient, 0, len(config.SecondaryURL)),
 		secondaryURL:     config.SecondaryURL,
 	}
-	clients.makeClient = func(url string, router *Router) (*broadcastclient.BroadcastClient, error) {
+	clients.latestSequenceNum.Store(uint64(currentMessageCount))
+	clients.makeClient = func(url string, router *Router, seqNum arbutil.MessageIndex) (*broadcastclient.BroadcastClient, error) {
 		return broadcastclient.NewBroadcastClient(
 			configFetcher,
 			url,
 			l2ChainId,
-			currentMessageCount,
+			seqNum,
 			router,
 			router.confirmedSequenceNumberChan,
 			fatalErrChan,
@@ -97,7 +99,7 @@ func NewBroadcastClients(
 
 	var lastClientErr error
 	for _, address := range config.URL {
-		client, err := clients.makeClient(address, clients.primaryRouter)
+		client, err := clients.makeClient(address, clients.primaryRouter, currentMessageCount)
 		if err != nil {
 			lastClientErr = err
 			log.Warn("init broadcast client failed", "address", address)
@@ -161,6 +163,17 @@ func (bcs *BroadcastClients) Start(ctx context.Context) {
 				return nil
 			}
 			recentFeedItemsNew[msg.SequenceNumber] = time.Now()
+
+			// Update the latest sequence number seen from any feed
+			currentLatest := bcs.latestSequenceNum.Load()
+			msgSeqNum := uint64(msg.SequenceNumber)
+			for msgSeqNum > currentLatest {
+				if bcs.latestSequenceNum.CompareAndSwap(currentLatest, msgSeqNum) {
+					break
+				}
+				currentLatest = bcs.latestSequenceNum.Load()
+			}
+
 			if err := router.forwardTxStreamer.AddBroadcastMessages([]*m.BroadcastFeedMessage{&msg}); err != nil {
 				return err
 			}
@@ -247,7 +260,9 @@ func (bcs *BroadcastClients) startSecondaryFeed(ctx context.Context) {
 	pos := len(bcs.secondaryClients)
 	if pos < len(bcs.secondaryURL) {
 		url := bcs.secondaryURL[pos]
-		client, err := bcs.makeClient(url, bcs.secondaryRouter)
+
+		latestSeqNum := arbutil.MessageIndex(bcs.latestSequenceNum.Load())
+		client, err := bcs.makeClient(url, bcs.secondaryRouter, latestSeqNum)
 		if err != nil {
 			log.Warn("init broadcast secondary client failed", "address", url)
 			bcs.secondaryURL = append(bcs.secondaryURL[:pos], bcs.secondaryURL[pos+1:]...)
@@ -255,7 +270,7 @@ func (bcs *BroadcastClients) startSecondaryFeed(ctx context.Context) {
 		}
 		bcs.secondaryClients = append(bcs.secondaryClients, client)
 		client.Start(ctx)
-		log.Info("secondary feed started", "url", url)
+		log.Info("secondary feed started", "url", url, "startingFromSeq", latestSeqNum)
 	} else if len(bcs.secondaryURL) > 0 {
 		log.Warn("failed to start a new secondary feed all available secondary feeds were started")
 	}

--- a/broadcastclients/broadcastclients_test.go
+++ b/broadcastclients/broadcastclients_test.go
@@ -1,0 +1,364 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package broadcastclients
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/broadcastclient"
+	"github.com/offchainlabs/nitro/broadcaster"
+	m "github.com/offchainlabs/nitro/broadcaster/message"
+	"github.com/offchainlabs/nitro/util/contracts"
+	"github.com/offchainlabs/nitro/util/signature"
+	"github.com/offchainlabs/nitro/util/testhelpers"
+	"github.com/offchainlabs/nitro/wsbroadcastserver"
+)
+
+type MockTransactionStreamer struct {
+	messageReceiver chan m.BroadcastFeedMessage
+	chainId         uint64
+	sequencerAddr   *common.Address
+}
+
+func NewMockTransactionStreamer(chainId uint64, sequencerAddr *common.Address) *MockTransactionStreamer {
+	return &MockTransactionStreamer{
+		messageReceiver: make(chan m.BroadcastFeedMessage, 100),
+		chainId:         chainId,
+		sequencerAddr:   sequencerAddr,
+	}
+}
+
+func (ts *MockTransactionStreamer) AddBroadcastMessages(feedMessages []*m.BroadcastFeedMessage) error {
+	for _, feedMessage := range feedMessages {
+		ts.messageReceiver <- *feedMessage
+	}
+	return nil
+}
+
+// Test that a basic setup of broadcaster and BroadcastClients works
+func TestBasicBroadcastClientSetup(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	chainId := uint64(1234)
+	broadcasterConfig := wsbroadcastserver.DefaultTestBroadcasterConfig
+	privateKey, err := crypto.GenerateKey()
+	Require(t, err)
+	sequencerAddr := crypto.PubkeyToAddress(privateKey.PublicKey)
+	dataSigner := signature.DataSignerFromPrivateKey(privateKey)
+
+	feedErrChan := make(chan error, 10)
+	b := broadcaster.NewBroadcaster(
+		func() *wsbroadcastserver.BroadcasterConfig { return &broadcasterConfig },
+		chainId,
+		feedErrChan,
+		dataSigner,
+	)
+
+	Require(t, b.Initialize())
+	Require(t, b.Start(ctx))
+	defer b.StopAndWait()
+
+	mockTxStreamer := NewMockTransactionStreamer(chainId, &sequencerAddr)
+
+	getPort := func(addr net.Addr) string {
+		_, portStr, err := net.SplitHostPort(addr.String())
+		if err != nil {
+			t.Fatalf("Failed to split host and port: %v", err)
+		}
+		return portStr
+	}
+
+	clientConfig := broadcastclient.DefaultTestConfig
+	configFetcher := func() *broadcastclient.Config {
+		config := clientConfig
+		config.URL = []string{"ws://127.0.0.1:" + getPort(b.ListenerAddr())}
+		config.SecondaryURL = []string{}
+		config.Verify.AcceptSequencer = true
+		return &config
+	}
+
+	addressVerifier := contracts.NewMockAddressVerifier(sequencerAddr)
+	broadcastClients, err := NewBroadcastClients(
+		configFetcher,
+		chainId,
+		0, // Start from sequence number 0
+		mockTxStreamer,
+		nil, // No confirmation listener
+		feedErrChan,
+		addressVerifier,
+	)
+	Require(t, err)
+	if broadcastClients == nil {
+		t.Fatal("BroadcastClients is nil")
+	}
+
+	broadcastClients.Start(ctx)
+	defer broadcastClients.StopAndWait()
+
+	const messageCount = 5
+	var wg sync.WaitGroup
+	wg.Add(messageCount)
+	go func() {
+		// Listen for messages
+		receivedMessages := 0
+		for i := 0; i < messageCount; i++ {
+			select {
+			case msg := <-mockTxStreamer.messageReceiver:
+				t.Logf("Received message with sequence number: %d", msg.SequenceNumber)
+				receivedMessages++
+				wg.Done()
+			case <-time.After(5 * time.Second):
+				t.Errorf("Timed out waiting for message %d/%d", i+1, messageCount)
+				for j := i; j < messageCount; j++ {
+					wg.Done()
+				}
+				return
+			}
+		}
+		t.Logf("Successfully received %d messages", receivedMessages)
+	}()
+
+	// Send messages with sequential sequence numbers
+	for i := 0; i < messageCount; i++ {
+		// #nosec G115
+		Require(t, b.BroadcastSingle(arbostypes.TestMessageWithMetadataAndRequestId, arbutil.MessageIndex(i), nil, nil))
+	}
+
+	wg.Wait()
+
+	if broadcastClients.connected.Load() != 1 {
+		t.Errorf("Expected 1 connected feed, got %d", broadcastClients.connected.Load())
+	}
+
+	latestSeq := broadcastClients.latestSequenceNum.Load()
+	if latestSeq != messageCount-1 {
+		t.Errorf("Expected latest sequence number to be %d, got %d", messageCount-1, latestSeq)
+	}
+}
+
+func createBroadcaster(t *testing.T, name string, chainId uint64, privateKey *ecdsa.PrivateKey) (*broadcaster.Broadcaster, chan error) {
+	t.Helper()
+
+	broadcasterConfig := wsbroadcastserver.DefaultTestBroadcasterConfig
+	broadcasterConfig.Ping = 100 * time.Millisecond
+	broadcasterConfig.ClientTimeout = 30 * time.Second
+
+	dataSigner := signature.DataSignerFromPrivateKey(privateKey)
+
+	feedErrChan := make(chan error, 10)
+	b := broadcaster.NewBroadcaster(
+		func() *wsbroadcastserver.BroadcasterConfig { return &broadcasterConfig },
+		chainId,
+		feedErrChan,
+		dataSigner,
+	)
+
+	err := b.Initialize()
+	if err != nil {
+		t.Fatalf("Failed to initialize %s broadcaster: %v", name, err)
+	}
+
+	err = b.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to start %s broadcaster: %v", name, err)
+	}
+
+	t.Logf("%s broadcaster listening on: %s", name, b.ListenerAddr())
+	return b, feedErrChan
+}
+
+// Test the failover from primary to secondary broadcaster
+func TestPrimaryToSecondaryFailover(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	chainId := uint64(1234)
+	primaryKey, err := crypto.GenerateKey()
+	Require(t, err)
+
+	primaryB, primaryErrChan := createBroadcaster(t, "Primary", chainId, primaryKey)
+	secondaryB, secondaryErrChan := createBroadcaster(t, "Secondary", chainId, primaryKey)
+
+	// We'll stop primary explicitly during the test, only defer the secondary
+	defer secondaryB.StopAndWait()
+
+	sequencerAddr := crypto.PubkeyToAddress(primaryKey.PublicKey)
+	mockTxStreamer := NewMockTransactionStreamer(chainId, &sequencerAddr)
+
+	getPort := func(addr net.Addr) string {
+		_, portStr, err := net.SplitHostPort(addr.String())
+		if err != nil {
+			t.Fatalf("Failed to split host and port: %v", err)
+		}
+		return portStr
+	}
+
+	// Create a configuration function for the broadcast client with both primary and secondary
+	clientConfig := broadcastclient.DefaultTestConfig
+	clientConfig.ReconnectInitialBackoff = 200 * time.Millisecond
+
+	primaryWsUrl := fmt.Sprintf("ws://127.0.0.1:%s", getPort(primaryB.ListenerAddr()))
+	secondaryWsUrl := fmt.Sprintf("ws://127.0.0.1:%s", getPort(secondaryB.ListenerAddr()))
+
+	t.Logf("Primary URL: %s", primaryWsUrl)
+	t.Logf("Secondary URL: %s", secondaryWsUrl)
+
+	configFetcher := func() *broadcastclient.Config {
+		config := clientConfig
+		config.URL = []string{primaryWsUrl}
+		config.SecondaryURL = []string{secondaryWsUrl}
+		config.Verify.AcceptSequencer = true
+		return &config
+	}
+
+	addressVerifier := contracts.NewMockAddressVerifier(sequencerAddr)
+
+	// Main error channel that both broadcasters will write to
+	feedErrChan := make(chan error, 20)
+
+	// Forward errors from individual broadcasters to the main error channel
+	go func() {
+		for {
+			select {
+			case err := <-primaryErrChan:
+				feedErrChan <- fmt.Errorf("primary broadcaster error: %w", err)
+			case err := <-secondaryErrChan:
+				feedErrChan <- fmt.Errorf("secondary broadcaster error: %w", err)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Create BroadcastClients
+	broadcastClients, err := NewBroadcastClients(
+		configFetcher,
+		chainId,
+		0, // Start from sequence number 0
+		mockTxStreamer,
+		nil, // No confirmation listener
+		feedErrChan,
+		addressVerifier,
+	)
+	Require(t, err)
+	if broadcastClients == nil {
+		t.Fatal("BroadcastClients is nil")
+	}
+
+	broadcastClients.Start(ctx)
+	defer broadcastClients.StopAndWait()
+
+	t.Log("Phase 1: Sending messages from primary broadcaster")
+	receivedChan := make(chan struct{}, 100)
+	seqNumChan := make(chan arbutil.MessageIndex, 100)
+
+	go func() {
+		for {
+			select {
+			case msg := <-mockTxStreamer.messageReceiver:
+				receivedChan <- struct{}{}
+				seqNumChan <- msg.SequenceNumber
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Send 5 messages from primary
+	const initialMessageCount = 5
+	for i := 0; i < initialMessageCount; i++ {
+		// #nosec G115
+		seq := arbutil.MessageIndex(i)
+		err := primaryB.BroadcastSingle(arbostypes.TestMessageWithMetadataAndRequestId, seq, nil, nil)
+		Require(t, err)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Verify we received all messages
+	for i := 0; i < initialMessageCount; i++ {
+		select {
+		case <-receivedChan:
+			// Message received
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Timed out waiting for message %d/%d from primary", i+1, initialMessageCount)
+		}
+	}
+
+	// Give the client time to process the messages
+	time.Sleep(500 * time.Millisecond)
+
+	latestSeq := broadcastClients.latestSequenceNum.Load()
+	if latestSeq != initialMessageCount-1 {
+		t.Errorf("Expected latest sequence number to be %d, got %d", initialMessageCount-1, latestSeq)
+	}
+
+	t.Log("Phase 2: Stopping primary broadcaster, using secondary")
+	primaryB.StopAndWait()
+	t.Log("Primary broadcaster stopped")
+
+	time.Sleep(time.Second * 2)
+
+	const secondaryMessageCount = 3
+	startSeq := initialMessageCount // Continue from where primary left off
+	t.Logf("Sending %d messages from secondary starting at sequence %d", secondaryMessageCount, startSeq)
+
+	for i := 0; i < secondaryMessageCount; i++ {
+		// #nosec G115
+		seq := arbutil.MessageIndex(startSeq + i)
+		err := secondaryB.BroadcastSingle(arbostypes.TestMessageWithMetadataAndRequestId, seq, nil, nil)
+		Require(t, err)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Wait for messages to be received
+	receivedFromSecondary := 0
+	for i := 0; i < secondaryMessageCount; i++ {
+		select {
+		case <-receivedChan:
+			receivedFromSecondary++
+		case <-time.After(5 * time.Second):
+			t.Errorf("Timed out waiting for message %d/%d from secondary", i+1, secondaryMessageCount)
+			break
+		}
+	}
+
+	if receivedFromSecondary != secondaryMessageCount {
+		t.Errorf("Only received %d/%d messages from secondary feed",
+			receivedFromSecondary, secondaryMessageCount)
+	}
+
+	// Verify sequence numbers were updated correctly
+	finalLatestSeq := broadcastClients.latestSequenceNum.Load()
+	if finalLatestSeq != latestSeq+secondaryMessageCount {
+		t.Errorf("Latest sequence number not updated after receiving from secondary. Expected %d, got %d",
+			latestSeq+secondaryMessageCount, finalLatestSeq)
+	}
+
+	// Check for any errors that occurred during the test
+	select {
+	case err := <-feedErrChan:
+		// Some errors are expected when the primary disconnects
+		t.Logf("Feed error received (expected): %v", err)
+	default:
+	}
+}
+
+func Require(t *testing.T, err error, printables ...interface{}) {
+	t.Helper()
+	testhelpers.RequireImpl(t, err, printables...)
+}


### PR DESCRIPTION
Track latest sequence number in BroadcastClients and use it when creating new secondary feed clients instead of always starting from 0.

This fixes an issue where secondary feed clients would request all historical messages when connecting, causing significant delays during failover (NIT-3276)

# Testing
Added tests to validate the fix:

1. When primary feed disconnects, secondary feed starts with the correct latest sequence number, not from zero
2. Secondary feed successfully receives and processes messages

We should add more tests around the primary/secondary failover logic, but this tests the fix and provides a scaffolding for adding more tests.