### PR TITLE
Upgrade go to 1.24.5

### DIFF
--- a/.github/workflows/arbitrator-ci.yml
+++ b/.github/workflows/arbitrator-ci.yml
@@ -50,12 +50,12 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
 
       - name: Install custom go-ethereum
         run: |
           cd /tmp
-          git clone --branch v1.14.11 --depth 1 https://github.com/ethereum/go-ethereum.git
+          git clone --branch v1.15.11 --depth 1 https://github.com/ethereum/go-ethereum.git
           cd go-ethereum
           go build -o /usr/local/bin/geth ./cmd/geth
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
 
       - name: Install wasm-ld
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Install go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
 
     - name: Install wasm-ld
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ COPY --from=wasm-libs-builder /workspace/ /
 FROM wasm-base AS wasm-bin-builder
 RUN apt update && apt install -y wabt
 # pinned go version
-RUN curl -L https://golang.org/dl/go1.23.1.linux-`dpkg --print-architecture`.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://golang.org/dl/go1.24.5.linux-`dpkg --print-architecture`.tar.gz | tar -C /usr/local -xzf -
 COPY ./Makefile ./go.mod ./go.sum ./
 COPY ./arbcompress ./arbcompress
 COPY ./arbos ./arbos
@@ -242,7 +242,7 @@ RUN ./download-machine.sh consensus-v42-rc.1 0x1be44d9f74056fc12af97ccbef7a2668b
 RUN ./download-machine.sh consensus-v50-alpha.1 0x28cfd8d81613ce4ebe750e77bfd95d6d95d4f53240488095a11c1ad3a494fa82
 RUN ./download-machine.sh consensus-v40 0xdb698a2576298f25448bc092e52cf13b1e24141c997135d70f217d674bbeb69a
 
-FROM golang:1.23.1-bookworm AS node-builder
+FROM golang:1.24.5-bookworm AS node-builder
 WORKDIR /workspace
 ARG version=""
 ARG datetime=""

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/offchainlabs/nitro
 
-go 1.23.0
+go 1.24
 
 replace github.com/VictoriaMetrics/fastcache => ./fastcache
 


### PR DESCRIPTION
There is a new version of VictoriaMetrics/fastcache that we'd like to use, but it depends on some features of go 1.24.

See the failing tests in #3405