### PR TITLE
Enable Golang linter misspell (for spell check)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - gocritic
     - gosec
     - nilerr
+    - misspell
   settings:
     errcheck:
       check-type-assertions: true

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -1315,7 +1315,7 @@ type ExternalSignerCfg struct {
 	// API method name (e.g. eth_signTransaction).
 	Method string `koanf:"method"`
 	// (Optional) Path to the external signer root CA certificate.
-	// This allows us to use self-signed certificats on the external signer.
+	// This allows us to use self-signed certificates on the external signer.
 	RootCA string `koanf:"root-ca"`
 	// (Optional) Client certificate for mtls.
 	ClientCert string `koanf:"client-cert"`

--- a/arbnode/dataposter/dataposter_test.go
+++ b/arbnode/dataposter/dataposter_test.go
@@ -242,7 +242,7 @@ func TestFeeAndTipCaps_EnoughBalance_NoBacklog_NoUnconfirmed_BlobTx(t *testing.T
 	// This is multiplied with the normalizedGas to get targetMaxCost.
 	// This is greatly in excess of currentTotalCost * MaxFeeBidMultipleBips,
 	// so targetMaxCost is reduced to the current base fee + suggested tip cap +
-	// current blob fee multipled by MaxFeeBidMultipleBips (factor of 10).
+	// current blob fee multiplied by MaxFeeBidMultipleBips (factor of 10).
 	// The blob and non blob factors are then proportionally split out and so
 	// the newGasFeeCap is set to (current base fee + suggested tip cap) * 10
 	// and newBlobFeeCap is set to current blob gas base fee (1 wei
@@ -378,7 +378,7 @@ func TestFeeAndTipCaps_RBF_RisingBlobFee_FallingBaseFee(t *testing.T) {
 	// This is multiplied with the normalizedGas to get targetMaxCost.
 	// This is greatly in excess of currentTotalCost * MaxFeeBidMultipleBips,
 	// so targetMaxCost is reduced to the current base fee + suggested tip cap +
-	// current blob fee multipled by MaxFeeBidMultipleBips (factor of 10).
+	// current blob fee multiplied by MaxFeeBidMultipleBips (factor of 10).
 	// The blob and non blob factors are then proportionally split out and so
 	// the newGasFeeCap is set to (current base fee + suggested tip cap) * 10
 	// and newBlobFeeCap is set to current blob gas base fee (1 wei

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -760,7 +760,7 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client *ethclien
 	}
 	multiplexer := arbstate.NewInboxMultiplexer(backend, prevbatchmeta.DelayedMessageCount, t.dapReaders, daprovider.KeysetValidate)
 	batchMessageCounts := make(map[uint64]arbutil.MessageIndex)
-	currentpos := prevbatchmeta.MessageCount + 1
+	currentPos := prevbatchmeta.MessageCount + 1
 	for {
 		if len(backend.batches) == 0 {
 			break
@@ -771,8 +771,8 @@ func (t *InboxTracker) AddSequencerBatches(ctx context.Context, client *ethclien
 			return err
 		}
 		messages = append(messages, *msg)
-		batchMessageCounts[batchSeqNum] = currentpos
-		currentpos += 1
+		batchMessageCounts[batchSeqNum] = currentPos
+		currentPos += 1
 	}
 
 	lastBatchMeta := prevbatchmeta

--- a/arbos/parse_l2.go
+++ b/arbos/parse_l2.go
@@ -27,7 +27,7 @@ func ParseL2Transactions(msg *arbostypes.L1IncomingMessage, chainId *big.Int) (t
 	case arbostypes.L1MessageType_L2Message:
 		return parseL2Message(bytes.NewReader(msg.L2msg), msg.Header.Poster, msg.Header.Timestamp, msg.Header.RequestId, chainId, 0)
 	case arbostypes.L1MessageType_Initialize:
-		return nil, errors.New("ParseL2Transactions encounted initialize message (should've been handled explicitly at genesis)")
+		return nil, errors.New("ParseL2Transactions encountered initialize message (should've been handled explicitly at genesis)")
 	case arbostypes.L1MessageType_EndOfBlock:
 		return nil, nil
 	case arbostypes.L1MessageType_L2FundedByL1:
@@ -180,7 +180,7 @@ func parseL2Message(rd io.Reader, poster common.Address, timestamp uint64, reque
 		return nil, errors.New("L2 message kind SignedCompressedTx is unimplemented")
 	default:
 		// ignore invalid message kind
-		return nil, fmt.Errorf("unkown L2 message kind %v", l2KindBuf[0])
+		return nil, fmt.Errorf("unknown L2 message kind %v", l2KindBuf[0])
 	}
 }
 

--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -276,7 +276,7 @@ func getLocalAsm(statedb vm.StateDB, moduleHash common.Hash, addressForLogging c
 		}
 	} else {
 		// program activated recently, possibly in this eth_call
-		// store it to statedb. It will be stored to database if statedb is commited
+		// store it to statedb. It will be stored to database if statedb is committed
 		statedb.ActivateWasm(moduleHash, asmMap)
 	}
 	asm, exists := asmMap[localTarget]

--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -75,7 +75,7 @@ func parseSequencerMessage(ctx context.Context, batchNum uint64, batchBlockHash 
 	// Stage 1: Extract the payload from any data availability header.
 	// It's important that multiple DAS strategies can't both be invoked in the same batch,
 	// as these headers are validated by the sequencer inbox and not other DASs.
-	// We try to extract payload from the first occuring valid DA reader in the dapReaders list
+	// We try to extract payload from the first occurring valid DA reader in the dapReaders list
 	if len(payload) > 0 {
 		foundDA := false
 		var err error

--- a/cmd/seq-coordinator-manager/seq-coordinator-manager.go
+++ b/cmd/seq-coordinator-manager/seq-coordinator-manager.go
@@ -166,7 +166,7 @@ func main() {
 	flex.SetDirection(tview.FlexRow).
 		AddItem(priorityHeading, 0, 1, false).
 		AddItem(tview.NewFlex().
-			// fixedSize is maxURLSize plus 20 characters to accomodate ellipsis, statuses and emojis
+			// fixedSize is maxURLSize plus 20 characters to accommodate ellipsis, statuses and emojis
 			AddItem(prioritySeqList, seqManager.maxURLSize+20, 0, true).
 			AddItem(priorityForm, 0, 3, true), 0, 12, true).
 		AddItem(nonPriorityHeading, 0, 1, false).

--- a/daprovider/das/aggregator.go
+++ b/daprovider/das/aggregator.go
@@ -298,7 +298,7 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64) 
 		if returned == 1 &&
 			a.maxAllowedServiceStoreFailures > 0 && // Ignore the case where AssumedHonest = 1, probably a testnet
 			int(storeFailures.Load())+1 > a.maxAllowedServiceStoreFailures {
-			log.Error("das.Aggregator: storing the batch data succeeded to enough DAS commitee members to generate the Data Availability Cert, but if one more had failed then the cert would not have been able to be generated. Look for preceding logs with \"Error from backend\"")
+			log.Error("das.Aggregator: storing the batch data succeeded to enough DAS committee members to generate the Data Availability Cert, but if one more had failed then the cert would not have been able to be generated. Look for preceding logs with \"Error from backend\"")
 		}
 	}()
 

--- a/daprovider/das/rest_server_list.go
+++ b/daprovider/das/rest_server_list.go
@@ -62,7 +62,7 @@ func restfulServerURLsFromList(
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("recieved error response (%d) fetching online-url-list at %s", resp.StatusCode, listUrl)
+		return nil, fmt.Errorf("received error response (%d) fetching online-url-list at %s", resp.StatusCode, listUrl)
 	}
 	scanner := bufio.NewScanner(resp.Body)
 	scanner.Split(bufio.ScanWords)

--- a/daprovider/util.go
+++ b/daprovider/util.go
@@ -69,7 +69,7 @@ const L1AuthenticatedMessageHeaderFlag byte = 0x40
 // ZeroheavyMessageHeaderFlag indicates that this message is zeroheavy-encoded.
 const ZeroheavyMessageHeaderFlag byte = 0x20
 
-// BlobHashesHeaderFlag indicates that this message contains EIP 4844 versioned hashes of the committments calculated over the blob data for the batch data.
+// BlobHashesHeaderFlag indicates that this message contains EIP 4844 versioned hashes of the commitments calculated over the blob data for the batch data.
 const BlobHashesHeaderFlag byte = L1AuthenticatedMessageHeaderFlag | 0x10 // 0x50
 
 // BrotliMessageHeaderByte indicates that the message is brotli-compressed.

--- a/execution/gethexec/forwarder.go
+++ b/execution/gethexec/forwarder.go
@@ -67,7 +67,7 @@ func AddOptionsForForwarderConfigImpl(prefix string, defaultConfig *ForwarderCon
 	f.Duration(prefix+".connection-timeout", defaultConfig.ConnectionTimeout, "total time to wait before cancelling connection")
 	f.Duration(prefix+".idle-connection-timeout", defaultConfig.IdleConnectionTimeout, "time until idle connections are closed")
 	f.Int(prefix+".max-idle-connections", defaultConfig.MaxIdleConnections, "maximum number of idle connections to keep open")
-	f.String(prefix+".redis-url", defaultConfig.RedisUrl, "the Redis URL to recomend target via")
+	f.String(prefix+".redis-url", defaultConfig.RedisUrl, "the Redis URL to recommend target via")
 	f.Duration(prefix+".update-interval", defaultConfig.UpdateInterval, "forwarding target update interval")
 	f.Duration(prefix+".retry-interval", defaultConfig.RetryInterval, "minimal time between update retries")
 }

--- a/execution/gethexec/wasmstorerebuilder.go
+++ b/execution/gethexec/wasmstorerebuilder.go
@@ -54,7 +54,7 @@ func WriteToKeyValueStore[T any](store ethdb.KeyValueStore, key []byte, val T) e
 // RebuildWasmStore function runs a loop looking at every codehash in diskDb, checking if its an activated stylus contract and
 // saving it to wasm store if it doesnt already exists. When errored it logs them and silently returns
 //
-// It stores the status of rebuilding to wasm store by updating the codehash (of the latest sucessfully checked contract) in
+// It stores the status of rebuilding to wasm store by updating the codehash (of the latest successfully checked contract) in
 // RebuildingPositionKey after every second of work.
 //
 // It also stores a special value that is only set once when rebuilding commenced in RebuildingStartBlockHashKey as the block

--- a/precompiles/ArbOwner.go
+++ b/precompiles/ArbOwner.go
@@ -82,7 +82,7 @@ func (con ArbOwner) SetNativeTokenManagementFrom(c ctx, evm mech, timestamp uint
 		(stored > now+NativeTokenEnableDelay && timestamp < now+NativeTokenEnableDelay) {
 		return ErrNativeTokenDelay
 	}
-	// If the feature is scheduled to be enabled earlier than the minumum delay,
+	// If the feature is scheduled to be enabled earlier than the minimum delay,
 	// then the new time to enable it must be only further in the future.
 	if stored > now && stored <= now+NativeTokenEnableDelay && timestamp < stored {
 		return ErrNativeTokenBackward

--- a/solgen/gen.go
+++ b/solgen/gen.go
@@ -157,7 +157,7 @@ func main() {
 		})
 	}
 
-	// add upgrade executor module which is not compiled locally, but imported from 'nitro-contracts' depedencies
+	// add upgrade executor module which is not compiled locally, but imported from 'nitro-contracts' dependencies
 	upgExecutorPath := filepath.Join(parent, "contracts", "node_modules", "@offchainlabs", "upgrade-executor", "build", "contracts", "src", "UpgradeExecutor.sol", "UpgradeExecutor.json")
 	_, err = os.Stat(upgExecutorPath)
 	if !os.IsNotExist(err) {

--- a/staker/bold/bold_state_provider.go
+++ b/staker/bold/bold_state_provider.go
@@ -412,7 +412,7 @@ func (s *BOLDStateProvider) messageNum(md *l2stateprovider.AssociatedAssertionMe
 // virtualState returns an optional global state.
 //
 // If messageNum is a virtual block or the last real block to which this
-// validator's assertion committed, then this function retuns a global state
+// validator's assertion committed, then this function returns a global state
 // representing that virtual block's finished machine. Otherwise, it returns
 // an Option.None.
 //

--- a/system_tests/retryable_test.go
+++ b/system_tests/retryable_test.go
@@ -343,7 +343,7 @@ func testSubmitRetryableEmptyEscrow(t *testing.T, arbosVersion uint64) {
 	Require(t, err)
 	escrowExists := state.Exist(escrowAccount)
 	if escrowExists != (arbosVersion < params.ArbosVersion_30) {
-		Fatal(t, "Escrow account existance", escrowExists, "doesn't correspond to ArbOS version", arbosVersion)
+		Fatal(t, "Escrow account existence", escrowExists, "doesn't correspond to ArbOS version", arbosVersion)
 	}
 }
 
@@ -656,7 +656,7 @@ func TestSubmitManyRetryableFailThenRetry(t *testing.T) {
 		Fatal(t, "The beneficiary shouldn't have received funds")
 	}
 
-	// the fee refund address should recieve the excess gas
+	// the fee refund address should receive the excess gas
 	colors.PrintBlue("Base Fee         ", l2BaseFee)
 	colors.PrintBlue("Excess Gas Price ", excessGasPrice)
 	colors.PrintBlue("Excess Gas       ", excessGasLimit)
@@ -1079,7 +1079,7 @@ func TestSubmissionGasCosts(t *testing.T) {
 		Fatal(t, "The beneficiary shouldn't have received funds")
 	}
 
-	// the fee refund address should recieve the excess gas
+	// the fee refund address should receive the excess gas
 	colors.PrintBlue("Base Fee         ", l2BaseFee)
 	colors.PrintBlue("Excess Gas Price ", excessGasPrice)
 	colors.PrintBlue("Excess Gas       ", excessGasLimit)

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -1095,7 +1095,7 @@ func TestTimeboostBulkBlockMetadataAPI(t *testing.T) {
 // 	Require(t, err)
 
 // 	time.Sleep(time.Second) // Wait for controller to change on the sequencer side
-// 	// Check that now Alice's tx gets priority since she's the controller after bob transfered it
+// 	// Check that now Alice's tx gets priority since she's the controller after bob transferred it
 // 	verifyControllerAdvantage(t, ctx, seqClient, aliceExpressLaneClient, seqInfo, "Alice", "Bob")
 
 // 	// Alice and Bob submit bids and Alice wins for the next round

--- a/timeboost/auctioneer.go
+++ b/timeboost/auctioneer.go
@@ -307,7 +307,7 @@ func (a *AuctioneerServer) Start(ctx_in context.Context) {
 			}
 			select {
 			case <-ctx.Done():
-				log.Info("Context done while checking redis stream existance", "error", ctx.Err().Error())
+				log.Info("Context done while checking redis stream existence", "error", ctx.Err().Error())
 				return
 			case <-time.After(time.Millisecond * 100):
 			}

--- a/util/containers/queue.go
+++ b/util/containers/queue.go
@@ -3,7 +3,7 @@
 
 package containers
 
-// Queue of an arbitrary type backed by a slice which is shrinked when it grows too large
+// Queue of an arbitrary type backed by a slice which is shrunk when it grows too large
 type Queue[T any] struct {
 	slice []T
 }

--- a/util/testhelpers/testhelpers.go
+++ b/util/testhelpers/testhelpers.go
@@ -64,13 +64,13 @@ func RandomCallValue(limit int64) *big.Int {
 	return big.NewInt(rand.Int63n(limit))
 }
 
-// Computes a psuedo-random uint64 on the interval [min, max]
+// Computes a pseudo-random uint64 on the interval [min, max]
 func RandomUint32(min, max uint32) uint32 {
 	//#nosec G115
 	return uint32(RandomUint64(uint64(min), uint64(max)))
 }
 
-// Computes a psuedo-random uint64 on the interval [min, max]
+// Computes a pseudo-random uint64 on the interval [min, max]
 func RandomUint64(min, max uint64) uint64 {
 	return uint64(rand.Uint64()%(max-min+1) + min)
 }

--- a/validator/valnode/redis/consumer.go
+++ b/validator/valnode/redis/consumer.go
@@ -91,7 +91,7 @@ func (s *ValidationServer) Start(ctx_in context.Context) {
 				}
 				select {
 				case <-ctx.Done():
-					log.Info("Context done while checking redis stream existance", "error", ctx.Err().Error())
+					log.Info("Context done while checking redis stream existence", "error", ctx.Err().Error())
 					return
 				case <-time.After(time.Millisecond * 100):
 				}


### PR DESCRIPTION
Fixes: NIT-2983

Enable Golang linter misspell (for spell check)