### PR TITLE
Improve TestStorageOpenFromEmpty with meaningful assertions

### DIFF
--- a/arbos/arbosState/arbosstate_test.go
+++ b/arbos/arbosState/arbosstate_test.go
@@ -16,7 +16,11 @@ import (
 )
 
 func TestStorageOpenFromEmpty(t *testing.T) {
-	NewArbosMemoryBackedArbOSState()
+	state, err := NewArbosMemoryBackedArbOSState()
+	Require(t, err)
+	if state == nil {
+		Fail(t, "NewArbosMemoryBackedArbOSState() returned nil state")
+	}
 }
 
 func TestMemoryBackingEvmStorage(t *testing.T) {


### PR DESCRIPTION
Enhanced the TestStorageOpenFromEmpty unit test in arbosstate_test.go by adding assertions to verify that NewArbosMemoryBackedArbOSState() does not return an error and returns a non-nil state. This makes the test more meaningful and ensures the initialization logic is properly validated.