### PR TITLE
Fix the ensure-rollup-deployment flag causing the node to hang

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -627,6 +627,10 @@ func mainImpl() int {
 		if err != nil && errors.Is(err, headerreader.ErrBlockNumberNotSupported) {
 			log.Info("Finality not supported by parent chain, disabling the check to verify if rollup deployment tx was finalized", "err", err)
 		} else {
+			if !l1Reader.Started() {
+				l1Reader.Start(ctx)
+				defer l1Reader.StopAndWait()
+			}
 			newHeaders, unsubscribe := l1Reader.Subscribe(false)
 			retriesOnError := 10
 			sigint := make(chan os.Signal, 1)


### PR DESCRIPTION
The flag enables a feature which waits until the block where the rollup was created is finalized. There is a bug right now which waits on the new finalized blocks but the l1 reader is not initialized thus no one writes in the channel which newHeaders subscribes on. The waiting hangs and the node does not start.

This is not present when the node is started after the current finalized block is ahead of the one which the node waits on. The reason is that the first check does not wait on the channel of the l1reader for updates but fetches the current finalized block instead thus it doesn't hit the uninialized reader bug.

The fix is to start the l1reader before subscribing.

The bug was introduced in https://github.com/OffchainLabs/nitro/pull/2582/files