### PR TITLE
Try NOT running the nitro CodeQL build in parallel

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -161,7 +161,7 @@ jobs:
       run: ./scripts/build-brotli.sh -w -d
 
     - name: Build Nitro for CodeQL
-      run: make build -j
+      run: make build
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun


### PR DESCRIPTION
There has been some flakiness in the pre-merge analysis runs lately. Checking to see if this could be why.

Closes: NIT-3636