### PR TITLE
feat: add static foundry profile for gas sensitive build

### DIFF
--- a/contracts-local/Makefile
+++ b/contracts-local/Makefile
@@ -9,7 +9,8 @@ build-forge: build-forge-sol build-forge-gas-dimensions build-forge-gas-dimensio
 
 build-forge-sol:
 	FOUNDRY_PROFILE=default forge build --skip *.yul && \
-	FOUNDRY_PROFILE=default forge build --evm-version paris src/mocks/Simple.sol
+	FOUNDRY_PROFILE=static forge build --evm-version paris src/mocks/Simple.sol && \
+	FOUNDRY_PROFILE=static forge build src/mocks/HostioTest.sol src/mocks/ArbOS11To32UpgradeTest.sol
 
 build-forge-gas-dimensions:
 	FOUNDRY_PROFILE=gas-dimensions forge build

--- a/contracts-local/Makefile
+++ b/contracts-local/Makefile
@@ -9,6 +9,7 @@ build-forge: build-forge-sol build-forge-gas-dimensions build-forge-gas-dimensio
 
 build-forge-sol:
 	FOUNDRY_PROFILE=default forge build --skip *.yul && \
+	FOUNDRY_PROFILE=static forge build --evm-version paris src/mocks/Simple.sol && \
 	FOUNDRY_PROFILE=static forge build src/mocks/HostioTest.sol src/mocks/ArbOS11To32UpgradeTest.sol
 
 build-forge-gas-dimensions:

--- a/contracts-local/Makefile
+++ b/contracts-local/Makefile
@@ -9,7 +9,7 @@ build-forge: build-forge-sol build-forge-gas-dimensions build-forge-gas-dimensio
 
 build-forge-sol:
 	FOUNDRY_PROFILE=default forge build --skip *.yul --skip src/mocks/HostioTest.sol --skip src/mocks/ArbOS11To32UpgradeTest.sol && \
-	FOUNDRY_PROFILE=newsolc forge build src/mocks/HostioTest.sol src/mocks/ArbOS11To32UpgradeTest.sol
+	FOUNDRY_PROFILE=solc824 forge build src/mocks/HostioTest.sol src/mocks/ArbOS11To32UpgradeTest.sol
 
 build-forge-gas-dimensions:
 	FOUNDRY_PROFILE=gas-dimensions forge build

--- a/contracts-local/Makefile
+++ b/contracts-local/Makefile
@@ -9,7 +9,6 @@ build-forge: build-forge-sol build-forge-gas-dimensions build-forge-gas-dimensio
 
 build-forge-sol:
 	FOUNDRY_PROFILE=default forge build --skip *.yul && \
-	FOUNDRY_PROFILE=static forge build --evm-version paris src/mocks/Simple.sol && \
 	FOUNDRY_PROFILE=static forge build src/mocks/HostioTest.sol src/mocks/ArbOS11To32UpgradeTest.sol
 
 build-forge-gas-dimensions:

--- a/contracts-local/Makefile
+++ b/contracts-local/Makefile
@@ -8,9 +8,8 @@ build: build-forge
 build-forge: build-forge-sol build-forge-gas-dimensions build-forge-gas-dimensions-yul
 
 build-forge-sol:
-	FOUNDRY_PROFILE=default forge build --skip *.yul && \
-	FOUNDRY_PROFILE=static forge build --evm-version paris --use 0.8.17 src/mocks/Simple.sol && \
-	FOUNDRY_PROFILE=static forge build src/mocks/HostioTest.sol src/mocks/ArbOS11To32UpgradeTest.sol
+	FOUNDRY_PROFILE=default forge build --skip *.yul --skip src/mocks/HostioTest.sol --skip src/mocks/ArbOS11To32UpgradeTest.sol && \
+	FOUNDRY_PROFILE=newsolc forge build src/mocks/HostioTest.sol src/mocks/ArbOS11To32UpgradeTest.sol
 
 build-forge-gas-dimensions:
 	FOUNDRY_PROFILE=gas-dimensions forge build

--- a/contracts-local/Makefile
+++ b/contracts-local/Makefile
@@ -9,7 +9,7 @@ build-forge: build-forge-sol build-forge-gas-dimensions build-forge-gas-dimensio
 
 build-forge-sol:
 	FOUNDRY_PROFILE=default forge build --skip *.yul && \
-	FOUNDRY_PROFILE=static forge build --evm-version paris src/mocks/Simple.sol && \
+	FOUNDRY_PROFILE=static forge build --evm-version paris --use 0.8.17 src/mocks/Simple.sol && \
 	FOUNDRY_PROFILE=static forge build src/mocks/HostioTest.sol src/mocks/ArbOS11To32UpgradeTest.sol
 
 build-forge-gas-dimensions:

--- a/contracts-local/foundry.toml
+++ b/contracts-local/foundry.toml
@@ -13,6 +13,22 @@ remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
               'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/']
 fs_permissions = [{ access = "read", path = "./"}]
 
+[profile.static]
+src = 'src'
+out = 'out/src'
+libs = ['node_modules', 'lib']
+test = 'test'
+cache_path = 'forge-cache/sol'
+optimizer = true
+optimizer_runs = 100
+via_ir = false
+evm_version = 'cancun'
+remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
+              'forge-std/=lib/forge-std/src/',
+              'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/']
+fs_permissions = [{ access = "read", path = "./"}]
+solc = '0.8.24'
+
 [profile.gas-dimensions]
 src = 'gas-dimensions/src'
 test = 'gas-dimensions/test'

--- a/contracts-local/foundry.toml
+++ b/contracts-local/foundry.toml
@@ -4,23 +4,22 @@ out = 'out/src'
 libs = ['node_modules', 'lib']
 test = 'test'
 cache_path = 'forge-cache/sol'
-optimizer = true
-optimizer_runs = 2000
 via_ir = false
 evm_version = 'cancun'
 remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
               'forge-std/=lib/forge-std/src/',
               'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/']
 fs_permissions = [{ access = "read", path = "./"}]
+solc = '0.8.17'
+optimizer = true
+optimizer_runs = 2000
 
-[profile.static]
+[profile.newsolc]
 src = 'src'
 out = 'out/src'
 libs = ['node_modules', 'lib']
 test = 'test'
 cache_path = 'forge-cache/sol'
-optimizer = true
-optimizer_runs = 100
 via_ir = false
 evm_version = 'cancun'
 remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
@@ -28,6 +27,8 @@ remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
               'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/']
 fs_permissions = [{ access = "read", path = "./"}]
 solc = '0.8.24'
+optimizer = true
+optimizer_runs = 100
 
 [profile.gas-dimensions]
 src = 'gas-dimensions/src'

--- a/contracts-local/foundry.toml
+++ b/contracts-local/foundry.toml
@@ -14,7 +14,7 @@ optimizer = true
 optimizer_runs = 2000
 evm_version = 'paris'
 
-[profile.newsolc]
+[profile.solc824]
 src = 'src'
 out = 'out/src'
 libs = ['node_modules', 'lib']

--- a/contracts-local/foundry.toml
+++ b/contracts-local/foundry.toml
@@ -5,7 +5,6 @@ libs = ['node_modules', 'lib']
 test = 'test'
 cache_path = 'forge-cache/sol'
 via_ir = false
-evm_version = 'cancun'
 remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
               'forge-std/=lib/forge-std/src/',
               'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/']
@@ -13,6 +12,7 @@ fs_permissions = [{ access = "read", path = "./"}]
 solc = '0.8.17'
 optimizer = true
 optimizer_runs = 2000
+evm_version = 'paris'
 
 [profile.newsolc]
 src = 'src'
@@ -21,7 +21,6 @@ libs = ['node_modules', 'lib']
 test = 'test'
 cache_path = 'forge-cache/sol'
 via_ir = false
-evm_version = 'cancun'
 remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
               'forge-std/=lib/forge-std/src/',
               'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/']
@@ -29,6 +28,7 @@ fs_permissions = [{ access = "read", path = "./"}]
 solc = '0.8.24'
 optimizer = true
 optimizer_runs = 100
+evm_version = 'cancun'
 
 [profile.gas-dimensions]
 src = 'gas-dimensions/src'

--- a/contracts-local/foundry.toml
+++ b/contracts-local/foundry.toml
@@ -4,15 +4,14 @@ out = 'out/src'
 libs = ['node_modules', 'lib']
 test = 'test'
 cache_path = 'forge-cache/sol'
+optimizer = true
+optimizer_runs = 2000
 via_ir = false
 evm_version = 'cancun'
 remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
               'forge-std/=lib/forge-std/src/',
               'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/']
 fs_permissions = [{ access = "read", path = "./"}]
-solc = '0.8.17'
-optimizer = true
-optimizer_runs = 2000
 
 [profile.static]
 src = 'src'
@@ -20,6 +19,8 @@ out = 'out/src'
 libs = ['node_modules', 'lib']
 test = 'test'
 cache_path = 'forge-cache/sol'
+optimizer = true
+optimizer_runs = 100
 via_ir = false
 evm_version = 'cancun'
 remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
@@ -27,8 +28,6 @@ remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
               'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/']
 fs_permissions = [{ access = "read", path = "./"}]
 solc = '0.8.24'
-optimizer = true
-optimizer_runs = 100
 
 [profile.gas-dimensions]
 src = 'gas-dimensions/src'

--- a/contracts-local/foundry.toml
+++ b/contracts-local/foundry.toml
@@ -4,14 +4,15 @@ out = 'out/src'
 libs = ['node_modules', 'lib']
 test = 'test'
 cache_path = 'forge-cache/sol'
-optimizer = true
-optimizer_runs = 2000
 via_ir = false
 evm_version = 'cancun'
 remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
               'forge-std/=lib/forge-std/src/',
               'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/']
 fs_permissions = [{ access = "read", path = "./"}]
+solc = '0.8.17'
+optimizer = true
+optimizer_runs = 2000
 
 [profile.static]
 src = 'src'
@@ -19,8 +20,6 @@ out = 'out/src'
 libs = ['node_modules', 'lib']
 test = 'test'
 cache_path = 'forge-cache/sol'
-optimizer = true
-optimizer_runs = 100
 via_ir = false
 evm_version = 'cancun'
 remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
@@ -28,6 +27,8 @@ remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
               'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/']
 fs_permissions = [{ access = "read", path = "./"}]
 solc = '0.8.24'
+optimizer = true
+optimizer_runs = 100
 
 [profile.gas-dimensions]
 src = 'gas-dimensions/src'

--- a/contracts-local/foundry.toml
+++ b/contracts-local/foundry.toml
@@ -46,6 +46,7 @@ remappings = ['ds-test/=lib/forge-std/lib/ds-test/src/',
 fs_permissions = [{ access = "read", path = "./"}]
 include_paths = ['gas-dimensions/src/', 'gas-dimensions/scripts']
 auto_detect_remappings = false
+solc = '0.8.30'
 
 [profile.gas-dimensions-yul]
 src = 'gas-dimensions/yul'


### PR DESCRIPTION
not sure if relevant, but might help some testes that expect precise gas usage to more closely replicate the previous behavior