### PR TITLE
Fix go formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -588,7 +588,7 @@ contracts/test/prover/proofs/%.json: $(arbitrator_cases)/%.wasm $(prover_bin)
 	@touch $@
 
 .make/fmt: $(DEP_PREDICATE) build-node-deps .make/yarndeps $(ORDER_ONLY_PREDICATE) .make
-	golangci-lint run --default=none --fix
+	gofmt -w .
 	cargo fmt -p arbutil -p prover -p jit -p stylus --manifest-path arbitrator/Cargo.toml -- --check
 	cargo fmt --all --manifest-path arbitrator/wasm-testsuite/Cargo.toml -- --check
 	yarn --cwd contracts prettier:solidity


### PR DESCRIPTION
Pulls in https://github.com/OffchainLabs/fastcache/pull/4

When `make push` is run, multiple checks are run, including applying any changes suggested by `gofmt`.  The new version of golangci-lint removed some parameters, so `gofmt` has to be run directly now.
