### PR TITLE
chore(ci): bump codecov/codecov-action from v2 to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
           path: full.log
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         if: matrix.test-mode == 'defaults'
         with:
           fail_ci_if_error: false

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -181,7 +181,7 @@ jobs:
           path: full.log
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
           files: ./coverage.txt,./coverage-redis.txt
@@ -369,7 +369,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
           files: ./coverage.txt,./coverage-redis.txt


### PR DESCRIPTION
Updated Codecov GitHub Action from v2 to v5 to adopt the latest pre-release version.
v5 includes Codecov CLI integration and major internal changes.
  
  https://github.com/codecov/codecov-action/releases/tag/v5.4.3