### PR TITLE
Handle incompatible wasmer serialize version

### DIFF
--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -509,12 +509,12 @@ func validateOrUpgradeWasmerSerializeVersion(db ethdb.Database) error {
 			}
 		}
 		if versionInDB != WasmerSerializeVersion {
-			log.Warn("Detected wasmer serialize version %v, expected version %v - removing all old wasm store entries", versionInDB, WasmerSerializeVersion)
+			log.Warn("Detected wasmer serialize version %v, expected version %v - removing old wasm entries", versionInDB, WasmerSerializeVersion)
 			prefixes := rawdb.WasmPrefixesExceptWavm()
 			if err := deleteWasmEntries(db, prefixes, false, 0); err != nil {
-				return fmt.Errorf("Failed to purge wasm store version 0 entries: %w", err)
+				return fmt.Errorf("Failed to purge wasm entries: %w", err)
 			}
-			log.Info("Wasmer serialize version entries successfully removed.")
+			log.Info("Wasm entries successfully removed.")
 			err = rawdb.WriteWasmerSerializeVersion(db, WasmerSerializeVersion)
 			if err != nil {
 				return fmt.Errorf("Failed to write wasmer serialize version: %w", err)

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -515,7 +515,10 @@ func validateOrUpgradeWasmerSerializeVersion(db ethdb.Database) error {
 				return fmt.Errorf("Failed to purge wasm store version 0 entries: %w", err)
 			}
 			log.Info("Wasmer serialize version entries successfully removed.")
-			rawdb.WriteWasmerSerializeVersion(db, WasmerSerializeVersion)
+			err = rawdb.WriteWasmerSerializeVersion(db, WasmerSerializeVersion)
+			if err != nil {
+				return fmt.Errorf("Failed to write wasmer serialize version: %w", err)
+			}
 		}
 	}
 	return nil

--- a/cmd/nitro/init_test.go
+++ b/cmd/nitro/init_test.go
@@ -563,7 +563,7 @@ func TestPurgeVersion0WasmStoreEntries(t *testing.T) {
 		var j int
 		for j = 0; j < 10; j++ {
 			randomSlice = testhelpers.RandomSlice(testhelpers.RandomUint64(1, 40))
-			if len(randomSlice) >= 3 && !bytes.Equal(randomSlice[:3], []byte{0x00, 'w', 'm'}) && !bytes.Equal(randomSlice[:3], []byte{0x00, 'w', 'm'}) {
+			if len(randomSlice) >= 3 && !bytes.Equal(randomSlice[:3], []byte{0x00, 'w', 'm'}) && !bytes.Equal(randomSlice[:3], []byte{0x00, 'w', 'a'}) {
 				break
 			}
 		}

--- a/cmd/nitro/init_test.go
+++ b/cmd/nitro/init_test.go
@@ -419,8 +419,8 @@ func TestOpenInitializeChainDbIncompatibleStateScheme(t *testing.T) {
 
 	stackConfig := testhelpers.CreateStackConfigForTest(t.TempDir())
 	stack, err := node.New(stackConfig)
-	defer stack.Close()
 	Require(t, err)
+	defer stack.Close()
 
 	nodeConfig := NodeConfigDefault
 	nodeConfig.Execution.Caching.StateScheme = rawdb.PathScheme
@@ -578,7 +578,8 @@ func TestPurgeVersion0WasmStoreEntries(t *testing.T) {
 	checkKeys(t, db, version0Keys, true)
 	checkKeys(t, db, collidedKeys, true)
 	checkKeys(t, db, otherKeys, true)
-	err = purgeVersion0WasmStoreEntries(db)
+	prefixes, keyLength := rawdb.DeprecatedPrefixesV0()
+	err = deleteWasmEntries(db, prefixes, true, keyLength)
 	if err != nil {
 		t.Fatal("Failed to purge version 0 keys, err:", err)
 	}
@@ -595,8 +596,8 @@ func TestOpenInitializeChainDbEmptyInit(t *testing.T) {
 
 	stackConfig := testhelpers.CreateStackConfigForTest(t.TempDir())
 	stack, err := node.New(stackConfig)
-	defer stack.Close()
 	Require(t, err)
+	defer stack.Close()
 
 	nodeConfig := NodeConfigDefault
 	nodeConfig.Execution.Caching.StateScheme = env.GetTestStateScheme()

--- a/cmd/nitro/init_test.go
+++ b/cmd/nitro/init_test.go
@@ -570,9 +570,10 @@ func TestPurgeIncompatibleWasmerSerializeVersionEntries(t *testing.T) {
 	checkKeys(t, db, hostKeys, true)
 	checkKeys(t, db, otherKeys, true)
 
-	// if Nitro's WasmerSerializeVersion is compatible WasmerSerializeVersion
+	// if Nitro's WasmerSerializeVersion is compatible with WasmerSerializeVersion
 	// stored in the database then all keys should still exist
-	rawdb.WriteWasmerSerializeVersion(db, WasmerSerializeVersion)
+	err = rawdb.WriteWasmerSerializeVersion(db, WasmerSerializeVersion)
+	Require(t, err)
 	err = validateOrUpgradeWasmerSerializeVersion(db)
 	Require(t, err)
 	checkKeys(t, db, version0Keys, true)
@@ -589,7 +590,8 @@ func TestPurgeIncompatibleWasmerSerializeVersionEntries(t *testing.T) {
 
 	// if Nitro's WasmerSerializeVersion is not compatible with WasmerSerializeVersion
 	// stored in the database then all keys, expect wavm and other keys, should be removed
-	rawdb.WriteWasmerSerializeVersion(db, WasmerSerializeVersion-1)
+	err = rawdb.WriteWasmerSerializeVersion(db, WasmerSerializeVersion-1)
+	Require(t, err)
 	err = validateOrUpgradeWasmerSerializeVersion(db)
 	Require(t, err)
 	checkKeys(t, db, version0Keys, false)

--- a/cmd/nitro/init_test.go
+++ b/cmd/nitro/init_test.go
@@ -589,7 +589,7 @@ func TestPurgeIncompatibleWasmerSerializeVersionEntries(t *testing.T) {
 	}
 
 	// if Nitro's WasmerSerializeVersion is not compatible with WasmerSerializeVersion
-	// stored in the database then all keys, expect wavm and other keys, should be removed
+	// stored in the database then all keys, except wavm and other keys, should be removed
 	err = rawdb.WriteWasmerSerializeVersion(db, WasmerSerializeVersion-1)
 	Require(t, err)
 	err = validateOrUpgradeWasmerSerializeVersion(db)


### PR DESCRIPTION
Resolves NIT-3063

Database entries that are incompatible with current wasmer serialize versions are removed during init.
This PR also fixes TestPurgeVersion0WasmStoreEntries.

Pulls https://github.com/OffchainLabs/go-ethereum/pull/464