### PR TITLE
fix: remove redundant context creation in poster_test.go

### DIFF
--- a/bold/assertions/poster_test.go
+++ b/bold/assertions/poster_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestPostAssertion(t *testing.T) {
-	ctx := context.Background()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	chainSetup, chalManager, assertionManager, stateManager := setupAssertionPosting(t)


### PR DESCRIPTION
Remove duplicate context.Background() creation in TestPostAssertion function.

The test was creating two contexts:
1. ctx := context.Background() (unused)
2. ctx, cancel := context.WithCancel(context.Background()) (used)

This was redundant and potentially confusing. Now only the context with 
cancel functionality is created, which is what the test actually needs.

Fixes code clarity and removes unnecessary variable assignment.