### PR TITLE
Limit parallel jobs within make to 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,10 +126,10 @@ jobs:
         run: ./scripts/build-brotli.sh -w -d
 
       - name: Build
-        run: make build test-go-deps -j
+        run: make build test-go-deps -j8
 
       - name: Build all lint dependencies
-        run: make -j build-node-deps
+        run: make -j8 build-node-deps
 
       - name: Lint
         uses: golangci/golangci-lint-action@v8


### PR DESCRIPTION
Currently, we very frequently see the build step in the CI workflow run into: `error: Resource temporarily unavailable (os error 11)`

This is typically because there are too many open file descriptors, and that's possible given that `-j` doesn't limit the number of jobs that make will try to run in parallel.

8 might still be too many, but let's try this value first, and then ramp down until we find a consistently healthy CI sweet spot.