### PR TITLE
[MEL] - Implement a Pure, Delayed Message Lookup Function

### DIFF
--- a/arbnode/message-extraction/extraction-function/abis.go
+++ b/arbnode/message-extraction/extraction-function/abis.go
@@ -7,21 +7,14 @@ import (
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 )
 
-var batchDeliveredID common.Hash
 var inboxMessageDeliveredID common.Hash
 var inboxMessageFromOriginID common.Hash
-var seqInboxABI *abi.ABI
 var iBridgeABI *abi.ABI
 var iInboxABI *abi.ABI
 var iDelayedMessageProviderABI *abi.ABI
 
 func init() {
 	var err error
-	sequencerBridgeABI, err := bridgegen.SequencerInboxMetaData.GetAbi()
-	if err != nil {
-		panic(err)
-	}
-	batchDeliveredID = sequencerBridgeABI.Events["SequencerBatchDelivered"].ID
 	parsedIBridgeABI, err := bridgegen.IBridgeMetaData.GetAbi()
 	if err != nil {
 		panic(err)
@@ -34,10 +27,6 @@ func init() {
 	iDelayedMessageProviderABI = parsedIMessageProviderABI
 	inboxMessageDeliveredID = parsedIMessageProviderABI.Events["InboxMessageDelivered"].ID
 	inboxMessageFromOriginID = parsedIMessageProviderABI.Events["InboxMessageDeliveredFromOrigin"].ID
-	seqInboxABI, err = bridgegen.SequencerInboxMetaData.GetAbi()
-	if err != nil {
-		panic(err)
-	}
 	parsedIInboxABI, err := bridgegen.IInboxMetaData.GetAbi()
 	if err != nil {
 		panic(err)

--- a/arbnode/message-extraction/extraction-function/abis.go
+++ b/arbnode/message-extraction/extraction-function/abis.go
@@ -1,0 +1,46 @@
+package extractionfunction
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
+)
+
+var batchDeliveredID common.Hash
+var inboxMessageDeliveredID common.Hash
+var inboxMessageFromOriginID common.Hash
+var seqInboxABI *abi.ABI
+var iBridgeABI *abi.ABI
+var iInboxABI *abi.ABI
+var iDelayedMessageProviderABI *abi.ABI
+
+func init() {
+	var err error
+	sequencerBridgeABI, err := bridgegen.SequencerInboxMetaData.GetAbi()
+	if err != nil {
+		panic(err)
+	}
+	batchDeliveredID = sequencerBridgeABI.Events["SequencerBatchDelivered"].ID
+	parsedIBridgeABI, err := bridgegen.IBridgeMetaData.GetAbi()
+	if err != nil {
+		panic(err)
+	}
+	iBridgeABI = parsedIBridgeABI
+	parsedIMessageProviderABI, err := bridgegen.IDelayedMessageProviderMetaData.GetAbi()
+	if err != nil {
+		panic(err)
+	}
+	iDelayedMessageProviderABI = parsedIMessageProviderABI
+	inboxMessageDeliveredID = parsedIMessageProviderABI.Events["InboxMessageDelivered"].ID
+	inboxMessageFromOriginID = parsedIMessageProviderABI.Events["InboxMessageDeliveredFromOrigin"].ID
+	seqInboxABI, err = bridgegen.SequencerInboxMetaData.GetAbi()
+	if err != nil {
+		panic(err)
+	}
+	parsedIInboxABI, err := bridgegen.IInboxMetaData.GetAbi()
+	if err != nil {
+		panic(err)
+	}
+	iInboxABI = parsedIInboxABI
+}

--- a/arbnode/message-extraction/extraction-function/delayed_message_lookup.go
+++ b/arbnode/message-extraction/extraction-function/delayed_message_lookup.go
@@ -1,0 +1,248 @@
+package extractionfunction
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/filters"
+
+	"github.com/offchainlabs/nitro/arbnode"
+	meltypes "github.com/offchainlabs/nitro/arbnode/message-extraction/types"
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
+)
+
+func parseDelayedMessagesFromBlock(
+	ctx context.Context,
+	melState *meltypes.State,
+	parentChainBlockNum *big.Int,
+	parentChainBlockTxs []*types.Transaction,
+	receiptFetcher ReceiptFetcher,
+) ([]*arbnode.DelayedInboxMessage, error) {
+	msgScaffolds := make([]*arbnode.DelayedInboxMessage, 0)
+	messageDeliveredEvents := make([]*bridgegen.IBridgeMessageDelivered, 0)
+	for i, tx := range parentChainBlockTxs {
+		if tx.To() == nil {
+			continue
+		}
+		// Fetch the receipts for the transaction to get the logs.
+		txIndex := uint(i) // #nosec G115
+		receipt, err := receiptFetcher.ReceiptForTransactionIndex(ctx, txIndex)
+		if err != nil {
+			return nil, err
+		}
+		relevantLogs := make([]*types.Log, 0, len(receipt.Logs))
+		// Check all logs in the receipt.
+		for _, log := range receipt.Logs {
+			// Check if the log was emitted by the delayed message posting address.
+			// On Arbitrum One, this is the bridge contract which emits a MessageDelivered event.
+			if log.Address == melState.DelayedMessagePostingTargetAddress {
+				relevantLogs = append(relevantLogs, log)
+			}
+		}
+		if len(relevantLogs) == 0 {
+			continue
+		}
+		delayedMessageScaffolds, parsedLogs, err := delayedMessageScaffoldsFromLogs(
+			parentChainBlockNum,
+			relevantLogs,
+		)
+		if err != nil {
+			return nil, err
+		}
+		msgScaffolds = append(msgScaffolds, delayedMessageScaffolds...)
+		messageDeliveredEvents = append(messageDeliveredEvents, parsedLogs...)
+	}
+	messageIds := make([]common.Hash, 0, len(messageDeliveredEvents))
+	inboxAddressSet := make(map[common.Address]struct{})
+	for _, event := range messageDeliveredEvents {
+		inboxAddressSet[event.Inbox] = struct{}{}
+		messageIds = append(messageIds, common.BigToHash(event.MessageIndex))
+	}
+	inboxAddressList := make([]common.Address, 0, len(inboxAddressSet))
+	for addr := range inboxAddressSet {
+		inboxAddressList = append(inboxAddressList, addr)
+	}
+	messageData := make(map[common.Hash][]byte)
+	for i, tx := range parentChainBlockTxs {
+		if tx.To() == nil {
+			continue
+		}
+		_, ok := inboxAddressSet[*tx.To()]
+		if !ok {
+			continue
+		}
+		txIndex := uint(i) // #nosec G115
+		receipt, err := receiptFetcher.ReceiptForTransactionIndex(ctx, txIndex)
+		if err != nil {
+			return nil, err
+		}
+		if len(receipt.Logs) == 0 {
+			continue
+		}
+		topics := [][]common.Hash{
+			{inboxMessageDeliveredID, inboxMessageFromOriginID}, // matches either of these IDs.
+			messageIds, // matches any of the message IDs.
+		}
+		filteredInboxMessageLogs := filters.FilterLogs(receipt.Logs, nil, nil, inboxAddressList, topics)
+		for _, inboxMsgLog := range filteredInboxMessageLogs {
+			msgNum, msg, err := parseDelayedMessage(
+				inboxMsgLog,
+				tx,
+			)
+			if err != nil {
+				return nil, err
+			}
+			messageData[common.BigToHash(msgNum)] = msg
+		}
+	}
+	for i, parsedLog := range messageDeliveredEvents {
+		msgKey := common.BigToHash(parsedLog.MessageIndex)
+		data, ok := messageData[msgKey]
+		if !ok {
+			return nil, fmt.Errorf("message %v data not found", parsedLog.MessageIndex)
+		}
+		if crypto.Keccak256Hash(data) != parsedLog.MessageDataHash {
+			return nil, fmt.Errorf("found message %v data with mismatched hash", parsedLog.MessageIndex)
+		}
+		// Fill in the message data for the delayed message scaffolds.
+		msgScaffolds[i].Message.L2msg = data
+	}
+	// Finally, we sort the messages by their request id.
+	sort.Sort(sortableMessageList(msgScaffolds))
+	return msgScaffolds, nil
+}
+
+func delayedMessageScaffoldsFromLogs(
+	parentChainBlockNum *big.Int, logs []*types.Log,
+) ([]*arbnode.DelayedInboxMessage, []*bridgegen.IBridgeMessageDelivered, error) {
+	if len(logs) == 0 {
+		return nil, nil, nil
+	}
+	parsedLogs := make([]*bridgegen.IBridgeMessageDelivered, 0, len(logs))
+
+	// First, do a pass over the logs to extract message delivered events, which
+	// contain an inbox address and a message index.
+	for _, ethLog := range logs {
+		if ethLog == nil {
+			continue
+		}
+		event := new(bridgegen.IBridgeMessageDelivered)
+		if err := unpackLogTo(event, iBridgeABI, "MessageDelivered", *ethLog); err != nil {
+			return nil, nil, err
+		}
+		parsedLogs = append(parsedLogs, event)
+	}
+
+	// A list of delayed messages that do not have nil L2msg data within, which
+	// will be filled in later after another pass over logs.
+	delayedMessageScaffolds := make([]*arbnode.DelayedInboxMessage, 0, len(parsedLogs))
+
+	// Next, we construct the messages themselves from the parsed logs.
+	for _, parsedLog := range parsedLogs {
+		msgKey := common.BigToHash(parsedLog.MessageIndex)
+		_ = msgKey
+		requestId := common.BigToHash(parsedLog.MessageIndex)
+		msg := &arbnode.DelayedInboxMessage{
+			BlockHash:      parsedLog.Raw.BlockHash,
+			BeforeInboxAcc: parsedLog.BeforeInboxAcc,
+			Message: &arbostypes.L1IncomingMessage{
+				Header: &arbostypes.L1IncomingMessageHeader{
+					Kind:        parsedLog.Kind,
+					Poster:      parsedLog.Sender,
+					BlockNumber: parentChainBlockNum.Uint64(),
+					Timestamp:   parsedLog.Timestamp,
+					RequestId:   &requestId,
+					L1BaseFee:   parsedLog.BaseFeeL1,
+				},
+				L2msg: nil, // Fill in later, once we loop over the block's logs to extract message data.
+			},
+			ParentChainBlockNumber: parsedLog.Raw.BlockNumber,
+		}
+		delayedMessageScaffolds = append(delayedMessageScaffolds, msg)
+	}
+	return delayedMessageScaffolds, parsedLogs, nil
+}
+
+func parseDelayedMessage(
+	ethLog *types.Log,
+	tx *types.Transaction,
+) (*big.Int, []byte, error) {
+	if ethLog == nil {
+		return nil, nil, nil
+	}
+	switch {
+	case ethLog.Topics[0] == inboxMessageDeliveredID:
+		event := new(bridgegen.IDelayedMessageProviderInboxMessageDelivered)
+		if err := unpackLogTo(event, iDelayedMessageProviderABI, "InboxMessageDelivered", *ethLog); err != nil {
+			return nil, nil, err
+		}
+		return event.MessageNum, event.Data, nil
+	case ethLog.Topics[0] == inboxMessageFromOriginID:
+		event := new(bridgegen.IDelayedMessageProviderInboxMessageDeliveredFromOrigin)
+		if err := unpackLogTo(event, iDelayedMessageProviderABI, "InboxMessageDeliveredFromOrigin", *ethLog); err != nil {
+			return nil, nil, err
+		}
+		args := make(map[string]any)
+		data := tx.Data()
+		if len(data) < 4 {
+			return nil, nil, fmt.Errorf("tx data %#x too short", data)
+		}
+		l2MessageFromOriginCallABI := iInboxABI.Methods["sendL2MessageFromOrigin"]
+		if err := l2MessageFromOriginCallABI.Inputs.UnpackIntoMap(args, data[4:]); err != nil {
+			return nil, nil, err
+		}
+		dataBytes, ok := args["messageData"].([]byte)
+		if !ok {
+			return nil, nil, errors.New("messageData not a byte array")
+		}
+		return event.MessageNum, dataBytes, nil
+	default:
+		return nil, nil, errors.New("unexpected log type")
+	}
+}
+
+type sortableMessageList []*arbnode.DelayedInboxMessage
+
+func (l sortableMessageList) Len() int {
+	return len(l)
+}
+
+func (l sortableMessageList) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+
+func (l sortableMessageList) Less(i, j int) bool {
+	return bytes.Compare(l[i].Message.Header.RequestId.Bytes(), l[j].Message.Header.RequestId.Bytes()) < 0
+}
+
+// Unpacks a log into the given struct with an event name string that is
+// present in the specified ABI.
+func unpackLogTo(out any, contractABI *abi.ABI, event string, log types.Log) error {
+	if len(log.Topics) == 0 {
+		return errors.New("no event signature")
+	}
+	if log.Topics[0] != contractABI.Events[event].ID {
+		return fmt.Errorf("event signature mismatch: expected %s, got %s", contractABI.Events[event].ID.Hex(), log.Topics[0].Hex())
+	}
+	if len(log.Data) > 0 {
+		if err := contractABI.UnpackIntoInterface(out, event, log.Data); err != nil {
+			return err
+		}
+	}
+	var indexed abi.Arguments
+	for _, arg := range contractABI.Events[event].Inputs {
+		if arg.Indexed {
+			indexed = append(indexed, arg)
+		}
+	}
+	return abi.ParseTopics(out, indexed, log.Topics[1:])
+}

--- a/arbnode/message-extraction/extraction-function/delayed_message_lookup.go
+++ b/arbnode/message-extraction/extraction-function/delayed_message_lookup.go
@@ -179,14 +179,14 @@ func parseDelayedMessage(
 	if ethLog == nil {
 		return nil, nil, nil
 	}
-	switch {
-	case ethLog.Topics[0] == inboxMessageDeliveredID:
+	switch ethLog.Topics[0] {
+	case inboxMessageDeliveredID:
 		event := new(bridgegen.IDelayedMessageProviderInboxMessageDelivered)
 		if err := unpackLogTo(event, iDelayedMessageProviderABI, "InboxMessageDelivered", *ethLog); err != nil {
 			return nil, nil, err
 		}
 		return event.MessageNum, event.Data, nil
-	case ethLog.Topics[0] == inboxMessageFromOriginID:
+	case inboxMessageFromOriginID:
 		event := new(bridgegen.IDelayedMessageProviderInboxMessageDeliveredFromOrigin)
 		if err := unpackLogTo(event, iDelayedMessageProviderABI, "InboxMessageDeliveredFromOrigin", *ethLog); err != nil {
 			return nil, nil, err

--- a/arbnode/message-extraction/extraction-function/delayed_message_lookup_test.go
+++ b/arbnode/message-extraction/extraction-function/delayed_message_lookup_test.go
@@ -6,15 +6,17 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/trie"
+
 	"github.com/offchainlabs/nitro/arbnode"
 	meltypes "github.com/offchainlabs/nitro/arbnode/message-extraction/types"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_parseDelayedMessagesFromBlock(t *testing.T) {

--- a/arbnode/message-extraction/extraction-function/delayed_message_lookup_test.go
+++ b/arbnode/message-extraction/extraction-function/delayed_message_lookup_test.go
@@ -159,8 +159,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 	t.Run("fetching message data from inbox message delivered event, but hash mismatched", func(t *testing.T) {
 		delayedMsgEvent, delayedMsgPackedLog := setupParseDelayedMessagesTest(t)
 		msgDataEvent := &bridgegen.IDelayedMessageProviderInboxMessageDelivered{
-			MessageNum: big.NewInt(1),
-			Data:       []byte("foobar"),
+			Data: []byte("foobar"),
 		}
 		eventABI := iDelayedMessageProviderABI.Events["InboxMessageDelivered"]
 		packedMsgDataLog, err := eventABI.Inputs.NonIndexed().Pack(msgDataEvent.Data)
@@ -448,7 +447,9 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 		l2MessageFromOriginCallABI := iInboxABI.Methods["sendL2MessageFromOrigin"]
 		originTxData, err := l2MessageFromOriginCallABI.Inputs.Pack(msgData)
 		require.NoError(t, err)
-		fullTxData := append(l2MessageFromOriginCallABI.ID, originTxData...)
+		fullTxData := make([]byte, 0)
+		fullTxData = append(fullTxData, l2MessageFromOriginCallABI.ID...)
+		fullTxData = append(fullTxData, originTxData...)
 
 		txData1 := &types.DynamicFeeTx{
 			To:        &delayedMsgPostingAddr,

--- a/arbnode/message-extraction/extraction-function/delayed_message_lookup_test.go
+++ b/arbnode/message-extraction/extraction-function/delayed_message_lookup_test.go
@@ -1,0 +1,607 @@
+package extractionfunction
+
+import (
+	"context"
+	"math/big"
+	"sort"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/offchainlabs/nitro/arbnode"
+	meltypes "github.com/offchainlabs/nitro/arbnode/message-extraction/types"
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseDelayedMessagesFromBlock(t *testing.T) {
+	ctx := context.Background()
+	delayedMsgPostingAddr := common.BytesToAddress([]byte("deadbeef"))
+	melState := &meltypes.State{
+		DelayedMessagePostingTargetAddress: delayedMsgPostingAddr,
+	}
+
+	parentChainBlockNum := big.NewInt(1)
+	parentChainBlockTxs := []*types.Transaction{}
+	receiptFetcher := &mockReceiptFetcher{}
+
+	t.Run("no transactions", func(t *testing.T) {
+		msgs, err := parseDelayedMessagesFromBlock(
+			ctx,
+			melState,
+			parentChainBlockNum,
+			parentChainBlockTxs,
+			receiptFetcher,
+		)
+		require.NoError(t, err)
+		require.Empty(t, msgs)
+	})
+	t.Run("tx with no to field set", func(t *testing.T) {
+		txData := &types.DynamicFeeTx{
+			To:        nil,
+			Nonce:     1,
+			GasFeeCap: big.NewInt(1),
+			GasTipCap: big.NewInt(1),
+			Gas:       1,
+			Value:     big.NewInt(0),
+			Data:      nil,
+		}
+		tx := types.NewTx(txData)
+		blockBody := &types.Body{
+			Transactions: []*types.Transaction{tx},
+		}
+		block := types.NewBlock(
+			&types.Header{},
+			blockBody,
+			nil,
+			trie.NewStackTrie(nil),
+		)
+		msgs, err := parseDelayedMessagesFromBlock(
+			ctx,
+			melState,
+			block.Number(),
+			block.Transactions(),
+			receiptFetcher,
+		)
+		require.NoError(t, err)
+		require.Empty(t, msgs)
+	})
+	t.Run("no receipt logs", func(t *testing.T) {
+		txData := &types.DynamicFeeTx{
+			To:        &delayedMsgPostingAddr,
+			Nonce:     1,
+			GasFeeCap: big.NewInt(1),
+			GasTipCap: big.NewInt(1),
+			Gas:       1,
+			Value:     big.NewInt(0),
+			Data:      nil,
+		}
+		tx := types.NewTx(txData)
+		blockBody := &types.Body{
+			Transactions: []*types.Transaction{tx},
+		}
+		receipt := &types.Receipt{
+			Logs: []*types.Log{},
+		}
+		receipts := []*types.Receipt{receipt}
+		block := types.NewBlock(
+			&types.Header{},
+			blockBody,
+			receipts,
+			trie.NewStackTrie(nil),
+		)
+		receiptFetcher = &mockReceiptFetcher{
+			receipts: receipts,
+		}
+		msgs, err := parseDelayedMessagesFromBlock(
+			ctx,
+			melState,
+			block.Number(),
+			block.Transactions(),
+			receiptFetcher,
+		)
+		require.NoError(t, err)
+		require.Empty(t, msgs)
+	})
+	t.Run("log emitted by delayed message posting address, but no message data found", func(t *testing.T) {
+		event, packedLog := setupParseDelayedMessagesTest(t)
+		txData := &types.DynamicFeeTx{
+			To:        &delayedMsgPostingAddr,
+			Nonce:     1,
+			GasFeeCap: big.NewInt(1),
+			GasTipCap: big.NewInt(1),
+			Gas:       1,
+			Value:     big.NewInt(0),
+			Data:      nil,
+		}
+		tx := types.NewTx(txData)
+		blockBody := &types.Body{
+			Transactions: []*types.Transaction{tx},
+		}
+		messageIndexBytes := common.BigToHash(event.MessageIndex)
+		receipt := &types.Receipt{
+			Logs: []*types.Log{
+				{
+					Address: delayedMsgPostingAddr,
+					Data:    packedLog,
+					Topics: []common.Hash{
+						iBridgeABI.Events["MessageDelivered"].ID,
+						messageIndexBytes,
+						event.BeforeInboxAcc,
+					},
+				},
+			},
+		}
+		receipts := []*types.Receipt{receipt}
+		block := types.NewBlock(
+			&types.Header{},
+			blockBody,
+			receipts,
+			trie.NewStackTrie(nil),
+		)
+		receiptFetcher = &mockReceiptFetcher{
+			receipts: receipts,
+		}
+		_, err := parseDelayedMessagesFromBlock(
+			ctx,
+			melState,
+			block.Number(),
+			block.Transactions(),
+			receiptFetcher,
+		)
+		require.ErrorContains(t, err, "message 1 data not found")
+	})
+	t.Run("fetching message data from inbox message delivered event, but hash mismatched", func(t *testing.T) {
+		delayedMsgEvent, delayedMsgPackedLog := setupParseDelayedMessagesTest(t)
+		msgDataEvent := &bridgegen.IDelayedMessageProviderInboxMessageDelivered{
+			MessageNum: big.NewInt(1),
+			Data:       []byte("foobar"),
+		}
+		eventABI := iDelayedMessageProviderABI.Events["InboxMessageDelivered"]
+		packedMsgDataLog, err := eventABI.Inputs.NonIndexed().Pack(msgDataEvent.Data)
+		require.NoError(t, err)
+
+		txData1 := &types.DynamicFeeTx{
+			To:        &delayedMsgPostingAddr,
+			Nonce:     1,
+			GasFeeCap: big.NewInt(1),
+			GasTipCap: big.NewInt(1),
+			Gas:       1,
+			Value:     big.NewInt(0),
+			Data:      nil,
+		}
+		tx1 := types.NewTx(txData1)
+		txData2 := &types.DynamicFeeTx{
+			To:        &delayedMsgEvent.Inbox,
+			Nonce:     1,
+			GasFeeCap: big.NewInt(1),
+			GasTipCap: big.NewInt(1),
+			Gas:       1,
+			Value:     big.NewInt(0),
+			Data:      nil,
+		}
+		tx2 := types.NewTx(txData2)
+		blockBody := &types.Body{
+			Transactions: []*types.Transaction{tx1, tx2},
+		}
+		messageIndexBytes := common.BigToHash(delayedMsgEvent.MessageIndex)
+		receipt1 := &types.Receipt{
+			Logs: []*types.Log{
+				{
+					Address: delayedMsgPostingAddr,
+					Data:    delayedMsgPackedLog,
+					Topics: []common.Hash{
+						iBridgeABI.Events["MessageDelivered"].ID,
+						messageIndexBytes,
+						delayedMsgEvent.BeforeInboxAcc,
+					},
+				},
+			},
+		}
+		receipt2 := &types.Receipt{
+			Logs: []*types.Log{
+				{
+					Address: delayedMsgEvent.Inbox,
+					Data:    packedMsgDataLog,
+					Topics: []common.Hash{
+						iDelayedMessageProviderABI.Events["InboxMessageDelivered"].ID,
+						messageIndexBytes,
+					},
+				},
+			},
+		}
+		receipts := []*types.Receipt{receipt1, receipt2}
+		block := types.NewBlock(
+			&types.Header{},
+			blockBody,
+			receipts,
+			trie.NewStackTrie(nil),
+		)
+		receiptFetcher = &mockReceiptFetcher{
+			receipts: receipts,
+		}
+		_, err = parseDelayedMessagesFromBlock(
+			ctx,
+			melState,
+			block.Number(),
+			block.Transactions(),
+			receiptFetcher,
+		)
+		require.ErrorContains(t, err, "mismatched hash")
+	})
+	t.Run("fetching message data from inbox message delivered event OK", func(t *testing.T) {
+		msgData := []byte("foobar")
+		delayedMsgEvent := &bridgegen.IBridgeMessageDelivered{
+			MessageIndex:    big.NewInt(1),
+			BeforeInboxAcc:  [32]byte{},
+			Inbox:           common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+			Kind:            1,
+			Sender:          [20]byte{},
+			MessageDataHash: crypto.Keccak256Hash(msgData),
+			BaseFeeL1:       big.NewInt(2),
+			Timestamp:       0,
+		}
+		eventABI := iBridgeABI.Events["MessageDelivered"]
+		delayedMsgPackedLog, err := eventABI.Inputs.NonIndexed().Pack(
+			delayedMsgEvent.Inbox,
+			delayedMsgEvent.Kind,
+			delayedMsgEvent.Sender,
+			delayedMsgEvent.MessageDataHash,
+			delayedMsgEvent.BaseFeeL1,
+			delayedMsgEvent.Timestamp,
+		)
+		require.NoError(t, err)
+		msgDataEvent := &bridgegen.IDelayedMessageProviderInboxMessageDelivered{
+			Data: msgData,
+		}
+		eventABI = iDelayedMessageProviderABI.Events["InboxMessageDelivered"]
+		packedMsgDataLog, err := eventABI.Inputs.NonIndexed().Pack(msgDataEvent.Data)
+		require.NoError(t, err)
+
+		txData1 := &types.DynamicFeeTx{
+			To:        &delayedMsgPostingAddr,
+			Nonce:     1,
+			GasFeeCap: big.NewInt(1),
+			GasTipCap: big.NewInt(1),
+			Gas:       1,
+			Value:     big.NewInt(0),
+			Data:      nil,
+		}
+		tx1 := types.NewTx(txData1)
+		txData2 := &types.DynamicFeeTx{
+			To:        &delayedMsgEvent.Inbox,
+			Nonce:     1,
+			GasFeeCap: big.NewInt(1),
+			GasTipCap: big.NewInt(1),
+			Gas:       1,
+			Value:     big.NewInt(0),
+			Data:      nil,
+		}
+		tx2 := types.NewTx(txData2)
+		blockBody := &types.Body{
+			Transactions: []*types.Transaction{tx1, tx2},
+		}
+		messageIndexBytes := common.BigToHash(delayedMsgEvent.MessageIndex)
+		receipt1 := &types.Receipt{
+			Logs: []*types.Log{
+				{
+					Address: delayedMsgPostingAddr,
+					Data:    delayedMsgPackedLog,
+					Topics: []common.Hash{
+						iBridgeABI.Events["MessageDelivered"].ID,
+						messageIndexBytes,
+						delayedMsgEvent.BeforeInboxAcc,
+					},
+				},
+			},
+		}
+		receipt2 := &types.Receipt{
+			Logs: []*types.Log{
+				{
+					Address: delayedMsgEvent.Inbox,
+					Data:    packedMsgDataLog,
+					Topics: []common.Hash{
+						iDelayedMessageProviderABI.Events["InboxMessageDelivered"].ID,
+						messageIndexBytes,
+					},
+				},
+			},
+		}
+		receipts := []*types.Receipt{receipt1, receipt2}
+		block := types.NewBlock(
+			&types.Header{},
+			blockBody,
+			receipts,
+			trie.NewStackTrie(nil),
+		)
+		receiptFetcher = &mockReceiptFetcher{
+			receipts: receipts,
+		}
+		delayedMessages, err := parseDelayedMessagesFromBlock(
+			ctx,
+			melState,
+			block.Number(),
+			block.Transactions(),
+			receiptFetcher,
+		)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(delayedMessages))
+		require.Equal(t, delayedMessages[0].Message.L2msg, msgData)
+	})
+	t.Run("fetching message data from inbox message delivered event from origin tx data too short", func(t *testing.T) {
+		msgData := []byte("foobar")
+		delayedMsgEvent := &bridgegen.IBridgeMessageDelivered{
+			MessageIndex:    big.NewInt(1),
+			BeforeInboxAcc:  [32]byte{},
+			Inbox:           common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+			Kind:            1,
+			Sender:          [20]byte{},
+			MessageDataHash: crypto.Keccak256Hash(msgData),
+			BaseFeeL1:       big.NewInt(2),
+			Timestamp:       0,
+		}
+		eventABI := iBridgeABI.Events["MessageDelivered"]
+		delayedMsgPackedLog, err := eventABI.Inputs.NonIndexed().Pack(
+			delayedMsgEvent.Inbox,
+			delayedMsgEvent.Kind,
+			delayedMsgEvent.Sender,
+			delayedMsgEvent.MessageDataHash,
+			delayedMsgEvent.BaseFeeL1,
+			delayedMsgEvent.Timestamp,
+		)
+		require.NoError(t, err)
+		txData1 := &types.DynamicFeeTx{
+			To:        &delayedMsgPostingAddr,
+			Nonce:     1,
+			GasFeeCap: big.NewInt(1),
+			GasTipCap: big.NewInt(1),
+			Gas:       1,
+			Value:     big.NewInt(0),
+			Data:      nil,
+		}
+		tx1 := types.NewTx(txData1)
+		txData2 := &types.DynamicFeeTx{
+			To:        &delayedMsgEvent.Inbox,
+			Nonce:     1,
+			GasFeeCap: big.NewInt(1),
+			GasTipCap: big.NewInt(1),
+			Gas:       1,
+			Value:     big.NewInt(0),
+			Data:      nil,
+		}
+		tx2 := types.NewTx(txData2)
+		blockBody := &types.Body{
+			Transactions: []*types.Transaction{tx1, tx2},
+		}
+		messageIndexBytes := common.BigToHash(delayedMsgEvent.MessageIndex)
+		receipt1 := &types.Receipt{
+			Logs: []*types.Log{
+				{
+					Address: delayedMsgPostingAddr,
+					Data:    delayedMsgPackedLog,
+					Topics: []common.Hash{
+						iBridgeABI.Events["MessageDelivered"].ID,
+						messageIndexBytes,
+						delayedMsgEvent.BeforeInboxAcc,
+					},
+				},
+			},
+		}
+		receipt2 := &types.Receipt{
+			Logs: []*types.Log{
+				{
+					Address: delayedMsgEvent.Inbox,
+					Topics: []common.Hash{
+						iDelayedMessageProviderABI.Events["InboxMessageDeliveredFromOrigin"].ID,
+						messageIndexBytes,
+					},
+				},
+			},
+		}
+		receipts := []*types.Receipt{receipt1, receipt2}
+		block := types.NewBlock(
+			&types.Header{},
+			blockBody,
+			receipts,
+			trie.NewStackTrie(nil),
+		)
+		receiptFetcher = &mockReceiptFetcher{
+			receipts: receipts,
+		}
+		_, err = parseDelayedMessagesFromBlock(
+			ctx,
+			melState,
+			block.Number(),
+			block.Transactions(),
+			receiptFetcher,
+		)
+		require.ErrorContains(t, err, "too short")
+	})
+	t.Run("fetching message data from inbox message delivered event from origin OK", func(t *testing.T) {
+		msgData := []byte("foobar")
+		delayedMsgEvent := &bridgegen.IBridgeMessageDelivered{
+			MessageIndex:    big.NewInt(1),
+			BeforeInboxAcc:  [32]byte{},
+			Inbox:           common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+			Kind:            1,
+			Sender:          [20]byte{},
+			MessageDataHash: crypto.Keccak256Hash(msgData),
+			BaseFeeL1:       big.NewInt(2),
+			Timestamp:       0,
+		}
+		eventABI := iBridgeABI.Events["MessageDelivered"]
+		delayedMsgPackedLog, err := eventABI.Inputs.NonIndexed().Pack(
+			delayedMsgEvent.Inbox,
+			delayedMsgEvent.Kind,
+			delayedMsgEvent.Sender,
+			delayedMsgEvent.MessageDataHash,
+			delayedMsgEvent.BaseFeeL1,
+			delayedMsgEvent.Timestamp,
+		)
+		require.NoError(t, err)
+		eventABI = iDelayedMessageProviderABI.Events["InboxMessageDeliveredFromOrigin"]
+		l2MessageFromOriginCallABI := iInboxABI.Methods["sendL2MessageFromOrigin"]
+		originTxData, err := l2MessageFromOriginCallABI.Inputs.Pack(msgData)
+		require.NoError(t, err)
+		fullTxData := append(l2MessageFromOriginCallABI.ID, originTxData...)
+
+		txData1 := &types.DynamicFeeTx{
+			To:        &delayedMsgPostingAddr,
+			Nonce:     1,
+			GasFeeCap: big.NewInt(1),
+			GasTipCap: big.NewInt(1),
+			Gas:       1,
+			Value:     big.NewInt(0),
+			Data:      nil,
+		}
+		tx1 := types.NewTx(txData1)
+		txData2 := &types.DynamicFeeTx{
+			To:        &delayedMsgEvent.Inbox,
+			Nonce:     1,
+			GasFeeCap: big.NewInt(1),
+			GasTipCap: big.NewInt(1),
+			Gas:       1,
+			Value:     big.NewInt(0),
+			Data:      fullTxData,
+		}
+		tx2 := types.NewTx(txData2)
+		blockBody := &types.Body{
+			Transactions: []*types.Transaction{tx1, tx2},
+		}
+		messageIndexBytes := common.BigToHash(delayedMsgEvent.MessageIndex)
+		receipt1 := &types.Receipt{
+			Logs: []*types.Log{
+				{
+					Address: delayedMsgPostingAddr,
+					Data:    delayedMsgPackedLog,
+					Topics: []common.Hash{
+						iBridgeABI.Events["MessageDelivered"].ID,
+						messageIndexBytes,
+						delayedMsgEvent.BeforeInboxAcc,
+					},
+				},
+			},
+		}
+		receipt2 := &types.Receipt{
+			Logs: []*types.Log{
+				{
+					Address: delayedMsgEvent.Inbox,
+					Topics: []common.Hash{
+						iDelayedMessageProviderABI.Events["InboxMessageDeliveredFromOrigin"].ID,
+						messageIndexBytes,
+					},
+				},
+			},
+		}
+		receipts := []*types.Receipt{receipt1, receipt2}
+		block := types.NewBlock(
+			&types.Header{},
+			blockBody,
+			receipts,
+			trie.NewStackTrie(nil),
+		)
+		receiptFetcher = &mockReceiptFetcher{
+			receipts: receipts,
+		}
+		delayedMessages, err := parseDelayedMessagesFromBlock(
+			ctx,
+			melState,
+			block.Number(),
+			block.Transactions(),
+			receiptFetcher,
+		)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(delayedMessages))
+		require.Equal(t, delayedMessages[0].Message.L2msg, msgData)
+	})
+}
+
+func Test_parseMessageScaffoldsFromLogs(t *testing.T) {
+	t.Run("empty logs", func(t *testing.T) {
+		delayedMsgs, events, err := delayedMessageScaffoldsFromLogs(nil, nil)
+		require.NoError(t, err)
+		require.Empty(t, delayedMsgs)
+		require.Empty(t, events)
+	})
+	t.Run("nil logs", func(t *testing.T) {
+		delayedMsgs, events, err := delayedMessageScaffoldsFromLogs(nil, []*types.Log{nil, nil})
+		require.NoError(t, err)
+		require.Empty(t, delayedMsgs)
+		require.Empty(t, events)
+	})
+	t.Run("log unpacking fails", func(t *testing.T) {
+		log := &types.Log{
+			Address: common.BytesToAddress([]byte("deadbeef")),
+			Data:    []byte("foobar"),
+			Topics:  []common.Hash{},
+		}
+		_, _, err := delayedMessageScaffoldsFromLogs(nil, []*types.Log{log})
+		require.ErrorContains(t, err, "no event signature")
+	})
+}
+
+func Test_sortableMessageList(t *testing.T) {
+	hash1 := common.BigToHash(big.NewInt(1))
+	hash2 := common.BigToHash(big.NewInt(2))
+	messages := []*arbnode.DelayedInboxMessage{
+		{
+			Message: &arbostypes.L1IncomingMessage{
+				Header: &arbostypes.L1IncomingMessageHeader{
+					RequestId: &hash2,
+				},
+			},
+		},
+		{
+			Message: &arbostypes.L1IncomingMessage{
+				Header: &arbostypes.L1IncomingMessageHeader{
+					RequestId: &hash1,
+				},
+			},
+		},
+	}
+	sort.Sort(sortableMessageList(messages))
+	require.Equal(t, hash1, *messages[0].Message.Header.RequestId)
+	require.Equal(t, hash2, *messages[1].Message.Header.RequestId)
+}
+
+func setupParseDelayedMessagesTest(t *testing.T) (*bridgegen.IBridgeMessageDelivered, []byte) {
+	event := &bridgegen.IBridgeMessageDelivered{
+		MessageIndex:    big.NewInt(1),
+		BeforeInboxAcc:  [32]byte{},
+		Inbox:           common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+		Kind:            1,
+		Sender:          [20]byte{},
+		MessageDataHash: [32]byte{},
+		BaseFeeL1:       big.NewInt(2),
+		Timestamp:       0,
+	}
+	eventABI := iBridgeABI.Events["MessageDelivered"]
+	packedLog, err := eventABI.Inputs.NonIndexed().Pack(
+		event.Inbox,
+		event.Kind,
+		event.Sender,
+		event.MessageDataHash,
+		event.BaseFeeL1,
+		event.Timestamp,
+	)
+	require.NoError(t, err)
+	return event, packedLog
+}
+
+type mockReceiptFetcher struct {
+	receipts []*types.Receipt
+	err      error
+}
+
+func (m *mockReceiptFetcher) ReceiptForTransactionIndex(
+	_ context.Context,
+	idx uint,
+) (*types.Receipt, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.receipts[idx], nil
+}


### PR DESCRIPTION
This PR is part of the message extraction function for MEL, originally from the main PR here https://github.com/OffchainLabs/nitro/pull/3174. 

This PR implements a delayed message lookup function that looks for transactions in a block that contain delayed messages being posted. As delayed messages can have their data within the same tx, or separately, this logic first builds delayed message "scaffolds", and then fills their data by looking at any logs that come from each delayed message's corresponding inbox address. Finally, returns messages sorted by header request ID, as arbos expects