### PR TITLE
Fix Typos in Log Messages and Comments Across Multiple Files

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -698,7 +698,7 @@ func mainImpl() int {
 
 	err = execNode.InitializeTimeboost(ctx, chainInfo.ChainConfig)
 	if err != nil {
-		fatalErrChan <- fmt.Errorf("error intializing timeboost: %w", err)
+		fatalErrChan <- fmt.Errorf("error initializing timeboost: %w", err)
 	}
 
 	err = nil

--- a/cmd/seq-coordinator-manager/seq-coordinator-manager.go
+++ b/cmd/seq-coordinator-manager/seq-coordinator-manager.go
@@ -166,7 +166,7 @@ func main() {
 	flex.SetDirection(tview.FlexRow).
 		AddItem(priorityHeading, 0, 1, false).
 		AddItem(tview.NewFlex().
-			// fixedSize is maxURLSize plus 20 characters to accomodate ellipsis, statuses and emojis
+			// fixedSize is maxURLSize plus 20 characters to accommodate ellipsis, statuses and emojis
 			AddItem(prioritySeqList, seqManager.maxURLSize+20, 0, true).
 			AddItem(priorityForm, 0, 3, true), 0, 12, true).
 		AddItem(nonPriorityHeading, 0, 1, false).

--- a/timeboost/auctioneer.go
+++ b/timeboost/auctioneer.go
@@ -306,7 +306,7 @@ func (a *AuctioneerServer) Start(ctx_in context.Context) {
 			}
 			select {
 			case <-ctx.Done():
-				log.Info("Context done while checking redis stream existance", "error", ctx.Err().Error())
+				log.Info("Context done while checking redis stream existence", "error", ctx.Err().Error())
 				return
 			case <-time.After(time.Millisecond * 100):
 			}


### PR DESCRIPTION


Description:  
This pull request corrects several typographical errors in log messages and comments throughout the codebase:
- Fixed the spelling of "initializing" in an error message in `cmd/nitro/nitro.go`.
- Corrected the word "accomodate" to "accommodate" in a comment in `cmd/seq-coordinator-manager/seq-coordinator-manager.go`.
- Fixed the spelling of "existance" to "existence" in a log message in `timeboost/auctioneer.go`.

These changes improve code readability and maintain professionalism in log outputs and documentation. No functional code was altered.
