### PR TITLE
Fix Broken and Outdated Links in Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines
 
-Note: The latest and most up-to-date documentation can be found on our [docs portal](https://docs.arbitrum.io/welcome/arbitrum-gentle-introduction).
+Note: The latest and most up-to-date documentation can be found on our [docs portal](https://docs.arbitrum.io/launch-arbitrum-chain/a-gentle-introduction).
 
 Excited by our work want to get more involved in making Arbitrum more successful? Or maybe you want to learn more about Layer 2 technologies and want to contribute as a first step?
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -3,7 +3,7 @@
 For new Architectural Decision Records (ADRs), please use one of the following templates as a starting point:
 
 * [adr-template.md](adr-template.md) has all sections, with explanations about them.
-* [adr-template-minmal.md](adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
+* [adr-template-minimal.md](adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
 * [adr-template-bare.md](adr-template-bare.md) has all sections, wich are empty (no explanations).
 * [adr-template-bare-minimal.md](adr-template-bare-minimal.md) has the mandatory sections, without explanations. <!-- ### Consequences also contained, though marked as "optional" -->
 


### PR DESCRIPTION


**Description:**  
This pull request updates outdated and broken links in the documentation:
- Replaces obsolete Arbitrum documentation URLs with current ones.
- Fixes a typo in the template link in `docs/decisions/README.md`.
- Ensures all referenced resources are accessible and up-to-date.

