### PR TITLE
Fix typo in ADR template link

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -3,7 +3,7 @@
 For new Architectural Decision Records (ADRs), please use one of the following templates as a starting point:
 
 * [adr-template.md](adr-template.md) has all sections, with explanations about them.
-* [adr-template-minmal.md](adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
+* [adr-template-minimal.md](adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
 * [adr-template-bare.md](adr-template-bare.md) has all sections, wich are empty (no explanations).
 * [adr-template-bare-minimal.md](adr-template-bare-minimal.md) has the mandatory sections, without explanations. <!-- ### Consequences also contained, though marked as "optional" -->
 


### PR DESCRIPTION
## What's Changed
Fixed a typo in the ADR template filename reference.

## Changes Made
- **File:** `docs/decisions/README.md`
- **Fix:** `adr-template-minmal.md` → `adr-template-minimal.md`
- **Type:** Documentation fix



---
*Small fix, big impact on documentation quality! 🎯*