### PR TITLE
Add progressive logging for expected surplus fetch failures

### DIFF
--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -417,6 +417,7 @@ type Sequencer struct {
 	expectedSurplusMutex              sync.RWMutex
 	expectedSurplus                   int64
 	expectedSurplusUpdated            bool
+	expectedSurplusFailureCount       int
 	auctioneerAddr                    common.Address
 	timeboostAuctionResolutionTxQueue chan txQueueItem
 }
@@ -1319,10 +1320,25 @@ func (s *Sequencer) InitializeExpressLaneService(
 	return nil
 }
 
+const maxConsecutiveExpectedSurplusFailures = 20
+
 var (
 	usableBytesInBlob    = big.NewInt(int64(len(kzg4844.Blob{}) * 31 / 32))
 	blobTxBlobGasPerBlob = big.NewInt(params.BlobTxBlobGasPerBlob)
 )
+
+func (s *Sequencer) logExpectedSurplusError(err error) {
+	s.expectedSurplusFailureCount++
+
+	logLevel := log.Error
+	if s.expectedSurplusFailureCount <= maxConsecutiveExpectedSurplusFailures {
+		logLevel = log.Warn
+	}
+
+	logLevel("expected surplus soft/hard thresholds are enabled but unable to fetch latest expected surplus, retrying",
+		"err", err,
+		"consecutiveFailures", s.expectedSurplusFailureCount)
+}
 
 func (s *Sequencer) updateExpectedSurplus(ctx context.Context) (int64, error) {
 	header, err := s.l1Reader.LastHeader(ctx)
@@ -1364,6 +1380,7 @@ func (s *Sequencer) updateExpectedSurplus(ctx context.Context) (int64, error) {
 	if config.ExpectedSurplusSoftThreshold != "default" && expectedSurplus < int64(config.expectedSurplusSoftThreshold) {
 		log.Warn("expected surplus is below soft threshold", "value", expectedSurplus, "threshold", config.expectedSurplusSoftThreshold)
 	}
+	s.expectedSurplusFailureCount = 0
 	return expectedSurplus, nil
 }
 
@@ -1402,7 +1419,7 @@ func (s *Sequencer) Start(ctxIn context.Context) error {
 			defer s.expectedSurplusMutex.Unlock()
 			if err != nil {
 				s.expectedSurplusUpdated = false
-				log.Error("expected surplus soft/hard thresholds are enabled but unable to fetch latest expected surplus, retrying", "err", err)
+				s.logExpectedSurplusError(err)
 				return 0
 			}
 			s.expectedSurplusUpdated = true


### PR DESCRIPTION
Implements progressive log level escalation for expected surplus errors:
- First 20 consecutive failures logged as Warn
- 21+ consecutive failures escalated to Error
- Reset counter on successful fetch
- Includes consecutiveFailures count in log message

This prevents log spam during transient L1 connectivity issues while ensuring persistent problems get proper Error-level attention.