### PR TITLE
Gas Dimension Trace Tests: Nested Call Tests

### DIFF
--- a/contracts-local/gas-dimensions/scripts/NestedCall.s.sol
+++ b/contracts-local/gas-dimensions/scripts/NestedCall.s.sol
@@ -1,0 +1,24 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.13;
+
+import {Script, VmSafe, console} from "forge-std/Script.sol";
+import {NestedCall, NestedTarget} from "../src/NestedCall.sol";
+
+contract NestedCallTestScript is Script {
+    function setUp() public {}
+
+    function run() public {
+        vm.startBroadcast(address(0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E));
+
+        NestedCall nestedCall = new NestedCall();
+        NestedTarget nestedTarget = new NestedTarget();
+
+        nestedCall.executeNestedCall(address(nestedTarget));
+
+        vm.stopBroadcast();
+    }
+}

--- a/contracts-local/gas-dimensions/src/NestedCall.sol
+++ b/contracts-local/gas-dimensions/src/NestedCall.sol
@@ -1,0 +1,38 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.13;
+
+contract NestedCall {
+    uint256 public mainValue;
+    uint256 public nestedValue;
+    uint256 public callCount;
+
+    // Entrypoint function
+    function entrypoint(address target) public {
+        mainValue = 0x0FFC13A1171AB5;
+        callCount++;
+        this.intermediateCall(target);
+    }
+
+    // Intermediate function that does a DELEGATECALL inside it
+    function intermediateCall(address target) public {
+        mainValue = 0x0A4B1CAFE;
+        (bool success,) = target.delegatecall(
+            abi.encodeWithSelector(NestedTarget.performNestedAction.selector)
+        );
+        require(success, "Delegatecall failed");
+    }
+}
+
+contract NestedTarget {
+    function performNestedAction() public {
+        // Need to access the storage slot directly 
+        // since we're in delegate called contract context
+        assembly {
+            sstore(0x1, 0xA4B1) // slot 1 for nestedValue
+        }
+    }
+}

--- a/system_tests/gas_dim_log_a_common_test.go
+++ b/system_tests/gas_dim_log_a_common_test.go
@@ -170,6 +170,9 @@ func callDebugTraceTransactionWithLogger(
 	var result json.RawMessage
 	err := rpcClient.CallContext(ctx, &result, "debug_traceTransaction", txHash, map[string]interface{}{
 		"tracer": "txGasDimensionLogger",
+		"tracerConfig": map[string]interface{}{
+			"debug": true,
+		},
 	})
 	Require(t, err)
 

--- a/system_tests/gas_dim_tx_op_a_common_test.go
+++ b/system_tests/gas_dim_tx_op_a_common_test.go
@@ -44,6 +44,8 @@ func TestDimTxOpComputationOnlyOpcodes(t *testing.T) {
 // #########################################################################################################
 // #########################################################################################################
 
+// helper function that automates calling debug_traceTransaction with the txGasDimensionByOpcode tracer
+// and does some minimal validation of the result
 func callDebugTraceTransactionWithTxGasDimensionByOpcodeTracer(
 	t *testing.T,
 	ctx context.Context,
@@ -56,6 +58,9 @@ func callDebugTraceTransactionWithTxGasDimensionByOpcodeTracer(
 	var result json.RawMessage
 	err := rpcClient.CallContext(ctx, &result, "debug_traceTransaction", txHash, map[string]interface{}{
 		"tracer": "txGasDimensionByOpcode",
+		"tracerConfig": map[string]interface{}{
+			"debug": true,
+		},
 	})
 	Require(t, err)
 

--- a/system_tests/gas_dim_tx_op_call_test.go
+++ b/system_tests/gas_dim_tx_op_call_test.go
@@ -938,3 +938,19 @@ func TestDimTxOpCallCodeWarmPayingContractFundedMemExpansion(t *testing.T) {
 
 	TxOpTraceAndCheck(t, ctx, builder, receipt)
 }
+
+// This tests a call that does another call,
+// specifically a CALL that then does a DELEGATECALL
+func TestDimTxOpCallNestedCall(t *testing.T) {
+	t.Parallel()
+	ctx, cancel, builder, auth, cleanup := gasDimensionTestSetup(t, false)
+	defer cancel()
+	defer cleanup()
+
+	_, caller := deployGasDimensionTestContract(t, builder, auth, gas_dimensionsgen.DeployNestedCall)
+	calleeAddress, _ := deployGasDimensionTestContract(t, builder, auth, gas_dimensionsgen.DeployNestedTarget)
+
+	receipt := callOnContractWithOneArg(t, builder, auth, caller.Entrypoint, calleeAddress)
+
+	TxOpTraceAndCheck(t, ctx, builder, receipt)
+}

--- a/system_tests/gas_dim_tx_op_call_test.go
+++ b/system_tests/gas_dim_tx_op_call_test.go
@@ -942,7 +942,6 @@ func TestDimTxOpCallCodeWarmPayingContractFundedMemExpansion(t *testing.T) {
 // This tests a call that does another call,
 // specifically a CALL that then does a DELEGATECALL
 func TestDimTxOpCallNestedCall(t *testing.T) {
-	t.Parallel()
 	ctx, cancel, builder, auth, cleanup := gasDimensionTestSetup(t, false)
 	defer cancel()
 	defer cleanup()


### PR DESCRIPTION
This PR tests an additional type of test case missed in #3233 where a call makes another call to another contract. 

All of the other calls only checked correct gas dimensions for a call stack of depth one.


Depends on the work in https://github.com/OffchainLabs/go-ethereum/pull/476 which fixes 2 pretty big bugs in the gas dimension tracer that were causing a large number of errors while live tracing transactions