### PR TITLE
Disable HTTP/2 for das aggregator by default

### DIFF
--- a/cmd/datool/datool.go
+++ b/cmd/datool/datool.go
@@ -93,6 +93,7 @@ type ClientStoreConfig struct {
 	SigningWalletPassword string        `koanf:"signing-wallet-password"`
 	MaxStoreChunkBodySize int           `koanf:"max-store-chunk-body-size"`
 	EnableChunkedStore    bool          `koanf:"enable-chunked-store"`
+	EnableHTTP2           bool          `koanf:"enable-http2"`
 }
 
 func parseClientStoreConfig(args []string) (*ClientStoreConfig, error) {
@@ -106,6 +107,7 @@ func parseClientStoreConfig(args []string) (*ClientStoreConfig, error) {
 	f.Duration("das-retention-period", 24*time.Hour, "The period which DASes are requested to retain the stored batches.")
 	f.Int("max-store-chunk-body-size", 512*1024, "The maximum HTTP POST body size for a chunked store request")
 	f.Bool("enable-chunked-store", true, "enable data to be sent to DAS in chunks instead of all at once")
+	f.Bool("enable-http2", true, "enable HTTP/2 for DAS connections")
 
 	k, err := confighelpers.BeginCommonParse(f, args)
 	if err != nil {
@@ -154,7 +156,7 @@ func startClientStore(args []string) error {
 		}
 	}
 
-	client, err := das.NewDASRPCClient(config.URL, signer, config.MaxStoreChunkBodySize, config.EnableChunkedStore)
+	client, err := das.NewDASRPCClient(config.URL, signer, config.MaxStoreChunkBodySize, config.EnableChunkedStore, config.EnableHTTP2)
 	if err != nil {
 		return err
 	}

--- a/daprovider/das/aggregator.go
+++ b/daprovider/das/aggregator.go
@@ -42,6 +42,7 @@ type AggregatorConfig struct {
 	Backends              BackendConfigList `koanf:"backends"`
 	MaxStoreChunkBodySize int               `koanf:"max-store-chunk-body-size"`
 	EnableChunkedStore    bool              `koanf:"enable-chunked-store"`
+	EnableHTTP2           bool              `koanf:"enable-http2"`
 }
 
 var DefaultAggregatorConfig = AggregatorConfig{
@@ -49,6 +50,7 @@ var DefaultAggregatorConfig = AggregatorConfig{
 	Backends:              nil,
 	MaxStoreChunkBodySize: 512 * 1024,
 	EnableChunkedStore:    true,
+	EnableHTTP2:           false,
 }
 
 var parsedBackendsConf BackendConfigList
@@ -59,6 +61,7 @@ func AggregatorConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Var(&parsedBackendsConf, prefix+".backends", "JSON RPC backend configuration. This can be specified on the command line as a JSON array, eg: [{\"url\": \"...\", \"pubkey\": \"...\"},...], or as a JSON array in the config file.")
 	f.Int(prefix+".max-store-chunk-body-size", DefaultAggregatorConfig.MaxStoreChunkBodySize, "maximum HTTP POST body size to use for individual batch chunks, including JSON RPC overhead and an estimated overhead of 512B of headers")
 	f.Bool(prefix+".enable-chunked-store", DefaultAggregatorConfig.EnableChunkedStore, "enable data to be sent to DAS in chunks instead of all at once")
+	f.Bool(prefix+".enable-http2", DefaultAggregatorConfig.EnableHTTP2, "enable HTTP/2 for backend connections (default is HTTP/1.1)")
 }
 
 type Aggregator struct {

--- a/daprovider/das/dasRpcClient.go
+++ b/daprovider/das/dasRpcClient.go
@@ -6,6 +6,7 @@ package das
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -48,8 +49,20 @@ func nilSigner(_ []byte) ([]byte, error) {
 
 const sendChunkJSONBoilerplate = "{\"jsonrpc\":\"2.0\",\"id\":4294967295,\"method\":\"das_sendChunked\",\"params\":[\"\"]}"
 
-func NewDASRPCClient(target string, signer signature.DataSignerFunc, maxStoreChunkBodySize int, enableChunkedStore bool) (*DASRPCClient, error) {
-	clnt, err := rpc.Dial(target)
+func NewDASRPCClient(target string, signer signature.DataSignerFunc, maxStoreChunkBodySize int, enableChunkedStore bool, enableHTTP2 bool) (*DASRPCClient, error) {
+	// Always create a custom transport based on the default
+	httpTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		panic("Failed conversion from DefaultTransport to http.Transport")
+	}
+	transport := httpTransport.Clone()
+	transport.ForceAttemptHTTP2 = enableHTTP2
+
+	httpClient := &http.Client{
+		Transport: transport,
+	}
+
+	clnt, err := rpc.DialOptions(context.Background(), target, rpc.WithHTTPClient(httpClient))
 	if err != nil {
 		return nil, err
 	}

--- a/daprovider/das/rpc_aggregator.go
+++ b/daprovider/das/rpc_aggregator.go
@@ -110,7 +110,7 @@ func ParseServices(config AggregatorConfig, signer signature.DataSignerFunc) ([]
 		}
 		metricName := metricsutil.CanonicalizeMetricName(url.Hostname())
 
-		service, err := NewDASRPCClient(b.URL, signer, config.MaxStoreChunkBodySize, config.EnableChunkedStore)
+		service, err := NewDASRPCClient(b.URL, signer, config.MaxStoreChunkBodySize, config.EnableChunkedStore, config.EnableHTTP2)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We have seen issues involving early termination of DAS store operations which could be explained by bugs in the Go HTTP/2 implementation, so we are disabling it by default and adding a flag to turn it back on.

NIT-3431