### PR TITLE
Native token management enable rename

### DIFF
--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -476,11 +476,11 @@ func (state *ArbosState) ChainOwners() *addressSet.AddressSet {
 	return state.chainOwners
 }
 
-func (state *ArbosState) NativeTokenEnabledFromTime() (uint64, error) {
+func (state *ArbosState) NativeTokenManagementFromTime() (uint64, error) {
 	return state.nativeTokenEnabledTime.Get()
 }
 
-func (state *ArbosState) SetNativeTokenEnabledFromTime(val uint64) error {
+func (state *ArbosState) SetNativeTokenManagementFromTime(val uint64) error {
 	return state.nativeTokenEnabledTime.Set(val)
 }
 

--- a/precompiles/ArbOwner.go
+++ b/precompiles/ArbOwner.go
@@ -60,15 +60,15 @@ func (con ArbOwner) GetAllChainOwners(c ctx, evm mech) ([]common.Address, error)
 	return c.State.ChainOwners().AllMembers(65536)
 }
 
-// SetNativeTokenEnabledFrom sets a time in epoch seconds when the native token
+// SetNativeTokenManagementFrom sets a time in epoch seconds when the native token
 // management becomes enabled. Setting it to 0 disables the feature.
 // If the feature is disabled, then the time must be at least 7 days in the
 // future.
-func (con ArbOwner) SetNativeTokenEnabledFrom(c ctx, evm mech, timestamp uint64) error {
+func (con ArbOwner) SetNativeTokenManagementFrom(c ctx, evm mech, timestamp uint64) error {
 	if timestamp == 0 {
-		return c.State.SetNativeTokenEnabledFromTime(0)
+		return c.State.SetNativeTokenManagementFromTime(0)
 	}
-	stored, err := c.State.NativeTokenEnabledFromTime()
+	stored, err := c.State.NativeTokenManagementFromTime()
 	if err != nil {
 		return err
 	}
@@ -87,12 +87,12 @@ func (con ArbOwner) SetNativeTokenEnabledFrom(c ctx, evm mech, timestamp uint64)
 	if stored > now && stored <= now+NativeTokenEnableDelay && timestamp < stored {
 		return ErrNativeTokenBackward
 	}
-	return c.State.SetNativeTokenEnabledFromTime(timestamp)
+	return c.State.SetNativeTokenManagementFromTime(timestamp)
 }
 
 // AddNativeTokenOwner adds account as a native token owner
 func (con ArbOwner) AddNativeTokenOwner(c ctx, evm mech, newOwner addr) error {
-	enabledTime, err := c.State.NativeTokenEnabledFromTime()
+	enabledTime, err := c.State.NativeTokenManagementFromTime()
 	if err != nil {
 		return err
 	}

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -639,7 +639,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 
 	ArbOwner.methodsByName["SetWasmMaxSize"].arbosVersion = params.ArbosVersion_40
 
-	ArbOwner.methodsByName["SetNativeTokenEnabledFrom"].arbosVersion = params.ArbosVersion_41
+	ArbOwner.methodsByName["SetNativeTokenManagementFrom"].arbosVersion = params.ArbosVersion_41
 	ArbOwner.methodsByName["AddNativeTokenOwner"].arbosVersion = params.ArbosVersion_41
 	ArbOwner.methodsByName["RemoveNativeTokenOwner"].arbosVersion = params.ArbosVersion_41
 	ArbOwner.methodsByName["IsNativeTokenOwner"].arbosVersion = params.ArbosVersion_41

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -696,27 +696,27 @@ func TestNativeTokenManagementDisabledByDefault(t *testing.T) {
 	eightDaysFromNow := uint64(now.Add(24 * 8 * time.Hour).Unix())
 
 	// attempts to enable the feature too early (6 days from now, instead of 7)
-	_, err = arbOwner.SetNativeTokenEnabledFrom(&authOwner, sixDaysFromNow)
+	_, err = arbOwner.SetNativeTokenManagementFrom(&authOwner, sixDaysFromNow)
 	if err == nil || err.Error() != "execution reverted" {
 		t.Error("expected enabling native token management to fail")
 	}
 
 	// succeeds to enable the feature enough in the future (8 days from now)
-	tx, err := arbOwner.SetNativeTokenEnabledFrom(&authOwner, eightDaysFromNow)
+	tx, err := arbOwner.SetNativeTokenManagementFrom(&authOwner, eightDaysFromNow)
 	Require(t, err)
 	_, err = builder.L2.EnsureTxSucceeded(tx)
 	Require(t, err)
 
 	// succeeds to shorten the time to enable the feature as long as it is still
 	// far enough in the future (7.5 days from now)
-	tx, err = arbOwner.SetNativeTokenEnabledFrom(&authOwner, sevenAndAHalfDaysFromNow)
+	tx, err = arbOwner.SetNativeTokenManagementFrom(&authOwner, sevenAndAHalfDaysFromNow)
 	Require(t, err)
 	_, err = builder.L2.EnsureTxSucceeded(tx)
 	Require(t, err)
 
 	// fails to shorten the time to enable the feature if it is too close to
 	// the current time (6 days from now)
-	_, err = arbOwner.SetNativeTokenEnabledFrom(&authOwner, sixDaysFromNow)
+	_, err = arbOwner.SetNativeTokenManagementFrom(&authOwner, sixDaysFromNow)
 	if err == nil || err.Error() != "execution reverted" {
 		t.Error("expected enabling native token management to fail")
 	}
@@ -729,7 +729,7 @@ func TestNativeTokenManagementDisabledByDefault(t *testing.T) {
 	// than 7 days from now.
 	// #nosec G115
 	sevenDaysFiveSecondsFromNow := uint64(now.Add(24*7*time.Hour + 5*time.Second).Unix())
-	tx, err = arbOwner.SetNativeTokenEnabledFrom(&authOwner, sevenDaysFiveSecondsFromNow)
+	tx, err = arbOwner.SetNativeTokenManagementFrom(&authOwner, sevenDaysFiveSecondsFromNow)
 	Require(t, err)
 	_, err = builder.L2.EnsureTxSucceeded(tx)
 	Require(t, err)
@@ -746,7 +746,7 @@ func TestNativeTokenManagementDisabledByDefault(t *testing.T) {
 	// less than 7 days from now. ~ 6.23:59:55
 	// #nosec G115
 	almostSevenDaysFromNow := uint64(now.Add(24*7*time.Hour - 5*time.Second).Unix())
-	tx, err = arbOwner.SetNativeTokenEnabledFrom(&authOwner, almostSevenDaysFromNow)
+	tx, err = arbOwner.SetNativeTokenManagementFrom(&authOwner, almostSevenDaysFromNow)
 	Require(t, err)
 	_, err = builder.L2.EnsureTxSucceeded(tx)
 	Require(t, err)
@@ -755,7 +755,7 @@ func TestNativeTokenManagementDisabledByDefault(t *testing.T) {
 	// ~ 6.23:59:40
 	// #nosec G115
 	tooFarFromSevenDaysFromNow := uint64(now.Add(24*7*time.Hour - 20*time.Second).Unix())
-	_, err = arbOwner.SetNativeTokenEnabledFrom(&authOwner, tooFarFromSevenDaysFromNow)
+	_, err = arbOwner.SetNativeTokenManagementFrom(&authOwner, tooFarFromSevenDaysFromNow)
 	if err == nil || err.Error() != "execution reverted" {
 		t.Error("expected enabling native token management to fail")
 	}


### PR DESCRIPTION
fixes: NIT-3389

This names describes the true function - enabling management of native token (add minters) and not enabling the native token itself


pulls in: https://github.com/OffchainLabs/nitro-contracts/pull/351