### PR TITLE
Use an Empty DataDir for L1 in System Tests to Force In-Memory DB Usage

### DIFF
--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -1411,7 +1411,7 @@ func createTestL1BlockChain(t *testing.T, l1info info, withClientWrapper bool) (
 	if l1info == nil {
 		l1info = NewL1TestInfo(t)
 	}
-	stackConfig := testhelpers.CreateStackConfigForTest(t.TempDir())
+	stackConfig := testhelpers.CreateStackConfigForTest("")
 	l1info.GenerateAccount("Faucet")
 
 	chainConfig := chaininfo.ArbitrumDevTestChainConfig()


### PR DESCRIPTION
By using an empty datadir, geth should be using an in-memory database for the L1 which should have performance benefits for our system tests. This is an experiment in CI speeds