### PR TITLE
Add a type for modeling a Resource Constraint 

### DIFF
--- a/arbos/constraints/constraints.go
+++ b/arbos/constraints/constraints.go
@@ -1,0 +1,57 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+// The constraints package tracks the multi-dimensional gas usage to apply constraint-based pricing.
+package constraints
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/arbitrum/multigas"
+)
+
+// The period duration for a resource constraint.
+type PeriodSecs uint32
+
+// resourceConstraint defines the max gas target per second for the given period for a single resource.
+type resourceConstraint struct {
+	period time.Duration
+	target uint64
+}
+
+// ResourceConstraints is a set of constraints for all resources.
+//
+// The chain owner defines constraints to limit the usage of each resource. A resource can have
+// multiple constraints with different periods, but there may be a single constraint given the
+// resource and period.
+//
+// Example constraints:
+// - X amount of computation over 12 seconds so nodes can keep up.
+// - Y amount of computation over 7 days so fresh nodes can catch up with the chain.
+// - Z amount of history growth over one month to avoid bloat.
+type ResourceConstraints map[multigas.ResourceKind]map[PeriodSecs]resourceConstraint
+
+// NewResourceConstraints creates a new set of constraints.
+// This type can be used as a reference.
+func NewResourceConstraints() ResourceConstraints {
+	c := ResourceConstraints{}
+	for resource := multigas.ResourceKindUnknown + 1; resource < multigas.NumResourceKind; resource++ {
+		c[resource] = map[PeriodSecs]resourceConstraint{}
+	}
+	return c
+}
+
+// SetConstraint adds or updates the given resource constraint.
+func (rc ResourceConstraints) SetConstraint(
+	resource multigas.ResourceKind, periodSecs PeriodSecs, targetPerPeriod uint64,
+) {
+	rc[resource][periodSecs] = resourceConstraint{
+		period: time.Duration(periodSecs) * time.Second,
+		target: targetPerPeriod / uint64(periodSecs),
+	}
+}
+
+// ClearConstraint removes the given resource constraint.
+func (rc ResourceConstraints) ClearConstraint(resource multigas.ResourceKind, periodSecs PeriodSecs) {
+	delete(rc[resource], periodSecs)
+}

--- a/arbos/constraints/constraints_test.go
+++ b/arbos/constraints/constraints_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package constraints
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/arbitrum/multigas"
+)
+
+func TestResourceConstraints(t *testing.T) {
+	rc := NewResourceConstraints()
+
+	const (
+		minuteSecs = 60
+		daySecs    = 24 * 60 * 60
+		weekSecs   = 7 * daySecs
+		monthSecs  = 30 * daySecs
+	)
+
+	// Adds a few constraints
+	rc.SetConstraint(multigas.ResourceKindComputation, minuteSecs, 5_000_000*minuteSecs)
+	rc.SetConstraint(multigas.ResourceKindComputation, weekSecs, 3_000_000*weekSecs)
+	rc.SetConstraint(multigas.ResourceKindHistoryGrowth, monthSecs, 1_000_000*monthSecs)
+	if got, want := len(rc[multigas.ResourceKindComputation]), 2; got != want {
+		t.Fatalf("unexpected number of computation constraints: got %v, want %v", got, want)
+	}
+	if got, want := rc[multigas.ResourceKindComputation][minuteSecs].period, time.Duration(minuteSecs)*time.Second; got != want {
+		t.Errorf("unexpected constraint period: got %v, want %v", got, want)
+	}
+	if got, want := rc[multigas.ResourceKindComputation][minuteSecs].target, uint64(5_000_000); got != want {
+		t.Errorf("unexpected constraint target: got %v, want %v", got, want)
+	}
+	if got, want := rc[multigas.ResourceKindComputation][weekSecs].period, time.Duration(weekSecs)*time.Second; got != want {
+		t.Errorf("unexpected constraint period: got %v, want %v", got, want)
+	}
+	if got, want := rc[multigas.ResourceKindComputation][weekSecs].target, uint64(3_000_000); got != want {
+		t.Errorf("unexpected constraint target: got %v, want %v", got, want)
+	}
+	if got, want := len(rc[multigas.ResourceKindHistoryGrowth]), 1; got != want {
+		t.Fatalf("unexpected number of history growth constraints: got %v, want %v", got, want)
+	}
+	if got, want := rc[multigas.ResourceKindHistoryGrowth][monthSecs].period, time.Duration(monthSecs)*time.Second; got != want {
+		t.Errorf("unexpected constraint period: got %v, want %v", got, want)
+	}
+	if got, want := rc[multigas.ResourceKindHistoryGrowth][monthSecs].target, uint64(1_000_000); got != want {
+		t.Errorf("unexpected constraint target: got %v, want %v", got, want)
+	}
+	if got, want := len(rc[multigas.ResourceKindStorageAccess]), 0; got != want {
+		t.Errorf("unexpected number of storage access constraints: got %v, want %v", got, want)
+	}
+	if got, want := len(rc[multigas.ResourceKindStorageGrowth]), 0; got != want {
+		t.Errorf("unexpected number of storage growth constraints: got %v, want %v", got, want)
+	}
+
+	// Updates a constraint
+	rc.SetConstraint(multigas.ResourceKindHistoryGrowth, monthSecs, 500_000*monthSecs)
+	if got, want := len(rc[multigas.ResourceKindHistoryGrowth]), 1; got != want {
+		t.Fatalf("unexpected number of history growth constraints: got %v, want %v", got, want)
+	}
+	if got, want := rc[multigas.ResourceKindHistoryGrowth][monthSecs].target, uint64(500_000); got != want {
+		t.Errorf("unexpected constraint target: got %v, want %v", got, want)
+	}
+
+	// Clear constraints
+	rc.ClearConstraint(multigas.ResourceKindComputation, minuteSecs)
+	rc.ClearConstraint(multigas.ResourceKindComputation, weekSecs)
+	rc.ClearConstraint(multigas.ResourceKindHistoryGrowth, monthSecs)
+	if got, want := len(rc[multigas.ResourceKindComputation]), 0; got != want {
+		t.Errorf("unexpected number of computation constraints: got %v, want %v", got, want)
+	}
+	if got, want := len(rc[multigas.ResourceKindHistoryGrowth]), 0; got != want {
+		t.Errorf("unexpected number of history growth constraints: got %v, want %v", got, want)
+	}
+	if got, want := len(rc[multigas.ResourceKindStorageAccess]), 0; got != want {
+		t.Errorf("unexpected number of storage access constraints: got %v, want %v", got, want)
+	}
+	if got, want := len(rc[multigas.ResourceKindStorageGrowth]), 0; got != want {
+		t.Errorf("unexpected number of storage growth constraints: got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
The ResourceConstraints struct tracks the constraints used in constraint-based pricing.

Depends on https://github.com/OffchainLabs/go-ethereum/pull/482
Close [NIT-3487](https://linear.app/offchain-labs/issue/NIT-3487)