### PR TITLE
perf: optimize regex compilation in colors.Uncolor function

### DIFF
--- a/util/colors/colors.go
+++ b/util/colors/colors.go
@@ -8,6 +8,11 @@ import (
 	"regexp"
 )
 
+var (
+	uncolorRegex = regexp.MustCompile("\x1b\\[([0-9]+;)*[0-9]+m")
+	unwhiteRegex = regexp.MustCompile(`\s+`)
+)
+
 var Red = "\033[31;1m"
 var Blue = "\033[34;1m"
 var Yellow = "\033[33;1m"
@@ -59,9 +64,6 @@ func PrintPink(args ...interface{}) {
 }
 
 func Uncolor(text string) string {
-	uncolor := regexp.MustCompile("\x1b\\[([0-9]+;)*[0-9]+m")
-	unwhite := regexp.MustCompile(`\s+`)
-
-	text = uncolor.ReplaceAllString(text, "")
-	return unwhite.ReplaceAllString(text, " ")
+	text = uncolorRegex.ReplaceAllString(text, "")
+	return unwhiteRegex.ReplaceAllString(text, " ")
 }


### PR DESCRIPTION
Move regex compilation from function scope to package level to avoid recompiling regular expressions on every Uncolor() call. This provides significant performance improvement when the function is called frequently.

Before: regexp.MustCompile() called twice per function invocation
After: Regex patterns compiled once at package initialization

This follows Go best practices for regex usage and eliminates unnecessary computational overhead in color processing utilities.