### PR TITLE
Add a submodule pin check for the openzeppelin-contracts submodule

### DIFF
--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -36,6 +36,7 @@ jobs:
             [bold]=origin/main
             [arbitrator/langs/c]=origin/vm-storage-cache
             [arbitrator/tools/wasmer]=origin/stylus
+            [contracts-local/lib/openzeppelin-contracts]=origin/v4.7.3
           )
           divergent=0
           for mod in `git submodule --quiet foreach 'echo $name'`; do


### PR DESCRIPTION
This has to be merged on the `master` branch before the check can pass in a branch.