### PR TITLE
Remove extraneous `--node.feed.output.disable-signing` parameter

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -224,7 +224,7 @@ func mainImpl() int {
 	var l1TransactionOptsBatchPoster *bind.TransactOpts
 	// If sequencer and signing is enabled or batchposter is enabled without
 	// external signing sequencer will need a key.
-	sequencerNeedsKey := (nodeConfig.Node.Sequencer && !nodeConfig.Node.Feed.Output.DisableSigning) ||
+	sequencerNeedsKey := (nodeConfig.Node.Sequencer && nodeConfig.Node.Feed.Output.Signed) ||
 		(nodeConfig.Node.BatchPoster.Enable && (nodeConfig.Node.BatchPoster.DataPoster.ExternalSigner.URL == "" || nodeConfig.Node.DataAvailability.Enable))
 	validatorNeedsKey := nodeConfig.Node.Staker.OnlyCreateWalletContract ||
 		(nodeConfig.Node.Staker.Enable && !strings.EqualFold(nodeConfig.Node.Staker.Strategy, "watchtower") && nodeConfig.Node.Staker.DataPoster.ExternalSigner.URL == "")

--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -60,7 +60,6 @@ type BroadcasterConfig struct {
 	Workers            int                     `koanf:"workers"`
 	MaxSendQueue       int                     `koanf:"max-send-queue" reload:"hot"`  // reloaded value will affect only new connections
 	RequireVersion     bool                    `koanf:"require-version" reload:"hot"` // reloaded value will affect only future upgrades to websocket
-	DisableSigning     bool                    `koanf:"disable-signing"`
 	LogConnect         bool                    `koanf:"log-connect"`
 	LogDisconnect      bool                    `koanf:"log-disconnect"`
 	EnableCompression  bool                    `koanf:"enable-compression" reload:"hot"`  // if reloaded to false will cause disconnection of clients with enabled compression on next broadcast
@@ -95,7 +94,6 @@ func BroadcasterConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Int(prefix+".workers", DefaultBroadcasterConfig.Workers, "number of threads to reserve for HTTP to WS upgrade")
 	f.Int(prefix+".max-send-queue", DefaultBroadcasterConfig.MaxSendQueue, "maximum number of messages allowed to accumulate before client is disconnected")
 	f.Bool(prefix+".require-version", DefaultBroadcasterConfig.RequireVersion, "don't connect if client version not present")
-	f.Bool(prefix+".disable-signing", DefaultBroadcasterConfig.DisableSigning, "don't sign feed messages")
 	f.Bool(prefix+".log-connect", DefaultBroadcasterConfig.LogConnect, "log every client connect")
 	f.Bool(prefix+".log-disconnect", DefaultBroadcasterConfig.LogDisconnect, "log every client disconnect")
 	f.Bool(prefix+".enable-compression", DefaultBroadcasterConfig.EnableCompression, "enable per message deflate compression support")
@@ -121,7 +119,6 @@ var DefaultBroadcasterConfig = BroadcasterConfig{
 	Workers:            100,
 	MaxSendQueue:       4096,
 	RequireVersion:     false,
-	DisableSigning:     true,
 	LogConnect:         false,
 	LogDisconnect:      false,
 	EnableCompression:  false,
@@ -147,7 +144,6 @@ var DefaultTestBroadcasterConfig = BroadcasterConfig{
 	Workers:            100,
 	MaxSendQueue:       4096,
 	RequireVersion:     false,
-	DisableSigning:     false,
 	LogConnect:         false,
 	LogDisconnect:      false,
 	EnableCompression:  true,


### PR DESCRIPTION
Fixes NIT-3229

Means the same thing as `--node.feed.output.signed`, so just use that.
