### PR TITLE
Add zero-config HA coordination for Timeboost auctioneer

### DIFF
--- a/timeboost/auctioneer_bid_consumption_test.go
+++ b/timeboost/auctioneer_bid_consumption_test.go
@@ -42,6 +42,8 @@ func (h *auctioneerTestHelper) resetState() {
 	h.auctioneer.unackedBids = make(map[string]*pubsub.Message[*JsonValidatedBid])
 	h.auctioneer.unackedBidsMutex.Unlock()
 
+	h.auctioneer.isPrimary.Store(true)
+
 	for {
 		select {
 		case <-h.auctioneer.bidsReceiver:

--- a/timeboost/auctioneer_failover_test.go
+++ b/timeboost/auctioneer_failover_test.go
@@ -1,0 +1,428 @@
+package timeboost
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/offchainlabs/nitro/cmd/genericconf"
+	"github.com/offchainlabs/nitro/pubsub"
+	"github.com/offchainlabs/nitro/util/redisutil"
+)
+
+// Test configuration with shorter timeouts for faster tests
+var testCoordinationConfig = pubsub.ConsumerConfig{
+	IdletimeToAutoclaim:  300 * time.Millisecond,
+	ResponseEntryTimeout: time.Minute,
+}
+
+// Helper function to create and start an auctioneer for testing
+func createAndStartAuctioneer(t *testing.T, ctx context.Context, redisURL string, testSetup *auctionSetup, name string) (*AuctioneerServer, *auctioneerTestHelper) {
+	tmpDir := t.TempDir()
+
+	auctioneerConfig := func() *AuctioneerServerConfig {
+		return &AuctioneerServerConfig{
+			RedisURL:               redisURL,
+			SequencerEndpoint:      testSetup.endpoint,
+			AuctionContractAddress: testSetup.expressLaneAuctionAddr.Hex(),
+			DbDirectory:            tmpDir,
+			ConsumerConfig:         testCoordinationConfig,
+			StreamTimeout:          10 * time.Millisecond, // Very short for tests
+			Wallet: genericconf.WalletConfig{
+				PrivateKey: fmt.Sprintf("%x", testSetup.accounts[0].privKey.D.Bytes()),
+			},
+		}
+	}
+
+	auctioneer, err := NewAuctioneerServer(ctx, auctioneerConfig)
+	require.NoError(t, err)
+
+	// Start the auctioneer
+	auctioneer.Start(ctx)
+
+	// Create producer for this test
+	redisClient, err := redisutil.RedisClientFromURL(redisURL)
+	require.NoError(t, err)
+
+	producer, err := pubsub.NewProducer[*JsonValidatedBid, error](
+		redisClient, validatedBidsRedisStream, &pubsub.TestProducerConfig,
+	)
+	require.NoError(t, err)
+	producer.Start(ctx)
+
+	helper := newAuctioneerTestHelper(ctx, auctioneer, producer, testSetup)
+
+	log.Info("Created auctioneer", "name", name, "id", auctioneer.GetId())
+
+	return auctioneer, helper
+}
+
+// Helper function to wait for an auctioneer to reach expected primary status
+func waitForPrimaryStatus(t *testing.T, auctioneer *AuctioneerServer, expectedPrimary bool, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if auctioneer.IsPrimary() == expectedPrimary {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("Auctioneer %s did not reach expected primary status %v within %v",
+		auctioneer.GetId(), expectedPrimary, timeout)
+}
+
+// Helper to verify that a specific auctioneer would consume bids
+func verifyPrimaryBehavior(t *testing.T, auctioneer *AuctioneerServer, shouldBePrimary bool) {
+	t.Helper()
+	if shouldBePrimary {
+		require.True(t, auctioneer.IsPrimary(), "Auctioneer should be primary")
+		// When primary, consumeNextBid should actively try to consume
+		// We don't need to actually produce bids, just verify the behavior
+	} else {
+		require.False(t, auctioneer.IsPrimary(), "Auctioneer should not be primary")
+		// When not primary, consumeNextBid should return quickly without consuming
+	}
+}
+
+func TestAuctioneerFailover_BasicScenario(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	redisURL := redisutil.CreateTestRedis(ctx, t)
+	testSetup := setupAuctionTest(t, ctx)
+
+	// Ensure Redis stream exists
+	redisClient, err := redisutil.RedisClientFromURL(redisURL)
+	require.NoError(t, err)
+	err = pubsub.CreateStream(ctx, validatedBidsRedisStream, redisClient)
+	require.NoError(t, err)
+
+	// Start primary auctioneer
+	primary, primaryHelper := createAndStartAuctioneer(t, ctx, redisURL, testSetup, "primary")
+	defer primary.StopAndWait()
+	defer primaryHelper.producer.StopAndWait()
+
+	// Verify it becomes primary
+	waitForPrimaryStatus(t, primary, true, 2*time.Second)
+	t.Log("Primary auctioneer established")
+
+	// Start secondary auctioneer
+	secondary, secondaryHelper := createAndStartAuctioneer(t, ctx, redisURL, testSetup, "secondary")
+	defer secondary.StopAndWait()
+	defer secondaryHelper.producer.StopAndWait()
+
+	// Verify secondary is NOT primary
+	time.Sleep(1 * time.Second) // Give it time to check coordination
+	assert.False(t, secondary.IsPrimary(), "Secondary should not be primary while primary is active")
+
+	// Verify primary behavior
+	t.Log("Testing primary behavior")
+	verifyPrimaryBehavior(t, primary, true)
+	verifyPrimaryBehavior(t, secondary, false)
+
+	// Stop primary auctioneer
+	t.Log("Stopping primary auctioneer")
+	primary.StopAndWait()
+
+	// Wait for failover (lock expiry + processing time)
+	t.Log("Waiting for failover...")
+	waitForPrimaryStatus(t, secondary, true, 2*time.Second)
+	t.Log("Secondary became primary after failover")
+
+	// Verify secondary is now primary
+	t.Log("Testing new primary behavior")
+	verifyPrimaryBehavior(t, secondary, true)
+}
+
+func TestAuctioneerFailover_MultipleInstances(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	redisURL := redisutil.CreateTestRedis(ctx, t)
+	testSetup := setupAuctionTest(t, ctx)
+
+	// Ensure Redis stream exists
+	redisClient, err := redisutil.RedisClientFromURL(redisURL)
+	require.NoError(t, err)
+	err = pubsub.CreateStream(ctx, validatedBidsRedisStream, redisClient)
+	require.NoError(t, err)
+
+	// Start 3 auctioneers
+	a1, h1 := createAndStartAuctioneer(t, ctx, redisURL, testSetup, "A")
+	defer h1.producer.StopAndWait()
+	defer a1.StopAndWait()
+
+	a2, h2 := createAndStartAuctioneer(t, ctx, redisURL, testSetup, "B")
+	defer h2.producer.StopAndWait()
+	defer a2.StopAndWait()
+
+	a3, h3 := createAndStartAuctioneer(t, ctx, redisURL, testSetup, "C")
+	defer h3.producer.StopAndWait()
+	defer a3.StopAndWait()
+
+	// One should become primary (we don't know which one)
+	time.Sleep(1 * time.Second)
+
+	// Count primaries
+	primaryCount := 0
+	var primaryName string
+
+	if a1.IsPrimary() {
+		primaryCount++
+		primaryName = "A"
+		t.Log("A is primary")
+	}
+	if a2.IsPrimary() {
+		primaryCount++
+		primaryName = "B"
+		t.Log("B is primary")
+	}
+	if a3.IsPrimary() {
+		primaryCount++
+		primaryName = "C"
+		t.Log("C is primary")
+	}
+
+	assert.Equal(t, 1, primaryCount, "Exactly one should be primary")
+	require.NotEmpty(t, primaryName, "Should have a primary")
+
+	// Stop current primary based on which one it is
+	t.Logf("Stopping current primary %s", primaryName)
+	switch primaryName {
+	case "A":
+		a1.StopAndWait()
+	case "B":
+		a2.StopAndWait()
+	case "C":
+		a3.StopAndWait()
+	}
+
+	// Wait for failover
+	time.Sleep(1500 * time.Millisecond)
+
+	// Check that exactly one of the remaining is now primary
+	primaryCount = 0
+	var newPrimaryName string
+
+	if primaryName != "A" && a1.IsPrimary() {
+		primaryCount++
+		newPrimaryName = "A"
+		t.Log("A became new primary")
+	}
+	if primaryName != "B" && a2.IsPrimary() {
+		primaryCount++
+		newPrimaryName = "B"
+		t.Log("B became new primary")
+	}
+	if primaryName != "C" && a3.IsPrimary() {
+		primaryCount++
+		newPrimaryName = "C"
+		t.Log("C became new primary")
+	}
+
+	assert.Equal(t, 1, primaryCount, "Exactly one should be new primary")
+	require.NotEmpty(t, newPrimaryName, "Should have a new primary")
+}
+
+func TestAuctioneerFailover_ConcurrentStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	redisURL := redisutil.CreateTestRedis(ctx, t)
+	testSetup := setupAuctionTest(t, ctx)
+
+	// Ensure Redis stream exists
+	redisClient, err := redisutil.RedisClientFromURL(redisURL)
+	require.NoError(t, err)
+	err = pubsub.CreateStream(ctx, validatedBidsRedisStream, redisClient)
+	require.NoError(t, err)
+
+	// Start 2 auctioneers concurrently
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var a1, a2 *AuctioneerServer
+	var h1, h2 *auctioneerTestHelper
+
+	go func() {
+		defer wg.Done()
+		a1, h1 = createAndStartAuctioneer(t, ctx, redisURL, testSetup, "concurrent1")
+	}()
+
+	go func() {
+		defer wg.Done()
+		a2, h2 = createAndStartAuctioneer(t, ctx, redisURL, testSetup, "concurrent2")
+	}()
+
+	wg.Wait()
+
+	defer a1.StopAndWait()
+	defer h1.producer.StopAndWait()
+	defer a2.StopAndWait()
+	defer h2.producer.StopAndWait()
+
+	// Wait for coordination to settle
+	time.Sleep(1 * time.Second)
+
+	// Verify exactly one is primary
+	primaryCount := 0
+	var primary *AuctioneerServer
+
+	if a1.IsPrimary() {
+		primaryCount++
+		primary = a1
+		t.Log("Concurrent1 is primary")
+	}
+	if a2.IsPrimary() {
+		primaryCount++
+		primary = a2
+		t.Log("Concurrent2 is primary")
+	}
+
+	assert.Equal(t, 1, primaryCount, "Exactly one should be primary with concurrent start")
+
+	// Verify primary behavior
+	require.NotNil(t, primary, "Should have a primary")
+	verifyPrimaryBehavior(t, primary, true)
+}
+
+// TestAuctioneerFailover_RapidRecovery tests that a restarted auctioneer doesn't
+// immediately become primary if another holds the lock
+func TestAuctioneerFailover_RapidRecovery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	redisURL := redisutil.CreateTestRedis(ctx, t)
+	testSetup := setupAuctionTest(t, ctx)
+
+	// Ensure Redis stream exists
+	redisClient, err := redisutil.RedisClientFromURL(redisURL)
+	require.NoError(t, err)
+	err = pubsub.CreateStream(ctx, validatedBidsRedisStream, redisClient)
+	require.NoError(t, err)
+
+	// Start primary
+	primary, primaryHelper := createAndStartAuctioneer(t, ctx, redisURL, testSetup, "primary")
+	defer primaryHelper.producer.StopAndWait()
+
+	waitForPrimaryStatus(t, primary, true, 2*time.Second)
+
+	// Start secondary
+	secondary, secondaryHelper := createAndStartAuctioneer(t, ctx, redisURL, testSetup, "secondary")
+	defer secondary.StopAndWait()
+	defer secondaryHelper.producer.StopAndWait()
+
+	time.Sleep(1 * time.Second)
+	assert.False(t, secondary.IsPrimary(), "Secondary should not be primary")
+
+	// Stop and immediately restart primary
+	t.Log("Restarting primary")
+	primary.StopAndWait()
+
+	// Immediately start a new instance (simulating restart)
+	newPrimary, newPrimaryHelper := createAndStartAuctioneer(t, ctx, redisURL, testSetup, "new-primary")
+	defer newPrimary.StopAndWait()
+	defer newPrimaryHelper.producer.StopAndWait()
+
+	// The lock should still be held, so new primary should not become primary immediately
+	time.Sleep(500 * time.Millisecond)
+	assert.False(t, newPrimary.IsPrimary(), "Restarted instance should not be primary immediately")
+
+	// Wait for failover - either secondary or newPrimary could become primary
+	time.Sleep(2 * time.Second)
+
+	// Check which one became primary
+	primaryCount := 0
+	var actualPrimary *AuctioneerServer
+
+	if secondary.IsPrimary() {
+		primaryCount++
+		actualPrimary = secondary
+		t.Log("Secondary became primary")
+	}
+	if newPrimary.IsPrimary() {
+		primaryCount++
+		actualPrimary = newPrimary
+		t.Log("Restarted instance became primary")
+	}
+
+	assert.Equal(t, 1, primaryCount, "Exactly one should be primary after failover")
+	require.NotNil(t, actualPrimary, "Should have a primary")
+}
+
+// TestAuctioneerFailover_StaleLockDetection tests the timestamp-based stale lock detection
+func TestAuctioneerFailover_StaleLockDetection(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	redisURL := redisutil.CreateTestRedis(ctx, t)
+	testSetup := setupAuctionTest(t, ctx)
+
+	// Ensure Redis stream exists
+	redisClient, err := redisutil.RedisClientFromURL(redisURL)
+	require.NoError(t, err)
+	err = pubsub.CreateStream(ctx, validatedBidsRedisStream, redisClient)
+	require.NoError(t, err)
+
+	// Start primary auctioneer
+	primary, primaryHelper := createAndStartAuctioneer(t, ctx, redisURL, testSetup, "primary")
+	defer primaryHelper.producer.StopAndWait()
+
+	// Wait for primary to be established
+	waitForPrimaryStatus(t, primary, true, 2*time.Second)
+	t.Log("Primary auctioneer established")
+
+	// Stop primary without cleanup (simulating crash)
+	t.Log("Simulating primary crash")
+	primary.StopAndWait()
+
+	// Start secondary immediately
+	secondary, secondaryHelper := createAndStartAuctioneer(t, ctx, redisURL, testSetup, "secondary")
+	defer secondary.StopAndWait()
+	defer secondaryHelper.producer.StopAndWait()
+
+	// Secondary should detect stale lock and take over
+	waitForPrimaryStatus(t, secondary, true, 2*time.Second)
+	t.Log("Secondary detected stale lock and became primary")
+
+	// Verify secondary is now primary
+	verifyPrimaryBehavior(t, secondary, true)
+}
+
+// TestAuctioneerFailover_InvalidLockFormat tests handling of invalid lock format
+func TestAuctioneerFailover_InvalidLockFormat(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	redisURL := redisutil.CreateTestRedis(ctx, t)
+	testSetup := setupAuctionTest(t, ctx)
+
+	// Ensure Redis stream exists
+	redisClient, err := redisutil.RedisClientFromURL(redisURL)
+	require.NoError(t, err)
+	err = pubsub.CreateStream(ctx, validatedBidsRedisStream, redisClient)
+	require.NoError(t, err)
+
+	// Manually set an invalid lock format
+	err = redisClient.Set(ctx, AUCTIONEER_CHOSEN_KEY, "invalid-format", time.Hour).Err()
+	require.NoError(t, err)
+
+	// Start auctioneer
+	auctioneer, helper := createAndStartAuctioneer(t, ctx, redisURL, testSetup, "auctioneer")
+	defer auctioneer.StopAndWait()
+	defer helper.producer.StopAndWait()
+
+	// Auctioneer should handle invalid format and eventually become primary
+	waitForPrimaryStatus(t, auctioneer, true, 2*time.Second)
+	t.Log("Auctioneer handled invalid lock format and became primary")
+
+	// Verify it's primary
+	verifyPrimaryBehavior(t, auctioneer, true)
+}

--- a/timeboost/auctioneer_test.go
+++ b/timeboost/auctioneer_test.go
@@ -303,8 +303,8 @@ func TestAuctioneerRecoversBidsOnRestart(t *testing.T) {
 	newAuctioneer.Start(ctx)
 	t.Log("Started new auctioneer instance")
 
-	// Allow time for the new auctioneer to initialize
-	time.Sleep(time.Second * 2)
+	// Allow time for the new auctioneer to initialize and get the lock
+	time.Sleep(auctioneer.auctioneerLivenessTimeout)
 
 	// Second round of bids - these would be lower than Alice's previous bid
 	t.Log("Submitting second round of bids...")
@@ -415,4 +415,237 @@ func mockOperation(successAfter int, currentAttempt *int) func() error {
 		}
 		return errors.New("operation failed")
 	}
+}
+
+// This test is similar in structure to TestAuctioneerRecoversBidsOnRestart except it does a failover
+// rather than restarting the same auctioneer.
+func TestAuctioneerFailoverMessageReprocessing(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testSetup := setupAuctionTest(t, ctx)
+	redisURL := redisutil.CreateTestRedis(ctx, t)
+	tmpDirPrimary := t.TempDir()
+	tmpDirSecondary := t.TempDir()
+	jwtFilePath := filepath.Join(tmpDirPrimary, "jwt.key")
+	jwtSecret := common.BytesToHash([]byte("jwt"))
+	require.NoError(t, os.WriteFile(jwtFilePath, []byte(hexutil.Encode(jwtSecret[:])), 0600))
+
+	// Set up a bid validator
+	randHttp := getRandomPort(t)
+	stackConf := node.Config{
+		DataDir:             "", // ephemeral.
+		HTTPPort:            randHttp,
+		HTTPModules:         []string{AuctioneerNamespace},
+		HTTPHost:            "localhost",
+		HTTPVirtualHosts:    []string{"localhost"},
+		HTTPTimeouts:        rpc.DefaultHTTPTimeouts,
+		WSPort:              getRandomPort(t),
+		WSModules:           []string{AuctioneerNamespace},
+		WSHost:              "localhost",
+		GraphQLVirtualHosts: []string{"localhost"},
+		P2P: p2p.Config{
+			ListenAddr:  "",
+			NoDial:      true,
+			NoDiscovery: true,
+		},
+	}
+	stack, err := node.New(&stackConf)
+	require.NoError(t, err)
+	validatorCfg := &BidValidatorConfig{
+		RpcEndpoint:            testSetup.endpoint,
+		AuctionContractAddress: testSetup.expressLaneAuctionAddr.Hex(),
+		RedisURL:               redisURL,
+		ProducerConfig:         pubsub.TestProducerConfig,
+		MaxBidsPerSender:       10,
+	}
+	validatorFetcher := func() *BidValidatorConfig {
+		return validatorCfg
+	}
+	bidValidator, err := NewBidValidator(
+		ctx,
+		stack,
+		validatorFetcher,
+	)
+	require.NoError(t, err)
+	require.NoError(t, bidValidator.Initialize(ctx))
+	require.NoError(t, stack.Start())
+	bidValidator.Start(ctx)
+	t.Log("Started bid validator")
+
+	// Use shorter timeouts for faster failover
+	testConsumerConfig := pubsub.ConsumerConfig{
+		IdletimeToAutoclaim:  300 * time.Millisecond,
+		ResponseEntryTimeout: time.Minute,
+	}
+
+	// Create primary auctioneer instance
+	primaryConfigFn := func() *AuctioneerServerConfig {
+		return &AuctioneerServerConfig{
+			SequencerEndpoint:      testSetup.endpoint,
+			SequencerJWTPath:       jwtFilePath,
+			AuctionContractAddress: testSetup.expressLaneAuctionAddr.Hex(),
+			RedisURL:               redisURL,
+			ConsumerConfig:         testConsumerConfig,
+			DbDirectory:            tmpDirPrimary,
+			Wallet: genericconf.WalletConfig{
+				PrivateKey: fmt.Sprintf("%x", testSetup.accounts[0].privKey.D.Bytes()),
+			},
+		}
+	}
+
+	primary, err := NewAuctioneerServer(ctx, primaryConfigFn)
+	require.NoError(t, err)
+	primary.Start(ctx)
+	t.Log("Started primary auctioneer instance")
+
+	// Set up bidder clients
+	aliceAddr := testSetup.accounts[1].txOpts.From
+	bobAddr := testSetup.accounts[2].txOpts.From
+	charlieAddr := testSetup.accounts[3].txOpts.From
+
+	alice := setupBidderClient(t, ctx, testSetup.accounts[1], testSetup, bidValidator.stack.HTTPEndpoint())
+	bob := setupBidderClient(t, ctx, testSetup.accounts[2], testSetup, bidValidator.stack.HTTPEndpoint())
+	charlie := setupBidderClient(t, ctx, testSetup.accounts[3], testSetup, bidValidator.stack.HTTPEndpoint())
+
+	// Make deposits
+	require.NoError(t, alice.Deposit(ctx, big.NewInt(50)))
+	require.NoError(t, bob.Deposit(ctx, big.NewInt(50)))
+	require.NoError(t, charlie.Deposit(ctx, big.NewInt(50)))
+
+	// Wait for auction round to start
+	info, err := alice.auctionContract.RoundTimingInfo(&bind.CallOpts{})
+	require.NoError(t, err)
+	timeToWait := time.Until(time.Unix(int64(info.OffsetTimestamp), 0))
+	t.Logf("Waiting for %v to start the bidding round, %v", timeToWait, time.Now())
+	<-time.After(timeToWait)
+	time.Sleep(time.Millisecond * 250) // Add 1/4 of a second to ensure we're in a round
+
+	// First round of bids - Alice will be the winner with 20, Bob second with 15
+	t.Log("Submitting first round of bids...")
+	_, err = alice.Bid(ctx, big.NewInt(5), aliceAddr)
+	require.NoError(t, err)
+	_, err = alice.Bid(ctx, big.NewInt(10), aliceAddr)
+	require.NoError(t, err)
+	_, err = alice.Bid(ctx, big.NewInt(20), aliceAddr)
+	require.NoError(t, err)
+
+	_, err = bob.Bid(ctx, big.NewInt(3), bobAddr)
+	require.NoError(t, err)
+	_, err = bob.Bid(ctx, big.NewInt(8), bobAddr)
+	require.NoError(t, err)
+	_, err = bob.Bid(ctx, big.NewInt(15), bobAddr)
+	require.NoError(t, err)
+
+	_, err = charlie.Bid(ctx, big.NewInt(2), charlieAddr)
+	require.NoError(t, err)
+	_, err = charlie.Bid(ctx, big.NewInt(30), charlieAddr) // High bid
+	require.NoError(t, err)
+	_, err = charlie.Bid(ctx, big.NewInt(10), charlieAddr) // Overwrite high bid
+	require.NoError(t, err)
+
+	// Allow time for bids to be processed
+	time.Sleep(time.Second * 2)
+
+	// Verify primary auctioneer state before failover
+	primary.bidCache.Lock()
+	require.Equal(t, 3, len(primary.bidCache.bidsByExpressLaneControllerAddr))
+	primary.bidCache.Unlock()
+
+	result := primary.bidCache.topTwoBids()
+	require.Equal(t, big.NewInt(20), result.firstPlace.Amount)
+	require.Equal(t, aliceAddr, result.firstPlace.Bidder)
+	require.Equal(t, big.NewInt(15), result.secondPlace.Amount)
+	require.Equal(t, bobAddr, result.secondPlace.Bidder)
+
+	// Check how many unacked bids the primary has
+	primary.unackedBidsMutex.Lock()
+	unackedCount := len(primary.unackedBids)
+	primary.unackedBidsMutex.Unlock()
+	t.Logf("Primary has %d unacked bids before failover", unackedCount)
+
+	// "Crash" the primary by stopping it
+	t.Log("Simulating primary crash...")
+	primary.StopAndWait()
+
+	// Create secondary auctioneer with different DB directory
+	secondaryConfigFn := func() *AuctioneerServerConfig {
+		return &AuctioneerServerConfig{
+			SequencerEndpoint:      testSetup.endpoint,
+			SequencerJWTPath:       jwtFilePath,
+			AuctionContractAddress: testSetup.expressLaneAuctionAddr.Hex(),
+			RedisURL:               redisURL,
+			ConsumerConfig:         testConsumerConfig,
+			DbDirectory:            tmpDirSecondary, // Different DB directory
+			Wallet: genericconf.WalletConfig{
+				PrivateKey: fmt.Sprintf("%x", testSetup.accounts[0].privKey.D.Bytes()),
+			},
+		}
+	}
+
+	t.Log("Starting secondary auctioneer...")
+	secondary, err := NewAuctioneerServer(ctx, secondaryConfigFn)
+	require.NoError(t, err)
+	secondary.Start(ctx)
+	t.Log("Started secondary auctioneer instance")
+
+	// Wait for failover to complete (lock expiry + takeover)
+	// The secondary should become primary after 3 * IdletimeToAutoclaim
+	failoverTime := testConsumerConfig.IdletimeToAutoclaim * 3
+	t.Logf("Waiting %v for failover to complete...", failoverTime)
+	time.Sleep(failoverTime + 500*time.Millisecond)
+
+	// Verify secondary is now primary
+	require.True(t, secondary.IsPrimary(), "Secondary should have become primary")
+
+	// Secondary should reprocess the unacked messages from Redis
+	// Wait a bit for message reprocessing
+	time.Sleep(2 * time.Second)
+
+	// Second round of bids - these would be lower than Alice's previous bid
+	t.Log("Submitting second round of bids...")
+	_, err = bob.Bid(ctx, big.NewInt(12), bobAddr)
+	require.NoError(t, err)
+	_, err = charlie.Bid(ctx, big.NewInt(8), charlieAddr)
+	require.NoError(t, err)
+
+	// Allow time for bids to be processed
+	time.Sleep(time.Second * 2)
+
+	// Verify secondary auctioneer state - should have all bids including reprocessed ones
+	secondary.bidCache.Lock()
+	bidCount := len(secondary.bidCache.bidsByExpressLaneControllerAddr)
+	secondary.bidCache.Unlock()
+
+	// We expect 3 bidders in the cache
+	require.Equal(t, 3, bidCount, "Should have all 3 bidders after reprocessing")
+
+	result = secondary.bidCache.topTwoBids()
+	require.Equal(t, big.NewInt(20), result.firstPlace.Amount, "Alice should still be the highest bidder after failover")
+	require.Equal(t, aliceAddr, result.firstPlace.Bidder)
+
+	secondPlaceAmount := result.secondPlace.Amount
+	require.True(t,
+		secondPlaceAmount.Cmp(big.NewInt(12)) == 0,
+		"Second place should be Bob's new 12 bid which overwrote the 15 bid, got %s", secondPlaceAmount.String())
+	require.Equal(t, bobAddr, result.secondPlace.Bidder)
+
+	// The key test: verify that the secondary processed all the messages
+	// including those that were unacked by the primary
+	secondary.bidCache.Lock()
+	aliceBids := secondary.bidCache.bidsByExpressLaneControllerAddr[aliceAddr]
+	bobBids := secondary.bidCache.bidsByExpressLaneControllerAddr[bobAddr]
+	charlieBids := secondary.bidCache.bidsByExpressLaneControllerAddr[charlieAddr]
+	secondary.bidCache.Unlock()
+
+	require.NotNil(t, aliceBids, "Should have Alice's bids")
+	require.NotNil(t, bobBids, "Should have Bob's bids")
+	require.NotNil(t, charlieBids, "Should have Charlie's bids")
+
+	// Verify the amounts are what we expect
+	require.Equal(t, big.NewInt(20), aliceBids.Amount, "Should have Alice's highest bid (from before failover)")
+	require.Equal(t, big.NewInt(12), bobBids.Amount, "Should have Bob's latest bid (updated by later message)")
+	require.Equal(t, big.NewInt(8), charlieBids.Amount, "Should have Charlie's final bid (updated by later message)")
+
+	t.Log("Test complete - secondary successfully reprocessed unacked messages after failover")
 }


### PR DESCRIPTION
Implements automatic primary/secondary failover for multiple auctioneer instances using a single Redis coordination key. This ensures high availability without requiring any additional configuration - just run multiple instances with the same Redis URL.

The design generates a unique ID for each auctioneer on startup, with all instances competing for a single "auctioneer.chosen" key in Redis. Only the primary instance that holds this key consumes bids from the Redis stream. The lock value stores both the instance ID and timestamp in the format "id:timestamp" to enable stale lock detection without relying on Redis TTL mechanisms. When acquiring stale locks, the system uses a delete + SetNX pattern to ensure atomic acquisition.

For failover protection, the system employs timestamp-based staleness detection that doesn't depend on Redis passive expiration timing. The delete + SetNX pattern prevents race conditions by ensuring only one instance can take over at a time. The stale lock timeout is set to 3x the IdletimeToAutoclaim duration to ensure proper coordination.

Failover Timeline Example:
  T=0s: Primary auctioneer crashes
  T=1s: Primary's unacked messages become autoclaimable (IdletimeToAutoclaim)
  T=3s: Secondary detects stale lock and acquires it
  T=3s+: Secondary starts consuming messages

This timing ensures that all messages are autoclaimable before the secondary takes over, preserving message ordering during failover and preventing split-brain scenarios. The result is a clean handoff with approximately 3 second failover time.

Regarding auction resolution, it's still possible that an auctioneer could crash when it was supposed to resolve the auction, and the new primary that comes up doesn't resolve it because resolution happens at a fixed time. Further work is needed if we want to handle this case - we'd need to check for resolution events and retry if no resolution occurred within the expected window. The auction contract does prevent double resolution, ensuring correctness even in edge cases.

For S3 storage, bids are stored locally before being uploaded to S3 on a default 15 minute interval. During failover, any bids not yet uploaded by a crashed primary may be lost. This is acceptable as the data is primarily for research purposes.

The implementation includes comprehensive failover tests covering basic failover scenarios, multiple instance coordination, concurrent start handling, rapid recovery prevention, stale lock detection, invalid lock format recovery, and message reprocessing after failover.

Usage (no config changes needed):
  # Start primary
  ./nitro --timeboost.auctioneer.redis-url="redis://localhost:6379"

  # Start secondary (identical command)
  ./nitro --timeboost.auctioneer.redis-url="redis://localhost:6379"

The first instance to start becomes primary. If it fails, the secondary automatically takes over after detecting the stale lock.

Fixes NIT-3412