### PR TITLE
Fix L2PricingState UpdatePricingModel panic if chain parameters are zero

### DIFF
--- a/arbos/l2pricing/model.go
+++ b/arbos/l2pricing/model.go
@@ -50,7 +50,7 @@ func (ps *L2PricingState) UpdatePricingModel(l2BaseFee *big.Int, timePassed uint
 	baseFee := minBaseFee
 	if backlog > tolerance*speedLimit {
 		excess := arbmath.SaturatingCast[int64](backlog - tolerance*speedLimit)
-		exponentBips := arbmath.NaturalToBips(excess) / arbmath.SaturatingCast[arbmath.Bips](inertia*speedLimit)
+		exponentBips := arbmath.NaturalToBips(excess) / arbmath.SaturatingCast[arbmath.Bips](arbmath.SaturatingUMul(inertia, speedLimit))
 		baseFee = arbmath.BigMulByBips(minBaseFee, arbmath.ApproxExpBasisPoints(exponentBips, 4))
 	}
 	_ = ps.SetBaseFeeWei(baseFee)

--- a/precompiles/ArbOwner.go
+++ b/precompiles/ArbOwner.go
@@ -141,6 +141,9 @@ func (con ArbOwner) SetMinimumL2BaseFee(c ctx, evm mech, priceInWei huge) error 
 
 // SetSpeedLimit sets the computational speed limit for the chain
 func (con ArbOwner) SetSpeedLimit(c ctx, evm mech, limit uint64) error {
+	if limit == 0 {
+		return errors.New("speed limit must be nonzero")
+	}
 	return c.State.L2PricingState().SetSpeedLimitPerSecond(limit)
 }
 
@@ -151,6 +154,9 @@ func (con ArbOwner) SetMaxTxGasLimit(c ctx, evm mech, limit uint64) error {
 
 // SetL2GasPricingInertia sets the L2 gas pricing inertia
 func (con ArbOwner) SetL2GasPricingInertia(c ctx, evm mech, sec uint64) error {
+	if sec == 0 {
+		return errors.New("price inertia must be nonzero")
+	}
 	return c.State.L2PricingState().SetPricingInertia(sec)
 }
 


### PR DESCRIPTION
Fixes: NIT-3075

Make sure SpeedLimit and PricingInertia are not set to zero and product of inertia and speedLimit does not overflow.
This is done so that exponentBips calculation does not panic due to divide by zero error.