### PR TITLE
Fix for changed-files action

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -203,6 +203,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 10           // Will cover most PRs
+          persist-credentials: true // In case changed-files requires deeper depth
           
       - name: Check changed files
         id: changed-files


### PR DESCRIPTION
The changed-files action won't work if it doesn't have access to enough commits, so increase default fetch depth and preserve credentials in case more depth is necessary
