### PR TITLE
Message extraction function works with logs instead of receipts

### DIFF
--- a/arbnode/db-schema/schema.go
+++ b/arbnode/db-schema/schema.go
@@ -15,7 +15,8 @@ var (
 	SequencerBatchMetaPrefix            []byte = []byte("s") // maps a batch sequence number to BatchMetadata
 	DelayedSequencedPrefix              []byte = []byte("a") // maps a delayed message count to the first sequencer batch sequence number with this delayed count
 	MelStatePrefix                      []byte = []byte("l") // maps a parent chain block number to its computed MEL state
-	MelDelayedMessagePrefix             []byte = []byte("y") // maps a delayed sequence number to an accumulator and an RLP encoded message [Note: might need to replace or be replaced by RlpDelayedMessagePrefix]
+	MelDelayedMessagePrefix             []byte = []byte("y") // maps a delayed sequence number to an accumulator and an RLP encoded message [TODO: might need to replace or be replaced by RlpDelayedMessagePrefix]
+	MelSequencerBatchMetaPrefix         []byte = []byte("q") // maps a batch sequence number to BatchMetadata [TODO: might need to replace or be replaced by SequencerBatchMetaPrefix
 
 	MessageCountKey             []byte = []byte("_messageCount")                // contains the current message count
 	LastPrunedMessageKey        []byte = []byte("_lastPrunedMessageKey")        // contains the last pruned message key

--- a/arbnode/mel/extraction/abis.go
+++ b/arbnode/mel/extraction/abis.go
@@ -7,11 +7,11 @@ import (
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 )
 
-var batchDeliveredID common.Hash
-var inboxMessageDeliveredID common.Hash
-var inboxMessageFromOriginID common.Hash
-var seqInboxABI *abi.ABI
-var iBridgeABI *abi.ABI
+var BatchDeliveredID common.Hash
+var InboxMessageDeliveredID common.Hash
+var InboxMessageFromOriginID common.Hash
+var SeqInboxABI *abi.ABI
+var IBridgeABI *abi.ABI
 var iInboxABI *abi.ABI
 var iDelayedMessageProviderABI *abi.ABI
 
@@ -21,20 +21,20 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	batchDeliveredID = sequencerBridgeABI.Events["SequencerBatchDelivered"].ID
+	BatchDeliveredID = sequencerBridgeABI.Events["SequencerBatchDelivered"].ID
 	parsedIBridgeABI, err := bridgegen.IBridgeMetaData.GetAbi()
 	if err != nil {
 		panic(err)
 	}
-	iBridgeABI = parsedIBridgeABI
+	IBridgeABI = parsedIBridgeABI
 	parsedIMessageProviderABI, err := bridgegen.IDelayedMessageProviderMetaData.GetAbi()
 	if err != nil {
 		panic(err)
 	}
 	iDelayedMessageProviderABI = parsedIMessageProviderABI
-	inboxMessageDeliveredID = parsedIMessageProviderABI.Events["InboxMessageDelivered"].ID
-	inboxMessageFromOriginID = parsedIMessageProviderABI.Events["InboxMessageDeliveredFromOrigin"].ID
-	seqInboxABI, err = bridgegen.SequencerInboxMetaData.GetAbi()
+	InboxMessageDeliveredID = parsedIMessageProviderABI.Events["InboxMessageDelivered"].ID
+	InboxMessageFromOriginID = parsedIMessageProviderABI.Events["InboxMessageDeliveredFromOrigin"].ID
+	SeqInboxABI, err = bridgegen.SequencerInboxMetaData.GetAbi()
 	if err != nil {
 		panic(err)
 	}
@@ -43,5 +43,5 @@ func init() {
 		panic(err)
 	}
 	iInboxABI = parsedIInboxABI
-	batchDeliveredID = sequencerBridgeABI.Events["SequencerBatchDelivered"].ID
+	BatchDeliveredID = sequencerBridgeABI.Events["SequencerBatchDelivered"].ID
 }

--- a/arbnode/mel/extraction/batch_lookup.go
+++ b/arbnode/mel/extraction/batch_lookup.go
@@ -20,82 +20,60 @@ func parseBatchesFromBlock(
 	ctx context.Context,
 	melState *mel.State,
 	parentChainHeader *types.Header,
-	txsFetcher TransactionsFetcher,
-	receiptFetcher ReceiptFetcher,
+	txFetcher TransactionFetcher,
+	logsFetcher LogsFetcher,
 	eventUnpacker eventUnpacker,
-) ([]*mel.SequencerInboxBatch, []*types.Transaction, []uint, error) {
-	allBatches := make([]*mel.SequencerInboxBatch, 0)
-	allBatchTxs := make([]*types.Transaction, 0)
-	allBatchTxIndices := make([]uint, 0)
-	parentChainBlockTxs, err := txsFetcher.TransactionsByHeader(ctx, parentChainHeader.Hash())
+) ([]*mel.SequencerInboxBatch, []*types.Transaction, error) {
+	batches := make([]*mel.SequencerInboxBatch, 0)
+	batchTxs := make([]*types.Transaction, 0)
+	logs, err := logsFetcher.LogsForBlockHash(ctx, parentChainHeader.Hash())
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to fetch transactions for parent chain block %v: %w", parentChainHeader.Hash(), err)
+		return nil, nil, fmt.Errorf("failed to fetch logs from parent chain block %v: %w", parentChainHeader.Hash(), err)
 	}
-	for i, tx := range parentChainBlockTxs {
-		// TODO: remove this temporary work around for handling init message, i.e skipping the check when msgCount==0
-		if melState.MsgCount != 0 {
-			if tx.To() == nil {
-				continue
-			}
-			if *tx.To() != melState.BatchPostingTargetAddress {
-				continue
-			}
-		}
-		// Fetch the receipts for the transaction to get the logs.
-		txIndex := uint(i) // #nosec G115
-		receipt, err := receiptFetcher.ReceiptForTransactionIndex(ctx, txIndex)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		if len(receipt.Logs) == 0 {
+	var lastSeqNum *uint64
+	for _, log := range logs {
+		if log == nil || log.Topics[0] != BatchDeliveredID {
 			continue
 		}
-		batches := make([]*mel.SequencerInboxBatch, 0, len(receipt.Logs))
-		txs := make([]*types.Transaction, 0, len(receipt.Logs))
-		txIndices := make([]uint, 0, len(receipt.Logs))
-		var lastSeqNum *uint64
-		for _, log := range receipt.Logs {
-			if log == nil || log.Topics[0] != batchDeliveredID {
-				continue
-			}
-			event := new(bridgegen.SequencerInboxSequencerBatchDelivered)
-			if err := eventUnpacker.unpackLogTo(event, seqInboxABI, "SequencerBatchDelivered", *log); err != nil {
-				return nil, nil, nil, err
-			}
-			if !event.BatchSequenceNumber.IsUint64() {
-				return nil, nil, nil, errors.New("sequencer inbox event has non-uint64 sequence number")
-			}
-			if !event.AfterDelayedMessagesRead.IsUint64() {
-				return nil, nil, nil, errors.New("sequencer inbox event has non-uint64 delayed messages read")
-			}
-
-			seqNum := event.BatchSequenceNumber.Uint64()
-			if lastSeqNum != nil {
-				if seqNum != *lastSeqNum+1 {
-					return nil, nil, nil, fmt.Errorf("sequencer batches out of order; after batch %v got batch %v", *lastSeqNum, seqNum)
-				}
-			}
-			lastSeqNum = &seqNum
-			batch := &mel.SequencerInboxBatch{
-				BlockHash:              log.BlockHash,
-				ParentChainBlockNumber: log.BlockNumber,
-				SequenceNumber:         seqNum,
-				BeforeInboxAcc:         event.BeforeAcc,
-				AfterInboxAcc:          event.AfterAcc,
-				AfterDelayedAcc:        event.DelayedAcc,
-				AfterDelayedCount:      event.AfterDelayedMessagesRead.Uint64(),
-				RawLog:                 *log,
-				TimeBounds:             event.TimeBounds,
-				DataLocation:           mel.BatchDataLocation(event.DataLocation),
-				BridgeAddress:          log.Address,
-			}
-			batches = append(batches, batch)
-			txs = append(txs, tx)
-			txIndices = append(txIndices, uint(i)) // #nosec G115
+		event := new(bridgegen.SequencerInboxSequencerBatchDelivered)
+		if err := eventUnpacker.unpackLogTo(event, SeqInboxABI, "SequencerBatchDelivered", *log); err != nil {
+			return nil, nil, err
 		}
-		allBatches = append(allBatches, batches...)
-		allBatchTxs = append(allBatchTxs, txs...)
-		allBatchTxIndices = append(allBatchTxIndices, txIndices...)
+		if !event.BatchSequenceNumber.IsUint64() {
+			return nil, nil, errors.New("sequencer inbox event has non-uint64 sequence number")
+		}
+		if !event.AfterDelayedMessagesRead.IsUint64() {
+			return nil, nil, errors.New("sequencer inbox event has non-uint64 delayed messages read")
+		}
+
+		seqNum := event.BatchSequenceNumber.Uint64()
+		if lastSeqNum != nil {
+			if seqNum != *lastSeqNum+1 {
+				return nil, nil, fmt.Errorf("sequencer batches out of order; after batch %v got batch %v", *lastSeqNum, seqNum)
+			}
+		}
+		lastSeqNum = &seqNum
+
+		tx, err := txFetcher.TransactionByLog(ctx, log)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error fetching tx by hash: %v in parseBatchesFromBlock: %w ", log.TxHash, err)
+		}
+
+		batch := &mel.SequencerInboxBatch{
+			BlockHash:              log.BlockHash,
+			ParentChainBlockNumber: log.BlockNumber,
+			SequenceNumber:         seqNum,
+			BeforeInboxAcc:         event.BeforeAcc,
+			AfterInboxAcc:          event.AfterAcc,
+			AfterDelayedAcc:        event.DelayedAcc,
+			AfterDelayedCount:      event.AfterDelayedMessagesRead.Uint64(),
+			RawLog:                 *log,
+			TimeBounds:             event.TimeBounds,
+			DataLocation:           mel.BatchDataLocation(event.DataLocation),
+			BridgeAddress:          log.Address,
+		}
+		batches = append(batches, batch)
+		batchTxs = append(batchTxs, tx)
 	}
-	return allBatches, allBatchTxs, allBatchTxIndices, nil
+	return batches, batchTxs, nil
 }

--- a/arbnode/mel/extraction/batch_lookup_test.go
+++ b/arbnode/mel/extraction/batch_lookup_test.go
@@ -3,6 +3,7 @@ package melextraction
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -22,7 +23,7 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 	batchPostingTargetAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 	event, packedLog, wantedBatch := setupParseBatchesTest(t, big.NewInt(1))
 
-	t.Run("block with no transactions", func(t *testing.T) {
+	t.Run("block with no logs", func(t *testing.T) {
 		blockHeader := &types.Header{}
 		blockBody := &types.Body{}
 		block := types.NewBlock(
@@ -31,99 +32,19 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 			nil,
 			trie.NewStackTrie(nil),
 		)
-		batches, txs, txIndices, err := parseBatchesFromBlock(
+		batches, txs, err := parseBatchesFromBlock(
 			ctx,
 			nil,
 			block.Header(),
-			&mockTxsFetcher{},
 			nil,
+			&mockBlockLogsFetcher{},
 			nil,
 		)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(batches))
 		require.Equal(t, 0, len(txs))
-		require.Equal(t, 0, len(txIndices))
 	})
-	t.Run("block with no transactions with a to field", func(t *testing.T) {
-		blockHeader := &types.Header{}
-		txData := &types.DynamicFeeTx{
-			To:        nil,
-			Nonce:     1,
-			GasFeeCap: big.NewInt(1),
-			GasTipCap: big.NewInt(1),
-			Gas:       1,
-			Value:     big.NewInt(0),
-			Data:      nil,
-		}
-		tx := types.NewTx(txData)
-		blockBody := &types.Body{
-			Transactions: []*types.Transaction{tx},
-		}
-		txsFetcher := &mockTxsFetcher{
-			txs: []*types.Transaction{tx},
-		}
-		block := types.NewBlock(
-			blockHeader,
-			blockBody,
-			nil,
-			trie.NewStackTrie(nil),
-		)
-		batches, txs, txIndices, err := parseBatchesFromBlock(
-			ctx,
-			&mel.State{MsgCount: 1},
-			block.Header(),
-			txsFetcher,
-			nil,
-			nil,
-		)
-		require.NoError(t, err)
-		require.Equal(t, 0, len(batches))
-		require.Equal(t, 0, len(txs))
-		require.Equal(t, 0, len(txIndices))
-	})
-	t.Run("block with transactions not targeting the batch posting target address", func(t *testing.T) {
-		blockHeader := &types.Header{}
-		addr := common.BytesToAddress([]byte("deadbeef"))
-		txData := &types.DynamicFeeTx{
-			To:        &addr,
-			Nonce:     1,
-			GasFeeCap: big.NewInt(1),
-			GasTipCap: big.NewInt(1),
-			Gas:       1,
-			Value:     big.NewInt(0),
-			Data:      nil,
-		}
-		tx := types.NewTx(txData)
-		blockBody := &types.Body{
-			Transactions: []*types.Transaction{tx},
-		}
-		txsFetcher := &mockTxsFetcher{
-			txs: []*types.Transaction{tx},
-		}
-		block := types.NewBlock(
-			blockHeader,
-			blockBody,
-			nil,
-			trie.NewStackTrie(nil),
-		)
-		melState := &mel.State{
-			BatchPostingTargetAddress: batchPostingTargetAddr,
-			MsgCount:                  1,
-		}
-		batches, txs, txIndices, err := parseBatchesFromBlock(
-			ctx,
-			melState,
-			block.Header(),
-			txsFetcher,
-			nil,
-			nil,
-		)
-		require.NoError(t, err)
-		require.Equal(t, 0, len(batches))
-		require.Equal(t, 0, len(txs))
-		require.Equal(t, 0, len(txIndices))
-	})
-	t.Run("bad receipt fetcher request", func(t *testing.T) {
+	t.Run("bad block logs fetcher request", func(t *testing.T) {
 		blockHeader := &types.Header{}
 		txData := &types.DynamicFeeTx{
 			To:        &batchPostingTargetAddr,
@@ -138,7 +59,7 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 		blockBody := &types.Body{
 			Transactions: []*types.Transaction{tx},
 		}
-		txsFetcher := &mockTxsFetcher{
+		txFetcher := &mockTxFetcher{
 			txs: []*types.Transaction{tx},
 		}
 		block := types.NewBlock(
@@ -150,16 +71,15 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 		melState := &mel.State{
 			BatchPostingTargetAddress: batchPostingTargetAddr,
 		}
-		receiptFetcher := &mockReceiptFetcher{
-			receipts: nil,
-			err:      errors.New("oops"),
+		blockLogsFetcher := &mockBlockLogsFetcher{
+			err: errors.New("oops"),
 		}
-		_, _, _, err := parseBatchesFromBlock(
+		_, _, err := parseBatchesFromBlock(
 			ctx,
 			melState,
 			block.Header(),
-			txsFetcher,
-			receiptFetcher,
+			txFetcher,
+			blockLogsFetcher,
 			nil,
 		)
 		require.ErrorContains(t, err, "oops")
@@ -179,7 +99,7 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 		blockBody := &types.Body{
 			Transactions: []*types.Transaction{tx},
 		}
-		txsFetcher := &mockTxsFetcher{
+		txFetcher := &mockTxFetcher{
 			txs: []*types.Transaction{tx},
 		}
 		receipt := &types.Receipt{
@@ -195,22 +115,20 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 		melState := &mel.State{
 			BatchPostingTargetAddress: batchPostingTargetAddr,
 		}
-		receiptFetcher := &mockReceiptFetcher{
-			receipts: receipts,
-			err:      nil,
+		blockLogsFetcher := &mockBlockLogsFetcher{
+			err: nil,
 		}
-		batches, txs, txIndices, err := parseBatchesFromBlock(
+		batches, txs, err := parseBatchesFromBlock(
 			ctx,
 			melState,
 			block.Header(),
-			txsFetcher,
-			receiptFetcher,
+			txFetcher,
+			blockLogsFetcher,
 			nil,
 		)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(batches))
 		require.Equal(t, 0, len(txs))
-		require.Equal(t, 0, len(txIndices))
 	})
 	t.Run("receipt log with wrong topic id", func(t *testing.T) {
 		blockHeader := &types.Header{}
@@ -244,25 +162,21 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 		melState := &mel.State{
 			BatchPostingTargetAddress: batchPostingTargetAddr,
 		}
-		receiptFetcher := &mockReceiptFetcher{
-			receipts: receipts,
-			err:      nil,
-		}
-		txsFetcher := &mockTxsFetcher{
+		blockLogsFetcher := newMockBlockLogsFetcher(receipts)
+		txFetcher := &mockTxFetcher{
 			txs: []*types.Transaction{tx},
 		}
-		batches, txs, txIndices, err := parseBatchesFromBlock(
+		batches, txs, err := parseBatchesFromBlock(
 			ctx,
 			melState,
 			block.Header(),
-			txsFetcher,
-			receiptFetcher,
+			txFetcher,
+			blockLogsFetcher,
 			nil,
 		)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(batches))
 		require.Equal(t, 0, len(txs))
-		require.Equal(t, 0, len(txIndices))
 	})
 	t.Run("Unpack log fails", func(t *testing.T) {
 		blockHeader := &types.Header{}
@@ -282,7 +196,7 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 		receipt := &types.Receipt{
 			Logs: []*types.Log{
 				{
-					Topics: []common.Hash{batchDeliveredID},
+					Topics: []common.Hash{BatchDeliveredID},
 					Data:   packedLog,
 				},
 			},
@@ -297,24 +211,21 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 		melState := &mel.State{
 			BatchPostingTargetAddress: batchPostingTargetAddr,
 		}
-		receiptFetcher := &mockReceiptFetcher{
-			receipts: receipts,
-			err:      nil,
-		}
+		blockLogsFetcher := newMockBlockLogsFetcher(receipts)
 		eventUnpacker := &mockEventUnpacker{
 			events: []*bridgegen.SequencerInboxSequencerBatchDelivered{event},
 			idx:    0,
 			err:    errors.New("oops event unpacking error"),
 		}
-		txsFetcher := &mockTxsFetcher{
+		txFetcher := &mockTxFetcher{
 			txs: []*types.Transaction{tx},
 		}
-		_, _, _, err := parseBatchesFromBlock(
+		_, _, err := parseBatchesFromBlock(
 			ctx,
 			melState,
 			block.Header(),
-			txsFetcher,
-			receiptFetcher,
+			txFetcher,
+			blockLogsFetcher,
 			eventUnpacker,
 		)
 		require.ErrorContains(t, err, "oops event unpacking error")
@@ -337,8 +248,9 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 		receipt := &types.Receipt{
 			Logs: []*types.Log{
 				{
-					Topics: []common.Hash{batchDeliveredID},
+					Topics: []common.Hash{BatchDeliveredID},
 					Data:   packedLog,
+					TxHash: tx.Hash(),
 				},
 			},
 		}
@@ -352,30 +264,26 @@ func Test_parseBatchesFromBlock(t *testing.T) {
 		melState := &mel.State{
 			BatchPostingTargetAddress: batchPostingTargetAddr,
 		}
-		receiptFetcher := &mockReceiptFetcher{
-			receipts: receipts,
-			err:      nil,
-		}
+		blockLogsFetcher := newMockBlockLogsFetcher(receipts)
 		eventUnpacker := &mockEventUnpacker{
 			events: []*bridgegen.SequencerInboxSequencerBatchDelivered{event},
 			idx:    0,
 		}
-		txsFetcher := &mockTxsFetcher{
+		txFetcher := &mockTxFetcher{
 			txs: []*types.Transaction{tx},
 		}
-		batches, txs, txIndices, err := parseBatchesFromBlock(
+		batches, txs, err := parseBatchesFromBlock(
 			ctx,
 			melState,
 			block.Header(),
-			txsFetcher,
-			receiptFetcher,
+			txFetcher,
+			blockLogsFetcher,
 			eventUnpacker,
 		)
 		require.NoError(t, err)
 
 		require.Equal(t, 1, len(batches))
 		require.Equal(t, 1, len(txs))
-		require.Equal(t, 1, len(txIndices))
 		require.Equal(t, wantedBatch.SequenceNumber, batches[0].SequenceNumber)
 		require.Equal(t, wantedBatch.BeforeInboxAcc, batches[0].BeforeInboxAcc)
 		require.Equal(t, wantedBatch.AfterInboxAcc, batches[0].AfterInboxAcc)
@@ -417,12 +325,14 @@ func Test_parseBatchesFromBlock_outOfOrderBatches(t *testing.T) {
 	receipt := &types.Receipt{
 		Logs: []*types.Log{
 			{
-				Topics: []common.Hash{batchDeliveredID},
+				Topics: []common.Hash{BatchDeliveredID},
 				Data:   packedLog1,
+				TxHash: tx1.Hash(),
 			},
 			{
-				Topics: []common.Hash{batchDeliveredID},
+				Topics: []common.Hash{BatchDeliveredID},
 				Data:   packedLog2,
+				TxHash: tx2.Hash(),
 			},
 		},
 	}
@@ -436,10 +346,7 @@ func Test_parseBatchesFromBlock_outOfOrderBatches(t *testing.T) {
 	melState := &mel.State{
 		BatchPostingTargetAddress: batchPostingTargetAddr,
 	}
-	receiptFetcher := &mockReceiptFetcher{
-		receipts: receipts,
-		err:      nil,
-	}
+	blockLogsFetcher := newMockBlockLogsFetcher(receipts)
 	eventUnpacker := &mockEventUnpacker{
 		events: []*bridgegen.SequencerInboxSequencerBatchDelivered{
 			event1,
@@ -447,15 +354,15 @@ func Test_parseBatchesFromBlock_outOfOrderBatches(t *testing.T) {
 		},
 		idx: 0,
 	}
-	txsFetcher := &mockTxsFetcher{
+	txFetcher := &mockTxFetcher{
 		txs: []*types.Transaction{tx1, tx2},
 	}
-	_, _, _, err := parseBatchesFromBlock(
+	_, _, err := parseBatchesFromBlock(
 		ctx,
 		melState,
 		block.Header(),
-		txsFetcher,
-		receiptFetcher,
+		txFetcher,
+		blockLogsFetcher,
 		eventUnpacker,
 	)
 	require.ErrorContains(t, err, "sequencer batches out of order")
@@ -480,7 +387,7 @@ func setupParseBatchesTest(t *testing.T, seqNumber *big.Int) (
 		},
 		DataLocation: 1,
 	}
-	eventABI := seqInboxABI.Events["SequencerBatchDelivered"]
+	eventABI := SeqInboxABI.Events["SequencerBatchDelivered"]
 	packedLog, err := eventABI.Inputs.Pack(
 		event.BatchSequenceNumber,
 		event.BeforeAcc,
@@ -522,32 +429,59 @@ func (m *mockEventUnpacker) unpackLogTo(
 	return nil
 }
 
-type mockTxsFetcher struct {
+type mockTxFetcher struct {
 	txs types.Transactions
 	err error
 }
 
-func (m *mockTxsFetcher) TransactionsByHeader(
+func (m *mockTxFetcher) TransactionByLog(
 	ctx context.Context,
-	parentChainHeaderHash common.Hash,
-) (types.Transactions, error) {
+	log *types.Log,
+) (*types.Transaction, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
-	return m.txs, nil
+	for _, tx := range m.txs {
+		if tx.Hash() == log.TxHash {
+			return tx, nil
+		}
+	}
+	return nil, fmt.Errorf("tx: %v not found", log.TxHash)
 }
 
-type mockReceiptFetcher struct {
-	receipts []*types.Receipt
-	err      error
+type mockBlockLogsFetcher struct {
+	blockLogs     []*types.Log
+	logsByTxIndex map[common.Hash]map[uint][]*types.Log
+	err           error
 }
 
-func (m *mockReceiptFetcher) ReceiptForTransactionIndex(
-	_ context.Context,
-	idx uint,
-) (*types.Receipt, error) {
+func newMockBlockLogsFetcher(blockReceipts []*types.Receipt) *mockBlockLogsFetcher {
+	fetcher := &mockBlockLogsFetcher{logsByTxIndex: make(map[common.Hash]map[uint][]*types.Log)}
+	for _, receipt := range blockReceipts {
+		fetcher.blockLogs = append(fetcher.blockLogs, receipt.Logs...)
+		if _, ok := fetcher.logsByTxIndex[receipt.BlockHash]; !ok {
+			fetcher.logsByTxIndex[receipt.BlockHash] = make(map[uint][]*types.Log)
+		}
+		fetcher.logsByTxIndex[receipt.BlockHash][receipt.TransactionIndex] = receipt.Logs
+	}
+	return fetcher
+}
+
+func (m *mockBlockLogsFetcher) LogsForBlockHash(ctx context.Context, parentChainBlockHash common.Hash) ([]*types.Log, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
-	return m.receipts[idx], nil
+	return m.blockLogs, nil
+}
+
+func (m *mockBlockLogsFetcher) LogsForTxIndex(ctx context.Context, parentChainBlockHash common.Hash, txIndex uint) ([]*types.Log, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if indexMap, ok := m.logsByTxIndex[parentChainBlockHash]; ok {
+		if _, ok := indexMap[txIndex]; ok {
+			return indexMap[txIndex], nil
+		}
+	}
+	return nil, fmt.Errorf("logs for blockHash: %v and txIndex: %d not found", parentChainBlockHash, txIndex)
 }

--- a/arbnode/mel/extraction/batch_serialization.go
+++ b/arbnode/mel/extraction/batch_serialization.go
@@ -18,8 +18,7 @@ func serializeBatch(
 	ctx context.Context,
 	batch *mel.SequencerInboxBatch,
 	tx *types.Transaction,
-	txIndex uint,
-	receiptFetcher ReceiptFetcher,
+	logsFetcher LogsFetcher,
 ) ([]byte, error) {
 	if batch.Serialized != nil {
 		return batch.Serialized, nil
@@ -46,8 +45,7 @@ func serializeBatch(
 		ctx,
 		batch,
 		tx,
-		txIndex,
-		receiptFetcher,
+		logsFetcher,
 	)
 	if err != nil {
 		return nil, err
@@ -62,10 +60,9 @@ func getSequencerBatchData(
 	ctx context.Context,
 	batch *mel.SequencerInboxBatch,
 	tx *types.Transaction,
-	txIndex uint,
-	receiptFetcher ReceiptFetcher,
+	logsFetcher LogsFetcher,
 ) ([]byte, error) {
-	addSequencerL2BatchFromOriginCallABI := seqInboxABI.Methods["addSequencerL2BatchFromOrigin0"]
+	addSequencerL2BatchFromOriginCallABI := SeqInboxABI.Methods["addSequencerL2BatchFromOrigin0"]
 	switch batch.DataLocation {
 	case mel.BatchDataTxInput:
 		data := tx.Data()
@@ -82,20 +79,20 @@ func getSequencerBatchData(
 		}
 		return dataBytes, nil
 	case mel.BatchDataSeparateEvent:
-		sequencerBatchDataABI := seqInboxABI.Events["SequencerBatchData"].ID
+		sequencerBatchDataABI := SeqInboxABI.Events["SequencerBatchData"].ID
 		var numberAsHash common.Hash
 		// we want to convert a batch sequencer number which is a uint64 into a big-endian byte slice of size 32,
 		// so the last 8 bytes of that slice will contain the serialized batch.SequenceNumber
 		binary.BigEndian.PutUint64(numberAsHash[(32-8):], batch.SequenceNumber)
-		receipt, err := receiptFetcher.ReceiptForTransactionIndex(ctx, txIndex)
+		logs, err := logsFetcher.LogsForTxIndex(ctx, batch.RawLog.BlockHash, batch.RawLog.TxIndex)
 		if err != nil {
 			return nil, err
 		}
-		if len(receipt.Logs) == 0 {
+		if len(logs) == 0 {
 			return nil, errors.New("no logs found in transaction receipt")
 		}
 		topics := [][]common.Hash{{sequencerBatchDataABI}, {numberAsHash}}
-		filteredLogs := types.FilterLogs(receipt.Logs, nil, nil, []common.Address{batch.BridgeAddress}, topics)
+		filteredLogs := types.FilterLogs(logs, nil, nil, []common.Address{batch.BridgeAddress}, topics)
 		if len(filteredLogs) == 0 {
 			return nil, errors.New("expected to find sequencer batch data")
 		}
@@ -103,7 +100,7 @@ func getSequencerBatchData(
 			return nil, errors.New("expected to find only one matching sequencer batch data")
 		}
 		event := new(bridgegen.SequencerInboxSequencerBatchData)
-		err = seqInboxABI.UnpackIntoInterface(event, "SequencerBatchData", filteredLogs[0].Data)
+		err = SeqInboxABI.UnpackIntoInterface(event, "SequencerBatchData", filteredLogs[0].Data)
 		if err != nil {
 			return nil, err
 		}

--- a/arbnode/mel/extraction/batch_serialization_test.go
+++ b/arbnode/mel/extraction/batch_serialization_test.go
@@ -29,7 +29,7 @@ func Test_serializeBatch(t *testing.T) {
 			AfterDelayedCount: 1,
 			DataLocation:      mel.BatchDataLocation(99),
 		}
-		_, err := serializeBatch(ctx, batch, nil, 0, nil)
+		_, err := serializeBatch(ctx, batch, nil, nil)
 		require.ErrorContains(t, err, "invalid data location")
 	})
 	t.Run("OK", func(t *testing.T) {
@@ -54,7 +54,7 @@ func Test_serializeBatch(t *testing.T) {
 			AfterDelayedCount: 1,
 			DataLocation:      mel.BatchDataBlobHashes,
 		}
-		serialized, err := serializeBatch(ctx, batch, tx, 0, nil)
+		serialized, err := serializeBatch(ctx, batch, tx, nil)
 		require.NoError(t, err)
 		// Serialization includes 5 uint64 values (8 bytes each) and the full batch
 		// data appended at the end of the batch.
@@ -63,7 +63,7 @@ func Test_serializeBatch(t *testing.T) {
 		require.Equal(t, 105, len(serialized))
 
 		// Expect some caching of serialized data.
-		secondRound, err := serializeBatch(ctx, batch, tx, 0, nil)
+		secondRound, err := serializeBatch(ctx, batch, tx, nil)
 		require.NoError(t, err)
 		require.Equal(t, serialized, secondRound)
 	})
@@ -78,7 +78,6 @@ func Test_getSequencerBatchData(t *testing.T) {
 				DataLocation: mel.BatchDataLocation(99),
 			},
 			nil,
-			0,
 			nil,
 		)
 		require.ErrorContains(t, err, "invalid data location")
@@ -90,7 +89,6 @@ func Test_getSequencerBatchData(t *testing.T) {
 				DataLocation: mel.BatchDataNone,
 			},
 			nil,
-			0,
 			nil,
 		)
 		require.NoError(t, err)
@@ -111,7 +109,6 @@ func Test_getSequencerBatchData(t *testing.T) {
 				DataLocation: mel.BatchDataBlobHashes,
 			},
 			tx,
-			0,
 			nil,
 		)
 		require.ErrorContains(t, err, "has no blobs")
@@ -132,7 +129,6 @@ func Test_getSequencerBatchData(t *testing.T) {
 				DataLocation: mel.BatchDataBlobHashes,
 			},
 			tx,
-			0,
 			nil,
 		)
 		require.NoError(t, err)
@@ -140,7 +136,7 @@ func Test_getSequencerBatchData(t *testing.T) {
 	})
 	t.Run("arbnode.BatchDataTxInput", func(t *testing.T) {
 		msgData := []byte("foobar")
-		addSequencerL2BatchFromOriginCallABI := seqInboxABI.Methods["addSequencerL2BatchFromOrigin0"]
+		addSequencerL2BatchFromOriginCallABI := SeqInboxABI.Methods["addSequencerL2BatchFromOrigin0"]
 		seqNumber := big.NewInt(1)
 		afterDelayedRead := big.NewInt(1)
 		gasRefunder := common.Address{}
@@ -167,7 +163,6 @@ func Test_getSequencerBatchData(t *testing.T) {
 				DataLocation: mel.BatchDataTxInput,
 			},
 			tx,
-			0,
 			nil,
 		)
 		require.ErrorContains(t, err, "transaction data too short")
@@ -187,7 +182,6 @@ func Test_getSequencerBatchData(t *testing.T) {
 				DataLocation: mel.BatchDataTxInput,
 			},
 			tx,
-			0,
 			nil,
 		)
 		require.NoError(t, err)
@@ -209,9 +203,8 @@ func Test_getSequencerBatchData(t *testing.T) {
 				Logs: []*types.Log{},
 			},
 		}
-		receiptFetcher := &mockReceiptFetcher{
-			receipts: receipts,
-			err:      errors.New("oops"),
+		blockLogsFetcher := &mockBlockLogsFetcher{
+			err: errors.New("oops"),
 		}
 		_, err := getSequencerBatchData(
 			ctx,
@@ -219,23 +212,18 @@ func Test_getSequencerBatchData(t *testing.T) {
 				DataLocation: mel.BatchDataSeparateEvent,
 			},
 			tx,
-			0,
-			receiptFetcher,
+			blockLogsFetcher,
 		)
 		require.ErrorContains(t, err, "oops")
 
-		receiptFetcher = &mockReceiptFetcher{
-			receipts: receipts,
-			err:      nil,
-		}
+		blockLogsFetcher = newMockBlockLogsFetcher(receipts)
 		_, err = getSequencerBatchData(
 			ctx,
 			&mel.SequencerInboxBatch{
 				DataLocation: mel.BatchDataSeparateEvent,
 			},
 			tx,
-			0,
-			receiptFetcher,
+			blockLogsFetcher,
 		)
 		require.ErrorContains(t, err, "no logs found")
 
@@ -248,22 +236,18 @@ func Test_getSequencerBatchData(t *testing.T) {
 				},
 			},
 		}
-		receiptFetcher = &mockReceiptFetcher{
-			receipts: receipts,
-			err:      nil,
-		}
+		blockLogsFetcher = newMockBlockLogsFetcher(receipts)
 		_, err = getSequencerBatchData(
 			ctx,
 			&mel.SequencerInboxBatch{
 				DataLocation: mel.BatchDataSeparateEvent,
 			},
 			tx,
-			0,
-			receiptFetcher,
+			blockLogsFetcher,
 		)
 		require.ErrorContains(t, err, "expected to find sequencer batch data")
 
-		sequencerBatchDataABI := seqInboxABI.Events["SequencerBatchData"].ID
+		sequencerBatchDataABI := SeqInboxABI.Events["SequencerBatchData"].ID
 		bridgeAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 		receipts = []*types.Receipt{
 			{
@@ -279,10 +263,7 @@ func Test_getSequencerBatchData(t *testing.T) {
 				},
 			},
 		}
-		receiptFetcher = &mockReceiptFetcher{
-			receipts: receipts,
-			err:      nil,
-		}
+		blockLogsFetcher = newMockBlockLogsFetcher(receipts)
 		_, err = getSequencerBatchData(
 			ctx,
 			&mel.SequencerInboxBatch{
@@ -290,15 +271,14 @@ func Test_getSequencerBatchData(t *testing.T) {
 				DataLocation:  mel.BatchDataSeparateEvent,
 			},
 			tx,
-			0,
-			receiptFetcher,
+			blockLogsFetcher,
 		)
 		require.ErrorContains(t, err, "expected to find only one")
 
 		event := &bridgegen.SequencerInboxSequencerBatchData{
 			Data: []byte("foobar"),
 		}
-		eventABI := seqInboxABI.Events["SequencerBatchData"]
+		eventABI := SeqInboxABI.Events["SequencerBatchData"]
 		packedLog, err := eventABI.Inputs.NonIndexed().Pack(
 			event.Data,
 		)
@@ -314,10 +294,7 @@ func Test_getSequencerBatchData(t *testing.T) {
 				},
 			},
 		}
-		receiptFetcher = &mockReceiptFetcher{
-			receipts: receipts,
-			err:      nil,
-		}
+		blockLogsFetcher = newMockBlockLogsFetcher(receipts)
 		data, err := getSequencerBatchData(
 			ctx,
 			&mel.SequencerInboxBatch{
@@ -326,8 +303,7 @@ func Test_getSequencerBatchData(t *testing.T) {
 				DataLocation:   mel.BatchDataSeparateEvent,
 			},
 			tx,
-			0,
-			receiptFetcher,
+			blockLogsFetcher,
 		)
 		require.NoError(t, err)
 		require.Equal(t, event.Data, data)

--- a/arbnode/mel/extraction/delayed_message_lookup.go
+++ b/arbnode/mel/extraction/delayed_message_lookup.go
@@ -22,40 +22,24 @@ func parseDelayedMessagesFromBlock(
 	ctx context.Context,
 	melState *mel.State,
 	parentChainHeader *types.Header,
-	receiptFetcher ReceiptFetcher,
-	txsFetcher TransactionsFetcher,
+	txFetcher TransactionFetcher,
+	logsFetcher LogsFetcher,
 ) ([]*mel.DelayedInboxMessage, error) {
 	msgScaffolds := make([]*mel.DelayedInboxMessage, 0)
 	messageDeliveredEvents := make([]*bridgegen.IBridgeMessageDelivered, 0)
-	parentChainBlockTxs, err := txsFetcher.TransactionsByHeader(
-		ctx,
-		parentChainHeader.Hash(),
-	)
+	logs, err := logsFetcher.LogsForBlockHash(ctx, parentChainHeader.Hash())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to fetch logs from parent chain block %v: %w", parentChainHeader.Hash(), err)
 	}
-	for i, tx := range parentChainBlockTxs {
-		if tx.To() == nil {
-			continue
+	relevantLogs := make([]*types.Log, 0, len(logs))
+	for _, log := range logs {
+		// Check if the log was emitted by the delayed message posting address.
+		// On Arbitrum One, this is the bridge contract which emits a MessageDelivered event.
+		if log.Address == melState.DelayedMessagePostingTargetAddress {
+			relevantLogs = append(relevantLogs, log)
 		}
-		// Fetch the receipts for the transaction to get the logs.
-		txIndex := uint(i) // #nosec G115
-		receipt, err := receiptFetcher.ReceiptForTransactionIndex(ctx, txIndex)
-		if err != nil {
-			return nil, err
-		}
-		relevantLogs := make([]*types.Log, 0, len(receipt.Logs))
-		// Check all logs in the receipt.
-		for _, log := range receipt.Logs {
-			// Check if the log was emitted by the delayed message posting address.
-			// On Arbitrum One, this is the bridge contract which emits a MessageDelivered event.
-			if log.Address == melState.DelayedMessagePostingTargetAddress {
-				relevantLogs = append(relevantLogs, log)
-			}
-		}
-		if len(relevantLogs) == 0 {
-			continue
-		}
+	}
+	if len(relevantLogs) > 0 {
 		delayedMessageScaffolds, parsedLogs, err := delayedMessageScaffoldsFromLogs(
 			parentChainHeader.Number,
 			relevantLogs,
@@ -77,40 +61,21 @@ func parseDelayedMessagesFromBlock(
 		inboxAddressList = append(inboxAddressList, addr)
 	}
 	messageData := make(map[common.Hash][]byte)
-	for i, tx := range parentChainBlockTxs {
-		// TODO: remove this temporary work around for handling init message, i.e skipping the check when msgCount==0
-		if melState.MsgCount != 0 {
-			if tx.To() == nil {
-				continue
-			}
-			_, ok := inboxAddressSet[*tx.To()]
-			if !ok {
-				continue
-			}
-		}
-		txIndex := uint(i) // #nosec G115
-		receipt, err := receiptFetcher.ReceiptForTransactionIndex(ctx, txIndex)
+	topics := [][]common.Hash{
+		{InboxMessageDeliveredID, InboxMessageFromOriginID}, // matches either of these IDs.
+		messageIds, // matches any of the message IDs.
+	}
+	filteredInboxMessageLogs := types.FilterLogs(logs, nil, nil, inboxAddressList, topics)
+	for _, inboxMsgLog := range filteredInboxMessageLogs {
+		msgNum, msg, err := parseDelayedMessage(
+			ctx,
+			inboxMsgLog,
+			txFetcher,
+		)
 		if err != nil {
 			return nil, err
 		}
-		if len(receipt.Logs) == 0 {
-			continue
-		}
-		topics := [][]common.Hash{
-			{inboxMessageDeliveredID, inboxMessageFromOriginID}, // matches either of these IDs.
-			messageIds, // matches any of the message IDs.
-		}
-		filteredInboxMessageLogs := types.FilterLogs(receipt.Logs, nil, nil, inboxAddressList, topics)
-		for _, inboxMsgLog := range filteredInboxMessageLogs {
-			msgNum, msg, err := parseDelayedMessage(
-				inboxMsgLog,
-				tx,
-			)
-			if err != nil {
-				return nil, err
-			}
-			messageData[common.BigToHash(msgNum)] = msg
-		}
+		messageData[common.BigToHash(msgNum)] = msg
 	}
 	for i, parsedLog := range messageDeliveredEvents {
 		msgKey := common.BigToHash(parsedLog.MessageIndex)
@@ -140,11 +105,11 @@ func delayedMessageScaffoldsFromLogs(
 	// First, do a pass over the logs to extract message delivered events, which
 	// contain an inbox address and a message index.
 	for _, ethLog := range logs {
-		if ethLog == nil || len(ethLog.Topics) == 0 || ethLog.Topics[0] != iBridgeABI.Events["MessageDelivered"].ID {
+		if ethLog == nil || len(ethLog.Topics) == 0 || ethLog.Topics[0] != IBridgeABI.Events["MessageDelivered"].ID {
 			continue
 		}
 		event := new(bridgegen.IBridgeMessageDelivered)
-		if err := unpackLogTo(event, iBridgeABI, "MessageDelivered", *ethLog); err != nil {
+		if err := unpackLogTo(event, IBridgeABI, "MessageDelivered", *ethLog); err != nil {
 			return nil, nil, err
 		}
 		parsedLogs = append(parsedLogs, event)
@@ -181,25 +146,30 @@ func delayedMessageScaffoldsFromLogs(
 }
 
 func parseDelayedMessage(
+	ctx context.Context,
 	ethLog *types.Log,
-	tx *types.Transaction,
+	txFetcher TransactionFetcher,
 ) (*big.Int, []byte, error) {
 	if ethLog == nil {
 		return nil, nil, nil
 	}
 	switch ethLog.Topics[0] {
-	case inboxMessageDeliveredID:
+	case InboxMessageDeliveredID:
 		event := new(bridgegen.IDelayedMessageProviderInboxMessageDelivered)
 		if err := unpackLogTo(event, iDelayedMessageProviderABI, "InboxMessageDelivered", *ethLog); err != nil {
 			return nil, nil, err
 		}
 		return event.MessageNum, event.Data, nil
-	case inboxMessageFromOriginID:
+	case InboxMessageFromOriginID:
 		event := new(bridgegen.IDelayedMessageProviderInboxMessageDeliveredFromOrigin)
 		if err := unpackLogTo(event, iDelayedMessageProviderABI, "InboxMessageDeliveredFromOrigin", *ethLog); err != nil {
 			return nil, nil, err
 		}
 		args := make(map[string]any)
+		tx, err := txFetcher.TransactionByLog(ctx, ethLog)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error fetching tx by hash: %v in parseBatchesFromBlock: %w ", ethLog.TxHash, err)
+		}
 		data := tx.Data()
 		if len(data) < 4 {
 			return nil, nil, fmt.Errorf("tx data %#x too short", data)

--- a/arbnode/mel/extraction/delayed_message_lookup_test.go
+++ b/arbnode/mel/extraction/delayed_message_lookup_test.go
@@ -29,51 +29,18 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 	header := &types.Header{
 		Number: big.NewInt(1),
 	}
-	txsFetcher := &mockTxsFetcher{
+	txFetcher := &mockTxFetcher{
 		txs: []*types.Transaction{},
 	}
-	receiptFetcher := &mockReceiptFetcher{}
+	blockLogsFetcher := &mockBlockLogsFetcher{}
 
 	t.Run("no transactions", func(t *testing.T) {
 		msgs, err := parseDelayedMessagesFromBlock(
 			ctx,
 			melState,
 			header,
-			receiptFetcher,
-			txsFetcher,
-		)
-		require.NoError(t, err)
-		require.Empty(t, msgs)
-	})
-	t.Run("tx with no to field set", func(t *testing.T) {
-		txData := &types.DynamicFeeTx{
-			To:        nil,
-			Nonce:     1,
-			GasFeeCap: big.NewInt(1),
-			GasTipCap: big.NewInt(1),
-			Gas:       1,
-			Value:     big.NewInt(0),
-			Data:      nil,
-		}
-		tx := types.NewTx(txData)
-		blockBody := &types.Body{
-			Transactions: []*types.Transaction{tx},
-		}
-		txsFetcher = &mockTxsFetcher{
-			txs: []*types.Transaction{tx},
-		}
-		block := types.NewBlock(
-			&types.Header{},
-			blockBody,
-			nil,
-			trie.NewStackTrie(nil),
-		)
-		msgs, err := parseDelayedMessagesFromBlock(
-			ctx,
-			melState,
-			block.Header(),
-			receiptFetcher,
-			txsFetcher,
+			txFetcher,
+			blockLogsFetcher,
 		)
 		require.NoError(t, err)
 		require.Empty(t, msgs)
@@ -92,7 +59,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 		blockBody := &types.Body{
 			Transactions: []*types.Transaction{tx},
 		}
-		txsFetcher = &mockTxsFetcher{
+		txFetcher = &mockTxFetcher{
 			txs: []*types.Transaction{tx},
 		}
 		receipt := &types.Receipt{
@@ -105,15 +72,13 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 			receipts,
 			trie.NewStackTrie(nil),
 		)
-		receiptFetcher = &mockReceiptFetcher{
-			receipts: receipts,
-		}
+		blockLogsFetcher = newMockBlockLogsFetcher(receipts)
 		msgs, err := parseDelayedMessagesFromBlock(
 			ctx,
 			melState,
 			block.Header(),
-			receiptFetcher,
-			txsFetcher,
+			txFetcher,
+			blockLogsFetcher,
 		)
 		require.NoError(t, err)
 		require.Empty(t, msgs)
@@ -133,7 +98,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 		blockBody := &types.Body{
 			Transactions: []*types.Transaction{tx},
 		}
-		txsFetcher = &mockTxsFetcher{
+		txFetcher = &mockTxFetcher{
 			txs: []*types.Transaction{tx},
 		}
 		messageIndexBytes := common.BigToHash(event.MessageIndex)
@@ -143,7 +108,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 					Address: delayedMsgPostingAddr,
 					Data:    packedLog,
 					Topics: []common.Hash{
-						iBridgeABI.Events["MessageDelivered"].ID,
+						IBridgeABI.Events["MessageDelivered"].ID,
 						messageIndexBytes,
 						event.BeforeInboxAcc,
 					},
@@ -157,15 +122,13 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 			receipts,
 			trie.NewStackTrie(nil),
 		)
-		receiptFetcher = &mockReceiptFetcher{
-			receipts: receipts,
-		}
+		blockLogsFetcher = newMockBlockLogsFetcher(receipts)
 		_, err := parseDelayedMessagesFromBlock(
 			ctx,
 			melState,
 			block.Header(),
-			receiptFetcher,
-			txsFetcher,
+			txFetcher,
+			blockLogsFetcher,
 		)
 		require.ErrorContains(t, err, "message 1 data not found")
 	})
@@ -201,7 +164,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 		blockBody := &types.Body{
 			Transactions: []*types.Transaction{tx1, tx2},
 		}
-		txsFetcher := &mockTxsFetcher{
+		txFetcher := &mockTxFetcher{
 			txs: []*types.Transaction{tx1, tx2},
 		}
 		messageIndexBytes := common.BigToHash(delayedMsgEvent.MessageIndex)
@@ -211,7 +174,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 					Address: delayedMsgPostingAddr,
 					Data:    delayedMsgPackedLog,
 					Topics: []common.Hash{
-						iBridgeABI.Events["MessageDelivered"].ID,
+						IBridgeABI.Events["MessageDelivered"].ID,
 						messageIndexBytes,
 						delayedMsgEvent.BeforeInboxAcc,
 					},
@@ -237,15 +200,13 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 			receipts,
 			trie.NewStackTrie(nil),
 		)
-		receiptFetcher = &mockReceiptFetcher{
-			receipts: receipts,
-		}
+		blockLogsFetcher = newMockBlockLogsFetcher(receipts)
 		_, err = parseDelayedMessagesFromBlock(
 			ctx,
 			melState,
 			block.Header(),
-			receiptFetcher,
-			txsFetcher,
+			txFetcher,
+			blockLogsFetcher,
 		)
 		require.ErrorContains(t, err, "mismatched hash")
 	})
@@ -261,7 +222,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 			BaseFeeL1:       big.NewInt(2),
 			Timestamp:       0,
 		}
-		eventABI := iBridgeABI.Events["MessageDelivered"]
+		eventABI := IBridgeABI.Events["MessageDelivered"]
 		delayedMsgPackedLog, err := eventABI.Inputs.NonIndexed().Pack(
 			delayedMsgEvent.Inbox,
 			delayedMsgEvent.Kind,
@@ -301,7 +262,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 		blockBody := &types.Body{
 			Transactions: []*types.Transaction{tx1, tx2},
 		}
-		txsFetcher := &mockTxsFetcher{
+		txFetcher := &mockTxFetcher{
 			txs: []*types.Transaction{tx1, tx2},
 		}
 		messageIndexBytes := common.BigToHash(delayedMsgEvent.MessageIndex)
@@ -311,7 +272,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 					Address: delayedMsgPostingAddr,
 					Data:    delayedMsgPackedLog,
 					Topics: []common.Hash{
-						iBridgeABI.Events["MessageDelivered"].ID,
+						IBridgeABI.Events["MessageDelivered"].ID,
 						messageIndexBytes,
 						delayedMsgEvent.BeforeInboxAcc,
 					},
@@ -337,15 +298,13 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 			receipts,
 			trie.NewStackTrie(nil),
 		)
-		receiptFetcher = &mockReceiptFetcher{
-			receipts: receipts,
-		}
+		blockLogsFetcher = newMockBlockLogsFetcher(receipts)
 		delayedMessages, err := parseDelayedMessagesFromBlock(
 			ctx,
 			melState,
 			block.Header(),
-			receiptFetcher,
-			txsFetcher,
+			txFetcher,
+			blockLogsFetcher,
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(delayedMessages))
@@ -363,7 +322,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 			BaseFeeL1:       big.NewInt(2),
 			Timestamp:       0,
 		}
-		eventABI := iBridgeABI.Events["MessageDelivered"]
+		eventABI := IBridgeABI.Events["MessageDelivered"]
 		delayedMsgPackedLog, err := eventABI.Inputs.NonIndexed().Pack(
 			delayedMsgEvent.Inbox,
 			delayedMsgEvent.Kind,
@@ -396,7 +355,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 		blockBody := &types.Body{
 			Transactions: []*types.Transaction{tx1, tx2},
 		}
-		txsFetcher := &mockTxsFetcher{
+		txFetcher := &mockTxFetcher{
 			txs: []*types.Transaction{tx1, tx2},
 		}
 		messageIndexBytes := common.BigToHash(delayedMsgEvent.MessageIndex)
@@ -406,10 +365,11 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 					Address: delayedMsgPostingAddr,
 					Data:    delayedMsgPackedLog,
 					Topics: []common.Hash{
-						iBridgeABI.Events["MessageDelivered"].ID,
+						IBridgeABI.Events["MessageDelivered"].ID,
 						messageIndexBytes,
 						delayedMsgEvent.BeforeInboxAcc,
 					},
+					TxHash: tx1.Hash(),
 				},
 			},
 		}
@@ -421,6 +381,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 						iDelayedMessageProviderABI.Events["InboxMessageDeliveredFromOrigin"].ID,
 						messageIndexBytes,
 					},
+					TxHash: tx2.Hash(),
 				},
 			},
 		}
@@ -431,15 +392,13 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 			receipts,
 			trie.NewStackTrie(nil),
 		)
-		receiptFetcher = &mockReceiptFetcher{
-			receipts: receipts,
-		}
+		blockLogsFetcher = newMockBlockLogsFetcher(receipts)
 		_, err = parseDelayedMessagesFromBlock(
 			ctx,
 			melState,
 			block.Header(),
-			receiptFetcher,
-			txsFetcher,
+			txFetcher,
+			blockLogsFetcher,
 		)
 		require.ErrorContains(t, err, "too short")
 	})
@@ -455,7 +414,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 			BaseFeeL1:       big.NewInt(2),
 			Timestamp:       0,
 		}
-		eventABI := iBridgeABI.Events["MessageDelivered"]
+		eventABI := IBridgeABI.Events["MessageDelivered"]
 		delayedMsgPackedLog, err := eventABI.Inputs.NonIndexed().Pack(
 			delayedMsgEvent.Inbox,
 			delayedMsgEvent.Kind,
@@ -494,7 +453,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 		blockBody := &types.Body{
 			Transactions: []*types.Transaction{tx1, tx2},
 		}
-		txsFetcher := &mockTxsFetcher{
+		txFetcher := &mockTxFetcher{
 			txs: []*types.Transaction{tx1, tx2},
 		}
 		messageIndexBytes := common.BigToHash(delayedMsgEvent.MessageIndex)
@@ -504,10 +463,11 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 					Address: delayedMsgPostingAddr,
 					Data:    delayedMsgPackedLog,
 					Topics: []common.Hash{
-						iBridgeABI.Events["MessageDelivered"].ID,
+						IBridgeABI.Events["MessageDelivered"].ID,
 						messageIndexBytes,
 						delayedMsgEvent.BeforeInboxAcc,
 					},
+					TxHash: tx1.Hash(),
 				},
 			},
 		}
@@ -519,6 +479,7 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 						iDelayedMessageProviderABI.Events["InboxMessageDeliveredFromOrigin"].ID,
 						messageIndexBytes,
 					},
+					TxHash: tx2.Hash(),
 				},
 			},
 		}
@@ -529,15 +490,13 @@ func Test_parseDelayedMessagesFromBlock(t *testing.T) {
 			receipts,
 			trie.NewStackTrie(nil),
 		)
-		receiptFetcher = &mockReceiptFetcher{
-			receipts: receipts,
-		}
+		blockLogsFetcher = newMockBlockLogsFetcher(receipts)
 		delayedMessages, err := parseDelayedMessagesFromBlock(
 			ctx,
 			melState,
 			block.Header(),
-			receiptFetcher,
-			txsFetcher,
+			txFetcher,
+			blockLogsFetcher,
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(delayedMessages))
@@ -595,7 +554,7 @@ func setupParseDelayedMessagesTest(t *testing.T) (*bridgegen.IBridgeMessageDeliv
 		BaseFeeL1:       big.NewInt(2),
 		Timestamp:       0,
 	}
-	eventABI := iBridgeABI.Events["MessageDelivered"]
+	eventABI := IBridgeABI.Events["MessageDelivered"]
 	packedLog, err := eventABI.Inputs.NonIndexed().Pack(
 		event.Inbox,
 		event.Kind,

--- a/arbnode/mel/extraction/message_extraction_function_test.go
+++ b/arbnode/mel/extraction/message_extraction_function_test.go
@@ -27,9 +27,9 @@ func TestExtractMessages(t *testing.T) {
 		name                 string
 		melStateParentHash   common.Hash
 		useExtractMessages   bool // If true, use ExtractMessages instead of extractMessagesImpl
-		lookupBatches        func(context.Context, *mel.State, *types.Header, TransactionsFetcher, ReceiptFetcher, eventUnpacker) ([]*mel.SequencerInboxBatch, []*types.Transaction, []uint, error)
-		lookupDelayedMsgs    func(context.Context, *mel.State, *types.Header, ReceiptFetcher, TransactionsFetcher) ([]*mel.DelayedInboxMessage, error)
-		serializer           func(context.Context, *mel.SequencerInboxBatch, *types.Transaction, uint, ReceiptFetcher) ([]byte, error)
+		lookupBatches        func(context.Context, *mel.State, *types.Header, TransactionFetcher, LogsFetcher, eventUnpacker) ([]*mel.SequencerInboxBatch, []*types.Transaction, error)
+		lookupDelayedMsgs    func(context.Context, *mel.State, *types.Header, TransactionFetcher, LogsFetcher) ([]*mel.DelayedInboxMessage, error)
+		serializer           func(context.Context, *mel.SequencerInboxBatch, *types.Transaction, LogsFetcher) ([]byte, error)
 		parseReport          func(io.Reader) (*big.Int, common.Address, common.Hash, uint64, *big.Int, uint64, error)
 		parseSequencerMsg    func(context.Context, uint64, common.Hash, []byte, []daprovider.Reader, daprovider.KeysetValidationMode) (*arbstate.SequencerMessage, error)
 		extractBatchMessages func(context.Context, *mel.State, *arbstate.SequencerMessage, DelayedMessageDatabase) ([]*arbostypes.MessageWithMetadata, error)
@@ -133,34 +133,36 @@ func TestExtractMessages(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			header := createBlockHeader(prevParentBlockHash)
 			melState := createMelState(tt.melStateParentHash)
-			txsFetcher := &mockTxsFetcher{}
+			blockLogsFetcher := &mockBlockLogsFetcher{}
+			txFetcher := &mockTxFetcher{}
 
 			var postState *mel.State
 			var messages []*arbostypes.MessageWithMetadata
 			var delayedMessages []*mel.DelayedInboxMessage
+			var batchMetas []*mel.BatchMetadata
 			var err error
 
 			if tt.useExtractMessages {
 				// Test the public ExtractMessages function
-				postState, messages, delayedMessages, err = ExtractMessages(
+				postState, messages, delayedMessages, batchMetas, err = ExtractMessages(
 					ctx,
 					melState,
 					header,
 					nil,
 					nil,
-					nil,
-					txsFetcher,
+					txFetcher,
+					blockLogsFetcher,
 				)
 			} else {
 				// Test the internal extractMessagesImpl function
-				postState, messages, delayedMessages, err = extractMessagesImpl(
+				postState, messages, delayedMessages, batchMetas, err = extractMessagesImpl(
 					ctx,
 					melState,
 					header,
 					nil,
 					nil,
-					txsFetcher,
-					nil,
+					txFetcher,
+					blockLogsFetcher,
 					nil,
 					tt.lookupBatches,
 					tt.lookupDelayedMsgs,
@@ -181,6 +183,7 @@ func TestExtractMessages(t *testing.T) {
 			require.Equal(t, tt.expectedDelayedSeen, postState.DelayedMessagedSeen)
 			require.Len(t, messages, tt.expectedMessages)
 			require.Len(t, delayedMessages, tt.expectedDelayedMsgs)
+			require.Len(t, batchMetas, int(postState.BatchCount-melState.BatchCount)) // #nosec G115
 		})
 	}
 }
@@ -204,44 +207,43 @@ func successfulLookupBatches(
 	ctx context.Context,
 	melState *mel.State,
 	parentChainBlock *types.Header,
-	txsFetcher TransactionsFetcher,
-	receiptFetcher ReceiptFetcher,
+	txFetcher TransactionFetcher,
+	logsFetcher LogsFetcher,
 	eventUnpacker eventUnpacker,
-) ([]*mel.SequencerInboxBatch, []*types.Transaction, []uint, error) {
+) ([]*mel.SequencerInboxBatch, []*types.Transaction, error) {
 	batches := []*mel.SequencerInboxBatch{{}}
 	txs := []*types.Transaction{{}}
-	txIndices := []uint{0}
-	return batches, txs, txIndices, nil
+	return batches, txs, nil
 }
 
 func emptyLookupBatches(
 	ctx context.Context,
 	melState *mel.State,
 	parentChainBlock *types.Header,
-	txsFetcher TransactionsFetcher,
-	receiptFetcher ReceiptFetcher,
+	txFetcher TransactionFetcher,
+	logsFetcher LogsFetcher,
 	eventUnpacker eventUnpacker,
-) ([]*mel.SequencerInboxBatch, []*types.Transaction, []uint, error) {
-	return nil, nil, nil, nil
+) ([]*mel.SequencerInboxBatch, []*types.Transaction, error) {
+	return nil, nil, nil
 }
 
 func failingLookupBatches(
 	ctx context.Context,
 	melState *mel.State,
 	parentChainBlock *types.Header,
-	txsFetcher TransactionsFetcher,
-	receiptFetcher ReceiptFetcher,
+	txFetcher TransactionFetcher,
+	logsFetcher LogsFetcher,
 	eventUnpacker eventUnpacker,
-) ([]*mel.SequencerInboxBatch, []*types.Transaction, []uint, error) {
-	return nil, nil, nil, errors.New("failed to lookup batches")
+) ([]*mel.SequencerInboxBatch, []*types.Transaction, error) {
+	return nil, nil, errors.New("failed to lookup batches")
 }
 
 func successfulLookupDelayedMsgs(
 	ctx context.Context,
 	melState *mel.State,
 	parentChainBlock *types.Header,
-	receiptFetcher ReceiptFetcher,
-	txsFetcher TransactionsFetcher,
+	txFetcher TransactionFetcher,
+	logsFetcher LogsFetcher,
 ) ([]*mel.DelayedInboxMessage, error) {
 	hash := common.MaxHash
 	delayedMsgs := []*mel.DelayedInboxMessage{
@@ -263,8 +265,8 @@ func failingLookupDelayedMsgs(
 	ctx context.Context,
 	melState *mel.State,
 	parentChainBlock *types.Header,
-	receiptFetcher ReceiptFetcher,
-	txsFetcher TransactionsFetcher,
+	txFetcher TransactionFetcher,
+	logsFetcher LogsFetcher,
 ) ([]*mel.DelayedInboxMessage, error) {
 	return nil, errors.New("failed to lookup delayed messages")
 }
@@ -272,8 +274,7 @@ func failingLookupDelayedMsgs(
 func successfulSerializer(ctx context.Context,
 	batch *mel.SequencerInboxBatch,
 	tx *types.Transaction,
-	txIndex uint,
-	receiptFetcher ReceiptFetcher,
+	logsFetcher LogsFetcher,
 ) ([]byte, error) {
 	return []byte("foobar"), nil
 }
@@ -281,8 +282,7 @@ func successfulSerializer(ctx context.Context,
 func emptySerializer(ctx context.Context,
 	batch *mel.SequencerInboxBatch,
 	tx *types.Transaction,
-	txIndex uint,
-	receiptFetcher ReceiptFetcher,
+	logsFetcher LogsFetcher,
 ) ([]byte, error) {
 	return nil, nil
 }
@@ -290,8 +290,7 @@ func emptySerializer(ctx context.Context,
 func failingSerializer(ctx context.Context,
 	batch *mel.SequencerInboxBatch,
 	tx *types.Transaction,
-	txIndex uint,
-	receiptFetcher ReceiptFetcher,
+	logsFetcher LogsFetcher,
 ) ([]byte, error) {
 	return nil, errors.New("serialization error")
 }

--- a/arbnode/mel/extraction/types.go
+++ b/arbnode/mel/extraction/types.go
@@ -30,10 +30,10 @@ type batchLookupFunc func(
 	ctx context.Context,
 	melState *mel.State,
 	parentChainHeader *types.Header,
-	txsFetcher TransactionsFetcher,
-	receiptFetcher ReceiptFetcher,
+	txFetcher TransactionFetcher,
+	logsFetcher LogsFetcher,
 	eventUnpacker eventUnpacker,
-) ([]*mel.SequencerInboxBatch, []*types.Transaction, []uint, error)
+) ([]*mel.SequencerInboxBatch, []*types.Transaction, error)
 
 // Defines a function that can lookup delayed messages for a given parent chain block.
 // See: parseDelayedMessagesFromBlock.
@@ -41,8 +41,8 @@ type delayedMsgLookupFunc func(
 	ctx context.Context,
 	melState *mel.State,
 	parentChainHeader *types.Header,
-	receiptFetcher ReceiptFetcher,
-	txsFetcher TransactionsFetcher,
+	txFetcher TransactionFetcher,
+	logsFetcher LogsFetcher,
 ) ([]*mel.DelayedInboxMessage, error)
 
 // Defines a function that can serialize a batch.
@@ -51,8 +51,7 @@ type batchSerializingFunc func(
 	ctx context.Context,
 	batch *mel.SequencerInboxBatch,
 	tx *types.Transaction,
-	txIndex uint,
-	receiptFetcher ReceiptFetcher,
+	logsFetcher LogsFetcher,
 ) ([]byte, error)
 
 // Defines a function that can parse a sequencer message from a batch.

--- a/arbnode/mel/runner/backlog.go
+++ b/arbnode/mel/runner/backlog.go
@@ -9,7 +9,9 @@ import (
 
 // InitializeDelayedMessageBacklog is to be only called by the Start fsm step of MEL. This function fills the backlog based on the seen and read count from the given mel state
 func InitializeDelayedMessageBacklog(ctx context.Context, d *mel.DelayedMessageBacklog, db *Database, state *mel.State, finalizedAndReadIndexFetcher func(context.Context) (uint64, error)) error {
-	// d.ctx = ctx
+	if state.DelayedMessagedSeen == 0 && state.DelayedMessagesRead == 0 { // this is the first mel state so no need to initialize backlog even if the state isnt finalized yet
+		return nil
+	}
 	finalizedDelayedMessagesRead := state.DelayedMessagesRead // Assume to be finalized, then update if needed
 	var err error
 	if finalizedAndReadIndexFetcher != nil {

--- a/arbnode/mel/runner/fsm.go
+++ b/arbnode/mel/runner/fsm.go
@@ -54,6 +54,7 @@ type saveMessages struct {
 	postState        *mel.State
 	messages         []*arbostypes.MessageWithMetadata
 	delayedMessages  []*mel.DelayedInboxMessage
+	batchMetas       []*mel.BatchMetadata
 }
 
 // An action that transitions the FSM to the reorging state.

--- a/arbnode/mel/runner/logs_fetcher.go
+++ b/arbnode/mel/runner/logs_fetcher.go
@@ -1,0 +1,124 @@
+package melrunner
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/offchainlabs/nitro/arbnode/mel"
+	melextraction "github.com/offchainlabs/nitro/arbnode/mel/extraction"
+)
+
+type logsFetcher struct {
+	parentChainReader ParentChainReader
+	blockHeight       uint64
+	blocksToFetch     uint64
+	chainHeight       uint64
+	logsByTxIndex     map[common.Hash]map[uint][]*types.Log
+	logsByBlockHash   map[common.Hash][]*types.Log
+}
+
+func newLogsFetcher(parentChainReader ParentChainReader, blocksToFetch uint64) *logsFetcher {
+	return &logsFetcher{
+		parentChainReader: parentChainReader,
+		blocksToFetch:     blocksToFetch,
+		logsByTxIndex:     make(map[common.Hash]map[uint][]*types.Log),
+		logsByBlockHash:   make(map[common.Hash][]*types.Log),
+	}
+}
+
+func (f *logsFetcher) LogsForBlockHash(_ context.Context, parentChainBlockHash common.Hash) ([]*types.Log, error) {
+	return f.logsByBlockHash[parentChainBlockHash], nil
+}
+
+func (f *logsFetcher) LogsForTxIndex(_ context.Context, parentChainBlockHash common.Hash, txIndex uint) ([]*types.Log, error) {
+	if txIndexToLogs, ok := f.logsByTxIndex[parentChainBlockHash]; ok {
+		if logs, ok := txIndexToLogs[txIndex]; ok {
+			return logs, nil
+		}
+	}
+	return nil, fmt.Errorf("logs for tx in block: %v with index: %d not found", parentChainBlockHash, txIndex)
+}
+
+func (f *logsFetcher) fetch(ctx context.Context, preState *mel.State) error {
+	parentChainBlockNumber := preState.ParentChainBlockNumber + 1
+	if parentChainBlockNumber <= f.blockHeight {
+		return nil
+	}
+	f.reset() // prune old logs
+	toBlockheight := parentChainBlockNumber + f.blocksToFetch
+	if toBlockheight > f.chainHeight {
+		head, err := f.parentChainReader.HeaderByNumber(ctx, nil)
+		if err != nil {
+			return err
+		}
+		if head.Number.Uint64() < parentChainBlockNumber {
+			return fmt.Errorf("reorg detected inside logsFetcher")
+		}
+		f.chainHeight = head.Number.Uint64()
+		toBlockheight = min(f.chainHeight, toBlockheight)
+	}
+	if err := f.fetchSequencerBatchLogs(ctx, parentChainBlockNumber, toBlockheight); err != nil {
+		return err
+	}
+	if err := f.fetchDelayedMessageLogs(ctx, parentChainBlockNumber, toBlockheight, preState.DelayedMessagePostingTargetAddress); err != nil {
+		return err
+	}
+	f.blockHeight = toBlockheight
+	return nil
+}
+
+func (f *logsFetcher) fetchSequencerBatchLogs(ctx context.Context, from, to uint64) error {
+	sequencerBatchDataABI := melextraction.SeqInboxABI.Events["SequencerBatchData"].ID
+	query := ethereum.FilterQuery{
+		FromBlock: new(big.Int).SetUint64(from),
+		ToBlock:   new(big.Int).SetUint64(to),
+		Topics:    [][]common.Hash{{melextraction.BatchDeliveredID, sequencerBatchDataABI}},
+	}
+	logs, err := f.parentChainReader.FilterLogs(ctx, query)
+	if err != nil {
+		return err
+	}
+	for _, log := range logs {
+		f.logsByBlockHash[log.BlockHash] = append(f.logsByBlockHash[log.BlockHash], &log)
+		if _, ok := f.logsByTxIndex[log.BlockHash]; !ok {
+			f.logsByTxIndex[log.BlockHash] = make(map[uint][]*types.Log)
+		}
+		f.logsByTxIndex[log.BlockHash][log.TxIndex] = append(f.logsByTxIndex[log.BlockHash][log.TxIndex], &log)
+	}
+	return nil
+}
+
+func (f *logsFetcher) fetchDelayedMessageLogs(ctx context.Context, from, to uint64, delayedMessagePostingTargetAddress common.Address) error {
+	conditionalFetch := func(addresses []common.Address, topics [][]common.Hash) error {
+		query := ethereum.FilterQuery{
+			FromBlock: new(big.Int).SetUint64(from),
+			ToBlock:   new(big.Int).SetUint64(to),
+			Addresses: addresses,
+			Topics:    topics,
+		}
+		logs, err := f.parentChainReader.FilterLogs(ctx, query)
+		if err != nil {
+			return err
+		}
+		for _, log := range logs {
+			f.logsByBlockHash[log.BlockHash] = append(f.logsByBlockHash[log.BlockHash], &log)
+		}
+		return nil
+	}
+	messageDeliveredID := melextraction.IBridgeABI.Events["MessageDelivered"].ID
+	if err := conditionalFetch([]common.Address{delayedMessagePostingTargetAddress}, [][]common.Hash{{messageDeliveredID}}); err != nil {
+		return err
+	}
+	return conditionalFetch(nil, [][]common.Hash{{melextraction.InboxMessageDeliveredID, melextraction.InboxMessageFromOriginID}})
+}
+
+func (f *logsFetcher) reset() {
+	f.blockHeight = 0
+	f.logsByTxIndex = make(map[common.Hash]map[uint][]*types.Log)
+	f.logsByBlockHash = make(map[common.Hash][]*types.Log)
+}

--- a/arbnode/mel/runner/logs_fetcher_test.go
+++ b/arbnode/mel/runner/logs_fetcher_test.go
@@ -1,0 +1,106 @@
+package melrunner
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/offchainlabs/nitro/arbnode/mel"
+	melextraction "github.com/offchainlabs/nitro/arbnode/mel/extraction"
+)
+
+func TestLogsFetcher(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sequencerBatchDataABI := melextraction.SeqInboxABI.Events["SequencerBatchData"].ID
+	batchBlockHash := common.HexToHash("blockContainingBatchTx")
+	batchTxHash := common.HexToHash("batchTx")
+	batchTxIndex := uint(1)
+	batchTxLogs := []*types.Log{
+		{
+			Index:     0,
+			Topics:    []common.Hash{melextraction.BatchDeliveredID},
+			TxIndex:   batchTxIndex,
+			TxHash:    batchTxHash,
+			BlockHash: batchBlockHash,
+		},
+		{
+			Index:     1,
+			Topics:    []common.Hash{sequencerBatchDataABI},
+			TxIndex:   batchTxIndex,
+			TxHash:    batchTxHash,
+			BlockHash: batchBlockHash,
+		},
+		{
+			Index:     2,
+			Topics:    []common.Hash{common.HexToHash("ignored")},
+			TxIndex:   batchTxIndex,
+			TxHash:    batchTxHash,
+			BlockHash: batchBlockHash,
+		},
+	}
+	messageDeliveredID := melextraction.IBridgeABI.Events["MessageDelivered"].ID
+	delayedMessagePostingTargetAddress := common.HexToAddress("delayedMessagePostingTargetAddress")
+	delayedBlockHash := common.HexToHash("blockContainingDelayedMsg")
+	delayedMsgTxHash := common.HexToHash("delayedTx")
+	delayedMsgTxIndex := uint(2)
+	delayedMsgTxLogs := []*types.Log{
+		{
+			Index:     0,
+			Topics:    []common.Hash{messageDeliveredID},
+			TxIndex:   delayedMsgTxIndex,
+			TxHash:    delayedMsgTxHash,
+			BlockHash: delayedBlockHash,
+			Address:   delayedMessagePostingTargetAddress,
+		},
+		{
+			Index:     1,
+			Topics:    []common.Hash{melextraction.InboxMessageFromOriginID},
+			TxIndex:   delayedMsgTxIndex,
+			TxHash:    delayedMsgTxHash,
+			BlockHash: delayedBlockHash,
+		},
+		{
+			Index:     2,
+			Topics:    []common.Hash{melextraction.InboxMessageDeliveredID},
+			TxIndex:   delayedMsgTxIndex,
+			TxHash:    delayedMsgTxHash,
+			BlockHash: delayedBlockHash,
+		},
+		{
+			Index:     3,
+			Topics:    []common.Hash{common.HexToHash("ignored")},
+			TxIndex:   delayedMsgTxIndex,
+			TxHash:    delayedMsgTxHash,
+			BlockHash: delayedBlockHash,
+		},
+	}
+
+	parentChainReader := &mockParentChainReader{logs: append(batchTxLogs, delayedMsgTxLogs...)}
+	fetcher := newLogsFetcher(parentChainReader, 10)
+	fetcher.chainHeight = 100
+	melState := &mel.State{
+		ParentChainBlockNumber:             1,
+		DelayedMessagePostingTargetAddress: delayedMessagePostingTargetAddress,
+	}
+	require.NoError(t, fetcher.fetch(ctx, melState))
+
+	// Verify that logsByBlockHash is correct
+	require.True(t, len(fetcher.logsByBlockHash) == 2)
+	require.True(t, fetcher.logsByBlockHash[batchBlockHash] != nil)
+	require.True(t, fetcher.logsByBlockHash[delayedBlockHash] != nil)
+	require.True(t, reflect.DeepEqual(fetcher.logsByBlockHash[batchBlockHash], batchTxLogs[:2]))        // last log shouldn't be returned by the filter query
+	require.True(t, reflect.DeepEqual(fetcher.logsByBlockHash[delayedBlockHash], delayedMsgTxLogs[:3])) // last log shouldn't be returned by the filter query
+	// Verify that logsByTxIndex is correct
+	require.True(t, len(fetcher.logsByTxIndex) == 1)
+	require.True(t, fetcher.logsByTxIndex[batchBlockHash] != nil)
+	require.True(t, reflect.DeepEqual(fetcher.logsByTxIndex[batchBlockHash][batchTxIndex], batchTxLogs[:2])) // last log shouldn't be returned by the filter query
+}

--- a/arbnode/mel/runner/mel.go
+++ b/arbnode/mel/runner/mel.go
@@ -7,10 +7,13 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/spf13/pflag"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/offchainlabs/bold/containers/fsm"
 	"github.com/offchainlabs/nitro/arbnode/mel"
@@ -24,6 +27,32 @@ import (
 // the extractor service stop waiter will wait for this duration before trying to act again.
 const defaultRetryInterval = time.Second
 
+type MessageExtractionConfig struct {
+	Enable                        bool          `koanf:"enable"`
+	RetryInterval                 time.Duration `koanf:"retry-interval"`
+	DelayedMessageBacklogCapacity int           `koanf:"delayed-message-backlog-capacity"`
+	BlocksToPrefetch              uint64        `koanf:"blocks-to-prefetch" reload:"hot"`
+}
+
+func (c *MessageExtractionConfig) Validate() error {
+	return nil
+}
+
+var DefaultMessageExtractionConfig = MessageExtractionConfig{
+	Enable:                        false,
+	RetryInterval:                 defaultRetryInterval,
+	DelayedMessageBacklogCapacity: 100, // TODO: right default? setting to a lower value means more calls to l1reader
+	BlocksToPrefetch:              499, // 500 is the eth_getLogs block range limit
+}
+
+func MessageExtractionConfigAddOptions(prefix string, f *pflag.FlagSet) {
+	f.Bool(prefix+".enable", DefaultMessageExtractionConfig.Enable, "enable message extraction service")
+	f.Duration(prefix+".retry-interval", DefaultMessageExtractionConfig.RetryInterval, "wait time before retring upon a failure")
+	f.Int(prefix+".delayed-message-backlog-capacity", DefaultMessageExtractionConfig.DelayedMessageBacklogCapacity, "target capacity of the delayed message backlog")
+	f.Uint64(prefix+".blocks-to-prefetch", DefaultMessageExtractionConfig.BlocksToPrefetch, "the number of blocks to prefetch relevant logs from")
+}
+
+// TODO (ganesh): cleanup unused methods from this interface after checking with wasm mode
 type ParentChainReader interface {
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
@@ -31,13 +60,17 @@ type ParentChainReader interface {
 	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
 	TransactionInBlock(ctx context.Context, blockHash common.Hash, index uint) (*types.Transaction, error)
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+	TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error)
+	FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
 }
 
 // Defines a message extraction service for a Nitro node which reads parent chain
 // blocks one by one to transform them into messages for the execution layer.
 type MessageExtractor struct {
 	stopwaiter.StopWaiter
+	config            *MessageExtractionConfig
 	parentChainReader ParentChainReader
+	logsPreFetcher    *logsFetcher
 	addrs             *chaininfo.RollupAddresses
 	melDB             *Database
 	msgConsumer       mel.MessageConsumer
@@ -72,6 +105,7 @@ func NewMessageExtractor(
 		dataProviders:     dataProviders,
 		fsm:               fsm,
 		retryInterval:     retryInterval,
+		config:            &DefaultMessageExtractionConfig, //TODO: remove retryInterval as a struct instead use config
 	}, nil
 }
 
@@ -97,55 +131,45 @@ func (m *MessageExtractor) Start(ctxIn context.Context) error {
 	)
 }
 
-// Instantiates a receipt fetcher for a specific parent chain block.
-type blockReceiptFetcher struct {
-	client           ParentChainReader
-	parentChainBlock *types.Block
+// txByLogFetcher is wrapper around ParentChainReader to implement TransactionByLog method
+type txByLogFetcher struct {
+	client ParentChainReader
 }
 
-func newBlockReceiptFetcher(client ParentChainReader, parentChainBlock *types.Block) *blockReceiptFetcher {
-	return &blockReceiptFetcher{
-		client:           client,
-		parentChainBlock: parentChainBlock,
+func (f *txByLogFetcher) TransactionByLog(ctx context.Context, log *types.Log) (*types.Transaction, error) {
+	if log == nil {
+		return nil, errors.New("transactionByLog got nil log value")
 	}
-}
-
-func (rf *blockReceiptFetcher) ReceiptForTransactionIndex(
-	ctx context.Context,
-	txIndex uint,
-) (*types.Receipt, error) {
-	tx, err := rf.client.TransactionInBlock(ctx, rf.parentChainBlock.Hash(), txIndex)
-	if err != nil {
-		return nil, err
-	}
-	return rf.client.TransactionReceipt(ctx, tx.Hash())
-}
-
-type blockTxsFetcher struct {
-	client           ParentChainReader
-	parentChainBlock *types.Block
-}
-
-func newBlockTxsFetcher(client ParentChainReader, parentChainBlock *types.Block) *blockTxsFetcher {
-	return &blockTxsFetcher{
-		client:           client,
-		parentChainBlock: parentChainBlock,
-	}
-}
-
-func (tf *blockTxsFetcher) TransactionsByHeader(
-	ctx context.Context,
-	parentChainHeaderHash common.Hash,
-) (types.Transactions, error) {
-	blk, err := tf.client.BlockByHash(ctx, parentChainHeaderHash)
-	if err != nil {
-		return nil, err
-	}
-	return blk.Transactions(), nil
+	tx, _, err := f.client.TransactionByHash(ctx, log.TxHash)
+	return tx, err
 }
 
 func (m *MessageExtractor) CurrentFSMState() FSMState {
 	return m.fsm.Current().State
+}
+
+func (m *MessageExtractor) getStateByRPCBlockNum(ctx context.Context, blockNum rpc.BlockNumber) (*mel.State, error) {
+	blk, err := m.parentChainReader.HeaderByNumber(ctx, big.NewInt(blockNum.Int64()))
+	if err != nil {
+		return nil, err
+	}
+	headMelStateBlockNum, err := m.melDB.GetHeadMelStateBlockNum()
+	if err != nil {
+		return nil, err
+	}
+	state, err := m.melDB.State(ctx, min(headMelStateBlockNum, blk.Number.Uint64()))
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func (m *MessageExtractor) GetFinalizedDelayedMessagesRead(ctx context.Context) (uint64, error) {
+	state, err := m.getStateByRPCBlockNum(ctx, rpc.FinalizedBlockNumber)
+	if err != nil {
+		return 0, err
+	}
+	return state.DelayedMessagesRead, nil
 }
 
 // Ticks the message extractor FSM and performs the action associated with the current state,
@@ -163,6 +187,16 @@ func (m *MessageExtractor) Act(ctx context.Context) (time.Duration, error) {
 		if err != nil {
 			return m.retryInterval, err
 		}
+		// Initialize delayedMessageBacklog and add it to the melState
+		delayedMessageBacklog, err := mel.NewDelayedMessageBacklog(m.GetContext(), m.config.DelayedMessageBacklogCapacity, m.GetFinalizedDelayedMessagesRead)
+		if err != nil {
+			return m.retryInterval, err
+		}
+		if err = InitializeDelayedMessageBacklog(ctx, delayedMessageBacklog, m.melDB, melState, m.GetFinalizedDelayedMessagesRead); err != nil {
+			return m.retryInterval, err
+		}
+		delayedMessageBacklog.CommitDirties()
+		melState.SetDelayedMessageBacklog(delayedMessageBacklog)
 		// Start mel state is now ready. Check if the state's parent chain block hash exists in the parent chain
 		startBlock, err := m.parentChainReader.HeaderByNumber(ctx, new(big.Int).SetUint64(melState.ParentChainBlockNumber))
 		if err != nil {
@@ -175,6 +209,8 @@ func (m *MessageExtractor) Act(ctx context.Context) (time.Duration, error) {
 				melState: melState,
 			})
 		}
+		// Initialize logsPreFetcher
+		m.logsPreFetcher = newLogsFetcher(m.parentChainReader, m.config.BlocksToPrefetch)
 		// Begin the next FSM state immediately.
 		return 0, m.fsm.Do(processNextBlock{
 			melState: melState,
@@ -191,8 +227,10 @@ func (m *MessageExtractor) Act(ctx context.Context) (time.Duration, error) {
 			return m.retryInterval, fmt.Errorf("invalid action: %T", current.SourceEvent)
 		}
 		preState := processAction.melState
-
-		parentChainBlock, err := m.parentChainReader.BlockByNumber(
+		if preState.GetDelayedMessageBacklog() == nil { // Safety check since its relevant for native mode
+			return m.retryInterval, errors.New("detected nil DelayedMessageBacklog of melState, shouldnt be possible")
+		}
+		parentChainBlock, err := m.parentChainReader.HeaderByNumber(
 			ctx,
 			new(big.Int).SetUint64(preState.ParentChainBlockNumber+1),
 		)
@@ -206,18 +244,24 @@ func (m *MessageExtractor) Act(ctx context.Context) (time.Duration, error) {
 				return m.retryInterval, err
 			}
 		}
-		// Creates a receipt fetcher for the specific parent chain block, to be used
-		// by the message extraction function.
-		receiptFetcher := newBlockReceiptFetcher(m.parentChainReader, parentChainBlock)
-		txsFetcher := newBlockTxsFetcher(m.parentChainReader, parentChainBlock)
-		postState, msgs, delayedMsgs, err := melextraction.ExtractMessages(
+		if parentChainBlock.ParentHash != preState.ParentChainBlockHash {
+			log.Info("MEL detected L1 reorg", "block", preState.ParentChainBlockNumber) // Log level is Info because L1 reorgs are a common occurrence
+			return 0, m.fsm.Do(reorgToOldBlock{
+				melState: preState,
+			})
+		}
+		// Conditionally prefetch logs for upcoming block/s
+		if err = m.logsPreFetcher.fetch(ctx, preState); err != nil {
+			return m.retryInterval, err
+		}
+		postState, msgs, delayedMsgs, batchMetas, err := melextraction.ExtractMessages(
 			ctx,
 			preState,
-			parentChainBlock.Header(),
+			parentChainBlock,
 			m.dataProviders,
 			m.melDB,
-			receiptFetcher,
-			txsFetcher,
+			&txByLogFetcher{m.parentChainReader},
+			m.logsPreFetcher,
 		)
 		if err != nil {
 			return m.retryInterval, err
@@ -228,6 +272,7 @@ func (m *MessageExtractor) Act(ctx context.Context) (time.Duration, error) {
 			postState:        postState,
 			messages:         msgs,
 			delayedMessages:  delayedMsgs,
+			batchMetas:       batchMetas,
 		})
 	// `SavingMessages` is the state responsible for saving the extracted messages
 	// and delayed messages to the database. It stores data in the node's consensus database
@@ -239,6 +284,10 @@ func (m *MessageExtractor) Act(ctx context.Context) (time.Duration, error) {
 		saveAction, ok := current.SourceEvent.(saveMessages)
 		if !ok {
 			return m.retryInterval, fmt.Errorf("invalid action: %T", current.SourceEvent)
+		}
+		saveAction.postState.GetDelayedMessageBacklog().CommitDirties()
+		if err := m.melDB.SaveBatchMetas(ctx, saveAction.postState, saveAction.batchMetas); err != nil {
+			return m.retryInterval, err
 		}
 		if err := m.melDB.SaveDelayedMessages(ctx, saveAction.postState, saveAction.delayedMessages); err != nil {
 			return m.retryInterval, err
@@ -258,8 +307,26 @@ func (m *MessageExtractor) Act(ctx context.Context) (time.Duration, error) {
 	// specified block. The FSM will transition to the `ProcessingNextBlock` state
 	// based on this old state after the reorg is handled.
 	case Reorging:
-		// TODO: Implement reorging logic.
-		return m.retryInterval, fmt.Errorf("reorg state not implemented")
+		reorgAction, ok := current.SourceEvent.(reorgToOldBlock)
+		if !ok {
+			return m.retryInterval, fmt.Errorf("invalid action: %T", current.SourceEvent)
+		}
+		currentDirtyState := reorgAction.melState
+		if currentDirtyState.ParentChainBlockNumber == 0 {
+			return m.retryInterval, errors.New("invalid reorging stage, ParentChainBlockNumber of current mel state has reached 0")
+		}
+		previousState, err := m.melDB.State(ctx, currentDirtyState.ParentChainBlockNumber-1)
+		if err != nil {
+			return m.retryInterval, err
+		}
+		// This adjusts delayedMessageBacklog
+		if err := currentDirtyState.ReorgTo(previousState); err != nil {
+			return m.retryInterval, err
+		}
+		m.logsPreFetcher.reset()
+		return 0, m.fsm.Do(processNextBlock{
+			melState: previousState,
+		})
 	default:
 		return m.retryInterval, fmt.Errorf("invalid state: %s", current.State)
 	}

--- a/arbnode/mel/runner/mel_test.go
+++ b/arbnode/mel/runner/mel_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/offchainlabs/nitro/arbnode/mel"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
@@ -23,17 +24,23 @@ import (
 var _ ParentChainReader = (*mockParentChainReader)(nil)
 
 func TestMessageExtractor(t *testing.T) {
-	t.Skip("Skipping as requires more MEL items merged in before it fully works")
 	ctx := context.Background()
+	emptyblk0 := types.NewBlock(&types.Header{Number: common.Big1}, nil, nil, nil)
+	emptyblk1 := types.NewBlock(&types.Header{Number: common.Big2, ParentHash: emptyblk0.Hash()}, nil, nil, nil)
+	emptyblk2 := types.NewBlock(&types.Header{Number: common.Big3}, nil, nil, nil)
 	parentChainReader := &mockParentChainReader{
 		blocks: map[common.Hash]*types.Block{
-			{}:                              {},
-			common.BigToHash(big.NewInt(1)): {},
+			{}: {},
 		},
 		headers: map[common.Hash]*types.Header{
 			{}: {},
 		},
 	}
+	parentChainReader.blocks[emptyblk1.Hash()] = emptyblk1
+	parentChainReader.blocks[emptyblk2.Hash()] = emptyblk2
+	parentChainReader.blocks[common.BigToHash(common.Big1)] = emptyblk0
+	parentChainReader.blocks[common.BigToHash(common.Big2)] = emptyblk1
+	parentChainReader.blocks[common.BigToHash(common.Big3)] = emptyblk2
 	arbDb := rawdb.NewMemoryDatabase()
 	melDb := NewDatabase(arbDb)
 	messageConsumer := &mockMessageConsumer{}
@@ -45,19 +52,13 @@ func TestMessageExtractor(t *testing.T) {
 		[]daprovider.Reader{},
 		0,
 	)
+	extractor.StopWaiter.Start(ctx, extractor)
 	require.NoError(t, err)
 	require.True(t, extractor.CurrentFSMState() == Start)
 
 	t.Run("Start", func(t *testing.T) {
 		// Expect that an error in the initial state of the FSM
 		// will cause the FSM to return to the start state.
-		parentChainReader.returnErr = errors.New("oops")
-		_, err := extractor.Act(ctx)
-		require.ErrorContains(t, err, "oops")
-
-		require.True(t, extractor.CurrentFSMState() == Start)
-		parentChainReader.returnErr = nil
-
 		_, err = extractor.Act(ctx)
 		require.ErrorContains(t, err, "error getting HeadMelStateBlockNum from database: not found")
 
@@ -65,15 +66,24 @@ func TestMessageExtractor(t *testing.T) {
 		// next block state.
 		melState := &mel.State{
 			Version:                42,
-			ParentChainBlockNumber: 0,
+			ParentChainBlockNumber: 1,
+			ParentChainBlockHash:   emptyblk0.Hash(),
 		}
 		require.NoError(t, melDb.SaveState(ctx, melState))
+
+		parentChainReader.returnErr = errors.New("oops")
+		_, err := extractor.Act(ctx)
+		require.ErrorContains(t, err, "oops")
+
+		require.True(t, extractor.CurrentFSMState() == Start)
+		parentChainReader.returnErr = nil
 		_, err = extractor.Act(ctx)
 		require.NoError(t, err)
 
 		require.True(t, extractor.CurrentFSMState() == ProcessingNextBlock)
 		processBlockAction, ok := extractor.fsm.Current().SourceEvent.(processNextBlock)
 		require.True(t, ok)
+		melState.SetDelayedMessageBacklog(processBlockAction.melState.GetDelayedMessageBacklog())
 		require.Equal(t, processBlockAction.melState, melState)
 	})
 	t.Run("ProcessingNextBlock", func(t *testing.T) {
@@ -102,6 +112,25 @@ func TestMessageExtractor(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, extractor.CurrentFSMState() == ProcessingNextBlock)
 	})
+	t.Run("Reorging", func(t *testing.T) {
+		parentChainReader.blocks[common.BigToHash(big.NewInt(1))] = types.NewBlock(
+			&types.Header{ParentHash: common.MaxHash}, nil, nil, nil,
+		)
+		headMelStateBlockNum, err := melDb.GetHeadMelStateBlockNum()
+		require.NoError(t, err)
+		require.True(t, headMelStateBlockNum == 2)
+
+		// Correctly transitions to the Reorging messages state.
+		parentChainReader.returnErr = nil
+		_, err = extractor.Act(ctx)
+		require.NoError(t, err)
+		require.True(t, extractor.CurrentFSMState() == Reorging)
+
+		// Reorging step should proceed to ProcessingNextBlock state
+		_, err = extractor.Act(ctx)
+		require.NoError(t, err)
+		require.True(t, extractor.CurrentFSMState() == ProcessingNextBlock)
+	})
 }
 
 type mockMessageConsumer struct{ returnErr error }
@@ -113,6 +142,7 @@ func (m *mockMessageConsumer) PushMessages(ctx context.Context, firstMsgIdx uint
 type mockParentChainReader struct {
 	blocks    map[common.Hash]*types.Block
 	headers   map[common.Hash]*types.Header
+	logs      []*types.Log
 	returnErr error
 }
 
@@ -127,6 +157,9 @@ func (m *mockParentChainReader) HeaderByNumber(ctx context.Context, number *big.
 func (m *mockParentChainReader) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
 	if m.returnErr != nil {
 		return nil, m.returnErr
+	}
+	if number == nil || number.Int64() == rpc.FinalizedBlockNumber.Int64() {
+		return types.NewBlock(&types.Header{Number: big.NewInt(1e10)}, nil, nil, nil), nil // Assume all parent chain blocks are finalized to prevent issues dealing with delayed message backlog, it is tested separately
 	}
 	block, ok := m.blocks[common.BigToHash(number)]
 	if !ok {
@@ -178,4 +211,17 @@ func (m *mockParentChainReader) TransactionReceipt(ctx context.Context, txHash c
 	}
 	// Mock implementation, return a dummy receipt
 	return &types.Receipt{}, nil
+}
+
+func (m *mockParentChainReader) TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+	return nil, false, nil
+}
+
+func (m *mockParentChainReader) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	filteredLogs := types.FilterLogs(m.logs, nil, nil, q.Addresses, q.Topics)
+	var result []types.Log
+	for _, log := range filteredLogs {
+		result = append(result, *log)
+	}
+	return result, nil
 }

--- a/arbnode/mel/state.go
+++ b/arbnode/mel/state.go
@@ -76,6 +76,10 @@ type MessageConsumer interface {
 	) error
 }
 
+func (s *State) Hash() common.Hash {
+	return common.Hash{}
+}
+
 // Performs a deep clone of the state struct to prevent any unintended
 // mutations of pointers at runtime.
 func (s *State) Clone() *State {


### PR DESCRIPTION
This PR changes the implementation of message extraction function to iterate over all the logs in a block instead of going over all txs- fetching receipts for each tx- to eventually work on the tx logs.

We add a new data structure to make this possible, `logsFetcher` which will fetch the relevant logs via a Filter query beforehand.