### PR TITLE
Change the MEL database to be a key-value mapping in arbDB

### DIFF
--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -12,153 +12,15 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbos/l2pricing"
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/cmd/chaininfo"
-	"github.com/offchainlabs/nitro/execution"
-	"github.com/offchainlabs/nitro/execution/gethexec"
-	"github.com/offchainlabs/nitro/statetransfer"
 	"github.com/offchainlabs/nitro/util/arbmath"
-	"github.com/offchainlabs/nitro/util/containers"
-	"github.com/offchainlabs/nitro/util/testhelpers"
-	"github.com/offchainlabs/nitro/util/testhelpers/env"
 )
-
-type execClientWrapper struct {
-	ExecutionEngine *gethexec.ExecutionEngine
-	t               *testing.T
-}
-
-func (w *execClientWrapper) Pause() { w.t.Error("not supported") }
-
-func (w *execClientWrapper) Activate() { w.t.Error("not supported") }
-
-func (w *execClientWrapper) ForwardTo(url string) error { w.t.Error("not supported"); return nil }
-
-func (w *execClientWrapper) SequenceDelayedMessage(message *arbostypes.L1IncomingMessage, delayedSeqNum uint64) error {
-	return w.ExecutionEngine.SequenceDelayedMessage(message, delayedSeqNum)
-}
-
-func (w *execClientWrapper) NextDelayedMessageNumber() (uint64, error) {
-	return w.ExecutionEngine.NextDelayedMessageNumber()
-}
-
-func (w *execClientWrapper) MarkFeedStart(to arbutil.MessageIndex) containers.PromiseInterface[struct{}] {
-	markFeedStartWithReturn := func(to arbutil.MessageIndex) (struct{}, error) {
-		w.ExecutionEngine.MarkFeedStart(to)
-		return struct{}{}, nil
-	}
-	return containers.NewReadyPromise(markFeedStartWithReturn(to))
-}
-
-func (w *execClientWrapper) Maintenance() containers.PromiseInterface[struct{}] {
-	return containers.NewReadyPromise(struct{}{}, nil)
-}
-
-func (w *execClientWrapper) Synced(ctx context.Context) bool {
-	w.t.Error("not supported")
-	return false
-}
-func (w *execClientWrapper) FullSyncProgressMap(ctx context.Context) map[string]interface{} {
-	w.t.Error("not supported")
-	return nil
-}
-func (w *execClientWrapper) SetFinalityData(
-	ctx context.Context,
-	safeFinalityData *arbutil.FinalityData,
-	finalizedFinalityData *arbutil.FinalityData,
-	validatedFinalityData *arbutil.FinalityData,
-) containers.PromiseInterface[struct{}] {
-	return containers.NewReadyPromise(struct{}{}, nil)
-}
-
-func (w *execClientWrapper) DigestMessage(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*execution.MessageResult] {
-	return containers.NewReadyPromise(w.ExecutionEngine.DigestMessage(num, msg, msgForPrefetch))
-}
-
-func (w *execClientWrapper) Reorg(count arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*execution.MessageResult] {
-	return containers.NewReadyPromise(w.ExecutionEngine.Reorg(count, newMessages, oldMessages))
-}
-
-func (w *execClientWrapper) HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex] {
-	return containers.NewReadyPromise(w.ExecutionEngine.HeadMessageIndex())
-}
-
-func (w *execClientWrapper) ResultAtMessageIndex(pos arbutil.MessageIndex) containers.PromiseInterface[*execution.MessageResult] {
-	return containers.NewReadyPromise(w.ExecutionEngine.ResultAtMessageIndex(pos))
-}
-
-func (w *execClientWrapper) Start(ctx context.Context) containers.PromiseInterface[struct{}] {
-	return containers.NewReadyPromise(struct{}{}, nil)
-}
-
-func (w *execClientWrapper) MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) containers.PromiseInterface[uint64] {
-	return containers.NewReadyPromise(w.ExecutionEngine.MessageIndexToBlockNumber(messageNum), nil)
-}
-
-func (w *execClientWrapper) BlockNumberToMessageIndex(blockNum uint64) containers.PromiseInterface[arbutil.MessageIndex] {
-	return containers.NewReadyPromise(w.ExecutionEngine.BlockNumberToMessageIndex(blockNum))
-}
-
-func (w *execClientWrapper) StopAndWait() containers.PromiseInterface[struct{}] {
-	return containers.NewReadyPromise(struct{}{}, nil)
-}
-
-func NewTransactionStreamerForTest(t *testing.T, ctx context.Context, ownerAddress common.Address) (*gethexec.ExecutionEngine, *TransactionStreamer, ethdb.Database, *core.BlockChain) {
-	chainConfig := chaininfo.ArbitrumDevTestChainConfig()
-
-	initData := statetransfer.ArbosInitializationInfo{
-		Accounts: []statetransfer.AccountInitializationInfo{
-			{
-				Addr:       ownerAddress,
-				EthBalance: big.NewInt(params.Ether),
-			},
-		},
-	}
-
-	chainDb := rawdb.NewMemoryDatabase()
-	arbDb := rawdb.NewMemoryDatabase()
-	initReader := statetransfer.NewMemoryInitDataReader(&initData)
-
-	cacheConfig := core.DefaultCacheConfigWithScheme(env.GetTestStateScheme())
-	bc, err := gethexec.WriteOrTestBlockChain(chainDb, cacheConfig, initReader, chainConfig, nil, nil, arbostypes.TestInitMessage, gethexec.ConfigDefault.TxLookupLimit, 0)
-
-	if err != nil {
-		Fail(t, err)
-	}
-
-	transactionStreamerConfigFetcher := func() *TransactionStreamerConfig { return &DefaultTransactionStreamerConfig }
-	execEngine, err := gethexec.NewExecutionEngine(bc, 0)
-	if err != nil {
-		Fail(t, err)
-	}
-	stylusTargetConfig := &gethexec.DefaultStylusTargetConfig
-	Require(t, stylusTargetConfig.Validate()) // pre-processes config (i.a. parses wasmTargets)
-	if err := execEngine.Initialize(gethexec.DefaultCachingConfig.StylusLRUCacheCapacity, &gethexec.DefaultStylusTargetConfig); err != nil {
-		Fail(t, err)
-	}
-	execSeq := &execClientWrapper{execEngine, t}
-	inbox, err := NewTransactionStreamer(ctx, arbDb, bc.Config(), execSeq, nil, make(chan error, 1), transactionStreamerConfigFetcher, &DefaultSnapSyncConfig)
-	if err != nil {
-		Fail(t, err)
-	}
-
-	// Add the init message
-	err = inbox.AddFakeInitMessage()
-	if err != nil {
-		Fail(t, err)
-	}
-
-	return execEngine, inbox, arbDb, bc
-}
 
 type blockTestState struct {
 	balances    map[common.Address]*big.Int
@@ -323,14 +185,4 @@ func TestTransactionStreamer(t *testing.T) {
 			}
 		}
 	}
-}
-
-func Require(t *testing.T, err error, printables ...interface{}) {
-	t.Helper()
-	testhelpers.RequireImpl(t, err, printables...)
-}
-
-func Fail(t *testing.T, printables ...interface{}) {
-	t.Helper()
-	testhelpers.FailImpl(t, printables...)
 }

--- a/arbnode/message-extraction/database.go
+++ b/arbnode/message-extraction/database.go
@@ -1,0 +1,149 @@
+package mel
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"github.com/offchainlabs/nitro/arbnode"
+	meltypes "github.com/offchainlabs/nitro/arbnode/message-extraction/types"
+)
+
+func dbKey(prefix []byte, pos uint64) []byte {
+	var key []byte
+	key = append(key, prefix...)
+	data := make([]byte, 8)
+	binary.BigEndian.PutUint64(data, pos)
+	key = append(key, data...)
+	return key
+}
+
+// Database is a wrapper around arbDB to avoid import cycle issue between arbnode package and mel
+type Database struct {
+	db ethdb.Database
+}
+
+func NewDatabase(db ethdb.Database) *Database {
+	return &Database{db}
+}
+
+// GetState method of the StateFetcher interface is implemented by the database as it would be the most used after the initial fetch
+func (d *Database) GetState(ctx context.Context, parentChainBlockHash common.Hash) (*meltypes.State, error) {
+	// We check if our current mel state corresponds to this parentChainBlockHash
+	headMelStateBlockNum, err := d.GetHeadMelStateBlockNum()
+	if err != nil {
+		return nil, fmt.Errorf("error getting HeadMelStateBlockNum from database: %w", err)
+	}
+	return d.State(ctx, headMelStateBlockNum)
+}
+
+func (d *Database) setHeadMelStateBlockNum(batch ethdb.KeyValueWriter, parentChainBlockNumber uint64) error {
+	parentChainBlockNumberBytes, err := rlp.EncodeToBytes(parentChainBlockNumber)
+	if err != nil {
+		return err
+	}
+	err = batch.Put(arbnode.HeadMelStateBlockNumKey, parentChainBlockNumberBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *Database) GetHeadMelStateBlockNum() (uint64, error) {
+	parentChainBlockNumberBytes, err := d.db.Get(arbnode.HeadMelStateBlockNumKey)
+	if err != nil {
+		return 0, err
+	}
+	var parentChainBlockNumber uint64
+	err = rlp.DecodeBytes(parentChainBlockNumberBytes, &parentChainBlockNumber)
+	if err != nil {
+		return 0, err
+	}
+	return parentChainBlockNumber, nil
+}
+
+func (d *Database) setMelState(batch ethdb.KeyValueWriter, parentChainBlockNumber uint64, state meltypes.State) error {
+	key := dbKey(arbnode.MelStatePrefix, parentChainBlockNumber)
+	melStateBytes, err := rlp.EncodeToBytes(state)
+	if err != nil {
+		return err
+	}
+	if err := batch.Put(key, melStateBytes); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SaveState should exclusively called for saving the recently generated "head" MEL state.
+// TODO: should we strictly enforce this? by returning an error if state.ParentChainBlockNumber <= GetHeadMelStateBlockNum()
+func (d *Database) SaveState(ctx context.Context, state *meltypes.State) error {
+	dbBatch := d.db.NewBatch()
+	if err := d.setMelState(dbBatch, state.ParentChainBlockNumber, *state); err != nil {
+		return err
+	}
+	if err := d.setHeadMelStateBlockNum(dbBatch, state.ParentChainBlockNumber); err != nil {
+		return err
+	}
+	return dbBatch.Write()
+}
+
+func (d *Database) State(ctx context.Context, parentChainBlockNumber uint64) (*meltypes.State, error) {
+	key := dbKey(arbnode.MelStatePrefix, parentChainBlockNumber)
+	data, err := d.db.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	var state meltypes.State
+	err = rlp.DecodeBytes(data, &state)
+	if err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+func (d *Database) SaveDelayedMessages(ctx context.Context, state *meltypes.State, delayedMessages []*arbnode.DelayedInboxMessage) error {
+	dbBatch := d.db.NewBatch()
+	if state.DelayedMessagedSeen < uint64(len(delayedMessages)) {
+		return fmt.Errorf("mel state's DelayedMessagedSeen: %d is lower than number of delayed messages: %d queued to be added", state.DelayedMessagedSeen, len(delayedMessages))
+	}
+	firstPos := state.DelayedMessagedSeen - uint64(len(delayedMessages))
+	for i, msg := range delayedMessages {
+		key := dbKey(arbnode.MelDelayedMessagePrefix, firstPos+uint64(i)) // #nosec G115
+		delayedBytes, err := rlp.EncodeToBytes(*msg)
+		if err != nil {
+			return err
+		}
+		err = dbBatch.Put(key, delayedBytes)
+		if err != nil {
+			return err
+		}
+
+	}
+	return dbBatch.Write()
+}
+
+func checkAgainstAccumulator(msg *arbnode.DelayedInboxMessage, state *meltypes.State) bool {
+	// TODO: Need to implement this merkle tree impl
+	return true
+}
+
+func (d *Database) ReadDelayedMessage(ctx context.Context, state *meltypes.State, index uint64) (*arbnode.DelayedInboxMessage, error) {
+	key := dbKey(arbnode.MelDelayedMessagePrefix, index)
+	delayedBytes, err := d.db.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	var delayed arbnode.DelayedInboxMessage
+	if err = rlp.DecodeBytes(delayedBytes, &delayed); err != nil {
+		return nil, err
+	}
+	if !checkAgainstAccumulator(&delayed, state) {
+		return nil, errors.New("message not part of the mel state accumulator")
+	}
+	return &delayed, nil
+}

--- a/arbnode/message-extraction/database_test.go
+++ b/arbnode/message-extraction/database_test.go
@@ -1,0 +1,96 @@
+package mel
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+
+	"github.com/offchainlabs/nitro/arbnode"
+	meltypes "github.com/offchainlabs/nitro/arbnode/message-extraction/types"
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+)
+
+func TestMelDatabase(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create database
+	arbDb := rawdb.NewMemoryDatabase()
+	melDb := NewDatabase(arbDb)
+
+	headMelState := &meltypes.State{
+		ParentChainBlockNumber: 2,
+		ParentChainBlockHash:   common.MaxHash,
+	}
+	require.NoError(t, melDb.SaveState(ctx, headMelState))
+
+	headMelStateBlockNum, err := melDb.GetHeadMelStateBlockNum()
+	require.NoError(t, err)
+	require.True(t, headMelStateBlockNum == headMelState.ParentChainBlockNumber)
+
+	var melState *meltypes.State
+	checkMelState := func() {
+		require.NoError(t, err)
+		if !reflect.DeepEqual(melState, headMelState) {
+			t.Fatal("unexpected melState retrieved via GetState using parentChainBlockHash")
+		}
+	}
+	melState, err = melDb.GetState(ctx, headMelState.ParentChainBlockHash)
+	checkMelState()
+	melState, err = melDb.State(ctx, headMelState.ParentChainBlockNumber)
+	checkMelState()
+
+}
+
+func TestMelDatabaseReadAndWriteDelayedMessages(t *testing.T) {
+	// Simple test for writing and reading of delayed messages.
+	// TODO: write a separate detailed test after delayed messages accumulation logic is implemented
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Init
+	exec, streamer, arbDb, _ := arbnode.NewTransactionStreamerForTest(t, ctx, common.Address{})
+	err := streamer.Start(ctx)
+	arbnode.Require(t, err)
+	exec.Start(ctx)
+	melDb := NewDatabase(arbDb)
+
+	init, err := streamer.GetMessage(0)
+	require.NoError(t, err)
+	initMsgDelayed := &arbnode.DelayedInboxMessage{
+		BlockHash:      [32]byte{},
+		BeforeInboxAcc: [32]byte{},
+		Message:        init.Message,
+	}
+	delayedRequestId := common.BigToHash(common.Big1)
+	delayedMsg := &arbnode.DelayedInboxMessage{
+		BlockHash:      [32]byte{},
+		BeforeInboxAcc: initMsgDelayed.AfterInboxAcc(),
+		Message: &arbostypes.L1IncomingMessage{
+			Header: &arbostypes.L1IncomingMessageHeader{
+				Kind:        arbostypes.L1MessageType_EndOfBlock,
+				Poster:      [20]byte{},
+				BlockNumber: 0,
+				Timestamp:   0,
+				RequestId:   &delayedRequestId,
+				L1BaseFee:   common.Big0,
+			},
+		},
+	}
+	require.NoError(t, melDb.SaveDelayedMessages(ctx, &meltypes.State{DelayedMessagedSeen: 1}, []*arbnode.DelayedInboxMessage{delayedMsg}))
+	have, err := melDb.ReadDelayedMessage(ctx, nil, 0)
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(have, delayedMsg) {
+		t.Fatal("delayed message mismatch")
+	}
+}

--- a/arbnode/message-extraction/extraction-function/batch_lookup_test.go
+++ b/arbnode/message-extraction/extraction-function/batch_lookup_test.go
@@ -6,14 +6,16 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/trie"
+
 	"github.com/offchainlabs/nitro/arbnode"
 	meltypes "github.com/offchainlabs/nitro/arbnode/message-extraction/types"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_parseBatchesFromBlock(t *testing.T) {

--- a/arbnode/message-extraction/extraction-function/batch_serialization_test.go
+++ b/arbnode/message-extraction/extraction-function/batch_serialization_test.go
@@ -6,12 +6,14 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/holiman/uint256"
+
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_serializeBatch(t *testing.T) {
@@ -146,7 +148,7 @@ func Test_getSequencerBatchData(t *testing.T) {
 		newMsgCount := big.NewInt(1)
 		originTxData, err := addSequencerL2BatchFromOriginCallABI.Inputs.Pack(seqNumber, msgData, afterDelayedRead, gasRefunder, prevMsgCount, newMsgCount)
 		require.NoError(t, err)
-		fullTxData := append(addSequencerL2BatchFromOriginCallABI.ID, originTxData...)
+		fullTxData := append(addSequencerL2BatchFromOriginCallABI.ID, originTxData...) //nolint:gocritic
 		txData := &types.DynamicFeeTx{
 			To:        nil,
 			Nonce:     1,

--- a/arbnode/message-extraction/extraction-function/delayed_message_lookup.go
+++ b/arbnode/message-extraction/extraction-function/delayed_message_lookup.go
@@ -179,14 +179,14 @@ func parseDelayedMessage(
 	if ethLog == nil {
 		return nil, nil, nil
 	}
-	switch {
-	case ethLog.Topics[0] == inboxMessageDeliveredID:
+	switch ethLog.Topics[0] {
+	case inboxMessageDeliveredID:
 		event := new(bridgegen.IDelayedMessageProviderInboxMessageDelivered)
 		if err := unpackLogTo(event, iDelayedMessageProviderABI, "InboxMessageDelivered", *ethLog); err != nil {
 			return nil, nil, err
 		}
 		return event.MessageNum, event.Data, nil
-	case ethLog.Topics[0] == inboxMessageFromOriginID:
+	case inboxMessageFromOriginID:
 		event := new(bridgegen.IDelayedMessageProviderInboxMessageDeliveredFromOrigin)
 		if err := unpackLogTo(event, iDelayedMessageProviderABI, "InboxMessageDeliveredFromOrigin", *ethLog); err != nil {
 			return nil, nil, err

--- a/arbnode/message-extraction/extraction-function/delayed_message_lookup_test.go
+++ b/arbnode/message-extraction/extraction-function/delayed_message_lookup_test.go
@@ -6,15 +6,17 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/trie"
+
 	"github.com/offchainlabs/nitro/arbnode"
 	meltypes "github.com/offchainlabs/nitro/arbnode/message-extraction/types"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_parseDelayedMessagesFromBlock(t *testing.T) {
@@ -157,8 +159,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 	t.Run("fetching message data from inbox message delivered event, but hash mismatched", func(t *testing.T) {
 		delayedMsgEvent, delayedMsgPackedLog := setupParseDelayedMessagesTest(t)
 		msgDataEvent := &bridgegen.IDelayedMessageProviderInboxMessageDelivered{
-			MessageNum: big.NewInt(1),
-			Data:       []byte("foobar"),
+			Data: []byte("foobar"),
 		}
 		eventABI := iDelayedMessageProviderABI.Events["InboxMessageDelivered"]
 		packedMsgDataLog, err := eventABI.Inputs.NonIndexed().Pack(msgDataEvent.Data)
@@ -446,7 +447,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 		l2MessageFromOriginCallABI := iInboxABI.Methods["sendL2MessageFromOrigin"]
 		originTxData, err := l2MessageFromOriginCallABI.Inputs.Pack(msgData)
 		require.NoError(t, err)
-		fullTxData := append(l2MessageFromOriginCallABI.ID, originTxData...)
+		fullTxData := append(l2MessageFromOriginCallABI.ID, originTxData...) //nolint:gocritic
 
 		txData1 := &types.DynamicFeeTx{
 			To:        &delayedMsgPostingAddr,

--- a/arbnode/message-extraction/extraction-function/message_extraction_function_test.go
+++ b/arbnode/message-extraction/extraction-function/message_extraction_function_test.go
@@ -7,16 +7,18 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/trie"
+
 	"github.com/offchainlabs/nitro/arbnode"
 	meltypes "github.com/offchainlabs/nitro/arbnode/message-extraction/types"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/daprovider"
-	"github.com/stretchr/testify/require"
 )
 
 func TestExtractMessages(t *testing.T) {

--- a/arbnode/message-extraction/extraction-function/message_extraction_function_test.go
+++ b/arbnode/message-extraction/extraction-function/message_extraction_function_test.go
@@ -6,31 +6,30 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/ethereum/go-ethereum/trie"
+
 	"github.com/offchainlabs/nitro/arbcompress"
 	"github.com/offchainlabs/nitro/arbnode"
 	meltypes "github.com/offchainlabs/nitro/arbnode/message-extraction/types"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbstate"
-	"github.com/stretchr/testify/require"
 )
 
-func TestExtractMessages(t *testing.T) {
-	t.Run("parent chain block hash mismatch", func(t *testing.T) {
-		prevParentBlockHash := common.Hex2Bytes("0x1234")
-		block := types.NewBlock(
-			&types.Header{
-				ParentHash: common.Hash(prevParentBlockHash),
-			},
-			&types.Body{},
-			nil,
-			trie.NewStackTrie(nil),
-		)
-	})
-}
+// func TestExtractMessages(t *testing.T) {
+// 	t.Run("parent chain block hash mismatch", func(t *testing.T) {
+// 		prevParentBlockHash := common.Hex2Bytes("0x1234")
+// 		block := types.NewBlock(
+// 			&types.Header{
+// 				ParentHash: common.Hash(prevParentBlockHash),
+// 			},
+// 			&types.Body{},
+// 			nil,
+// 			trie.NewStackTrie(nil),
+// 		)
+// 	})
+// }
 
 func Test_extractMessagesInBatch(t *testing.T) {
 	ctx := context.Background()

--- a/arbnode/message-extraction/extraction-function/messages_in_batch.go
+++ b/arbnode/message-extraction/extraction-function/messages_in_batch.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
+
 	"github.com/offchainlabs/nitro/arbcompress"
 	meltypes "github.com/offchainlabs/nitro/arbnode/message-extraction/types"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"

--- a/arbnode/message-extraction/extraction-function/messages_in_batch_test.go
+++ b/arbnode/message-extraction/extraction-function/messages_in_batch_test.go
@@ -6,13 +6,15 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/rlp"
+
 	"github.com/offchainlabs/nitro/arbcompress"
 	"github.com/offchainlabs/nitro/arbnode"
 	meltypes "github.com/offchainlabs/nitro/arbnode/message-extraction/types"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbstate"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_extractMessagesInBatch(t *testing.T) {

--- a/arbnode/message-extraction/extraction-function/types.go
+++ b/arbnode/message-extraction/extraction-function/types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/offchainlabs/nitro/arbnode"
 	meltypes "github.com/offchainlabs/nitro/arbnode/message-extraction/types"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"

--- a/arbnode/message-extraction/fsm.go
+++ b/arbnode/message-extraction/fsm.go
@@ -49,11 +49,21 @@ type processNextBlock struct {
 	melState *meltypes.State
 }
 
+type savingStage int
+
+const (
+	atDelayed savingStage = iota
+	atMessages
+	atState
+)
+
 // An action that transitions the FSM to the saving messages state.
 type saveMessages struct {
-	postState       *meltypes.State
-	messages        []*arbostypes.MessageWithMetadata
-	delayedMessages []*arbnode.DelayedInboxMessage
+	preStateMsgCount uint64
+	stage            *savingStage
+	postState        *meltypes.State
+	messages         []*arbostypes.MessageWithMetadata
+	delayedMessages  []*arbnode.DelayedInboxMessage
 }
 
 type reorgToOldBlock struct {

--- a/arbnode/message-extraction/fsm.go
+++ b/arbnode/message-extraction/fsm.go
@@ -49,18 +49,9 @@ type processNextBlock struct {
 	melState *meltypes.State
 }
 
-type savingStage int
-
-const (
-	atDelayed savingStage = iota
-	atMessages
-	atState
-)
-
 // An action that transitions the FSM to the saving messages state.
 type saveMessages struct {
 	preStateMsgCount uint64
-	stage            *savingStage
 	postState        *meltypes.State
 	messages         []*arbostypes.MessageWithMetadata
 	delayedMessages  []*arbnode.DelayedInboxMessage

--- a/arbnode/message-extraction/mel.go
+++ b/arbnode/message-extraction/mel.go
@@ -39,6 +39,7 @@ type MessageExtractor struct {
 	initialStateFetcher       meltypes.StateFetcher
 	addrs                     *chaininfo.RollupAddresses
 	melDB                     meltypes.StateDatabase
+	msgConsumer               meltypes.MessageConsumer
 	dataProviders             []daprovider.Reader
 	startParentChainBlockHash common.Hash
 	fsm                       *fsm.Fsm[action, FSMState]
@@ -53,6 +54,7 @@ func NewMessageExtractor(
 	rollupAddrs *chaininfo.RollupAddresses,
 	initialStateFetcher meltypes.StateFetcher,
 	melDB meltypes.StateDatabase,
+	msgConsumer meltypes.MessageConsumer,
 	dataProviders []daprovider.Reader,
 	startParentChainBlockHash common.Hash,
 	retryInterval time.Duration,
@@ -69,6 +71,7 @@ func NewMessageExtractor(
 		addrs:                     rollupAddrs,
 		initialStateFetcher:       initialStateFetcher,
 		melDB:                     melDB,
+		msgConsumer:               msgConsumer,
 		dataProviders:             dataProviders,
 		startParentChainBlockHash: startParentChainBlockHash,
 		fsm:                       fsm,
@@ -208,10 +211,13 @@ func (m *MessageExtractor) Act(ctx context.Context) (time.Duration, error) {
 			return m.retryInterval, err
 		}
 		// Begin the next FSM state immediately.
+		var stage savingStage
 		return 0, m.fsm.Do(saveMessages{
-			postState:       postState,
-			messages:        msgs,
-			delayedMessages: delayedMsgs,
+			preStateMsgCount: preState.MsgCount,
+			stage:            &stage,
+			postState:        postState,
+			messages:         msgs,
+			delayedMessages:  delayedMsgs,
 		})
 	// `SavingMessages` is the state responsible for saving the extracted messages
 	// and delayed messages to the database. It stores data in the node's consensus database
@@ -224,13 +230,28 @@ func (m *MessageExtractor) Act(ctx context.Context) (time.Duration, error) {
 		if !ok {
 			return m.retryInterval, fmt.Errorf("invalid action: %T", current.SourceEvent)
 		}
-		// TODO: Use a DB batch to ensure these writes atomic, so if one fails, nothing will be persisted.
-		// The ArbDB batcher has support for this.
-		if err := m.melDB.SaveDelayedMessages(ctx, saveAction.postState, saveAction.delayedMessages); err != nil {
-			return m.retryInterval, err
+		if saveAction.stage == nil {
+			return m.retryInterval, errors.New("stage of SavingMessages fsm state is nil")
 		}
-		if err := m.melDB.SaveState(ctx, saveAction.postState, saveAction.messages); err != nil {
-			return m.retryInterval, err
+		switch *saveAction.stage {
+		case atDelayed:
+			if err := m.melDB.SaveDelayedMessages(ctx, saveAction.postState, saveAction.delayedMessages); err != nil {
+				return m.retryInterval, err
+			}
+			*saveAction.stage = atMessages
+			fallthrough
+		case atMessages:
+			if err := m.msgConsumer.PushMessages(ctx, saveAction.preStateMsgCount, saveAction.messages); err != nil {
+				return m.retryInterval, err
+			}
+			*saveAction.stage = atState
+			fallthrough
+		case atState:
+			if err := m.melDB.SaveState(ctx, saveAction.postState); err != nil {
+				log.Error("Error saving messages from MessageExtractor to MessageConsumer", "err", err)
+				return m.retryInterval, err
+			}
+			*saveAction.stage++
 		}
 		return 0, m.fsm.Do(processNextBlock{
 			melState: saveAction.postState,
@@ -247,13 +268,11 @@ func (m *MessageExtractor) Act(ctx context.Context) (time.Duration, error) {
 		// TODO: we need access to melstate via db here
 		// First gets previous state and then delete dirtyMelState from db so that if node crashes midway its recoverable
 		currentDirtyState := reorgAction.melState
-		previousState, err := m.melDB.State(ctx, currentDirtyState.ParentChainPreviousBlockHash)
-		if err != nil {
-			return m.retryInterval, err
+		if currentDirtyState.ParentChainBlockNumber == 0 {
+			return m.retryInterval, errors.New("invalid reorging stage, ParentChainBlockNumber of current mel state has reached 0")
 		}
-		// TODO: update melstate `head` blockhash in DB and delete sequencer messages etc...
-		// m.melDB.updateHeadMELState(currentDirtyState.ParentChainPreviousBlockHash)
-		if err := m.melDB.DeleteState(ctx, currentDirtyState.ParentChainBlockHash); err != nil {
+		previousState, err := m.melDB.State(ctx, currentDirtyState.ParentChainBlockNumber-1)
+		if err != nil {
 			return m.retryInterval, err
 		}
 		return 0, m.fsm.Do(processNextBlock{

--- a/arbnode/message-extraction/mel_test.go
+++ b/arbnode/message-extraction/mel_test.go
@@ -25,26 +25,28 @@ var _ meltypes.StateDatabase = (*mockMELDB)(nil)
 
 func TestMessageExtractor(t *testing.T) {
 	ctx := context.Background()
-	emptyblk := types.NewBlock(&types.Header{}, nil, nil, nil)
+	emptyblk := types.NewBlock(&types.Header{Number: common.Big2}, nil, nil, nil)
 	parentChainReader := &mockParentChainReader{
 		blocks: map[common.Hash]*types.Block{
-			{}:                              {},
-			common.BigToHash(big.NewInt(1)): {},
+			{}: {},
 		},
 		headers: map[common.Hash]*types.Header{
 			{}: {},
 		},
 	}
-	parentChainReader.blocks[common.BigToHash(big.NewInt(1))] = emptyblk
+	parentChainReader.blocks[common.BigToHash(big.NewInt(2))] = emptyblk
+	parentChainReader.blocks[common.BigToHash(big.NewInt(3))] = emptyblk
 	initialStateFetcher := &mockInitialStateFetcher{}
 	mockDB := &mockMELDB{
-		states: make(map[common.Hash]*meltypes.State),
+		states: make(map[uint64]*meltypes.State),
 	}
+	messageConsumer := &mockMessageConsumer{}
 	extractor, err := NewMessageExtractor(
 		parentChainReader,
 		&chaininfo.RollupAddresses{},
 		initialStateFetcher,
 		mockDB,
+		messageConsumer,
 		[]daprovider.Reader{},
 		common.Hash{},
 		0,
@@ -70,8 +72,9 @@ func TestMessageExtractor(t *testing.T) {
 		// next block state.
 		melState := &meltypes.State{
 			Version:                42,
-			ParentChainBlockNumber: 0,
+			ParentChainBlockNumber: 1,
 		}
+		mockDB.states[1] = melState
 		initialStateFetcher.returnErr = nil
 		initialStateFetcher.state = melState
 		_, err = extractor.Act(ctx)
@@ -103,7 +106,19 @@ func TestMessageExtractor(t *testing.T) {
 		require.True(t, extractor.CurrentFSMState() == SavingMessages)
 	})
 	t.Run("SavingMessages", func(t *testing.T) {
-		// Correctly transitions back to the ProcessingNextBlock state.
+		getSavingStage := func() savingStage {
+			saveAction, ok := extractor.fsm.Current().SourceEvent.(saveMessages)
+			require.True(t, ok)
+			return *saveAction.stage
+		}
+
+		// If messageConsumer errors at PushMessages then we retry from that stage in the savingMessages step
+		messageConsumer.returnErr = errors.New("oops")
+		_, err = extractor.Act(ctx)
+		require.True(t, extractor.CurrentFSMState() == SavingMessages)
+		require.True(t, getSavingStage() == atMessages)
+
+		messageConsumer.returnErr = nil
 		_, err = extractor.Act(ctx)
 		require.NoError(t, err)
 		require.True(t, extractor.CurrentFSMState() == ProcessingNextBlock)
@@ -112,8 +127,7 @@ func TestMessageExtractor(t *testing.T) {
 		parentChainReader.blocks[common.BigToHash(big.NewInt(1))] = types.NewBlock(
 			&types.Header{ParentHash: common.MaxHash}, nil, nil, nil,
 		)
-		require.True(t, len(mockDB.states) == 1)
-		mockDB.states[common.Hash{}] = &meltypes.State{}
+		require.True(t, mockDB.headMelStateBlockNum == 2)
 
 		// Correctly transitions to the Reorging messages state.
 		parentChainReader.returnErr = nil
@@ -121,12 +135,17 @@ func TestMessageExtractor(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, extractor.CurrentFSMState() == Reorging)
 
-		// Reorging step should delete the state? and then proceed to ProcessingNextBlock state
+		// Reorging step should proceed to ProcessingNextBlock state
 		_, err = extractor.Act(ctx)
 		require.NoError(t, err)
-		require.True(t, len(mockDB.states) == 1)
 		require.True(t, extractor.CurrentFSMState() == ProcessingNextBlock)
 	})
+}
+
+type mockMessageConsumer struct{ returnErr error }
+
+func (m *mockMessageConsumer) PushMessages(ctx context.Context, firstMsgIdx uint64, messages []*arbostypes.MessageWithMetadata) error {
+	return m.returnErr
 }
 
 type mockInitialStateFetcher struct {
@@ -195,14 +214,15 @@ func (m *mockParentChainReader) TransactionReceipt(ctx context.Context, txHash c
 }
 
 type mockMELDB struct {
-	states map[common.Hash]*meltypes.State
+	headMelStateBlockNum uint64
+	states               map[uint64]*meltypes.State
 }
 
 func (m *mockMELDB) State(
 	_ context.Context,
-	parentChainBlockHash common.Hash,
+	parentChainBlockNumber uint64,
 ) (*meltypes.State, error) {
-	if state, ok := m.states[parentChainBlockHash]; ok {
+	if state, ok := m.states[parentChainBlockNumber]; ok {
 		return state, nil
 	}
 	return nil, errors.New("doesn't exist")
@@ -211,16 +231,9 @@ func (m *mockMELDB) State(
 func (m *mockMELDB) SaveState(
 	_ context.Context,
 	state *meltypes.State,
-	_ []*arbostypes.MessageWithMetadata,
 ) error {
-	m.states[state.ParentChainBlockHash] = state
-	return nil
-}
-
-func (m *mockMELDB) DeleteState(
-	ctx context.Context, parentChainBlockHash common.Hash,
-) error {
-	delete(m.states, parentChainBlockHash)
+	m.states[state.ParentChainBlockNumber] = state
+	m.headMelStateBlockNum = state.ParentChainBlockNumber
 	return nil
 }
 

--- a/arbnode/message-extraction/mel_test.go
+++ b/arbnode/message-extraction/mel_test.go
@@ -106,19 +106,7 @@ func TestMessageExtractor(t *testing.T) {
 		require.True(t, extractor.CurrentFSMState() == SavingMessages)
 	})
 	t.Run("SavingMessages", func(t *testing.T) {
-		getSavingStage := func() savingStage {
-			saveAction, ok := extractor.fsm.Current().SourceEvent.(saveMessages)
-			require.True(t, ok)
-			return *saveAction.stage
-		}
-
-		// If messageConsumer errors at PushMessages then we retry from that stage in the savingMessages step
-		messageConsumer.returnErr = errors.New("oops")
-		_, err = extractor.Act(ctx)
-		require.True(t, extractor.CurrentFSMState() == SavingMessages)
-		require.True(t, getSavingStage() == atMessages)
-
-		messageConsumer.returnErr = nil
+		// Correctly transitions back to the ProcessingNextBlock state.
 		_, err = extractor.Act(ctx)
 		require.NoError(t, err)
 		require.True(t, extractor.CurrentFSMState() == ProcessingNextBlock)

--- a/arbnode/message-extraction/types/state.go
+++ b/arbnode/message-extraction/types/state.go
@@ -33,15 +33,11 @@ type State struct {
 type StateDatabase interface {
 	State(
 		ctx context.Context,
-		parentChainBlockHash common.Hash,
+		parentChainBlockNumber uint64,
 	) (*State, error)
 	SaveState(
 		ctx context.Context,
 		state *State,
-		messages []*arbostypes.MessageWithMetadata,
-	) error
-	DeleteState(
-		ctx context.Context, parentChainBlockHash common.Hash,
 	) error
 	SaveDelayedMessages(
 		ctx context.Context,
@@ -53,6 +49,15 @@ type StateDatabase interface {
 		state *State,
 		index uint64,
 	) (*arbnode.DelayedInboxMessage, error)
+}
+
+// MessageConsumer is an interface to be implemented by readers of MEL such as transaction streamer of the nitro node
+type MessageConsumer interface {
+	PushMessages(
+		ctx context.Context,
+		firstMsgIdx uint64,
+		messages []*arbostypes.MessageWithMetadata,
+	) error
 }
 
 // Defines an interface for fetching a MEL state by parent chain block hash.

--- a/arbnode/schema.go
+++ b/arbnode/schema.go
@@ -14,6 +14,8 @@ var (
 	parentChainBlockNumberPrefix        []byte = []byte("p") // maps a delayed sequence number to a parent chain block number
 	sequencerBatchMetaPrefix            []byte = []byte("s") // maps a batch sequence number to BatchMetadata
 	delayedSequencedPrefix              []byte = []byte("a") // maps a delayed message count to the first sequencer batch sequence number with this delayed count
+	MelStatePrefix                      []byte = []byte("l") // maps a parent chain block number to its computed MEL state
+	MelDelayedMessagePrefix             []byte = []byte("y") // maps a delayed sequence number to an accumulator and an RLP encoded message [Note: might need to replace or be replaced by rlpDelayedMessagePrefix]
 
 	messageCountKey             []byte = []byte("_messageCount")                // contains the current message count
 	lastPrunedMessageKey        []byte = []byte("_lastPrunedMessageKey")        // contains the last pruned message key
@@ -21,6 +23,7 @@ var (
 	delayedMessageCountKey      []byte = []byte("_delayedMessageCount")         // contains the current delayed message count
 	sequencerBatchCountKey      []byte = []byte("_sequencerBatchCount")         // contains the current sequencer message count
 	dbSchemaVersion             []byte = []byte("_schemaVersion")               // contains a uint64 representing the database schema version
+	HeadMelStateBlockNumKey     []byte = []byte("_headMelStateBlockNum")        // contains the latest computed MEL state's parent chain block number
 )
 
 const currentDbSchemaVersion uint64 = 1

--- a/arbnode/test_helpers.go
+++ b/arbnode/test_helpers.go
@@ -1,0 +1,161 @@
+package arbnode
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/cmd/chaininfo"
+	"github.com/offchainlabs/nitro/execution"
+	"github.com/offchainlabs/nitro/execution/gethexec"
+	"github.com/offchainlabs/nitro/statetransfer"
+	"github.com/offchainlabs/nitro/util/containers"
+	"github.com/offchainlabs/nitro/util/testhelpers"
+	"github.com/offchainlabs/nitro/util/testhelpers/env"
+)
+
+type execClientWrapper struct {
+	ExecutionEngine *gethexec.ExecutionEngine
+	t               *testing.T
+}
+
+func (w *execClientWrapper) Pause() { w.t.Error("not supported") }
+
+func (w *execClientWrapper) Activate() { w.t.Error("not supported") }
+
+func (w *execClientWrapper) ForwardTo(url string) error { w.t.Error("not supported"); return nil }
+
+func (w *execClientWrapper) SequenceDelayedMessage(message *arbostypes.L1IncomingMessage, delayedSeqNum uint64) error {
+	return w.ExecutionEngine.SequenceDelayedMessage(message, delayedSeqNum)
+}
+
+func (w *execClientWrapper) NextDelayedMessageNumber() (uint64, error) {
+	return w.ExecutionEngine.NextDelayedMessageNumber()
+}
+
+func (w *execClientWrapper) MarkFeedStart(to arbutil.MessageIndex) containers.PromiseInterface[struct{}] {
+	markFeedStartWithReturn := func(to arbutil.MessageIndex) (struct{}, error) {
+		w.ExecutionEngine.MarkFeedStart(to)
+		return struct{}{}, nil
+	}
+	return containers.NewReadyPromise(markFeedStartWithReturn(to))
+}
+
+func (w *execClientWrapper) Maintenance() containers.PromiseInterface[struct{}] {
+	return containers.NewReadyPromise(struct{}{}, nil)
+}
+
+func (w *execClientWrapper) Synced(ctx context.Context) bool {
+	w.t.Error("not supported")
+	return false
+}
+func (w *execClientWrapper) FullSyncProgressMap(ctx context.Context) map[string]interface{} {
+	w.t.Error("not supported")
+	return nil
+}
+func (w *execClientWrapper) SetFinalityData(
+	ctx context.Context,
+	safeFinalityData *arbutil.FinalityData,
+	finalizedFinalityData *arbutil.FinalityData,
+	validatedFinalityData *arbutil.FinalityData,
+) containers.PromiseInterface[struct{}] {
+	return containers.NewReadyPromise(struct{}{}, nil)
+}
+
+func (w *execClientWrapper) DigestMessage(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*execution.MessageResult] {
+	return containers.NewReadyPromise(w.ExecutionEngine.DigestMessage(num, msg, msgForPrefetch))
+}
+
+func (w *execClientWrapper) Reorg(count arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*execution.MessageResult] {
+	return containers.NewReadyPromise(w.ExecutionEngine.Reorg(count, newMessages, oldMessages))
+}
+
+func (w *execClientWrapper) HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex] {
+	return containers.NewReadyPromise(w.ExecutionEngine.HeadMessageIndex())
+}
+
+func (w *execClientWrapper) ResultAtMessageIndex(pos arbutil.MessageIndex) containers.PromiseInterface[*execution.MessageResult] {
+	return containers.NewReadyPromise(w.ExecutionEngine.ResultAtMessageIndex(pos))
+}
+
+func (w *execClientWrapper) Start(ctx context.Context) containers.PromiseInterface[struct{}] {
+	return containers.NewReadyPromise(struct{}{}, nil)
+}
+
+func (w *execClientWrapper) MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) containers.PromiseInterface[uint64] {
+	return containers.NewReadyPromise(w.ExecutionEngine.MessageIndexToBlockNumber(messageNum), nil)
+}
+
+func (w *execClientWrapper) BlockNumberToMessageIndex(blockNum uint64) containers.PromiseInterface[arbutil.MessageIndex] {
+	return containers.NewReadyPromise(w.ExecutionEngine.BlockNumberToMessageIndex(blockNum))
+}
+
+func (w *execClientWrapper) StopAndWait() containers.PromiseInterface[struct{}] {
+	return containers.NewReadyPromise(struct{}{}, nil)
+}
+
+func NewTransactionStreamerForTest(t *testing.T, ctx context.Context, ownerAddress common.Address) (*gethexec.ExecutionEngine, *TransactionStreamer, ethdb.Database, *core.BlockChain) {
+	chainConfig := chaininfo.ArbitrumDevTestChainConfig()
+
+	initData := statetransfer.ArbosInitializationInfo{
+		Accounts: []statetransfer.AccountInitializationInfo{
+			{
+				Addr:       ownerAddress,
+				EthBalance: big.NewInt(params.Ether),
+			},
+		},
+	}
+
+	chainDb := rawdb.NewMemoryDatabase()
+	arbDb := rawdb.NewMemoryDatabase()
+	initReader := statetransfer.NewMemoryInitDataReader(&initData)
+
+	cacheConfig := core.DefaultCacheConfigWithScheme(env.GetTestStateScheme())
+	bc, err := gethexec.WriteOrTestBlockChain(chainDb, cacheConfig, initReader, chainConfig, nil, nil, arbostypes.TestInitMessage, gethexec.ConfigDefault.TxLookupLimit, 0)
+
+	if err != nil {
+		Fail(t, err)
+	}
+
+	transactionStreamerConfigFetcher := func() *TransactionStreamerConfig { return &DefaultTransactionStreamerConfig }
+	execEngine, err := gethexec.NewExecutionEngine(bc, 0)
+	if err != nil {
+		Fail(t, err)
+	}
+	stylusTargetConfig := &gethexec.DefaultStylusTargetConfig
+	Require(t, stylusTargetConfig.Validate()) // pre-processes config (i.a. parses wasmTargets)
+	if err := execEngine.Initialize(gethexec.DefaultCachingConfig.StylusLRUCacheCapacity, &gethexec.DefaultStylusTargetConfig); err != nil {
+		Fail(t, err)
+	}
+	execSeq := &execClientWrapper{execEngine, t}
+	inbox, err := NewTransactionStreamer(ctx, arbDb, bc.Config(), execSeq, nil, make(chan error, 1), transactionStreamerConfigFetcher, &DefaultSnapSyncConfig)
+	if err != nil {
+		Fail(t, err)
+	}
+
+	// Add the init message
+	err = inbox.AddFakeInitMessage()
+	if err != nil {
+		Fail(t, err)
+	}
+
+	return execEngine, inbox, arbDb, bc
+}
+
+func Require(t *testing.T, err error, printables ...interface{}) {
+	t.Helper()
+	testhelpers.RequireImpl(t, err, printables...)
+}
+
+func Fail(t *testing.T, printables ...interface{}) {
+	t.Helper()
+	testhelpers.FailImpl(t, printables...)
+}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -719,6 +719,14 @@ func endBatch(batch ethdb.Batch) error {
 	return batch.Write()
 }
 
+func (s *TransactionStreamer) PushMessages(firstMsgIdx uint64, msgs []*arbostypes.MessageWithMetadata) error {
+	var messages []arbostypes.MessageWithMetadata
+	for _, msg := range msgs {
+		messages = append(messages, *msg)
+	}
+	return s.AddMessagesAndEndBatch(arbutil.MessageIndex(firstMsgIdx), true, messages, nil, nil)
+}
+
 func (s *TransactionStreamer) AddMessagesAndEndBatch(firstMsgIdx arbutil.MessageIndex, messagesAreConfirmed bool, messages []arbostypes.MessageWithMetadata, blockMetadataArr []common.BlockMetadata, batch ethdb.Batch) error {
 	messagesWithBlockInfo := make([]arbostypes.MessageWithMetadataAndBlockInfo, 0, len(messages))
 	for _, message := range messages {

--- a/arbos/arbostypes/incomingmessage.go
+++ b/arbos/arbostypes/incomingmessage.go
@@ -57,7 +57,7 @@ func (h L1IncomingMessageHeader) SeqNum() (uint64, error) {
 
 type L1IncomingMessage struct {
 	Header *L1IncomingMessageHeader `json:"header"`
-	L2msg  []byte                   `json:"l2Msg"`
+	L2msg  []byte                   `json:"l2Msg" rlp:"optional"` // Question= it wasnt tested before if L2msg is nil then rlp decoding correctly decodes it as nil as well, does adding it now make this a breaking change?
 
 	// Only used for `L1MessageType_BatchPostingReport`
 	BatchGasCost *uint64 `json:"batchGasCost,omitempty" rlp:"optional"`


### PR DESCRIPTION
This PR introduces a new wrapper struct `Database` inside `mel` package to support database related operations from MEL 
on to any db that implements `ethdb.Database` interface. 

We also introduce `MessageConsumer` interface that should be implemented by any service that plans to utilize the extracted L2 messages from MEL, in nitro's use case, this would be `txStreamer`.

MEL stores relevant data directly to the current consensus database (arbDB) used by nitro in the form of a key-value pair. Nitro node currently stores delayed messages as `delayedSeqNum - <accumulator hash> + <arbostypes.L1IncomingMessage>`, but for MEL it would be stored as `index - <arbnode.DelayedInboxMessage>`.

# Testing done
Unit tests for the `Database` struct have been added.
Added a new system test to verify the correctness that delayed inbox messages can be written to arbDB and read successfully. 