### PR TITLE
Bring in Missing BoLD PRs

### DIFF
--- a/bold/assertions/manager.go
+++ b/bold/assertions/manager.go
@@ -94,6 +94,8 @@ type Manager struct {
 	autoDeposit                 bool
 	autoAllowanceApproval       bool
 	maxGetLogBlocks             uint64
+	confirming                  *threadsafe.LruSet[protocol.AssertionHash]
+	confirmQueueMutex           sync.Mutex
 }
 
 type assertionChainData struct {
@@ -248,6 +250,8 @@ func NewManager(
 		autoDeposit:                 true,
 		autoAllowanceApproval:       true,
 		maxGetLogBlocks:             1000,
+		confirming:                  threadsafe.NewLruSet[protocol.AssertionHash](maxAssertions),
+		confirmQueueMutex:           sync.Mutex{},
 	}
 	for _, o := range opts {
 		o(m)

--- a/bold/assertions/manager_test.go
+++ b/bold/assertions/manager_test.go
@@ -344,6 +344,7 @@ func TestFastConfirmation(t *testing.T) {
 	ctx := context.Background()
 	testData, err := setup.ChainsWithEdgeChallengeManager(
 		setup.WithMockOneStepProver(),
+		setup.WithAutoDeposit(),
 		setup.WithChallengeTestingOpts(
 			challenge_testing.WithLayerZeroHeights(&protocol.LayerZeroHeights{
 				BlockChallengeHeight:     64,
@@ -416,7 +417,7 @@ func TestFastConfirmation(t *testing.T) {
 func TestFastConfirmationWithSafe(t *testing.T) {
 	ctx := context.Background()
 	testData, err := setup.ChainsWithEdgeChallengeManager(
-		// setup.WithMockBridge(),
+		setup.WithAutoDeposit(),
 		setup.WithMockOneStepProver(),
 		setup.WithChallengeTestingOpts(
 			challenge_testing.WithLayerZeroHeights(&protocol.LayerZeroHeights{

--- a/bold/assertions/poster.go
+++ b/bold/assertions/poster.go
@@ -196,7 +196,8 @@ func (m *Manager) PostAssertionBasedOnParent(
 		"postedExecutionState", fmt.Sprintf("%+v", newState),
 		"assertionHash", assertion.Id(),
 	)
-	m.observedCanonicalAssertions <- assertion.Id()
+
+	m.sendToConfirmationQueue(assertion.Id(), "PostAssertionBasedOnParent")
 	return option.Some(assertion), nil
 }
 

--- a/bold/assertions/poster_test.go
+++ b/bold/assertions/poster_test.go
@@ -6,12 +6,16 @@ package assertions_test
 
 import (
 	"context"
+	"math/big"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/offchainlabs/bold/assertions"
 	protocol "github.com/offchainlabs/bold/chain-abstraction"
@@ -20,14 +24,118 @@ import (
 	challenge_testing "github.com/offchainlabs/bold/testing"
 	statemanager "github.com/offchainlabs/bold/testing/mocks/state-provider"
 	"github.com/offchainlabs/bold/testing/setup"
+	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/solgen/go/mocksgen"
+	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
+	"github.com/offchainlabs/nitro/solgen/go/testgen"
 )
 
 func TestPostAssertion(t *testing.T) {
 	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chainSetup, chalManager, assertionManager, stateManager := setupAssertionPosting(t)
+	aliceChain := chainSetup.Chains[0]
+
+	// Force the posting of a new sequencer batch.
+	forceSequencerMessageBatchPosting(
+		t, ctx, chainSetup.Accounts[0].TxOpts, chainSetup.Addrs.SequencerInbox, chainSetup.Backend,
+	)
+
+	// We have enabled auto-deposits for this test, so we expect that before starting the challenge manager,
+	// Alice has an ERC20 deposit token balance of 0. After starting, we should expect a non-zero balance.
+	rollup, err := rollupgen.NewRollupUserLogic(chainSetup.Addrs.Rollup, chainSetup.Backend)
+	require.NoError(t, err)
+	requiredStake, err := rollup.BaseStake(&bind.CallOpts{})
+	require.NoError(t, err)
+	stakeTokenAddr, err := rollup.StakeToken(&bind.CallOpts{})
+	require.NoError(t, err)
+
+	erc20, err := testgen.NewERC20Token(stakeTokenAddr, chainSetup.Backend)
+	require.NoError(t, err)
+	balance, err := erc20.BalanceOf(&bind.CallOpts{}, aliceChain.StakerAddress())
+	require.NoError(t, err)
+	require.True(t, big.NewInt(0).Cmp(balance) == 0)
+
+	chalManager.Start(ctx)
+
+	// Wait a little for the chain watcher to be ready.
+	time.Sleep(time.Second)
+
+	preState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 0, protocol.GoGlobalState{})
+	require.NoError(t, err)
+	postState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 1, preState.GlobalState)
+	require.NoError(t, err)
+	nextState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 2, postState.GlobalState)
+	require.NoError(t, err)
+
+	// Expect a non-zero balance equal to the required stake after the challenge manager auto-deposited.
+	balance, err = erc20.BalanceOf(&bind.CallOpts{}, aliceChain.StakerAddress())
+	require.NoError(t, err)
+	require.True(t, requiredStake.Cmp(balance) == 0)
+
+	// Verify that alice can post an assertion correctly.
+	posted, err := assertionManager.PostAssertion(ctx)
+	require.NoError(t, err)
+	require.Equal(t, true, posted.IsSome())
+
+	creationInfo, err := aliceChain.ReadAssertionCreationInfo(ctx, posted.Unwrap().Id())
+	require.NoError(t, err)
+	require.Equal(t, postState, protocol.GoExecutionStateFromSolidity(creationInfo.AfterState))
+
+	// Wait a little and advance the chain to allow the next assertion to be posted.
+	time.Sleep(time.Second * 5)
+	chainSetup.Backend.Commit()
+
+	// Expect a zero ERC20 balance after the first staked assertion was posted.
+	balance, err = erc20.BalanceOf(&bind.CallOpts{}, aliceChain.StakerAddress())
+	require.NoError(t, err)
+	require.True(t, big.NewInt(0).Cmp(balance) == 0)
+
+	posted, err = assertionManager.PostAssertion(ctx)
+	require.NoError(t, err)
+	require.Equal(t, true, posted.IsSome())
+
+	creationInfo, err = aliceChain.ReadAssertionCreationInfo(ctx, posted.Unwrap().Id())
+	require.NoError(t, err)
+	require.Equal(t, nextState, protocol.GoExecutionStateFromSolidity(creationInfo.AfterState))
+
+	// Continue to expect a zero ERC20 balance after the second assertion was posted, as no new
+	// stake was expected for the validator.
+	time.Sleep(time.Second * 5)
+	chainSetup.Backend.Commit()
+
+	balance, err = erc20.BalanceOf(&bind.CallOpts{}, chainSetup.Accounts[0].TxOpts.From)
+	require.NoError(t, err)
+	require.True(t, big.NewInt(0).Cmp(balance) == 0)
+
+	// We then filter all the transactions to the staken address from the validator and expect
+	// there was only a single deposit event (a transfer event with from set to 0x0).
+	it, err := erc20.FilterTransfer(
+		&bind.FilterOpts{
+			Start: 0,
+			End:   nil,
+		},
+		[]common.Address{{}},
+		[]common.Address{aliceChain.StakerAddress()},
+	)
+	require.NoError(t, err)
+	defer func() {
+		if err = it.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	totalTransfers := 0
+	for it.Next() {
+		totalTransfers++
+	}
+	require.Equal(t, 1, totalTransfers, "Expected only one deposit event by the staker")
+}
+
+func setupAssertionPosting(t *testing.T) (*setup.ChainSetup, *cm.Manager, *assertions.Manager, *statemanager.L2StateBackend) {
 	setup, err := setup.ChainsWithEdgeChallengeManager(
-		// setup.WithMockBridge(),
 		setup.WithMockOneStepProver(),
+		setup.WithAutoDeposit(),
 		setup.WithChallengeTestingOpts(
 			challenge_testing.WithLayerZeroHeights(&protocol.LayerZeroHeights{
 				BlockChallengeHeight:     64,
@@ -37,16 +145,12 @@ func TestPostAssertion(t *testing.T) {
 		),
 	)
 	require.NoError(t, err)
-
 	bridgeBindings, err := mocksgen.NewBridgeStub(setup.Addrs.Bridge, setup.Backend)
 	require.NoError(t, err)
-
 	msgCount, err := bridgeBindings.SequencerMessageCount(setup.Chains[0].GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{}))
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), msgCount.Uint64())
-
 	aliceChain := setup.Chains[0]
-
 	stateManagerOpts := setup.StateManagerOpts
 	stateManagerOpts = append(
 		stateManagerOpts,
@@ -54,7 +158,6 @@ func TestPostAssertion(t *testing.T) {
 	)
 	stateManager, err := statemanager.NewForSimpleMachine(t, stateManagerOpts...)
 	require.NoError(t, err)
-
 	// Set MinimumGapToBlockCreationTime as 1 second to verify that a new assertion is only posted after 1 sec has passed
 	// from parent assertion creation. This will make the test run for ~19 seconds as the parent assertion time is
 	// ~18 seconds in the future
@@ -68,7 +171,6 @@ func TestPostAssertion(t *testing.T) {
 		assertions.WithMinimumGapToParentAssertion(time.Second),
 	)
 	require.NoError(t, err)
-
 	chalManager, err := cm.NewChallengeStack(
 		aliceChain,
 		stateManager,
@@ -77,19 +179,28 @@ func TestPostAssertion(t *testing.T) {
 		cm.OverrideAssertionManager(assertionManager),
 	)
 	require.NoError(t, err)
-	chalManager.Start(ctx)
+	return setup, chalManager, assertionManager, stateManager
+}
 
-	preState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 0, protocol.GoGlobalState{})
+func forceSequencerMessageBatchPosting(
+	t *testing.T,
+	ctx context.Context,
+	sequencerOpts *bind.TransactOpts,
+	seqInboxAddr common.Address,
+	backend *setup.SimulatedBackendWrapper,
+) {
+	batchCompressedBytes := hexutil.MustDecode("0x94643ec208c5558027fa768281f28aa273f01537942cd58cdd9c17e97e30281f")
+	message := append([]byte{0}, batchCompressedBytes...)
+	seqNum := new(big.Int).Lsh(common.Big1, 256)
+	seqNum.Sub(seqNum, common.Big1)
+	seqInbox, err := bridgegen.NewSequencerInbox(seqInboxAddr, backend)
 	require.NoError(t, err)
-	postState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 1, preState.GlobalState)
+	tx, err := seqInbox.AddSequencerL2BatchFromOrigin8f111f3c(
+		sequencerOpts, seqNum, message, big.NewInt(1), common.Address{}, big.NewInt(0), big.NewInt(0),
+	)
 	require.NoError(t, err)
-
-	time.Sleep(time.Second)
-
-	posted, err := assertionManager.PostAssertion(ctx)
+	require.NoError(t, challenge_testing.WaitForTx(ctx, backend, tx))
+	receipt, err := backend.TransactionReceipt(ctx, tx.Hash())
 	require.NoError(t, err)
-	require.Equal(t, true, posted.IsSome())
-	creationInfo, err := aliceChain.ReadAssertionCreationInfo(ctx, posted.Unwrap().Id())
-	require.NoError(t, err)
-	require.Equal(t, postState, protocol.GoExecutionStateFromSolidity(creationInfo.AfterState))
+	require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 }

--- a/bold/assertions/sync_test.go
+++ b/bold/assertions/sync_test.go
@@ -136,6 +136,7 @@ func Test_findCanonicalAssertionBranch(t *testing.T) {
 		execProvider:                provider,
 		chain:                       setup.Chains[0],
 		observedCanonicalAssertions: make(chan protocol.AssertionHash),
+		confirming:                  threadsafe.NewLruSet[protocol.AssertionHash](1000),
 		assertionChainData: &assertionChainData{
 			latestAgreedAssertion: numToAssertionHash(1),
 			canonicalAssertions:   make(map[protocol.AssertionHash]*protocol.AssertionCreatedInfo),
@@ -267,6 +268,7 @@ func Test_respondToAnyInvalidAssertions(t *testing.T) {
 	manager := &Manager{
 		observedCanonicalAssertions: make(chan protocol.AssertionHash),
 		submittedAssertions:         threadsafe.NewLruSet(1000, threadsafe.LruSetWithMetric[protocol.AssertionHash]("submittedAssertions")),
+		confirming:                  threadsafe.NewLruSet[protocol.AssertionHash](1000),
 		assertionChainData: &assertionChainData{
 			latestAgreedAssertion: numToAssertionHash(1),
 			canonicalAssertions:   make(map[protocol.AssertionHash]*protocol.AssertionCreatedInfo),

--- a/bold/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/bold/chain-abstraction/sol-implementation/assertion_chain.go
@@ -630,8 +630,14 @@ func (a *AssertionChain) createAndStakeOnAssertion(
 		return nil, errors.Wrapf(err, "could not fetch assertion with computed hash %#x", computedHash)
 	default:
 	}
-	if err = a.autoDepositFunds(ctx, parentAssertionCreationInfo.RequiredStake); err != nil {
-		return nil, errors.Wrapf(err, "could not auto-deposit funds for assertion creation")
+	staked, err := a.IsStaked(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !staked {
+		if err = a.autoDepositFunds(ctx, parentAssertionCreationInfo.RequiredStake); err != nil {
+			return nil, errors.Wrapf(err, "could not auto-deposit funds for assertion creation")
+		}
 	}
 	receipt, err := a.transact(ctx, a.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return stakeFn(

--- a/bold/testing/setup/rollup_stack.go
+++ b/bold/testing/setup/rollup_stack.go
@@ -1,6 +1,6 @@
 // Copyright 2023-2024, Offchain Labs, Inc.
 // For license information, see:
-// https://github.com/offchainlabs/nitro/blob/master/LICENSE.md
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 // Package setup prepares a simulated backend for testing.
 package setup
@@ -173,6 +173,7 @@ type ChainSetup struct {
 	numAccountsToGen           uint64
 	numFundedAccounts          uint64
 	minimumAssertionPeriod     int64
+	autoDeposit                bool
 	challengeTestingOpts       []challenge_testing.Opt
 	StateManagerOpts           []statemanager.Opt
 	StakeTokenAddress          common.Address
@@ -236,10 +237,17 @@ func WithNumFundedAccounts(n uint64) Opt {
 	}
 }
 
+func WithAutoDeposit() Opt {
+	return func(setup *ChainSetup) {
+		setup.autoDeposit = true
+	}
+}
+
 func ChainsWithEdgeChallengeManager(opts ...Opt) (*ChainSetup, error) {
 	ctx := context.Background()
 	setp := &ChainSetup{
 		numAccountsToGen: 4,
+		autoDeposit:      false,
 	}
 	for _, o := range opts {
 		o(setp)
@@ -274,22 +282,24 @@ func ChainsWithEdgeChallengeManager(opts ...Opt) (*ChainSetup, error) {
 	if !ok {
 		return nil, errors.New("could not set value")
 	}
-	accs[0].TxOpts.Value = value
-	mintTx, err := tokenBindings.Deposit(accs[0].TxOpts)
-	if err != nil {
-		return nil, err
+	if !setp.autoDeposit {
+		accs[0].TxOpts.Value = value
+		mintTx, err3 := tokenBindings.Deposit(accs[0].TxOpts)
+		if err3 != nil {
+			return nil, err3
+		}
+		if waitErr := challenge_testing.WaitForTx(ctx, backend, mintTx); waitErr != nil {
+			return nil, errors.Wrap(waitErr, "errored waiting for transaction")
+		}
+		receipt, err = backend.TransactionReceipt(ctx, mintTx.Hash())
+		if err != nil {
+			return nil, err
+		}
+		if receipt.Status != types.ReceiptStatusSuccessful {
+			return nil, errors.New("receipt not successful")
+		}
+		accs[0].TxOpts.Value = big.NewInt(0)
 	}
-	if waitErr := challenge_testing.WaitForTx(ctx, backend, mintTx); waitErr != nil {
-		return nil, errors.Wrap(waitErr, "errored waiting for transaction")
-	}
-	receipt, err = backend.TransactionReceipt(ctx, mintTx.Hash())
-	if err != nil {
-		return nil, err
-	}
-	if receipt.Status != types.ReceiptStatusSuccessful {
-		return nil, errors.New("receipt not successful")
-	}
-	accs[0].TxOpts.Value = big.NewInt(0)
 
 	prod := false
 	wasmModuleRoot := common.Hash{}
@@ -445,49 +455,51 @@ func ChainsWithEdgeChallengeManager(opts ...Opt) (*ChainSetup, error) {
 	if !ok {
 		return nil, errors.New("could not set big int")
 	}
-	for i := 0; i < len(accs); i++ {
-		acc := accs[i]
-		transferTx, err := tokenBindings.Transfer(accs[0].TxOpts, acc.TxOpts.From, seed)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not approve account")
-		}
-		if waitErr := challenge_testing.WaitForTx(ctx, backend, transferTx); waitErr != nil {
-			return nil, errors.Wrap(waitErr, "errored waiting for transfer transaction")
-		}
-		receipt, err := backend.TransactionReceipt(ctx, transferTx.Hash())
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get tx receipt")
-		}
-		if receipt.Status != types.ReceiptStatusSuccessful {
-			return nil, errors.New("receipt not successful")
-		}
-		approveTx, err := tokenBindings.Approve(acc.TxOpts, addresses.Rollup, value)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not approve account")
-		}
-		if waitErr := challenge_testing.WaitForTx(ctx, backend, approveTx); waitErr != nil {
-			return nil, errors.Wrap(waitErr, "errored waiting for approval transaction")
-		}
-		receipt, err = backend.TransactionReceipt(ctx, approveTx.Hash())
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get tx receipt")
-		}
-		if receipt.Status != types.ReceiptStatusSuccessful {
-			return nil, errors.New("receipt not successful")
-		}
-		approveTx, err = tokenBindings.Approve(acc.TxOpts, chalManagerAddr, value)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not approve account")
-		}
-		if waitErr := challenge_testing.WaitForTx(ctx, backend, approveTx); waitErr != nil {
-			return nil, errors.Wrap(waitErr, "errored waiting for approval transaction")
-		}
-		receipt, err = backend.TransactionReceipt(ctx, approveTx.Hash())
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get tx receipt")
-		}
-		if receipt.Status != types.ReceiptStatusSuccessful {
-			return nil, errors.New("receipt not successful")
+	if !setp.autoDeposit {
+		for i := 0; i < len(accs); i++ {
+			acc := accs[i]
+			transferTx, err := tokenBindings.Transfer(accs[0].TxOpts, acc.TxOpts.From, seed)
+			if err != nil {
+				return nil, errors.Wrap(err, "could not approve account")
+			}
+			if waitErr := challenge_testing.WaitForTx(ctx, backend, transferTx); waitErr != nil {
+				return nil, errors.Wrap(waitErr, "errored waiting for transfer transaction")
+			}
+			receipt, err := backend.TransactionReceipt(ctx, transferTx.Hash())
+			if err != nil {
+				return nil, errors.Wrap(err, "could not get tx receipt")
+			}
+			if receipt.Status != types.ReceiptStatusSuccessful {
+				return nil, errors.New("receipt not successful")
+			}
+			approveTx, err := tokenBindings.Approve(acc.TxOpts, addresses.Rollup, value)
+			if err != nil {
+				return nil, errors.Wrap(err, "could not approve account")
+			}
+			if waitErr := challenge_testing.WaitForTx(ctx, backend, approveTx); waitErr != nil {
+				return nil, errors.Wrap(waitErr, "errored waiting for approval transaction")
+			}
+			receipt, err = backend.TransactionReceipt(ctx, approveTx.Hash())
+			if err != nil {
+				return nil, errors.Wrap(err, "could not get tx receipt")
+			}
+			if receipt.Status != types.ReceiptStatusSuccessful {
+				return nil, errors.New("receipt not successful")
+			}
+			approveTx, err = tokenBindings.Approve(acc.TxOpts, chalManagerAddr, value)
+			if err != nil {
+				return nil, errors.Wrap(err, "could not approve account")
+			}
+			if waitErr := challenge_testing.WaitForTx(ctx, backend, approveTx); waitErr != nil {
+				return nil, errors.Wrap(waitErr, "errored waiting for approval transaction")
+			}
+			receipt, err = backend.TransactionReceipt(ctx, approveTx.Hash())
+			if err != nil {
+				return nil, errors.Wrap(err, "could not get tx receipt")
+			}
+			if receipt.Status != types.ReceiptStatusSuccessful {
+				return nil, errors.New("receipt not successful")
+			}
 		}
 	}
 

--- a/bold/testing/setup/rollup_stack.go
+++ b/bold/testing/setup/rollup_stack.go
@@ -1,6 +1,6 @@
 // Copyright 2023-2024, Offchain Labs, Inc.
 // For license information, see:
-// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+// https://github.com/offchainlabs/nitro/blob/main/LICENSE.md
 
 // Package setup prepares a simulated backend for testing.
 package setup


### PR DESCRIPTION
After the big BoLD merge (#3430) was completed a few days ago, two PRs had been merged into the [bold](https://github.com/OffchainLabs/bold) repo that are not included in Nitro master. This PR brings them in

[Fix multi assertion confirmation tx sending (](https://github.com/OffchainLabs/nitro/commit/e0980eac75e0818faae223f0a87aba10e43f2967)https://github.com/OffchainLabs/nitro/pull/752[)](https://github.com/OffchainLabs/nitro/commit/e0980eac75e0818faae223f0a87aba10e43f2967) by @Jason-W123 

[Fix Double Deposit Issue (](https://github.com/OffchainLabs/nitro/commit/7a750e3021e95c90b7f166adbcfae9d73ece137f)https://github.com/OffchainLabs/nitro/pull/758[)](https://github.com/OffchainLabs/nitro/commit/7a750e3021e95c90b7f166adbcfae9d73ece137f) by @rauljordan 
