### PR TITLE
ValidationInputsAt accepts wasm as a target

### DIFF
--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -199,8 +199,12 @@ func activateProgramInternal(
 	for _, target := range nativeTargets {
 		target := target
 		go func() {
-			asm, err := compileNative(wasm, stylusVersion, debug, target)
-			results <- result{target, asm, err}
+			if target == rawdb.TargetWasm {
+				results <- result{target, wasm, nil}
+			} else {
+				asm, err := compileNative(wasm, stylusVersion, debug, target)
+				results <- result{target, asm, err}
+			}
 		}()
 	}
 	expectedResults := len(nativeTargets)

--- a/execution/gethexec/block_recorder.go
+++ b/execution/gethexec/block_recorder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/arbitrum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -101,8 +102,8 @@ func (r *BlockRecorder) RecordBlockCreation(
 	ctx context.Context,
 	pos arbutil.MessageIndex,
 	msg *arbostypes.MessageWithMetadata,
+	wasmTargets []rawdb.WasmTarget,
 ) (*execution.RecordResult, error) {
-
 	blockNum := r.execEngine.MessageIndexToBlockNumber(pos)
 
 	var prevHeader *types.Header
@@ -158,7 +159,7 @@ func (r *BlockRecorder) RecordBlockCreation(
 			recordingdb,
 			chaincontext,
 			false,
-			core.NewMessageRecordingContext(r.execEngine.wasmTargets),
+			core.NewMessageRecordingContext(wasmTargets),
 		)
 		if err != nil {
 			return nil, err

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -489,8 +489,9 @@ func (n *ExecutionNode) RecordBlockCreation(
 	ctx context.Context,
 	pos arbutil.MessageIndex,
 	msg *arbostypes.MessageWithMetadata,
+	wasmTargets []rawdb.WasmTarget,
 ) (*execution.RecordResult, error) {
-	return n.Recorder.RecordBlockCreation(ctx, pos, msg)
+	return n.Recorder.RecordBlockCreation(ctx, pos, msg, wasmTargets)
 }
 func (n *ExecutionNode) MarkValid(pos arbutil.MessageIndex, resultHash common.Hash) {
 	n.Recorder.MarkValid(pos, resultHash)

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
@@ -61,6 +62,7 @@ type ExecutionRecorder interface {
 		ctx context.Context,
 		pos arbutil.MessageIndex,
 		msg *arbostypes.MessageWithMetadata,
+		wasmTargets []rawdb.WasmTarget,
 	) (*RecordResult, error)
 	MarkValid(pos arbutil.MessageIndex, resultHash common.Hash)
 	PrepareForRecord(ctx context.Context, start, end arbutil.MessageIndex) error

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -562,13 +562,17 @@ func (v *StatelessBlockValidator) GetLatestWasmModuleRoot() common.Hash {
 }
 
 func (v *StatelessBlockValidator) Start(ctx_in context.Context) error {
+	wasmTargetsSet := make(map[rawdb.WasmTarget]struct{})
+
 	if v.redisValidator != nil {
 		if err := v.redisValidator.Start(ctx_in); err != nil {
 			return fmt.Errorf("starting execution spawner: %w", err)
 		}
+		for _, wasmTarget := range v.redisValidator.StylusArchs() {
+			wasmTargetsSet[wasmTarget] = struct{}{}
+		}
 	}
 
-	wasmTargetsSet := make(map[rawdb.WasmTarget]struct{})
 	for _, spawner := range v.execSpawners {
 		if err := spawner.Start(ctx_in); err != nil {
 			return err
@@ -577,6 +581,7 @@ func (v *StatelessBlockValidator) Start(ctx_in context.Context) error {
 			wasmTargetsSet[wasmTarget] = struct{}{}
 		}
 	}
+
 	wasmTargets := make([]rawdb.WasmTarget, 0)
 	for wasmTarget := range wasmTargetsSet {
 		wasmTargets = append(wasmTargets, wasmTarget)

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -372,12 +372,16 @@ func copyPreimagesInto(dest, source map[arbutil.PreimageType]map[common.Hash][]b
 	}
 }
 
-func (v *StatelessBlockValidator) ValidationEntryRecord(ctx context.Context, e *validationEntry) error {
+func (v *StatelessBlockValidator) ValidationEntryRecord(ctx context.Context, e *validationEntry, targets ...rawdb.WasmTarget) error {
 	if e.Stage != ReadyForRecord {
 		return fmt.Errorf("validation entry should be ReadyForRecord, is: %v", e.Stage)
 	}
 	if e.Pos != 0 {
-		recording, err := v.recorder.RecordBlockCreation(ctx, e.Pos, e.msg, v.wasmTargets)
+		// if not targets is provided then fallback to the targets required by the validators
+		if len(targets) == 0 {
+			targets = v.wasmTargets
+		}
+		recording, err := v.recorder.RecordBlockCreation(ctx, e.Pos, e.msg, targets)
 		if err != nil {
 			return err
 		}
@@ -435,7 +439,7 @@ func (v *StatelessBlockValidator) GlobalStatePositionsAtCount(count arbutil.Mess
 	return GlobalStatePositionsAtCount(v.inboxTracker, count, batch)
 }
 
-func (v *StatelessBlockValidator) CreateReadyValidationEntry(ctx context.Context, pos arbutil.MessageIndex) (*validationEntry, error) {
+func (v *StatelessBlockValidator) CreateReadyValidationEntry(ctx context.Context, pos arbutil.MessageIndex, targets ...rawdb.WasmTarget) (*validationEntry, error) {
 	msg, err := v.streamer.GetMessage(pos)
 	if err != nil {
 		return nil, err
@@ -491,7 +495,7 @@ func (v *StatelessBlockValidator) CreateReadyValidationEntry(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	err = v.ValidationEntryRecord(ctx, entry)
+	err = v.ValidationEntryRecord(ctx, entry, targets...)
 	if err != nil {
 		return nil, err
 	}
@@ -542,7 +546,7 @@ func (v *StatelessBlockValidator) ValidateResult(
 }
 
 func (v *StatelessBlockValidator) ValidationInputsAt(ctx context.Context, pos arbutil.MessageIndex, targets ...rawdb.WasmTarget) (server_api.InputJSON, error) {
-	entry, err := v.CreateReadyValidationEntry(ctx, pos)
+	entry, err := v.CreateReadyValidationEntry(ctx, pos, targets...)
 	if err != nil {
 		return server_api.InputJSON{}, err
 	}

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -377,7 +377,7 @@ func (v *StatelessBlockValidator) ValidationEntryRecord(ctx context.Context, e *
 		return fmt.Errorf("validation entry should be ReadyForRecord, is: %v", e.Stage)
 	}
 	if e.Pos != 0 {
-		// if wasmTargets is provided then fallback to the targets required by the validators
+		// if wasmTargets is not provided then fallback to the targets required by the validators
 		if len(wasmTargets) == 0 {
 			wasmTargets = v.wasmTargets
 		}

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -372,16 +372,16 @@ func copyPreimagesInto(dest, source map[arbutil.PreimageType]map[common.Hash][]b
 	}
 }
 
-func (v *StatelessBlockValidator) ValidationEntryRecord(ctx context.Context, e *validationEntry, targets ...rawdb.WasmTarget) error {
+func (v *StatelessBlockValidator) ValidationEntryRecord(ctx context.Context, e *validationEntry, wasmTargets ...rawdb.WasmTarget) error {
 	if e.Stage != ReadyForRecord {
 		return fmt.Errorf("validation entry should be ReadyForRecord, is: %v", e.Stage)
 	}
 	if e.Pos != 0 {
-		// if not targets is provided then fallback to the targets required by the validators
-		if len(targets) == 0 {
-			targets = v.wasmTargets
+		// if wasmTargets is provided then fallback to the targets required by the validators
+		if len(wasmTargets) == 0 {
+			wasmTargets = v.wasmTargets
 		}
-		recording, err := v.recorder.RecordBlockCreation(ctx, e.Pos, e.msg, targets)
+		recording, err := v.recorder.RecordBlockCreation(ctx, e.Pos, e.msg, wasmTargets)
 		if err != nil {
 			return err
 		}
@@ -439,7 +439,7 @@ func (v *StatelessBlockValidator) GlobalStatePositionsAtCount(count arbutil.Mess
 	return GlobalStatePositionsAtCount(v.inboxTracker, count, batch)
 }
 
-func (v *StatelessBlockValidator) CreateReadyValidationEntry(ctx context.Context, pos arbutil.MessageIndex, targets ...rawdb.WasmTarget) (*validationEntry, error) {
+func (v *StatelessBlockValidator) CreateReadyValidationEntry(ctx context.Context, pos arbutil.MessageIndex, wasmTargets ...rawdb.WasmTarget) (*validationEntry, error) {
 	msg, err := v.streamer.GetMessage(pos)
 	if err != nil {
 		return nil, err
@@ -495,7 +495,7 @@ func (v *StatelessBlockValidator) CreateReadyValidationEntry(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	err = v.ValidationEntryRecord(ctx, entry, targets...)
+	err = v.ValidationEntryRecord(ctx, entry, wasmTargets...)
 	if err != nil {
 		return nil, err
 	}
@@ -545,12 +545,12 @@ func (v *StatelessBlockValidator) ValidateResult(
 	return true, &entry.End, nil
 }
 
-func (v *StatelessBlockValidator) ValidationInputsAt(ctx context.Context, pos arbutil.MessageIndex, targets ...rawdb.WasmTarget) (server_api.InputJSON, error) {
-	entry, err := v.CreateReadyValidationEntry(ctx, pos, targets...)
+func (v *StatelessBlockValidator) ValidationInputsAt(ctx context.Context, pos arbutil.MessageIndex, wasmTargets ...rawdb.WasmTarget) (server_api.InputJSON, error) {
+	entry, err := v.CreateReadyValidationEntry(ctx, pos, wasmTargets...)
 	if err != nil {
 		return server_api.InputJSON{}, err
 	}
-	input, err := entry.ToInput(targets)
+	input, err := entry.ToInput(wasmTargets)
 	if err != nil {
 		return server_api.InputJSON{}, err
 	}

--- a/system_tests/validation_inputs_at_test.go
+++ b/system_tests/validation_inputs_at_test.go
@@ -1,0 +1,84 @@
+// Copyright 2021-2025, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package arbtest
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/offchainlabs/nitro/arbutil"
+	pgen "github.com/offchainlabs/nitro/solgen/go/precompilesgen"
+	"github.com/offchainlabs/nitro/util/testhelpers"
+	"github.com/offchainlabs/nitro/validator/server_api"
+)
+
+func TestValidationInputsAtWithWasmTarget(t *testing.T) {
+	builder, auth, cleanup := setupProgramTest(t, false)
+	ctx := builder.ctx
+	l2client := builder.L2.Client
+	l2info := builder.L2Info
+	defer cleanup()
+
+	auth.GasLimit = 32000000
+	auth.Value = oneEth
+
+	// deploys contract
+	wasmToDeploy, wasmExpected := readWasmFile(t, rustFile("storage"))
+	arbWasm, err := pgen.NewArbWasm(types.ArbWasmAddress, l2client)
+	Require(t, err)
+	programAddress := deployContract(t, ctx, auth, l2client, wasmToDeploy)
+	tx, err := arbWasm.ActivateProgram(&auth, programAddress)
+	Require(t, err)
+	receipt, err := EnsureTxSucceeded(ctx, l2client, tx)
+	Require(t, err)
+
+	// gets module hash
+	if len(receipt.Logs) != 1 {
+		Fatal(t, "expected 1 log while activating, got ", len(receipt.Logs))
+	}
+	l, err := arbWasm.ParseProgramActivated(*receipt.Logs[0])
+	Require(t, err)
+	moduleHash := l.ModuleHash
+
+	// calls contract
+	key := testhelpers.RandomHash()
+	value := testhelpers.RandomHash()
+	tx = l2info.PrepareTxTo("Owner", &programAddress, l2info.TransferGas, nil, argsForStorageWrite(key, value))
+	err = l2client.SendTransaction(ctx, tx)
+	Require(t, err)
+	receipt, err = EnsureTxSucceeded(ctx, l2client, tx)
+	Require(t, err)
+
+	inboxPos := arbutil.MessageIndex(receipt.BlockNumber.Uint64())
+	for range 40 {
+		time.Sleep(250 * time.Millisecond)
+		batches, err := builder.L2.ConsensusNode.InboxTracker.GetBatchCount()
+		Require(t, err)
+		haveMessages, err := builder.L2.ConsensusNode.InboxTracker.GetBatchMessageCount(batches - 1)
+		Require(t, err)
+		if haveMessages >= inboxPos {
+			break
+		}
+	}
+
+	inputJson, err := builder.L2.ConsensusNode.StatelessBlockValidator.ValidationInputsAt(ctx, inboxPos, rawdb.LocalTarget(), rawdb.TargetWasm)
+	Require(t, err)
+	validationInput, err := server_api.ValidationInputFromJson(&inputJson)
+	Require(t, err)
+	wasmMap, ok := validationInput.UserWasms[rawdb.TargetWasm]
+	if !ok {
+		t.Fatal("expected TargetWasm in user wasm map")
+	}
+	wasm, ok := wasmMap[moduleHash]
+	if !ok {
+		t.Fatal("expected wasm module hash in user wasm map")
+	}
+	if !bytes.Equal(wasm, wasmExpected) {
+		t.Fatal("wasm does not match expected wasm")
+	}
+}

--- a/system_tests/validation_mock_test.go
+++ b/system_tests/validation_mock_test.go
@@ -391,6 +391,7 @@ func (m *mockBlockRecorder) RecordBlockCreation(
 	ctx context.Context,
 	pos arbutil.MessageIndex,
 	msg *arbostypes.MessageWithMetadata,
+	wasmTargets []rawdb.WasmTarget,
 ) (*execution.RecordResult, error) {
 	_, globalpos, err := m.validator.GlobalStatePositionsAtCount(pos + 1)
 	if err != nil {

--- a/validator/server_arb/validator_spawner.go
+++ b/validator/server_arb/validator_spawner.go
@@ -105,7 +105,7 @@ func (s *ArbitratorSpawner) WasmModuleRoots() ([]common.Hash, error) {
 }
 
 func (s *ArbitratorSpawner) StylusArchs() []rawdb.WasmTarget {
-	return []rawdb.WasmTarget{rawdb.TargetWavm}
+	return []rawdb.WasmTarget{rawdb.TargetWavm, rawdb.LocalTarget()}
 }
 
 func (s *ArbitratorSpawner) Name() string {


### PR DESCRIPTION
Resolves NIT-3528

Attention to the base branch.

ValidationInputsAt accepts wasm as a target.
For now wasm targets are not stored in the database.

Pulls