### PR TITLE
Update to modern golangci-lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         run: make -j build-node-deps
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           skip-pkg-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           cache-dependency-path: '**/yarn.lock'
 
       - name: Install go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.23.x
 
@@ -135,7 +135,8 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: latest
-          skip-pkg-cache: true
+          skip-cache: true
+          skip-save-cache: true
       - name: Custom Lint
         run: |
           go run ./linters ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,60 +1,75 @@
-# golangci-lint configuration
-
-run:
-  timeout: 10m
-
-issues:
-  exclude-dirs:
-    - go-ethereum
-    - fastcache
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - staticcheck
-
+version: "2"
 linters:
   enable:
-    - asciicheck  # check for non-ascii characters
-    - errorlint   # enure error wrapping is safely done
-    - gci         # keep imports sorted deterministically
-    - gocritic    # check for certain simplifications
-    - gofmt       # ensure code is formatted
-    - gosec       # check for security concerns
-    - nilerr      # ensure errors aren't mishandled
-    - staticcheck # check for suspicious constructs
-    - unused      # check for unused constructs
-
-linters-settings:
-  errcheck:
-    # report when type assertions aren't checked for errors as in
-    #         a := b.(MyStruct)
-    #
-    check-type-assertions: true
-
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/ethereum/go-ethereum)
-      - prefix(github.com/offchainlabs)
-
-  gocritic:
-    disabled-tags:
-      - experimental
-      - opinionated
-
-    disabled-checks:
-      - ifElseChain
-      - assignOp
-      - unlambda
-      - exitAfterDefer
-
-  gosec:
-    excludes:
-      - G404  # checks that random numbers are securely generated
-
-  govet:
-    enable-all: true
-    disable:
-      - shadow
-      - fieldalignment
+    - asciicheck
+    - errorlint
+    - gocritic
+    - gosec
+    - nilerr
+  settings:
+    errcheck:
+      check-type-assertions: true
+    gocritic:
+      disabled-checks:
+        - ifElseChain
+        - assignOp
+        - unlambda
+        - exitAfterDefer
+      disabled-tags:
+        - experimental
+        - opinionated
+    gosec:
+      excludes:
+        - G404
+    govet:
+      disable:
+        - shadow
+        - fieldalignment
+      enable-all: true
+    staticcheck:
+      checks:
+        - all
+        - '-QF1001' # Apply De Morgan's law
+        - '-QF1003' # Tagged switch instead of if/else blocks
+        - '-QF1006' # Lift break into loop condition
+        - '-QF1008' # Remove embeded fields
+        - '-ST1005' # Errors shouldn't end in punctuation or start with capitals
+        - '-ST1012' # Errors should be named errFoo or ErrFoo
+        - '-ST1003' # Variable naming rules (e.g. underscores in packages, and abbreviations)
+        - '-ST1016' # Methods on the same type should ahve the same reciever name
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        path: _test\.go
+    paths:
+      - go-ethereum
+      - fastcache
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/ethereum/go-ethereum)
+        - prefix(github.com/offchainlabs)
+  exclusions:
+    generated: lax
+    paths:
+      - go-ethereum
+      - fastcache
+      - third_party$
+      - builtin$
+      - examples$

--- a/arbnode/delayed.go
+++ b/arbnode/delayed.go
@@ -313,14 +313,14 @@ func (b *DelayedBridge) parseMessage(ctx context.Context, ethLog types.Log) (*bi
 		}
 		b.messageProviders[ethLog.Address] = con
 	}
-	switch {
-	case ethLog.Topics[0] == inboxMessageDeliveredID:
+	switch ethLog.Topics[0] {
+	case inboxMessageDeliveredID:
 		parsedLog, err := con.ParseInboxMessageDelivered(ethLog)
 		if err != nil {
 			return nil, nil, err
 		}
 		return parsedLog.MessageNum, parsedLog.Data, nil
-	case ethLog.Topics[0] == inboxMessageFromOriginID:
+	case inboxMessageFromOriginID:
 		parsedLog, err := con.ParseInboxMessageDeliveredFromOrigin(ethLog)
 		if err != nil {
 			return nil, nil, err

--- a/arbnode/resourcemanager/resource_management.go
+++ b/arbnode/resourcemanager/resource_management.go
@@ -60,7 +60,7 @@ func Init(conf *Config) error {
 
 func ParseMemLimit(limitStr string) (int, error) {
 	var (
-		limit int = 1
+		limit = 1
 		s     string
 	)
 	if _, err := fmt.Sscanf(limitStr, "%d%s", &limit, &s); err != nil {
@@ -164,11 +164,11 @@ func NewCgroupsMemoryLimitCheckerIfSupported(memLimitBytes int) (*cgroupsMemoryL
 // trivialLimitChecker checks no limits, so its limits are never exceeded.
 type trivialLimitChecker struct{}
 
-func (_ trivialLimitChecker) IsLimitExceeded() (bool, error) {
+func (trivialLimitChecker) IsLimitExceeded() (bool, error) {
 	return false, nil
 }
 
-func (_ trivialLimitChecker) String() string { return "trivial" }
+func (trivialLimitChecker) String() string { return "trivial" }
 
 type cgroupsMemoryFiles struct {
 	limitFile, usageFile, statsFile string

--- a/arbos/l1pricing/l1pricing.go
+++ b/arbos/l1pricing/l1pricing.go
@@ -21,7 +21,6 @@ import (
 	"github.com/offchainlabs/nitro/arbos/storage"
 	"github.com/offchainlabs/nitro/arbos/util"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
-	"github.com/offchainlabs/nitro/util/arbmath"
 	am "github.com/offchainlabs/nitro/util/arbmath"
 )
 
@@ -78,8 +77,8 @@ const (
 )
 
 // one minute at 100000 bytes / sec
-var InitialEquilibrationUnitsV0 = arbmath.UintToBig(60 * params.TxDataNonZeroGasEIP2028 * 100000)
-var InitialEquilibrationUnitsV6 = arbmath.UintToBig(params.TxDataNonZeroGasEIP2028 * 10000000)
+var InitialEquilibrationUnitsV0 = am.UintToBig(60 * params.TxDataNonZeroGasEIP2028 * 100000)
+var InitialEquilibrationUnitsV6 = am.UintToBig(params.TxDataNonZeroGasEIP2028 * 10000000)
 
 func InitializeL1PricingState(sto *storage.Storage, initialRewardsRecipient common.Address, initialL1BaseFee *big.Int) error {
 	bptStorage := sto.OpenCachedSubStorage(BatchPosterTableKey)
@@ -207,8 +206,8 @@ func (ps *L1PricingState) GetL1PricingSurplus() (*big.Int, error) {
 	if err != nil {
 		return nil, err
 	}
-	needFunds := arbmath.BigAdd(fundsDueForRefunds, fundsDueForRewards)
-	return arbmath.BigSub(haveFunds, needFunds), nil
+	needFunds := am.BigAdd(fundsDueForRefunds, fundsDueForRewards)
+	return am.BigSub(haveFunds, needFunds), nil
 }
 
 func (ps *L1PricingState) LastSurplus() (*big.Int, error) {
@@ -542,7 +541,7 @@ var randomNonce = binary.BigEndian.Uint64(crypto.Keccak256([]byte("Nonce"))[:8])
 var randomGasTipCap = new(big.Int).SetBytes(crypto.Keccak256([]byte("GasTipCap"))[:4])
 var randomGasFeeCap = new(big.Int).SetBytes(crypto.Keccak256([]byte("GasFeeCap"))[:4])
 var RandomGas = uint64(binary.BigEndian.Uint32(crypto.Keccak256([]byte("Gas"))[:4]))
-var randV = arbmath.BigMulByUint(chaininfo.ArbitrumOneChainConfig().ChainID, 3)
+var randV = am.BigMulByUint(chaininfo.ArbitrumOneChainConfig().ChainID, 3)
 var randR = crypto.Keccak256Hash([]byte("R")).Big()
 var randS = crypto.Keccak256Hash([]byte("S")).Big()
 
@@ -591,7 +590,7 @@ func (ps *L1PricingState) PosterDataCost(message *core.Message, poster common.Ad
 	// We'll instead make a fake tx from the message info we do have, and then pad our cost a bit to be safe.
 	tx = makeFakeTxForMessage(message)
 	units := ps.getPosterUnitsWithoutCache(tx, poster, brotliCompressionLevel)
-	units = arbmath.UintMulByBips(units+estimationPaddingUnits, arbmath.OneInBips+estimationPaddingBasisPoints)
+	units = am.UintMulByBips(units+estimationPaddingUnits, am.OneInBips+estimationPaddingBasisPoints)
 	pricePerUnit, _ := ps.PricePerUnit()
 	return am.BigMulByUint(pricePerUnit, units), units
 }

--- a/arbos/programs/api.go
+++ b/arbos/programs/api.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbos/util"
-	"github.com/offchainlabs/nitro/util/arbmath"
 	am "github.com/offchainlabs/nitro/util/arbmath"
 )
 
@@ -225,7 +224,7 @@ func newApiClosures(
 			res = nil // returnData is only provided in the revert case (opCreate)
 		}
 		interpreter.SetReturnData(res)
-		cost := arbmath.SaturatingUSub(startGas, returnGas+one64th) // user gets 1/64th back
+		cost := am.SaturatingUSub(startGas, returnGas+one64th) // user gets 1/64th back
 		return addr, res, cost, nil
 	}
 	emitLog := func(topics []common.Hash, data []byte) error {

--- a/arbos/util/util.go
+++ b/arbos/util/util.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	pgen "github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/util/arbmath"
 )
@@ -43,10 +42,10 @@ func init() {
 	ParseL2ToL1TxLog = NewLogParser[pgen.ArbSysL2ToL1Tx](pgen.ArbSysABI, "L2ToL1Tx")
 	ParseL2ToL1TransactionLog = NewLogParser[pgen.ArbSysL2ToL1Transaction](pgen.ArbSysABI, "L2ToL1Transaction")
 
-	acts := precompilesgen.ArbosActsABI
+	acts := pgen.ArbosActsABI
 	PackInternalTxDataStartBlock, UnpackInternalTxDataStartBlock = NewCallParser(acts, "startBlock")
 	PackInternalTxDataBatchPostingReport, UnpackInternalTxDataBatchPostingReport = NewCallParser(acts, "batchPostingReport")
-	PackArbRetryableTxRedeem, _ = NewCallParser(precompilesgen.ArbRetryableTxABI, "redeem")
+	PackArbRetryableTxRedeem, _ = NewCallParser(pgen.ArbRetryableTxABI, "redeem")
 }
 
 // Create a mechanism for packing and unpacking calls

--- a/daprovider/das/syncing_fallback_storage.go
+++ b/daprovider/das/syncing_fallback_storage.go
@@ -154,7 +154,7 @@ func writeSyncState(syncDir string, blockNr uint64) error {
 	if err != nil {
 		return err
 	}
-	_, err = f.WriteString(fmt.Sprintf("%d\n", blockNr))
+	_, err = fmt.Fprintf(f, "%d\n", blockNr)
 	if err != nil {
 		return err
 	}

--- a/execution/gethexec/contract_adapter.go
+++ b/execution/gethexec/contract_adapter.go
@@ -63,7 +63,7 @@ func (a *contractAdapter) CodeAt(ctx context.Context, contract common.Address, b
 }
 
 func (a *contractAdapter) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-	var num rpc.BlockNumber = rpc.LatestBlockNumber
+	var num = rpc.LatestBlockNumber
 	if blockNumber != nil {
 		num = rpc.BlockNumber(blockNumber.Int64())
 	}

--- a/util/log.go
+++ b/util/log.go
@@ -45,7 +45,7 @@ func (h *EphemeralErrorHandler) LogLevel(err error, currentLogLevel func(msg str
 		return currentLogLevel
 	}
 
-	if *h.FirstOccurrence == (time.Time{}) {
+	if h.FirstOccurrence.Equal((time.Time{})) {
 		*h.FirstOccurrence = time.Now()
 	}
 


### PR DESCRIPTION
This updates the configuration file to work with versions of golangci-lint greater than 2.0 and also upgrades the CI action to version 8 (from version 3).

For now, 8 of the static checks are disabled because enabling them makes large diffs in our codebase. We can open a separate Linear ticket if we want to enable some of those checks. (And, frankly, I would like that very much.)

Fixes NIT-3286