### PR TITLE
Add option to MEL to only read safe/finalized blocks

### DIFF
--- a/arbnode/mel/runner/fsm.go
+++ b/arbnode/mel/runner/fsm.go
@@ -57,6 +57,7 @@ type saveMessages struct {
 	batchMetas       []*mel.BatchMetadata
 }
 
+// An action that transitions the FSM to the reorging state.
 type reorgToOldBlock struct {
 	melState *mel.State
 }


### PR DESCRIPTION
This PR adds an option to MEL to choose reading only `safe/finalized` blocks, similar to the feature currently present in inbox_reader. The config option is `--node.message-extraction.read-mode=<string>` and the allowed values are `"latest", "safe" and "finalized"`

Resolves NIT-3458