### PR TITLE
Disable logging in maxprocs

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -63,6 +63,7 @@ import (
 	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
 	legacystaker "github.com/offchainlabs/nitro/staker/legacy"
 	"github.com/offchainlabs/nitro/staker/validatorwallet"
+	nitroutil "github.com/offchainlabs/nitro/util"
 	"github.com/offchainlabs/nitro/util/colors"
 	"github.com/offchainlabs/nitro/util/dbutil"
 	"github.com/offchainlabs/nitro/util/headerreader"
@@ -199,6 +200,7 @@ func mainImpl() int {
 	}
 
 	log.Info("Running Arbitrum nitro node", "revision", vcsRevision, "vcs.time", vcsTime)
+	log.Info("Resources detected", "GOMAXPROCS", nitroutil.GoMaxProcs())
 
 	if nodeConfig.Node.Dangerous.NoL1Listener {
 		nodeConfig.Node.ParentChainReader.Enable = false

--- a/util/runtime.go
+++ b/util/runtime.go
@@ -3,11 +3,16 @@ package util
 import (
 	"runtime"
 
-	_ "go.uber.org/automaxprocs"
+	"go.uber.org/automaxprocs/maxprocs"
 )
 
-// Automaxprocs automatically set GOMAXPROCS to match Linux container CPU quota.
-// So we are wrapping it here to make sure we do not call it anywhere else without importing automaxprocs.
+func init() {
+	// Disable maxprocs logs
+	_, _ = maxprocs.Set(maxprocs.Logger(func(_ string, _ ...any) {}))
+}
+
+// GoMaxProcs wraps runtime.GOMAXPROCS here to ensure that maxprocs.Set()
+// is always called first.
 func GoMaxProcs() int {
 	return runtime.GOMAXPROCS(-1)
 }


### PR DESCRIPTION
`automaxprocs` prints messages to stdout before node is initialized, causing various issues.
