### PR TITLE
Remove parallel test from TestPruning

### DIFF
--- a/system_tests/pruning_test.go
+++ b/system_tests/pruning_test.go
@@ -41,7 +41,6 @@ func TestPruning(t *testing.T) {
 }
 
 func testPruning(t *testing.T, mode string, pruneParallelStorageTraversal bool) {
-	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
This is causing PathDB test to fail, cause of some overlap between the test in parallel more, so removing t.parallel for TestPruning