### PR TITLE
Update delayed message backlog to verify against head MEL state's delayed-merkle-root

### DIFF
--- a/arbnode/mel/runner/database_test.go
+++ b/arbnode/mel/runner/database_test.go
@@ -80,7 +80,6 @@ func TestMelDatabaseReadAndWriteDelayedMessages(t *testing.T) {
 	}
 	state := &mel.State{}
 	state.SetDelayedMessageBacklog(&mel.DelayedMessageBacklog{})
-	// state.SetReadDelayedMsgsAcc(merkleAccumulator.NewNonpersistentMerkleAccumulator())
 	require.NoError(t, state.AccumulateDelayedMessage(delayedMsg)) // Initialize delayedMessageBacklog
 	state.DelayedMessagedSeen++
 

--- a/arbnode/mel/runner/database_test.go
+++ b/arbnode/mel/runner/database_test.go
@@ -15,7 +15,6 @@ import (
 	dbschema "github.com/offchainlabs/nitro/arbnode/db-schema"
 	"github.com/offchainlabs/nitro/arbnode/mel"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
-	"github.com/offchainlabs/nitro/arbos/merkleAccumulator"
 )
 
 func TestMelDatabase(t *testing.T) {
@@ -81,7 +80,7 @@ func TestMelDatabaseReadAndWriteDelayedMessages(t *testing.T) {
 	}
 	state := &mel.State{}
 	state.SetDelayedMessageBacklog(&mel.DelayedMessageBacklog{})
-	state.SetReadDelayedMsgsAcc(merkleAccumulator.NewNonpersistentMerkleAccumulator())
+	// state.SetReadDelayedMsgsAcc(merkleAccumulator.NewNonpersistentMerkleAccumulator())
 	require.NoError(t, state.AccumulateDelayedMessage(delayedMsg)) // Initialize delayedMessageBacklog
 	state.DelayedMessagedSeen++
 

--- a/arbnode/mel/runner/dm_backlog_initialization_test.go
+++ b/arbnode/mel/runner/dm_backlog_initialization_test.go
@@ -79,9 +79,9 @@ func TestDelayedMessageBacklogInitialization(t *testing.T) {
 	require.NoError(t, InitializeDelayedMessageBacklog(ctx, delayedMessageBacklog, melDb, state, nil))
 	require.True(t, delayedMessageBacklog.Len() == 25)
 	state.SetDelayedMessageBacklog(delayedMessageBacklog)
+	state.SetReadCountFromBacklog(state.DelayedMessagedSeen) // skip checking against accumulator- not the purpose of this test
 
-	// Lets read the delayed messages and verify their correctness against accumulator and that they match with what we stored
-	// we read against the latest melState
+	// Lets read the delayed messages and verify that they match with what we stored
 	for i, wantDelayed := range delayedMsgs {
 		haveDelayed, err := melDb.ReadDelayedMessage(ctx, state, uint64(i+1)) // #nosec G115
 		require.NoError(t, err)

--- a/arbnode/mel/state.go
+++ b/arbnode/mel/state.go
@@ -30,12 +30,13 @@ type State struct {
 	DelayedMessagedSeen                uint64
 	DelayedMessageMerklePartials       []common.Hash `rlp:"optional"`
 
-	// delayedMessageBacklog is initialized once in the Start fsm step of mel runner and is persisted across all future states
-	delayedMessageBacklog *DelayedMessageBacklog
+	delayedMessageBacklog *DelayedMessageBacklog // delayedMessageBacklog is initialized once in the Start fsm step of mel runner and is persisted across all future states
+	readCountFromBacklog  uint64                 // delayed messages with index lower than this count have been pre-read and we have hashes for them in-memory for verification
 
-	// seen and read DelayedMsgsAcc are MerkleAccumulators that reset after the current melstate is finished generating, to prevent stale validations
+	// seenDelayedMsgsAcc is MerkleAccumulator that accumulates delayed messages seen
+	// from parent chain. It resets after the current melstate is finished generating
+	// and is reinitialized using appropriate DelayedMessageMerklePartials of the state
 	seenDelayedMsgsAcc *merkleAccumulator.MerkleAccumulator
-	readDelayedMsgsAcc *merkleAccumulator.MerkleAccumulator
 }
 
 // Defines a basic interface for MEL, including saving states, messages,
@@ -126,6 +127,7 @@ func (s *State) Clone() *State {
 		DelayedMessagedSeen:                s.DelayedMessagedSeen,
 		DelayedMessageMerklePartials:       delayedMessageMerklePartials,
 		delayedMessageBacklog:              delayedMessageBacklog,
+		readCountFromBacklog:               s.readCountFromBacklog,
 	}
 }
 
@@ -144,18 +146,15 @@ func (s *State) AccumulateDelayedMessage(msg *DelayedInboxMessage) error {
 		}
 		s.seenDelayedMsgsAcc = acc
 	}
-	if _, err := s.seenDelayedMsgsAcc.Append(msg.Hash()); err != nil {
-		return err
-	}
-	merkleRoot, err := s.seenDelayedMsgsAcc.Root()
-	if err != nil {
+	msgHash := msg.Hash()
+	if _, err := s.seenDelayedMsgsAcc.Append(msgHash); err != nil {
 		return err
 	}
 	if s.delayedMessageBacklog != nil {
 		if err := s.delayedMessageBacklog.Add(
 			&DelayedMessageBacklogEntry{
 				Index:                       s.DelayedMessagedSeen,
-				MerkleRoot:                  merkleRoot,
+				MsgHash:                     msgHash,
 				MelStateParentChainBlockNum: s.ParentChainBlockNumber,
 			}); err != nil {
 			return err
@@ -177,12 +176,8 @@ func (s *State) GenerateDelayedMessageMerklePartials() error {
 	return nil
 }
 
-func (s *State) GetReadDelayedMsgsAcc() *merkleAccumulator.MerkleAccumulator {
-	return s.readDelayedMsgsAcc
-}
-
-func (s *State) SetReadDelayedMsgsAcc(acc *merkleAccumulator.MerkleAccumulator) {
-	s.readDelayedMsgsAcc = acc
+func (s *State) GetSeenDelayedMsgsAcc() *merkleAccumulator.MerkleAccumulator {
+	return s.seenDelayedMsgsAcc
 }
 
 func (s *State) GetDelayedMessageBacklog() *DelayedMessageBacklog {
@@ -193,12 +188,17 @@ func (s *State) SetDelayedMessageBacklog(delayedMessageBacklog *DelayedMessageBa
 	s.delayedMessageBacklog = delayedMessageBacklog
 }
 
+func (s *State) GetReadCountFromBacklog() uint64      { return s.readCountFromBacklog }
+func (s *State) SetReadCountFromBacklog(count uint64) { s.readCountFromBacklog = count }
+
 func (s *State) ReorgTo(newState *State) error {
 	delayedMessageBacklog := s.delayedMessageBacklog
 	if err := delayedMessageBacklog.reorg(newState.DelayedMessagedSeen); err != nil {
 		return err
 	}
 	newState.delayedMessageBacklog = delayedMessageBacklog
+	// Reset the pre-read delayed messages count since they havent been verified against latest state's merkle root
+	newState.readCountFromBacklog = 0
 	return nil
 }
 


### PR DESCRIPTION
This PR updates the `DelayedMessageBacklog` implementation to verify read delayed messages against current merkle root of all seen delayed messages, unlike what was done previously (intermediary verifications). For optimization, future messages that are prefetched for generating the merkle root are also `pre-verified` i.e we dont re-verify them again when we read them in future, instead we check that the pre-verified message's hash matches the hash of delayed message we fetched from the DB.

Resolves NIT-3526