### PR TITLE
Add a close-trivial-prs workflow

### DIFF
--- a/.github/workflows/close-trival-prs.yml
+++ b/.github/workflows/close-trival-prs.yml
@@ -1,0 +1,47 @@
+name: Close trivial PRs
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  close-trivial-pr:
+    if: github.event.label.name == 'trivial'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Fetch CONTRIBUTING.md snippet
+        id: snippet
+        env:
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
+        run: |
+          SNIPPET=$(curl -sSfL "https://raw.githubusercontent.com/${REPO}/${REF}/CONTRIBUTING.md" \
+            | sed -n '/<!-- start-trivial-prs -->/,/<!-- end-trivial-prs -->/p' \
+            | sed '/<!--.*-->/d')
+
+          # Use GitHub Actions heredoc-style output to preserve multiline content
+          echo "snippet<<EOF" >> $GITHUB_OUTPUT
+          echo "$SNIPPET" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Comment and Close PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+          DEF_BRANCH=${{ github.event.repository.default_branch }}
+          SNIPPET="${{ steps.snippet.outputs.snippet }}"
+
+          gh pr close $PR_NUMBER --repo $REPO --comment "Thank you for your contribution. However, this PR has been automatically closed because it was labeled as **trivial**. As stated in our [CONTRIBUTING.md](../blob/${DEF_BRANCH}/CONTRIBUTING.md):
+
+          ---
+
+          ${SNIPPET}
+
+          ---
+
+          We appreciate meaningful contributions!"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,10 @@ Excited by our work want to get more involved in making Arbitrum more successful
 
 You can explore our [Open Issues](https://github.com/offchainlabs/nitro/issues) or [run a Nitro node](https://docs.arbitrum.io/run-arbitrum-node/run-nitro-dev-node) yourself and suggest improvements. 
 
+<!-- start-trivial-prs -->
 > [!IMPORTANT] 
 > Please, **do not send pull requests for trivial changes**, such as typos, these will be rejected. These types of pull requests incur a cost to reviewers and do not provide much value to the project. If you are unsure, please open an issue first to discuss the change.
+<!-- end-trivial-prs -->
 
 ## Contribution Steps
 


### PR DESCRIPTION
This allows us to polietly, but automatically close PRs with a nice comment on closing that we trigger automatically just by adding a label.

P.S. This is something I automated because I found myself about to do it for the 3rd time in a week.