### PR TITLE
Add support for events and public methods 

### DIFF
--- a/precompiles/ArbOwnerPublic.go
+++ b/precompiles/ArbOwnerPublic.go
@@ -36,6 +36,16 @@ func (con ArbOwnerPublic) IsChainOwner(c ctx, evm mech, addr addr) (bool, error)
 	return c.State.ChainOwners().IsMember(addr)
 }
 
+// IsNativeTokenOwner checks if the account is a native token owner
+func (con ArbOwnerPublic) IsNativeTokenOwner(c ctx, evm mech, addr addr) (bool, error) {
+	return c.State.NativeTokenOwners().IsMember(addr)
+}
+
+// GetAllNativeTokenOwners retrieves the list of native token owners
+func (con ArbOwnerPublic) GetAllNativeTokenOwners(c ctx, evm mech) ([]common.Address, error) {
+	return c.State.NativeTokenOwners().AllMembers(65536)
+}
+
 // GetNetworkFeeAccount gets the network fee collector
 func (con ArbOwnerPublic) GetNetworkFeeAccount(c ctx, evm mech) (addr, error) {
 	return c.State.NetworkFeeAccount()

--- a/precompiles/ArbSys.go
+++ b/precompiles/ArbSys.go
@@ -120,12 +120,17 @@ func (con *ArbSys) SendTxToL1(c ctx, evm mech, value huge, destination addr, cal
 		// As of ArbOS 41, the concept of "native token owners" was introduced.
 		// Native token owners are accounts that are allowed to mint and burn
 		// the chain's native token to and from their own address.
-		// Typically, the "burn" functionality is used to send funds to the
-		// parent chain (L1) through some off-chain mechanism.
-		// If users were allowed to ALSO send value to the parent chain with
-		// the SendTxToL1 precompile, it would be possible to send the value
-		// both to the parent chain through the outbox contract and by burning
-		// the native token.
+		//
+		// Without the "mint" and "burn" functionality, a "bridge" contract on
+		// the parent chain (L1) locks up funds equivalent to all the funds on
+		// the child chain, so it is always safe to withdraw funds from the
+		// child chain to the parent chain.
+		//
+		// With the "mint" and "burn" functionality, a "bridge" contract on
+		// the parent chain can become under collateralized because the native
+		// token owners can mint funds on the child chain without putting
+		// funds into the bridge contract. So, it is not safe to withdraw funds
+		// from the child chain to the parent chain in the normal way.
 		numOwners, err := arbosState.NativeTokenOwners().Size()
 		if err != nil {
 			return nil, err

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -552,6 +552,8 @@ func Precompiles() map[addr]ArbosPrecompile {
 	ArbOwnerPublic.methodsByName["RectifyChainOwner"].arbosVersion = params.ArbosVersion_11
 	ArbOwnerPublic.methodsByName["GetBrotliCompressionLevel"].arbosVersion = params.ArbosVersion_20
 	ArbOwnerPublic.methodsByName["GetScheduledUpgrade"].arbosVersion = params.ArbosVersion_20
+	ArbOwnerPublic.methodsByName["IsNativeTokenOwner"].arbosVersion = params.ArbosVersion_41
+	ArbOwnerPublic.methodsByName["GetAllNativeTokenOwners"].arbosVersion = params.ArbosVersion_41
 
 	ArbWasmImpl := &ArbWasm{Address: types.ArbWasmAddress}
 	ArbWasm := insert(MakePrecompile(pgen.ArbWasmMetaData, ArbWasmImpl))

--- a/precompiles/precompile_test.go
+++ b/precompiles/precompile_test.go
@@ -191,7 +191,7 @@ func TestPrecompilesPerArbosVersion(t *testing.T) {
 		params.ArbosVersion_30: 39,
 		params.ArbosVersion_31: 1,
 		params.ArbosVersion_40: 3,
-		params.ArbosVersion_41: 8,
+		params.ArbosVersion_41: 10,
 	}
 
 	precompiles := Precompiles()

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -12,12 +12,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/google/go-cmp/cmp"
 
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/l1pricing"

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"slices"
 	"sort"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/l1pricing"
@@ -495,6 +497,8 @@ func TestArbNativeTokenManager(t *testing.T) {
 
 	arbOwner, err := precompilesgen.NewArbOwner(types.ArbOwnerAddress, builder.L2.Client)
 	Require(t, err)
+	arbOwnerPub, err := precompilesgen.NewArbOwnerPublic(types.ArbOwnerPublicAddress, builder.L2.Client)
+	Require(t, err)
 
 	nativeTokenOwnerName := "NativeTokenOwner"
 	builder.L2Info.GenerateAccount(nativeTokenOwnerName)
@@ -507,6 +511,17 @@ func TestArbNativeTokenManager(t *testing.T) {
 		t.Fatal("expected native token owner to not be set")
 	}
 	nativeTokenOwners, err := arbOwner.GetAllNativeTokenOwners(callOpts)
+	Require(t, err)
+	if len(nativeTokenOwners) != 0 {
+		t.Fatal("expected no native token owners")
+	}
+	// same checks to exercise the public interface
+	isNativeTokenOwner, err = arbOwnerPub.IsNativeTokenOwner(callOpts, nativeTokenOwnerAddr)
+	Require(t, err)
+	if isNativeTokenOwner {
+		t.Fatal("expected native token owner to not be set")
+	}
+	nativeTokenOwners, err = arbOwnerPub.GetAllNativeTokenOwners(callOpts)
 	Require(t, err)
 	if len(nativeTokenOwners) != 0 {
 		t.Fatal("expected no native token owners")
@@ -529,21 +544,27 @@ func TestArbNativeTokenManager(t *testing.T) {
 		t.Fatal("expected native token owner to be set")
 	}
 	expectedNativeTokenOwners := []common.Address{nativeTokenOwnerAddr, ownerAddr}
-	sort.Slice(expectedNativeTokenOwners, func(i, j int) bool {
-		return expectedNativeTokenOwners[i].Cmp(expectedNativeTokenOwners[j]) < 0
-	})
+	addrSorter := func(a, b common.Address) int {
+		return a.Cmp(b)
+	}
+	slices.SortFunc(expectedNativeTokenOwners, addrSorter)
 	nativeTokenOwners, err = arbOwner.GetAllNativeTokenOwners(callOpts)
 	Require(t, err)
-	sort.Slice(nativeTokenOwners, func(i, j int) bool {
-		return nativeTokenOwners[i].Cmp(nativeTokenOwners[j]) < 0
-	})
-	if len(nativeTokenOwners) != len(expectedNativeTokenOwners) {
-		t.Fatal("expected native token owners to be the same length")
+	slices.SortFunc(nativeTokenOwners, addrSorter)
+	if diff := cmp.Diff(nativeTokenOwners, expectedNativeTokenOwners); diff != "" {
+		t.Errorf("native token owners differ: %s", diff)
 	}
-	for i := 0; i < len(nativeTokenOwners); i += 1 {
-		if nativeTokenOwners[i].Cmp(expectedNativeTokenOwners[i]) != 0 {
-			t.Fatal("expected native token owners to be the same")
-		}
+	// same checks to exercise the public interface
+	isNativeTokenOwner, err = arbOwnerPub.IsNativeTokenOwner(callOpts, nativeTokenOwnerAddr)
+	Require(t, err)
+	if !isNativeTokenOwner {
+		t.Fatal("expected native token owner to be set")
+	}
+	nativeTokenOwners, err = arbOwner.GetAllNativeTokenOwners(callOpts)
+	slices.SortFunc(nativeTokenOwners, addrSorter)
+	Require(t, err)
+	if diff := cmp.Diff(nativeTokenOwners, expectedNativeTokenOwners); diff != "" {
+		t.Errorf("native token owners differ: %s", diff)
 	}
 
 	// removes native token owner
@@ -566,6 +587,11 @@ func TestArbNativeTokenManager(t *testing.T) {
 	}
 
 	// tests minting and burning native tokens
+
+	nativeTokenOwnerABI, err := precompilesgen.ArbNativeTokenManagerMetaData.GetAbi()
+	Require(t, err)
+	mintTopic := nativeTokenOwnerABI.Events["NativeTokenMinted"].ID
+	burnTopic := nativeTokenOwnerABI.Events["NativeTokenBurned"].ID
 
 	arbNativeTokenManager, err := precompilesgen.NewArbNativeTokenManager(types.ArbNativeTokenManagerAddress, builder.L2.Client)
 	Require(t, err)
@@ -604,6 +630,23 @@ func TestArbNativeTokenManager(t *testing.T) {
 	Require(t, err)
 	receipt, err := builder.L2.EnsureTxSucceeded(tx)
 	Require(t, err)
+	mintLogged := false
+	for _, log := range receipt.Logs {
+		if log.Topics[0] == mintTopic {
+			mintLogged = true
+			parsedLog, err := arbNativeTokenManager.ParseNativeTokenMinted(*log)
+			Require(t, err)
+			if parsedLog.To != nativeTokenOwnerAddr {
+				t.Fatal("expected mint to be to", nativeTokenOwnerAddr, "got", parsedLog.To)
+			}
+			if parsedLog.Amount.Cmp(toMint) != 0 {
+				t.Fatal("expected mint amount to be", toMint, "got", parsedLog.Amount)
+			}
+		}
+	}
+	if !mintLogged {
+		t.Fatal("expected mint event to be logged")
+	}
 	balanceAfterMinting, err := builder.L2.Client.BalanceAt(ctx, nativeTokenOwnerAddr, nil)
 	Require(t, err)
 	gasUsed := getGasUsed(receipt)
@@ -619,6 +662,23 @@ func TestArbNativeTokenManager(t *testing.T) {
 	Require(t, err)
 	receipt, err = builder.L2.EnsureTxSucceeded(tx)
 	Require(t, err)
+	burnLogged := false
+	for _, log := range receipt.Logs {
+		if log.Topics[0] == burnTopic {
+			burnLogged = true
+			parsedLog, err := arbNativeTokenManager.ParseNativeTokenBurned(*log)
+			Require(t, err)
+			if parsedLog.From != nativeTokenOwnerAddr {
+				t.Fatal("expected mint to be from", nativeTokenOwnerAddr, "got", parsedLog.From)
+			}
+			if parsedLog.Amount.Cmp(toBurn) != 0 {
+				t.Fatal("expected mint amount to be", toBurn, "got", parsedLog.Amount)
+			}
+		}
+	}
+	if !burnLogged {
+		t.Fatal("expected burn event to be logged")
+	}
 	balanceAfterBurning, err := builder.L2.Client.BalanceAt(ctx, nativeTokenOwnerAddr, nil)
 	Require(t, err)
 	gasUsed = getGasUsed(receipt)

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -561,7 +561,7 @@ func TestArbNativeTokenManager(t *testing.T) {
 	if !isNativeTokenOwner {
 		t.Fatal("expected native token owner to be set")
 	}
-	nativeTokenOwners, err = arbOwner.GetAllNativeTokenOwners(callOpts)
+	nativeTokenOwners, err = arbOwnerPub.GetAllNativeTokenOwners(callOpts)
 	slices.SortFunc(nativeTokenOwners, addrSorter)
 	Require(t, err)
 	if diff := cmp.Diff(nativeTokenOwners, expectedNativeTokenOwners); diff != "" {


### PR DESCRIPTION
The Trail of Bits audit for the Mint and Burn feature for NativeTokens suggested
that we should make it possible to tell if there were active NativeTokenOwners
from the ArbOwnerPublic precompiles, and that we should be emitting events when
minting and burning.

This PR does both of those.

Closes [NIT-3391](https://linear.app/offchain-labs/issue/NIT-3391)