### PR TITLE
chore(lint): add require-exhaustive-init linter to structs (1/n)

### DIFF
--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -37,6 +37,7 @@ type InboxBackend interface {
 	ReadDelayedInbox(seqNum uint64) (*arbostypes.L1IncomingMessage, error)
 }
 
+// lint:require-exhaustive-initialization
 type SequencerMessage struct {
 	MinTimestamp         uint64
 	MaxTimestamp         uint64
@@ -162,6 +163,7 @@ func ParseSequencerMessage(ctx context.Context, batchNum uint64, batchBlockHash 
 	return parsedMsg, nil
 }
 
+// lint:require-exhaustive-initialization
 type inboxMultiplexer struct {
 	backend                   InboxBackend
 	delayedMessagesRead       uint64

--- a/arbstate/inbox_fuzz_test.go
+++ b/arbstate/inbox_fuzz_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/offchainlabs/nitro/daprovider"
 )
 
+// lint:require-exhaustive-initialization
 type multiplexerBackend struct {
 	batchSeqNum           uint64
 	batch                 []byte

--- a/arbutil/finality_data.go
+++ b/arbutil/finality_data.go
@@ -5,6 +5,7 @@ package arbutil
 
 import "github.com/ethereum/go-ethereum/common"
 
+// lint:require-exhaustive-initialization
 type FinalityData struct {
 	MsgIdx    MessageIndex
 	BlockHash common.Hash

--- a/blocks_reexecutor/blocks_reexecutor.go
+++ b/blocks_reexecutor/blocks_reexecutor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
+// lint:require-exhaustive-initialization
 type Config struct {
 	Enable             bool   `koanf:"enable"`
 	Mode               string `koanf:"mode"`
@@ -87,6 +88,7 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Int(prefix+".trie-clean-limit", DefaultConfig.TrieCleanLimit, "memory allowance (MB) to use for caching trie nodes in memory")
 }
 
+// lint:require-exhaustive-initialization
 type BlocksReExecutor struct {
 	stopwaiter.StopWaiter
 	config       *Config


### PR DESCRIPTION
## Description
Addresses #3121 

Add the linter to packages: `arbstate`, `arbutil`, `blocks_reexecutor`