### PR TITLE
Fix `make .make/fmt` by upgrading golangci-lint from v1 to v2 command line arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -588,7 +588,7 @@ contracts/test/prover/proofs/%.json: $(arbitrator_cases)/%.wasm $(prover_bin)
 	@touch $@
 
 .make/fmt: $(DEP_PREDICATE) build-node-deps .make/yarndeps $(ORDER_ONLY_PREDICATE) .make
-	golangci-lint run --disable-all -E gofmt --fix
+	golangci-lint run --default=none --fix
 	cargo fmt -p arbutil -p prover -p jit -p stylus --manifest-path arbitrator/Cargo.toml -- --check
 	cargo fmt --all --manifest-path arbitrator/wasm-testsuite/Cargo.toml -- --check
 	yarn --cwd contracts prettier:solidity


### PR DESCRIPTION
Fixes NIT-3611

I am trying to build nitro locally following https://docs.arbitrum.io/run-arbitrum-node/nitro/build-nitro-locally and I ran into a problem where the `make` command would fail, due to golangci-lint. Recently CI was updated to use `golangci-lint v2+` NIT-3286, but updating the Makefile's `.make/fmt` command was missed, which causes make to fail due to using now unsupported arguments for golangci-lint

When I ran `make` following the instructions

I would get

```
golangci-lint run --disable-all -E gofmt --fix
Error: unknown flag: --disable-all
The command is terminated due to an error: unknown flag: --disable-all
make: *** [Makefile:591: .make/fmt] エラー 3
```

and

```
DONE 5 tests in 1.078s
done!
golangci-lint run --default=none -E gofmt --fix
Error: can't load config: gofmt is a formatter
The command is terminated due to an error: can't load config: gofmt is a formatter
make: *** [Makefile:591: .make/fmt] エラー 3
```

Since
-  https://github.com/golangci/golangci-lint/blob/5ab4747bd91c5942d2d54e3505a5971cb3f5da37/docs/src/docs/product/migration-guide.mdx#--disable-all-and---enable-all
  They changed the arguments syntax from ``--disable-all`` to `--default=none`
- gofmt isn't supposed to be enabled with -E anymore


After making these changes `make` works for me

```
src/test-helpers/ValueArrayTester.sol 7ms
Done in 2.73s.
done building 2
ready for push!
```