### PR TITLE
Lower log levels for pubsub producer errors

### DIFF
--- a/pubsub/producer.go
+++ b/pubsub/producer.go
@@ -154,7 +154,7 @@ func (p *Producer[Request, Response]) checkResponses(ctx context.Context) time.D
 			// If we found the error key, then delete it and return the error to the promise and continue.
 			p.client.Del(ctx, errorKey)
 			promise.ProduceError(errors.New(errorResponse))
-			log.Error("error getting response", "error", errorResponse)
+			log.Debug("consumer returned error", "error", errorResponse, "msgId", id)
 			errored++
 			delete(p.promises, id)
 			continue
@@ -169,7 +169,7 @@ func (p *Producer[Request, Response]) checkResponses(ctx context.Context) time.D
 				// The request this producer is waiting for has been past its TTL or is older than current PEL's lower,
 				// so safe to error and stop tracking this promise
 				promise.ProduceError(errors.New("error getting response, request has been waiting for too long"))
-				log.Error("error getting response, request has been waiting past its TTL")
+				log.Debug("request timed out waiting for response", "msgId", id, "allowedOldestId", allowedOldestID)
 				errored++
 				delete(p.promises, id)
 			}


### PR DESCRIPTION
Changed consumer error and timeout logs from Error to Debug level in the pubsub producer. These aren't always system errors - in the timeboost bid flow, both consumer rejections (due to timing constraints) and timeouts (bids unprocessed until round end) are legitimate business logic behaviors.

Since the Promise pattern already allows callers to check and handle errors appropriately, callers can decide whether to log at higher levels based on their specific use case. This change eliminates false alarms in monitoring while maintaining error visibility through the Promise API.