### PR TITLE
Fix nil deref when checking for ReplacementNotAllowed error

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -950,8 +950,8 @@ func (p *DataPoster) sendTx(ctx context.Context, prevTx *storage.QueuedTransacti
 		isAlreadyKnown = isAlreadyKnown || strings.Contains(err.Error(), "nonce too low")
 		// If we previously sent this nonce and the same tx, some L1 clients may return ReplacementNotAllowed instead of
 		// an already known error (might be due to their cache size constraints) so we dont return an error in such a case
-		_, _, err := p.client.TransactionByHash(ctx, newTx.FullTx.Hash())
-		isAlreadyKnown = isAlreadyKnown || (strings.Contains(err.Error(), "ReplacementNotAllowed") && err == nil)
+		_, _, errTxByHash := p.client.TransactionByHash(ctx, newTx.FullTx.Hash())
+		isAlreadyKnown = isAlreadyKnown || (strings.Contains(err.Error(), "ReplacementNotAllowed") && errTxByHash == nil)
 		if !isAlreadyKnown {
 			log.Warn("DataPoster failed to send transaction", "err", err, "nonce", newTx.FullTx.Nonce(), "feeCap", newTx.FullTx.GasFeeCap(), "tipCap", newTx.FullTx.GasTipCap(), "blobFeeCap", newTx.FullTx.BlobGasFeeCap(), "gas", newTx.FullTx.Gas())
 			return err


### PR DESCRIPTION
This PR fixes nil dereference because of mishandling of err variable when checking for misrepresentation of Already known error as ReplacementNotAllowed