### PR TITLE
Fix panic indirectly caused by uninitialized statelessBlockValidator when starting a node with staker as enabled

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -880,7 +880,7 @@ func getStatelessBlockValidator(
 		err = errors.New("no validator url specified")
 	}
 	if err != nil {
-		if config.ValidatorRequired() {
+		if config.Staker.Enable { // TODO: Replace this with original config.ValidatorRequired(), as staker shouldn't depend on statelessBlockValidator for things other than validation
 			return nil, fmt.Errorf("%w: failed to init block validator", err)
 		}
 		log.Warn("validation not supported", "err", err)
@@ -1396,7 +1396,7 @@ func (n *Node) Start(ctx context.Context) error {
 	if n.StatelessBlockValidator != nil {
 		err = n.StatelessBlockValidator.Start(ctx)
 		if err != nil {
-			if n.configFetcher.Get().ValidatorRequired() {
+			if n.configFetcher.Get().Staker.Enable { // TODO: Replace this with original n.configFetcher.Get().ValidatorRequired(), as staker shouldn't depend on statelessBlockValidator for things other than validation
 				return fmt.Errorf("error initializing stateless block validator: %w", err)
 			}
 			log.Info("validation not set up", "err", err)

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -880,7 +880,10 @@ func getStatelessBlockValidator(
 		err = errors.New("no validator url specified")
 	}
 	if err != nil {
-		if config.Staker.Enable { // TODO: Replace this with original config.ValidatorRequired(), as staker shouldn't depend on statelessBlockValidator for things other than validation
+		// TODO(NIT-3444): Staker shoudn't depend on statelessBlockValidator except for validation.
+		// Switch back to:
+		// if config.ValidatorRequired() {
+		if config.Staker.Enable {
 			return nil, fmt.Errorf("%w: failed to init block validator", err)
 		}
 		log.Warn("validation not supported", "err", err)
@@ -1396,7 +1399,10 @@ func (n *Node) Start(ctx context.Context) error {
 	if n.StatelessBlockValidator != nil {
 		err = n.StatelessBlockValidator.Start(ctx)
 		if err != nil {
-			if n.configFetcher.Get().Staker.Enable { // TODO: Replace this with original n.configFetcher.Get().ValidatorRequired(), as staker shouldn't depend on statelessBlockValidator for things other than validation
+			// TODO(NIT-3444): Staker shoudn't depend on statelessBlockValidator except for validation.
+			// Switch back to:
+			// if n.configFetcher.Get().ValidatorRequired() {
+			if n.configFetcher.Get().Staker.Enable {
 				return fmt.Errorf("error initializing stateless block validator: %w", err)
 			}
 			log.Info("validation not set up", "err", err)

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -532,7 +532,10 @@ func mainImpl() int {
 		return 1
 	}
 	var wasmModuleRoot common.Hash
-	if liveNodeConfig.Get().Node.ValidatorRequired() {
+	// TODO(NIT-3444): Staker shoudn't depend on statelessBlockValidator except for validation.
+	// Switch back to:
+	// if liveNodeConfig.Get().Node.ValidatorRequired() {
+	if liveNodeConfig.Get().Node.Staker.Enable {
 		locator, err := server_common.NewMachineLocator(liveNodeConfig.Get().Validation.Wasm.RootPath)
 		if err != nil {
 			log.Error("failed to create machine locator: %w", err)


### PR DESCRIPTION
This PR makes it that errors in initializing/starting `statelessBlockValidator` are no longer ignored when `--node.staker.enable` is set, as staker currently uses `statelessBlockValidator` extensively for other purposes.