### PR TITLE
Update actions/setup-go from v4 to v5

### DIFF
--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -48,7 +48,7 @@ jobs:
           sudo ln -s /usr/bin/wasm-ld-14 /usr/local/bin/wasm-ld
 
       - name: Install go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.23.x
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,7 +61,7 @@ jobs:
         cache-dependency-path: '**/yarn.lock'
 
     - name: Install go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.23.x
 


### PR DESCRIPTION
.github/workflows/arbitrator-ci.yml:
Changed actions/setup-go@v4 → actions/setup-go@v5
.github/workflows/codeql-analysis.yml:
Changed actions/setup-go@v4 → actions/setup-go@v5

https://github.com/actions/setup-go/releases/tag/v5.5.0
