### PR TITLE
Swtich to pull_request_target for the trigger events

### DIFF
--- a/.github/workflows/close-trivial-prs.yml
+++ b/.github/workflows/close-trivial-prs.yml
@@ -1,7 +1,7 @@
 name: Close trivial PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 jobs:
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      issues: write
 
     steps:
       - name: Fetch CONTRIBUTING.md snippet


### PR DESCRIPTION
When targeting a `pull_request` event on a public repository, the permissions are always restricted to read-only for github actions even if the `write` permissions are explicity requested. This is to keep contributors from being able to inject malicious code into the actions.

Technically, it should be fine to go back to the `REF` variable as this should now be the ref for the target of the pull request which should be committed code. But, it is also still fine to just use `refs/heads/master` in a hard-coded fashion.