### PR TITLE
Implement prefetcher for logs that are relevant to MEL

### DIFF
--- a/arbnode/mel/extraction/abis.go
+++ b/arbnode/mel/extraction/abis.go
@@ -7,11 +7,11 @@ import (
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 )
 
-var batchDeliveredID common.Hash
-var inboxMessageDeliveredID common.Hash
-var inboxMessageFromOriginID common.Hash
-var seqInboxABI *abi.ABI
-var iBridgeABI *abi.ABI
+var BatchDeliveredID common.Hash
+var InboxMessageDeliveredID common.Hash
+var InboxMessageFromOriginID common.Hash
+var SeqInboxABI *abi.ABI
+var IBridgeABI *abi.ABI
 var iInboxABI *abi.ABI
 var iDelayedMessageProviderABI *abi.ABI
 
@@ -21,20 +21,20 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	batchDeliveredID = sequencerBridgeABI.Events["SequencerBatchDelivered"].ID
+	BatchDeliveredID = sequencerBridgeABI.Events["SequencerBatchDelivered"].ID
 	parsedIBridgeABI, err := bridgegen.IBridgeMetaData.GetAbi()
 	if err != nil {
 		panic(err)
 	}
-	iBridgeABI = parsedIBridgeABI
+	IBridgeABI = parsedIBridgeABI
 	parsedIMessageProviderABI, err := bridgegen.IDelayedMessageProviderMetaData.GetAbi()
 	if err != nil {
 		panic(err)
 	}
 	iDelayedMessageProviderABI = parsedIMessageProviderABI
-	inboxMessageDeliveredID = parsedIMessageProviderABI.Events["InboxMessageDelivered"].ID
-	inboxMessageFromOriginID = parsedIMessageProviderABI.Events["InboxMessageDeliveredFromOrigin"].ID
-	seqInboxABI, err = bridgegen.SequencerInboxMetaData.GetAbi()
+	InboxMessageDeliveredID = parsedIMessageProviderABI.Events["InboxMessageDelivered"].ID
+	InboxMessageFromOriginID = parsedIMessageProviderABI.Events["InboxMessageDeliveredFromOrigin"].ID
+	SeqInboxABI, err = bridgegen.SequencerInboxMetaData.GetAbi()
 	if err != nil {
 		panic(err)
 	}
@@ -43,5 +43,5 @@ func init() {
 		panic(err)
 	}
 	iInboxABI = parsedIInboxABI
-	batchDeliveredID = sequencerBridgeABI.Events["SequencerBatchDelivered"].ID
+	BatchDeliveredID = sequencerBridgeABI.Events["SequencerBatchDelivered"].ID
 }

--- a/arbnode/mel/extraction/batch_lookup.go
+++ b/arbnode/mel/extraction/batch_lookup.go
@@ -32,11 +32,11 @@ func parseBatchesFromBlock(
 	}
 	var lastSeqNum *uint64
 	for _, log := range logs {
-		if log == nil || log.Topics[0] != batchDeliveredID {
+		if log == nil || log.Topics[0] != BatchDeliveredID {
 			continue
 		}
 		event := new(bridgegen.SequencerInboxSequencerBatchDelivered)
-		if err := eventUnpacker.unpackLogTo(event, seqInboxABI, "SequencerBatchDelivered", *log); err != nil {
+		if err := eventUnpacker.unpackLogTo(event, SeqInboxABI, "SequencerBatchDelivered", *log); err != nil {
 			return nil, nil, err
 		}
 		if !event.BatchSequenceNumber.IsUint64() {

--- a/arbnode/mel/extraction/batch_lookup_test.go
+++ b/arbnode/mel/extraction/batch_lookup_test.go
@@ -196,7 +196,7 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 		receipt := &types.Receipt{
 			Logs: []*types.Log{
 				{
-					Topics: []common.Hash{batchDeliveredID},
+					Topics: []common.Hash{BatchDeliveredID},
 					Data:   packedLog,
 				},
 			},
@@ -248,7 +248,7 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 		receipt := &types.Receipt{
 			Logs: []*types.Log{
 				{
-					Topics: []common.Hash{batchDeliveredID},
+					Topics: []common.Hash{BatchDeliveredID},
 					Data:   packedLog,
 					TxHash: tx.Hash(),
 				},
@@ -325,12 +325,12 @@ func Test_parseBatchesFromBlock_outOfOrderBatches(t *testing.T) {
 	receipt := &types.Receipt{
 		Logs: []*types.Log{
 			{
-				Topics: []common.Hash{batchDeliveredID},
+				Topics: []common.Hash{BatchDeliveredID},
 				Data:   packedLog1,
 				TxHash: tx1.Hash(),
 			},
 			{
-				Topics: []common.Hash{batchDeliveredID},
+				Topics: []common.Hash{BatchDeliveredID},
 				Data:   packedLog2,
 				TxHash: tx2.Hash(),
 			},
@@ -387,7 +387,7 @@ func setupParseBatchesTest(t *testing.T, seqNumber *big.Int) (
 		},
 		DataLocation: 1,
 	}
-	eventABI := seqInboxABI.Events["SequencerBatchDelivered"]
+	eventABI := SeqInboxABI.Events["SequencerBatchDelivered"]
 	packedLog, err := eventABI.Inputs.Pack(
 		event.BatchSequenceNumber,
 		event.BeforeAcc,

--- a/arbnode/mel/extraction/batch_serialization.go
+++ b/arbnode/mel/extraction/batch_serialization.go
@@ -62,7 +62,7 @@ func getSequencerBatchData(
 	tx *types.Transaction,
 	logsFetcher LogsFetcher,
 ) ([]byte, error) {
-	addSequencerL2BatchFromOriginCallABI := seqInboxABI.Methods["addSequencerL2BatchFromOrigin0"]
+	addSequencerL2BatchFromOriginCallABI := SeqInboxABI.Methods["addSequencerL2BatchFromOrigin0"]
 	switch batch.DataLocation {
 	case mel.BatchDataTxInput:
 		data := tx.Data()
@@ -79,7 +79,7 @@ func getSequencerBatchData(
 		}
 		return dataBytes, nil
 	case mel.BatchDataSeparateEvent:
-		sequencerBatchDataABI := seqInboxABI.Events["SequencerBatchData"].ID
+		sequencerBatchDataABI := SeqInboxABI.Events["SequencerBatchData"].ID
 		var numberAsHash common.Hash
 		// we want to convert a batch sequencer number which is a uint64 into a big-endian byte slice of size 32,
 		// so the last 8 bytes of that slice will contain the serialized batch.SequenceNumber
@@ -100,7 +100,7 @@ func getSequencerBatchData(
 			return nil, errors.New("expected to find only one matching sequencer batch data")
 		}
 		event := new(bridgegen.SequencerInboxSequencerBatchData)
-		err = seqInboxABI.UnpackIntoInterface(event, "SequencerBatchData", filteredLogs[0].Data)
+		err = SeqInboxABI.UnpackIntoInterface(event, "SequencerBatchData", filteredLogs[0].Data)
 		if err != nil {
 			return nil, err
 		}

--- a/arbnode/mel/extraction/batch_serialization_test.go
+++ b/arbnode/mel/extraction/batch_serialization_test.go
@@ -136,7 +136,7 @@ func Test_getSequencerBatchData(t *testing.T) {
 	})
 	t.Run("arbnode.BatchDataTxInput", func(t *testing.T) {
 		msgData := []byte("foobar")
-		addSequencerL2BatchFromOriginCallABI := seqInboxABI.Methods["addSequencerL2BatchFromOrigin0"]
+		addSequencerL2BatchFromOriginCallABI := SeqInboxABI.Methods["addSequencerL2BatchFromOrigin0"]
 		seqNumber := big.NewInt(1)
 		afterDelayedRead := big.NewInt(1)
 		gasRefunder := common.Address{}
@@ -247,7 +247,7 @@ func Test_getSequencerBatchData(t *testing.T) {
 		)
 		require.ErrorContains(t, err, "expected to find sequencer batch data")
 
-		sequencerBatchDataABI := seqInboxABI.Events["SequencerBatchData"].ID
+		sequencerBatchDataABI := SeqInboxABI.Events["SequencerBatchData"].ID
 		bridgeAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 		receipts = []*types.Receipt{
 			{
@@ -278,7 +278,7 @@ func Test_getSequencerBatchData(t *testing.T) {
 		event := &bridgegen.SequencerInboxSequencerBatchData{
 			Data: []byte("foobar"),
 		}
-		eventABI := seqInboxABI.Events["SequencerBatchData"]
+		eventABI := SeqInboxABI.Events["SequencerBatchData"]
 		packedLog, err := eventABI.Inputs.NonIndexed().Pack(
 			event.Data,
 		)

--- a/arbnode/mel/extraction/delayed_message_lookup.go
+++ b/arbnode/mel/extraction/delayed_message_lookup.go
@@ -62,7 +62,7 @@ func parseDelayedMessagesFromBlock(
 	}
 	messageData := make(map[common.Hash][]byte)
 	topics := [][]common.Hash{
-		{inboxMessageDeliveredID, inboxMessageFromOriginID}, // matches either of these IDs.
+		{InboxMessageDeliveredID, InboxMessageFromOriginID}, // matches either of these IDs.
 		messageIds, // matches any of the message IDs.
 	}
 	filteredInboxMessageLogs := types.FilterLogs(logs, nil, nil, inboxAddressList, topics)
@@ -105,11 +105,11 @@ func delayedMessageScaffoldsFromLogs(
 	// First, do a pass over the logs to extract message delivered events, which
 	// contain an inbox address and a message index.
 	for _, ethLog := range logs {
-		if ethLog == nil || len(ethLog.Topics) == 0 || ethLog.Topics[0] != iBridgeABI.Events["MessageDelivered"].ID {
+		if ethLog == nil || len(ethLog.Topics) == 0 || ethLog.Topics[0] != IBridgeABI.Events["MessageDelivered"].ID {
 			continue
 		}
 		event := new(bridgegen.IBridgeMessageDelivered)
-		if err := unpackLogTo(event, iBridgeABI, "MessageDelivered", *ethLog); err != nil {
+		if err := unpackLogTo(event, IBridgeABI, "MessageDelivered", *ethLog); err != nil {
 			return nil, nil, err
 		}
 		parsedLogs = append(parsedLogs, event)
@@ -154,13 +154,13 @@ func parseDelayedMessage(
 		return nil, nil, nil
 	}
 	switch ethLog.Topics[0] {
-	case inboxMessageDeliveredID:
+	case InboxMessageDeliveredID:
 		event := new(bridgegen.IDelayedMessageProviderInboxMessageDelivered)
 		if err := unpackLogTo(event, iDelayedMessageProviderABI, "InboxMessageDelivered", *ethLog); err != nil {
 			return nil, nil, err
 		}
 		return event.MessageNum, event.Data, nil
-	case inboxMessageFromOriginID:
+	case InboxMessageFromOriginID:
 		event := new(bridgegen.IDelayedMessageProviderInboxMessageDeliveredFromOrigin)
 		if err := unpackLogTo(event, iDelayedMessageProviderABI, "InboxMessageDeliveredFromOrigin", *ethLog); err != nil {
 			return nil, nil, err

--- a/arbnode/mel/extraction/delayed_message_lookup_test.go
+++ b/arbnode/mel/extraction/delayed_message_lookup_test.go
@@ -108,7 +108,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 					Address: delayedMsgPostingAddr,
 					Data:    packedLog,
 					Topics: []common.Hash{
-						iBridgeABI.Events["MessageDelivered"].ID,
+						IBridgeABI.Events["MessageDelivered"].ID,
 						messageIndexBytes,
 						event.BeforeInboxAcc,
 					},
@@ -174,7 +174,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 					Address: delayedMsgPostingAddr,
 					Data:    delayedMsgPackedLog,
 					Topics: []common.Hash{
-						iBridgeABI.Events["MessageDelivered"].ID,
+						IBridgeABI.Events["MessageDelivered"].ID,
 						messageIndexBytes,
 						delayedMsgEvent.BeforeInboxAcc,
 					},
@@ -222,7 +222,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 			BaseFeeL1:       big.NewInt(2),
 			Timestamp:       0,
 		}
-		eventABI := iBridgeABI.Events["MessageDelivered"]
+		eventABI := IBridgeABI.Events["MessageDelivered"]
 		delayedMsgPackedLog, err := eventABI.Inputs.NonIndexed().Pack(
 			delayedMsgEvent.Inbox,
 			delayedMsgEvent.Kind,
@@ -272,7 +272,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 					Address: delayedMsgPostingAddr,
 					Data:    delayedMsgPackedLog,
 					Topics: []common.Hash{
-						iBridgeABI.Events["MessageDelivered"].ID,
+						IBridgeABI.Events["MessageDelivered"].ID,
 						messageIndexBytes,
 						delayedMsgEvent.BeforeInboxAcc,
 					},
@@ -322,7 +322,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 			BaseFeeL1:       big.NewInt(2),
 			Timestamp:       0,
 		}
-		eventABI := iBridgeABI.Events["MessageDelivered"]
+		eventABI := IBridgeABI.Events["MessageDelivered"]
 		delayedMsgPackedLog, err := eventABI.Inputs.NonIndexed().Pack(
 			delayedMsgEvent.Inbox,
 			delayedMsgEvent.Kind,
@@ -365,7 +365,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 					Address: delayedMsgPostingAddr,
 					Data:    delayedMsgPackedLog,
 					Topics: []common.Hash{
-						iBridgeABI.Events["MessageDelivered"].ID,
+						IBridgeABI.Events["MessageDelivered"].ID,
 						messageIndexBytes,
 						delayedMsgEvent.BeforeInboxAcc,
 					},
@@ -414,7 +414,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 			BaseFeeL1:       big.NewInt(2),
 			Timestamp:       0,
 		}
-		eventABI := iBridgeABI.Events["MessageDelivered"]
+		eventABI := IBridgeABI.Events["MessageDelivered"]
 		delayedMsgPackedLog, err := eventABI.Inputs.NonIndexed().Pack(
 			delayedMsgEvent.Inbox,
 			delayedMsgEvent.Kind,
@@ -463,7 +463,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 					Address: delayedMsgPostingAddr,
 					Data:    delayedMsgPackedLog,
 					Topics: []common.Hash{
-						iBridgeABI.Events["MessageDelivered"].ID,
+						IBridgeABI.Events["MessageDelivered"].ID,
 						messageIndexBytes,
 						delayedMsgEvent.BeforeInboxAcc,
 					},
@@ -554,7 +554,7 @@ func setupParseDelayedMessagesTest(t *testing.T) (*bridgegen.IBridgeMessageDeliv
 		BaseFeeL1:       big.NewInt(2),
 		Timestamp:       0,
 	}
-	eventABI := iBridgeABI.Events["MessageDelivered"]
+	eventABI := IBridgeABI.Events["MessageDelivered"]
 	packedLog, err := eventABI.Inputs.NonIndexed().Pack(
 		event.Inbox,
 		event.Kind,

--- a/arbnode/mel/runner/logs_fetcher.go
+++ b/arbnode/mel/runner/logs_fetcher.go
@@ -1,0 +1,124 @@
+package melrunner
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/offchainlabs/nitro/arbnode/mel"
+	melextraction "github.com/offchainlabs/nitro/arbnode/mel/extraction"
+)
+
+type logsFetcher struct {
+	parentChainReader ParentChainReader
+	blockHeight       uint64
+	blocksToFetch     uint64
+	chainHeight       uint64
+	logsByTxIndex     map[common.Hash]map[uint][]*types.Log
+	logsByBlockHash   map[common.Hash][]*types.Log
+}
+
+func newLogsFetcher(parentChainReader ParentChainReader, blocksToFetch uint64) *logsFetcher {
+	return &logsFetcher{
+		parentChainReader: parentChainReader,
+		blocksToFetch:     blocksToFetch,
+		logsByTxIndex:     make(map[common.Hash]map[uint][]*types.Log),
+		logsByBlockHash:   make(map[common.Hash][]*types.Log),
+	}
+}
+
+func (f *logsFetcher) LogsForBlockHash(_ context.Context, parentChainBlockHash common.Hash) ([]*types.Log, error) {
+	return f.logsByBlockHash[parentChainBlockHash], nil
+}
+
+func (f *logsFetcher) LogsForTxIndex(_ context.Context, parentChainBlockHash common.Hash, txIndex uint) ([]*types.Log, error) {
+	if txIndexToLogs, ok := f.logsByTxIndex[parentChainBlockHash]; ok {
+		if logs, ok := txIndexToLogs[txIndex]; ok {
+			return logs, nil
+		}
+	}
+	return nil, fmt.Errorf("logs for tx in block: %v with index: %d not found", parentChainBlockHash, txIndex)
+}
+
+func (f *logsFetcher) fetch(ctx context.Context, preState *mel.State) error {
+	parentChainBlockNumber := preState.ParentChainBlockNumber + 1
+	if parentChainBlockNumber <= f.blockHeight {
+		return nil
+	}
+	f.reset() // prune old logs
+	toBlockheight := parentChainBlockNumber + f.blocksToFetch
+	if toBlockheight > f.chainHeight {
+		head, err := f.parentChainReader.HeaderByNumber(ctx, nil)
+		if err != nil {
+			return err
+		}
+		if head.Number.Uint64() < parentChainBlockNumber {
+			return fmt.Errorf("reorg detected inside logsFetcher")
+		}
+		f.chainHeight = head.Number.Uint64()
+		toBlockheight = min(f.chainHeight, toBlockheight)
+	}
+	if err := f.fetchSequencerBatchLogs(ctx, parentChainBlockNumber, toBlockheight); err != nil {
+		return err
+	}
+	if err := f.fetchDelayedMessageLogs(ctx, parentChainBlockNumber, toBlockheight, preState.DelayedMessagePostingTargetAddress); err != nil {
+		return err
+	}
+	f.blockHeight = toBlockheight
+	return nil
+}
+
+func (f *logsFetcher) fetchSequencerBatchLogs(ctx context.Context, from, to uint64) error {
+	sequencerBatchDataABI := melextraction.SeqInboxABI.Events["SequencerBatchData"].ID
+	query := ethereum.FilterQuery{
+		FromBlock: new(big.Int).SetUint64(from),
+		ToBlock:   new(big.Int).SetUint64(to),
+		Topics:    [][]common.Hash{{melextraction.BatchDeliveredID, sequencerBatchDataABI}},
+	}
+	logs, err := f.parentChainReader.FilterLogs(ctx, query)
+	if err != nil {
+		return err
+	}
+	for _, log := range logs {
+		f.logsByBlockHash[log.BlockHash] = append(f.logsByBlockHash[log.BlockHash], &log)
+		if _, ok := f.logsByTxIndex[log.BlockHash]; !ok {
+			f.logsByTxIndex[log.BlockHash] = make(map[uint][]*types.Log)
+		}
+		f.logsByTxIndex[log.BlockHash][log.TxIndex] = append(f.logsByTxIndex[log.BlockHash][log.TxIndex], &log)
+	}
+	return nil
+}
+
+func (f *logsFetcher) fetchDelayedMessageLogs(ctx context.Context, from, to uint64, delayedMessagePostingTargetAddress common.Address) error {
+	conditionalFetch := func(addresses []common.Address, topics [][]common.Hash) error {
+		query := ethereum.FilterQuery{
+			FromBlock: new(big.Int).SetUint64(from),
+			ToBlock:   new(big.Int).SetUint64(to),
+			Addresses: addresses,
+			Topics:    topics,
+		}
+		logs, err := f.parentChainReader.FilterLogs(ctx, query)
+		if err != nil {
+			return err
+		}
+		for _, log := range logs {
+			f.logsByBlockHash[log.BlockHash] = append(f.logsByBlockHash[log.BlockHash], &log)
+		}
+		return nil
+	}
+	messageDeliveredID := melextraction.IBridgeABI.Events["MessageDelivered"].ID
+	if err := conditionalFetch([]common.Address{delayedMessagePostingTargetAddress}, [][]common.Hash{{messageDeliveredID}}); err != nil {
+		return err
+	}
+	return conditionalFetch(nil, [][]common.Hash{{melextraction.InboxMessageDeliveredID, melextraction.InboxMessageFromOriginID}})
+}
+
+func (f *logsFetcher) reset() {
+	f.blockHeight = 0
+	f.logsByTxIndex = make(map[common.Hash]map[uint][]*types.Log)
+	f.logsByBlockHash = make(map[common.Hash][]*types.Log)
+}

--- a/arbnode/mel/runner/logs_fetcher_test.go
+++ b/arbnode/mel/runner/logs_fetcher_test.go
@@ -1,0 +1,106 @@
+package melrunner
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/offchainlabs/nitro/arbnode/mel"
+	melextraction "github.com/offchainlabs/nitro/arbnode/mel/extraction"
+)
+
+func TestLogsFetcher(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sequencerBatchDataABI := melextraction.SeqInboxABI.Events["SequencerBatchData"].ID
+	batchBlockHash := common.HexToHash("blockContainingBatchTx")
+	batchTxHash := common.HexToHash("batchTx")
+	batchTxIndex := uint(1)
+	batchTxLogs := []*types.Log{
+		{
+			Index:     0,
+			Topics:    []common.Hash{melextraction.BatchDeliveredID},
+			TxIndex:   batchTxIndex,
+			TxHash:    batchTxHash,
+			BlockHash: batchBlockHash,
+		},
+		{
+			Index:     1,
+			Topics:    []common.Hash{sequencerBatchDataABI},
+			TxIndex:   batchTxIndex,
+			TxHash:    batchTxHash,
+			BlockHash: batchBlockHash,
+		},
+		{
+			Index:     2,
+			Topics:    []common.Hash{common.HexToHash("ignored")},
+			TxIndex:   batchTxIndex,
+			TxHash:    batchTxHash,
+			BlockHash: batchBlockHash,
+		},
+	}
+	messageDeliveredID := melextraction.IBridgeABI.Events["MessageDelivered"].ID
+	delayedMessagePostingTargetAddress := common.HexToAddress("delayedMessagePostingTargetAddress")
+	delayedBlockHash := common.HexToHash("blockContainingDelayedMsg")
+	delayedMsgTxHash := common.HexToHash("delayedTx")
+	delayedMsgTxIndex := uint(2)
+	delayedMsgTxLogs := []*types.Log{
+		{
+			Index:     0,
+			Topics:    []common.Hash{messageDeliveredID},
+			TxIndex:   delayedMsgTxIndex,
+			TxHash:    delayedMsgTxHash,
+			BlockHash: delayedBlockHash,
+			Address:   delayedMessagePostingTargetAddress,
+		},
+		{
+			Index:     1,
+			Topics:    []common.Hash{melextraction.InboxMessageFromOriginID},
+			TxIndex:   delayedMsgTxIndex,
+			TxHash:    delayedMsgTxHash,
+			BlockHash: delayedBlockHash,
+		},
+		{
+			Index:     2,
+			Topics:    []common.Hash{melextraction.InboxMessageDeliveredID},
+			TxIndex:   delayedMsgTxIndex,
+			TxHash:    delayedMsgTxHash,
+			BlockHash: delayedBlockHash,
+		},
+		{
+			Index:     3,
+			Topics:    []common.Hash{common.HexToHash("ignored")},
+			TxIndex:   delayedMsgTxIndex,
+			TxHash:    delayedMsgTxHash,
+			BlockHash: delayedBlockHash,
+		},
+	}
+
+	parentChainReader := &mockParentChainReader{logs: append(batchTxLogs, delayedMsgTxLogs...)}
+	fetcher := newLogsFetcher(parentChainReader, 10)
+	fetcher.chainHeight = 100
+	melState := &mel.State{
+		ParentChainBlockNumber:             1,
+		DelayedMessagePostingTargetAddress: delayedMessagePostingTargetAddress,
+	}
+	require.NoError(t, fetcher.fetch(ctx, melState))
+
+	// Verify that logsByBlockHash is correct
+	require.True(t, len(fetcher.logsByBlockHash) == 2)
+	require.True(t, fetcher.logsByBlockHash[batchBlockHash] != nil)
+	require.True(t, fetcher.logsByBlockHash[delayedBlockHash] != nil)
+	require.True(t, reflect.DeepEqual(fetcher.logsByBlockHash[batchBlockHash], batchTxLogs[:2]))        // last log shouldn't be returned by the filter query
+	require.True(t, reflect.DeepEqual(fetcher.logsByBlockHash[delayedBlockHash], delayedMsgTxLogs[:3])) // last log shouldn't be returned by the filter query
+	// Verify that logsByTxIndex is correct
+	require.True(t, len(fetcher.logsByTxIndex) == 1)
+	require.True(t, fetcher.logsByTxIndex[batchBlockHash] != nil)
+	require.True(t, reflect.DeepEqual(fetcher.logsByTxIndex[batchBlockHash][batchTxIndex], batchTxLogs[:2])) // last log shouldn't be returned by the filter query
+}

--- a/arbnode/mel/runner/mel_test.go
+++ b/arbnode/mel/runner/mel_test.go
@@ -142,6 +142,7 @@ func (m *mockMessageConsumer) PushMessages(ctx context.Context, firstMsgIdx uint
 type mockParentChainReader struct {
 	blocks    map[common.Hash]*types.Block
 	headers   map[common.Hash]*types.Header
+	logs      []*types.Log
 	returnErr error
 }
 
@@ -217,5 +218,10 @@ func (m *mockParentChainReader) TransactionByHash(ctx context.Context, hash comm
 }
 
 func (m *mockParentChainReader) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
-	return nil, nil
+	filteredLogs := types.FilterLogs(m.logs, nil, nil, q.Addresses, q.Topics)
+	var result []types.Log
+	for _, log := range filteredLogs {
+		result = append(result, *log)
+	}
+	return result, nil
 }

--- a/arbnode/mel/runner/mel_test.go
+++ b/arbnode/mel/runner/mel_test.go
@@ -157,7 +157,7 @@ func (m *mockParentChainReader) BlockByNumber(ctx context.Context, number *big.I
 	if m.returnErr != nil {
 		return nil, m.returnErr
 	}
-	if number.Int64() == rpc.FinalizedBlockNumber.Int64() {
+	if number == nil || number.Int64() == rpc.FinalizedBlockNumber.Int64() {
 		return types.NewBlock(&types.Header{Number: big.NewInt(1e10)}, nil, nil, nil), nil // Assume all parent chain blocks are finalized to prevent issues dealing with delayed message backlog, it is tested separately
 	}
 	block, ok := m.blocks[common.BigToHash(number)]
@@ -216,6 +216,6 @@ func (m *mockParentChainReader) TransactionByHash(ctx context.Context, hash comm
 	return nil, false, nil
 }
 
-func (m *mockParentChainReader) BlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error) {
-	return []*types.Receipt{}, nil
+func (m *mockParentChainReader) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	return nil, nil
 }

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -710,12 +710,14 @@ func getMessageExtractor(
 		return nil, nil
 	}
 	melDB := melrunner.NewDatabase(arbDb)
-	initialState, err := createInitialMELState(ctx, deployInfo, l1client)
-	if err != nil {
-		return nil, err
-	}
-	if err = melDB.SaveState(ctx, initialState); err != nil {
-		return nil, fmt.Errorf("failed to save initial mel state: %w", err)
+	if _, err := melDB.GetHeadMelState(ctx); err != nil {
+		initialState, err := createInitialMELState(ctx, deployInfo, l1client)
+		if err != nil {
+			return nil, err
+		}
+		if err = melDB.SaveState(ctx, initialState); err != nil {
+			return nil, fmt.Errorf("failed to save initial mel state: %w", err)
+		}
 	}
 	msgExtractor, err := melrunner.NewMessageExtractor(
 		l1client,


### PR DESCRIPTION
This PR introduces `logsFetcher` that is prefetcher for MEL, fetching logs (in advance for future blocks) needed for processing a parent chain block. The logs to be prefetched for number of blocks can be configured via `--node.message-extraction.blocks-to-prefetch` config option.

Resolves NIT-3542