### PR TITLE
Add the missing prefix in dasserver config

### DIFF
--- a/daprovider/das/dasserver/dasserver.go
+++ b/daprovider/das/dasserver/dasserver.go
@@ -59,7 +59,7 @@ func ServerConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Uint64(prefix+".port", DefaultServerConfig.Port, "JSON rpc server listening port")
 	f.String(prefix+".jwtsecret", DefaultServerConfig.JWTSecret, "path to file with jwtsecret for validation")
 	f.Bool(prefix+".enable-da-writer", DefaultServerConfig.EnableDAWriter, "implies if the das server supports daprovider's writer interface")
-	f.Int(prefix+"rpc-server-body-limit", DefaultServerConfig.RPCServerBodyLimit, "HTTP-RPC server maximum request body size in bytes; the default (0) uses geth's 5MB limit")
+	f.Int(prefix+".rpc-server-body-limit", DefaultServerConfig.RPCServerBodyLimit, "HTTP-RPC server maximum request body size in bytes; the default (0) uses geth's 5MB limit")
 	das.DataAvailabilityConfigAddNodeOptions(prefix+".data-availability", f)
 	genericconf.HTTPServerTimeoutConfigAddOptions(prefix+".server-timeouts", f)
 }

--- a/daprovider/das/dasserver/dasserver.go
+++ b/daprovider/das/dasserver/dasserver.go
@@ -59,7 +59,7 @@ func ServerConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Uint64(prefix+".port", DefaultServerConfig.Port, "JSON rpc server listening port")
 	f.String(prefix+".jwtsecret", DefaultServerConfig.JWTSecret, "path to file with jwtsecret for validation")
 	f.Bool(prefix+".enable-da-writer", DefaultServerConfig.EnableDAWriter, "implies if the das server supports daprovider's writer interface")
-	f.Int("rpc-server-body-limit", DefaultServerConfig.RPCServerBodyLimit, "HTTP-RPC server maximum request body size in bytes; the default (0) uses geth's 5MB limit")
+	f.Int(prefix+"rpc-server-body-limit", DefaultServerConfig.RPCServerBodyLimit, "HTTP-RPC server maximum request body size in bytes; the default (0) uses geth's 5MB limit")
 	das.DataAvailabilityConfigAddNodeOptions(prefix+".data-availability", f)
 	genericconf.HTTPServerTimeoutConfigAddOptions(prefix+".server-timeouts", f)
 }


### PR DESCRIPTION
Fixes: NIT-3438
Add the missing prefix in dasserver config
