### PR TITLE
Add system test to verify mel message extraction from blobs

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -712,6 +712,7 @@ func getMessageExtractor(
 	deployInfo *chaininfo.RollupAddresses,
 	arbDb ethdb.Database,
 	txStreamer *TransactionStreamer,
+	dapReaders []daprovider.Reader,
 ) (*mel.MessageExtractor, error) {
 	if !config.MessageExtraction.Enable {
 		return nil, nil
@@ -730,7 +731,7 @@ func getMessageExtractor(
 		melDB, // MEL db can also act as the initial state fetcher.
 		melDB,
 		txStreamer,
-		nil, // TODO: Pass in da readers.
+		dapReaders,
 		initialState.ParentChainBlockHash,
 		config.MessageExtraction.RetryInterval,
 	)
@@ -1188,7 +1189,7 @@ func createNodeImpl(
 		return nil, err
 	}
 
-	messageExtractor, err := getMessageExtractor(ctx, config, l1client, deployInfo, arbDb, txStreamer)
+	messageExtractor, err := getMessageExtractor(ctx, config, l1client, deployInfo, arbDb, txStreamer, dapReaders)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR pulls in the geth PR - https://github.com/OffchainLabs/go-ethereum/pull/474 that adds methods from `BlobReader` interface to simulated beacon, and we use this to verify that MEL is able to extract from batches posted as blobs.

Resolves NIT-3328