### PR TITLE
Add option to enable PreImages

### DIFF
--- a/execution/gethexec/blockchain.go
+++ b/execution/gethexec/blockchain.go
@@ -44,6 +44,7 @@ type CachingConfig struct {
 	DisableStylusCacheMetricsCollection bool          `koanf:"disable-stylus-cache-metrics-collection"`
 	StateScheme                         string        `koanf:"state-scheme"`
 	StateHistory                        uint64        `koanf:"state-history"`
+	EnablePreimages                     bool          `koanf:"enable-preimages"`
 }
 
 func CachingConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -65,6 +66,7 @@ func CachingConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".disable-stylus-cache-metrics-collection", DefaultCachingConfig.DisableStylusCacheMetricsCollection, "disable metrics collection for the stylus cache")
 	f.String(prefix+".state-scheme", DefaultCachingConfig.StateScheme, "scheme to use for state trie storage (hash, path)")
 	f.Uint64(prefix+".state-history", DefaultCachingConfig.StateHistory, "number of recent blocks to retain state history for (path state-scheme only)")
+	f.Bool(prefix+".enable-preimages", DefaultCachingConfig.EnablePreimages, "enable recording of preimages")
 }
 
 func getStateHistory(maxBlockSpeed time.Duration) uint64 {
@@ -109,7 +111,7 @@ func DefaultCacheConfigFor(stack *node.Node, cachingConfig *CachingConfig) *core
 		TriesInMemory:                      cachingConfig.BlockCount,
 		TrieRetention:                      cachingConfig.BlockAge,
 		SnapshotLimit:                      cachingConfig.SnapshotCache,
-		Preimages:                          baseConf.Preimages,
+		Preimages:                          baseConf.Preimages || cachingConfig.EnablePreimages,
 		SnapshotRestoreMaxGas:              cachingConfig.SnapshotRestoreGasLimit,
 		HeadRewindBlocksLimit:              cachingConfig.HeadRewindBlocksLimit,
 		MaxNumberOfBlocksToSkipStateSaving: cachingConfig.MaxNumberOfBlocksToSkipStateSaving,


### PR DESCRIPTION
Fixes: NIT-2995

Add a config option to enable Preimages, this is required for some debug_* calls.