### PR TITLE
Fix brotli build script: correct softfloat check and target directory handling

### DIFF
--- a/scripts/build-brotli.sh
+++ b/scripts/build-brotli.sh
@@ -68,14 +68,14 @@ while getopts "n:s:t:c:D:wldhf" option; do
     esac
 done
 
-if ! $BUILD_WASM && ! $BUILD_LOCAL && ! $BUILD_SOFT; then
+if ! $BUILD_WASM && ! $BUILD_LOCAL && ! $BUILD_SOFTFLOAT; then
     usage
     exit
 fi
 
 if [ ! -d "$TARGET_DIR" ]; then
-    mkdir -p "${TARGET_DIR}lib"
-    ln -s "lib" "${TARGET_DIR}lib64" # Fedora build
+    mkdir -p "${TARGET_DIR}/lib"
+    ln -s "lib" "${TARGET_DIR}/lib64" # Fedora build
 fi
 TARGET_DIR_ABS=$(cd -P "$TARGET_DIR"; pwd)
 


### PR DESCRIPTION
Previously, the build-brotli.sh script contained two issues:

- The conditional check for build modes used a non-existent variable $BUILD_SOFT instead of $BUILD_SOFTFLOAT, which could cause the script to misinterpret the selected build options and exit unexpectedly.
- The script created the target lib directory as ${TARGET_DIR}lib instead of ${TARGET_DIR}/lib, and the symbolic link for lib64 was created relative to the current directory, which could result in incorrect directory structure or broken symlinks if the working directory was not as expected.

These issues have been fixed by:

- Using the correct $BUILD_SOFTFLOAT variable in the build mode check.
- Ensuring the lib directory is created as ${TARGET_DIR}/lib and the lib64 symlink is created as ${TARGET_DIR}/lib64, making the directory structure and symlink creation robust regardless of the working directory.

This improves the reliability and correctness of the brotli build process.