### PR TITLE
Do not return promises in ExecutionClient.Start and ExecutionClientStopAndWait

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1322,7 +1322,7 @@ func (n *Node) Start(ctx context.Context) error {
 	if execClient != nil {
 		execClient.SetConsensusClient(n)
 	}
-	_, err = n.ExecutionClient.Start(ctx).Await(ctx)
+	err = n.ExecutionClient.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("error starting exec client: %w", err)
 	}
@@ -1507,10 +1507,7 @@ func (n *Node) StopAndWait() {
 		n.dasServerCloseFn()
 	}
 	if n.ExecutionClient != nil {
-		_, err := n.ExecutionClient.StopAndWait().Await(n.ctx)
-		if err != nil {
-			log.Error("error stopping execution client", "err", err)
-		}
+		n.ExecutionClient.StopAndWait()
 	}
 	if err := n.Stack.Close(); err != nil {
 		log.Error("error on stack close", "err", err)

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -45,8 +45,8 @@ type ExecutionClient interface {
 
 	Maintenance() containers.PromiseInterface[struct{}]
 
-	Start(ctx context.Context) containers.PromiseInterface[struct{}]
-	StopAndWait() containers.PromiseInterface[struct{}]
+	Start(ctx context.Context) error
+	StopAndWait()
 }
 
 // needed for validators / stakers


### PR DESCRIPTION
Resolves NIT-3365

There will be no communication from Consensus to Execution related to those funcs.
Execution side will be responsible to properly call Start and StopAndWait by itself