### PR TITLE
Disable SendTxToL1 when there is at least 1 NativeTokenOwner

### DIFF
--- a/precompiles/ArbSys.go
+++ b/precompiles/ArbSys.go
@@ -120,12 +120,17 @@ func (con *ArbSys) SendTxToL1(c ctx, evm mech, value huge, destination addr, cal
 		// As of ArbOS 41, the concept of "native token owners" was introduced.
 		// Native token owners are accounts that are allowed to mint and burn
 		// the chain's native token to and from their own address.
-		// Typically, the "burn" functionality is used to send funds to the
-		// parent chain (L1) through some off-chain mechanism.
-		// If users were allowed to ALSO send value to the parent chain with
-		// the SendTxToL1 precompile, it would be possible to send the value
-		// both to the parent chain through the outbox contract and by burning
-		// the native token.
+		//
+		// Without the "mint" and "burn" functionality, a "bridge" contract on
+		// the parent chain (L1) locks up funds equivalent to all the funds on
+		// the child chain, so it is always safe to withdraw funds from the
+		// child chain to the parent chain.
+		//
+		// With the "mint" and "burn" functionality, a "bridge" contract on
+		// the parent chain can become under collateralized because the native
+		// token owners can mint funds on the child chain without putting
+		// funds into the bridge contract. So, it is not safe to withdraw funds
+		// from the child chain to the parent chain in the normal way.
 		numOwners, err := arbosState.NativeTokenOwners().Size()
 		if err != nil {
 			return nil, err

--- a/precompiles/ArbSys.go
+++ b/precompiles/ArbSys.go
@@ -117,6 +117,15 @@ func (con *ArbSys) SendTxToL1(c ctx, evm mech, value huge, destination addr, cal
 	arbosState := c.State
 
 	if arbosState.ArbOSVersion() >= params.ArbosVersion_41 && value.BitLen() != 0 {
+		// As of ArbOS 41, the concept of "native token owners" was introduced.
+		// Native token owners are accounts that are allowed to mint and burn
+		// the chain's native token to and from their own address.
+		// Typically, the "burn" functionality is used to send funds to the
+		// parent chain (L1) through some off-chain mechanism.
+		// If users were allowed to ALSO send value to the parent chain with
+		// the SendTxToL1 precompile, it would be possible to send the value
+		// both to the parent chain through the outbox contract and by burning
+		// the native token.
 		numOwners, err := arbosState.NativeTokenOwners().Size()
 		if err != nil {
 			return nil, err

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -627,6 +627,15 @@ func TestArbNativeTokenManager(t *testing.T) {
 	if balanceAfterBurning.Cmp(expectedBalance) != 0 {
 		t.Fatal("expected balance to be", expectedBalance, "got", balanceAfterBurning)
 	}
+
+	// checks sending L2 to L1 value is disabled while native token owners exist
+	arbSys, err := precompilesgen.NewArbSys(types.ArbSysAddress, builder.L2.Client)
+	Require(t, err)
+	authNativeTokenOwner.Value = big.NewInt(100)
+	_, err = arbSys.SendTxToL1(&authNativeTokenOwner, common.Address{}, []byte{})
+	if err == nil || err.Error() != "execution reverted" {
+		t.Fatal("expected sending L2 to L1 value to fail")
+	}
 }
 
 func TestNativeTokenManagementDisabledByDefault(t *testing.T) {

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -636,6 +636,18 @@ func TestArbNativeTokenManager(t *testing.T) {
 	if err == nil || err.Error() != "execution reverted" {
 		t.Fatal("expected sending L2 to L1 value to fail")
 	}
+
+	// After clearning the native token owners, sending L2 to L1 value should
+	// work again.
+	tx, err = arbOwner.RemoveNativeTokenOwner(&authOwner, nativeTokenOwnerAddr)
+	Require(t, err)
+	_, err = builder.L2.EnsureTxSucceeded(tx)
+	Require(t, err)
+	authNativeTokenOwner.Value = big.NewInt(100)
+	_, err = arbSys.SendTxToL1(&authNativeTokenOwner, common.Address{}, []byte{})
+	if err != nil {
+		t.Fatal("expected sending L2 to L1 value to succeed")
+	}
 }
 
 func TestNativeTokenManagementDisabledByDefault(t *testing.T) {


### PR DESCRIPTION
If we don't disable this, then, in theory, when the NativeTokenOwner is set, it could simultaneously burn some of the native token and try to send it to L1 as a withdrawal.

Fixes NIT-3390