### PR TITLE
Stylus cranelift

### DIFF
--- a/arbitrator/prover/src/programs/config.rs
+++ b/arbitrator/prover/src/programs/config.rs
@@ -129,8 +129,6 @@ pub struct CompileDebugParams {
     pub debug_info: bool,
     /// Add instrumentation to count the number of times each kind of opcode is executed
     pub count_ops: bool,
-    /// Whether to use the Cranelift compiler
-    pub cranelift: bool,
 }
 
 impl Default for CompilePricingParams {
@@ -181,10 +179,10 @@ impl CompileConfig {
     }
 
     #[cfg(feature = "native")]
-    pub fn engine(&self, target: Target) -> Engine {
+    fn engine_type(&self, target: Target, cranelift: bool) -> Engine {
         use wasmer::sys::EngineBuilder;
 
-        let mut wasmer_config: Box<dyn wasmer::CompilerConfig> = match self.debug.cranelift {
+        let mut wasmer_config: Box<dyn wasmer::CompilerConfig> = match cranelift {
             true => {
                 let mut wasmer_config = Cranelift::new();
                 wasmer_config.opt_level(CraneliftOptLevel::Speed);
@@ -220,7 +218,14 @@ impl CompileConfig {
     }
 
     #[cfg(feature = "native")]
-    pub fn store(&self, target: Target) -> Store {
-        Store::new(self.engine(target))
+    // cranelift only matters for compilation and not usually needed
+    pub fn engine(&self, target: Target) -> Engine {
+        self.engine_type(target, true)
     }
+
+    #[cfg(feature = "native")]
+    pub fn store(&self, target: Target, cranelift: bool) -> Store {
+        Store::new(self.engine_type(target, cranelift))
+    }
+
 }

--- a/arbitrator/stylus/src/lib.rs
+++ b/arbitrator/stylus/src/lib.rs
@@ -153,21 +153,22 @@ pub unsafe extern "C" fn stylus_compile(
     wasm: GoSliceData,
     version: u16,
     debug: bool,
-    name: GoSliceData,
+    target: GoSliceData,
+    cranelift: bool,
     output: *mut RustBytes,
 ) -> UserOutcomeKind {
     let wasm = wasm.slice();
     let output = &mut *output;
-    let name = match String::from_utf8(name.slice().to_vec()) {
+    let target = match String::from_utf8(target.slice().to_vec()) {
         Ok(val) => val,
         Err(err) => return write_err(output, err.into()),
     };
-    let target = match target_cache_get(&name) {
+    let target = match target_cache_get(&target) {
         Ok(val) => val,
         Err(err) => return write_err(output, err),
     };
 
-    let asm = match native::compile(wasm, version, debug, target) {
+    let asm = match native::compile(wasm, version, debug, target, cranelift) {
         Ok(val) => val,
         Err(err) => return write_err(output, err),
     };

--- a/arbitrator/stylus/src/native.rs
+++ b/arbitrator/stylus/src/native.rs
@@ -100,7 +100,7 @@ impl<D: DataReader, E: EvmApi<D>> NativeInstance<D, E> {
         evm_data: EvmData,
     ) -> Result<Self> {
         let env = WasmEnv::new(compile, None, evm, evm_data);
-        let store = env.compile.store(target_native());
+        let store = env.compile.store(target_native(), false);
         let module = unsafe { Module::deserialize_unchecked(&store, module)? };
         Self::from_module(module, store, env)
     }
@@ -153,7 +153,7 @@ impl<D: DataReader, E: EvmApi<D>> NativeInstance<D, E> {
         target: Target,
     ) -> Result<Self> {
         let env = WasmEnv::new(compile.clone(), Some(config), evm_api, evm_data);
-        let store = env.compile.store(target);
+        let store = env.compile.store(target, false);
         let module = Module::new(&store, bytes)?;
         Self::from_module(module, store, env)
     }
@@ -362,8 +362,8 @@ impl<D: DataReader, E: EvmApi<D>> StartlessMachine for NativeInstance<D, E> {
     }
 }
 
-pub fn module(wasm: &[u8], compile: CompileConfig, target: Target) -> Result<Vec<u8>> {
-    let mut store = compile.store(target);
+pub fn module(wasm: &[u8], compile: CompileConfig, target: Target, cranelift: bool) -> Result<Vec<u8>> {
+    let mut store = compile.store(target, cranelift);
     let module = Module::new(&store, wasm)?;
     macro_rules! stub {
         (u8 <- $($types:tt)+) => {
@@ -472,7 +472,7 @@ pub fn activate(
     Ok((module, stylus_data))
 }
 
-pub fn compile(wasm: &[u8], version: u16, debug: bool, target: Target) -> Result<Vec<u8>> {
+pub fn compile(wasm: &[u8], version: u16, debug: bool, target: Target, cranelift: bool) -> Result<Vec<u8>> {
     let compile = CompileConfig::version(version, debug);
-    self::module(wasm, compile, target)
+    self::module(wasm, compile, target, cranelift)
 }

--- a/arbitrator/stylus/src/test/api.rs
+++ b/arbitrator/stylus/src/test/api.rs
@@ -54,7 +54,7 @@ impl TestEvmApi {
     pub fn deploy(&mut self, address: Bytes20, config: StylusConfig, name: &str) -> Result<()> {
         let file = format!("tests/{name}/target/wasm32-unknown-unknown/release/{name}.wasm");
         let wasm = std::fs::read(file)?;
-        let module = native::module(&wasm, self.compile.clone(), Target::default())?;
+        let module = native::module(&wasm, self.compile.clone(), Target::default(), false)?;
         self.contracts.lock().insert(address, module);
         self.configs.lock().insert(address, config);
         Ok(())

--- a/arbitrator/stylus/src/test/misc.rs
+++ b/arbitrator/stylus/src/test/misc.rs
@@ -14,7 +14,7 @@ use wasmer::{imports, Function, Target};
 #[test]
 fn test_bulk_memory() -> Result<()> {
     let (compile, config, ink) = test_configs();
-    let mut store = compile.store(Target::default());
+    let mut store = compile.store(Target::default(), false);
     let filename = "../prover/test-cases/bulk-memory.wat";
     let imports = imports! {
         "env" => {

--- a/arbitrator/stylus/src/test/mod.rs
+++ b/arbitrator/stylus/src/test/mod.rs
@@ -36,7 +36,7 @@ type TestInstance = NativeInstance<VecReader, TestEvmApi>;
 
 impl TestInstance {
     fn new_test(path: &str, compile: CompileConfig) -> Result<Self> {
-        let mut store = compile.store(Target::default());
+        let mut store = compile.store(Target::default(), false);
         let imports = imports! {
             "test" => {
                 "noop" => Function::new_typed(&mut store, || {}),

--- a/arbos/programs/cgo_test.go
+++ b/arbos/programs/cgo_test.go
@@ -31,7 +31,11 @@ func TestCompileArch(t *testing.T) {
 		fmt.Print("use -test_compile=[STORE|LOAD] to allow store/load in compile test")
 	}
 	store := strings.Contains(*testflag.CompileFlag, "STORE")
-	err := testCompileArch(store)
+	err := testCompileArch(store, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = testCompileArch(store, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -133,6 +133,7 @@ func compileNative(
 	stylusVersion uint16,
 	debug bool,
 	target rawdb.WasmTarget,
+	cranelift bool,
 ) ([]byte, error) {
 	output := &rustBytes{}
 	status_asm := C.stylus_compile(
@@ -140,6 +141,7 @@ func compileNative(
 		u16(stylusVersion),
 		cbool(debug),
 		goSlice([]byte(target)),
+		cbool(cranelift),
 		output,
 	)
 	asm := rustBytesIntoBytes(output)
@@ -199,7 +201,7 @@ func activateProgramInternal(
 	for _, target := range nativeTargets {
 		target := target
 		go func() {
-			asm, err := compileNative(wasm, stylusVersion, debug, target)
+			asm, err := compileNative(wasm, stylusVersion, debug, target, false)
 			results <- result{target, asm, err}
 		}()
 	}

--- a/arbos/programs/testcompile.go
+++ b/arbos/programs/testcompile.go
@@ -41,12 +41,16 @@ func Wat2Wasm(wat []byte) ([]byte, error) {
 	return rustBytesIntoBytes(output), nil
 }
 
-func testCompileArch(store bool) error {
+func testCompileArch(store bool, cranelift bool) error {
 
 	localTarget := rawdb.LocalTarget()
 	nativeArm64 := localTarget == rawdb.TargetArm64
 	nativeAmd64 := localTarget == rawdb.TargetAmd64
 
+	nameSuffix := ".bin"
+	if cranelift {
+		nameSuffix = "_cranelift.bin"
+	}
 	_, err := fmt.Print("starting test.. native arm? ", nativeArm64, " amd? ", nativeAmd64, " GOARCH/GOOS: ", runtime.GOARCH+"/"+runtime.GOOS, "\n")
 	if err != nil {
 		return err
@@ -90,12 +94,12 @@ func testCompileArch(store bool) error {
 		}
 	}
 
-	_, err = compileNative(wasm, 2, true, "booga")
+	_, err = compileNative(wasm, 2, true, "booga", false)
 	if err == nil {
 		return fmt.Errorf("succeeded compiling non-existent arch: %w", err)
 	}
 
-	outBytes, err := compileNative(wasm, 1, true, localTarget)
+	outBytes, err := compileNative(wasm, 1, true, localTarget, false)
 
 	if err != nil {
 		return fmt.Errorf("failed compiling native: %w", err)
@@ -106,13 +110,13 @@ func testCompileArch(store bool) error {
 			return err
 		}
 
-		err = os.WriteFile("../../target/testdata/host.bin", outBytes, 0644)
+		err = os.WriteFile("../../target/testdata/host"+nameSuffix, outBytes, 0644)
 		if err != nil {
 			return err
 		}
 	}
 
-	outBytes, err = compileNative(wasm, 1, true, rawdb.TargetArm64)
+	outBytes, err = compileNative(wasm, 1, true, rawdb.TargetArm64, false)
 
 	if err != nil {
 		return fmt.Errorf("failed compiling arm: %w", err)
@@ -123,13 +127,13 @@ func testCompileArch(store bool) error {
 			return err
 		}
 
-		err = os.WriteFile("../../target/testdata/arm64.bin", outBytes, 0644)
+		err = os.WriteFile("../../target/testdata/arm64"+nameSuffix, outBytes, 0644)
 		if err != nil {
 			return err
 		}
 	}
 
-	outBytes, err = compileNative(wasm, 1, true, rawdb.TargetAmd64)
+	outBytes, err = compileNative(wasm, 1, true, rawdb.TargetAmd64, false)
 
 	if err != nil {
 		return fmt.Errorf("failed compiling amd: %v", err)
@@ -140,7 +144,7 @@ func testCompileArch(store bool) error {
 			return err
 		}
 
-		err = os.WriteFile("../../target/testdata/amd64.bin", outBytes, 0644)
+		err = os.WriteFile("../../target/testdata/amd64"+nameSuffix, outBytes, 0644)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
fixes: NIT-3675

adds cranelift support for stylus

Todo:
- [ ]  Allow configuring default to be either
- [ ]  In case of error or timeout, switch to the other engine and retry