### PR TITLE
Use gotestsum.sh in Makefile

### DIFF
--- a/.github/workflows/gotestsum.sh
+++ b/.github/workflows/gotestsum.sh
@@ -11,6 +11,7 @@ timeout=""
 tags=""
 run=""
 test_state_scheme=""
+log=true
 race=false
 cover=false
 while [[ $# -gt 0 ]]; do
@@ -47,6 +48,10 @@ while [[ $# -gt 0 ]]; do
       cover=true
       shift
       ;;
+		--nolog)
+			log=false
+			shift
+			;;
     *)
       echo "Invalid argument: $1"
       exit 1
@@ -83,7 +88,11 @@ for package in $packages; do
       cmd="$cmd -args -- --test_loglevel=8" # Use error log level, which is the value 8 in the slog level enum for tests.
   fi
 
-  cmd="$cmd > >(stdbuf -oL tee -a full.log | grep -vE \"INFO|seal\")"
+	if [ "$log" == true ]; then
+			cmd="$cmd > >(stdbuf -oL tee -a full.log | grep -vE \"INFO|seal\")"
+	else
+			cmd="$cmd | grep -vE \"INFO|seal\""
+	fi
 
   echo ""
   echo running tests for "$package"

--- a/Makefile
+++ b/Makefile
@@ -230,22 +230,22 @@ test-go: .make/test-go
 
 .PHONY: test-go-challenge
 test-go-challenge: test-go-deps
-	gotestsum --format short-verbose --no-color=false -- -timeout 120m ./system_tests/... -run TestChallenge -tags challengetest
+	.github/workflows/gotestsum.sh --timeout 120m --run TestChallenge --tags challengetest --nolog
 	@printf $(done)
 
 .PHONY: test-go-stylus
 test-go-stylus: test-go-deps
-	gotestsum --format short-verbose --no-color=false -- -timeout 120m ./system_tests/... -run TestProgramArbitrator -tags stylustest
+	.github/workflows/gotestsum.sh --timeout 120m --run TestProgramArbitrator --tags stylustest --nolog
 	@printf $(done)
 
 .PHONY: test-go-redis
 test-go-redis: test-go-deps
-	gotestsum --format short-verbose --no-color=false -- -p 1 -run TestRedis ./system_tests/... ./arbnode/... -- --test_redis=redis://localhost:6379/0
+	.github/workflows/gotestsum.sh --timeout 120m --run TestRedis --nolog -- --test_redis=redis://localhost:6379/0
 	@printf $(done)
 
 .PHONY: test-go-gas-dimensions
 test-go-gas-dimensions: test-go-deps
-	gotestsum --format short-verbose --no-color=false -- -timeout 120m ./system_tests/... -run "TestDim(Log|TxOp)" -tags gasdimensionstest
+	.github/workflows/gotestsum.sh --timeout 120m --run "TestDim(Log|TxOp)" --tags gasdimensionstest --nolog
 	@printf $(done)
 
 .PHONY: test-gen-proofs
@@ -589,7 +589,7 @@ contracts/test/prover/proofs/%.json: $(arbitrator_cases)/%.wasm $(prover_bin)
 	@touch $@
 
 .make/test-go: $(DEP_PREDICATE) $(go_source) build-node-deps test-go-deps $(ORDER_ONLY_PREDICATE) .make
-	gotestsum --format short-verbose --no-color=false
+	.github/workflows/gotestsum.sh --timeout 120m --nolog
 	@touch $@
 
 .make/test-rust: $(DEP_PREDICATE) wasm-ci-build $(ORDER_ONLY_PREDICATE) .make


### PR DESCRIPTION
This is primarily to make CI closer to what users do locally to validate their changes.

But, it also gives us a friendly way to extend the timeout when building locally, and a way to not create log files when building locally.