### PR TITLE
Remove two unreachable constatnts

### DIFF
--- a/arbos/l2pricing/model.go
+++ b/arbos/l2pricing/model.go
@@ -17,8 +17,6 @@ const InitialSpeedLimitPerSecondV6 = 7000000
 const InitialPerBlockGasLimitV6 uint64 = 32 * 1000000
 const InitialMinimumBaseFeeWei = params.GWei / 10
 const InitialBaseFeeWei = InitialMinimumBaseFeeWei
-const InitialGasPoolSeconds = 10 * 60
-const InitialRateEstimateInertia = 60
 const InitialPricingInertia = 102
 const InitialBacklogTolerance = 10
 


### PR DESCRIPTION
Having them in the file actively makes it harder to unerstand what information is actually used in the calculation of the L2 base price.