### PR TITLE
[MEL] - Use geth's FilterLogs function

### DIFF
--- a/arbnode/message-extraction/extraction-function/batch_serialization.go
+++ b/arbnode/message-extraction/extraction-function/batch_serialization.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/filters"
 
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbstate/daprovider"
@@ -100,7 +101,7 @@ func getSequencerBatchData(
 			return nil, errors.New("no logs found in transaction receipt")
 		}
 		topics := [][]common.Hash{{sequencerBatchDataABI}, {numberAsHash}}
-		filteredLogs := filterLogs(receipt.Logs, []common.Address{batch.BridgeAddress}, topics)
+		filteredLogs := filters.FilterLogs(receipt.Logs, nil, nil, []common.Address{batch.BridgeAddress}, topics)
 		if len(filteredLogs) == 0 {
 			return nil, errors.New("expected to find sequencer batch data")
 		}


### PR DESCRIPTION
This PR removes the `filterLogs` impl in `delayed_message_lookup.go` file, instead we use the exported `FilterLogs` function from geth's `filters` package. 

# Testing 
We already have `TestMessageExtractionLayer_DelayedMessageEquivalence_Simple` that indirectly tests that the exported function works as intended, but we add an additional comparison check with ethclient's `FilterLogs` method and verify they both return the same logs as a result inside `TestBloom` system_test.

Pulls Geth PR- https://github.com/OffchainLabs/go-ethereum/pull/453
Resolves NIT-3351