### PR TITLE
Fix maintenance lock

### DIFF
--- a/arbnode/redislock/redis.go
+++ b/arbnode/redislock/redis.go
@@ -203,6 +203,8 @@ func (l *Simple) Release(ctx context.Context) {
 
 	if err != nil {
 		log.Error("release returned error", "err", err)
+	} else {
+		atomicTimeWrite(&l.lockedUntil, time.Time{})
 	}
 }
 

--- a/arbnode/redislock/redis.go
+++ b/arbnode/redislock/redis.go
@@ -126,6 +126,52 @@ func (l *Simple) attemptLock(ctx context.Context) (bool, error) {
 	return gotLock, nil
 }
 
+func (l *Simple) AttemptLockAndPeriodicallyRefreshIt(ctx context.Context, release <-chan struct{}) bool {
+	gotLock, err := l.attemptLock(ctx)
+	if err != nil {
+		log.Error("attemptLock returned error", "err", err)
+		return false
+	}
+	if !gotLock {
+		return false
+	}
+
+	refreshLock := func() {
+		defer l.Release(ctx)
+		refreshTick := time.Tick(l.config().RefreshDuration)
+		for {
+			select {
+			case <-release:
+				l.Release(ctx)
+				return
+			case <-ctx.Done():
+				l.Release(ctx)
+				return
+			default:
+				select {
+				case <-release:
+					l.Release(ctx)
+					return
+				case <-ctx.Done():
+					l.Release(ctx)
+					return
+				case <-refreshTick:
+					gotLock, err := l.attemptLock(ctx)
+					if err != nil {
+						log.Error("attemptLock returned error during refresh: %w", err)
+					}
+					if !gotLock {
+						log.Error("unable to refresh lock since it is already taken by other")
+					}
+				}
+			}
+		}
+	}
+	go refreshLock()
+
+	return true
+}
+
 func (l *Simple) AttemptLock(ctx context.Context) bool {
 	if l.Locked() {
 		return true


### PR DESCRIPTION
Resolves NIT-3235

This PR includes two fixes:
- Updates lockedUntil when releasing Simple redislock
- Refreshes lock until maintenance completes running