### PR TITLE
add msgIdx to error print when blockhash mismatch

### DIFF
--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1287,6 +1287,7 @@ func (s *TransactionStreamer) checkResult(msgIdx arbutil.MessageIndex, msgResult
 	if msgResult.BlockHash != *msgAndBlockInfo.BlockHash {
 		log.Error(
 			BlockHashMismatchLogMsg,
+			"msgIdx", msgIdx,
 			"expected", msgAndBlockInfo.BlockHash,
 			"actual", msgResult.BlockHash,
 		)


### PR DESCRIPTION
Small fix for the log, that we wished we had when we were debugging related problems.