### PR TITLE
Blob prices should not be used if parent chain doesn't return blob price

### DIFF
--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -1367,10 +1367,10 @@ func (s *Sequencer) updateExpectedSurplus(ctx context.Context) (int64, error) {
 		if s.config().Dangerous.DisableBlobBaseFeeCheck {
 			log.Warn("expected surplus calculation is set to use blob price but --execution.sequencer.dangerous.disable-blob-base-fee-check is set, falling back to calldata price model")
 			backlogCost = backlogCallDataUnits * header.BaseFee.Int64()
+		} else if header.BlobGasUsed == nil || header.ExcessBlobGas == nil {
+			log.Warn("expected surplus calculation is set to use blob price but latest parent chain header has BlobGasUsed or ExcessBlobGas as nil, falling back to calldata price model")
+			backlogCost = backlogCallDataUnits * header.BaseFee.Int64()
 		} else {
-			if header.BlobGasUsed == nil || header.ExcessBlobGas == nil {
-				return 0, errors.New("expected surplus calculation is set to use blob price but latest parent chain header has BlobGasUsed or ExcessBlobGas as nil")
-			}
 			blobFeePerByte, err := s.l1Reader.Client().BlobBaseFee(ctx)
 			if err != nil {
 				return 0, fmt.Errorf("error encountered getting blob base fee while updating expectedSurplus: %w", err)


### PR DESCRIPTION
Fixes: NIT-3652

Ensures that blob prices are only used when the parent chain supports them.

Even if the config expected-surplus-gas-price-mode is set to BlobPrice, we now check whether the parent chain supports blobs by verifying that both header.BlobGasUsed and header.ExcessBlobGas are non-nil.

If either of these fields is nil (indicating lack of blob support), the logic falls back to the calldata price model.

This prevents incorrect behavior on chains that do not support EIP-4844.