### PR TITLE
Address 3 minor issues in the close-trivial-prs workflow

### DIFF
--- a/.github/workflows/close-trivial-prs.yml
+++ b/.github/workflows/close-trivial-prs.yml
@@ -19,7 +19,7 @@ jobs:
           REPO: ${{ github.repository }}
           REF: ${{ github.sha }}
         run: |
-          SNIPPET=$(curl -sSfL "https://raw.githubusercontent.com/${REPO}/${REF}/CONTRIBUTING.md" \
+          SNIPPET=$(curl -sSfL "https://raw.githubusercontent.com/${REPO}/refs/heads/master/CONTRIBUTING.md" \
             | sed -n '/<!-- start-trivial-prs -->/,/<!-- end-trivial-prs -->/p' \
             | sed '/<!--.*-->/d')
 

--- a/.github/workflows/close-trivial-prs.yml
+++ b/.github/workflows/close-trivial-prs.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
 
     steps:
       - name: Fetch CONTRIBUTING.md snippet


### PR DESCRIPTION
The three fixes are:
1. Rename the file to fix the spelling of `trivial`
2. Grant the `GITHUB_TOKEN` write access to `issues` as that is how comments get added to PRs (which are modeled as special kinds of issues in GitHub's servers.
3. Switch to using `refs/heads/master` instead of the ref of the commit hash from the PR branch (since this is a public repo)
