### PR TITLE
Basic seq-coordinator config validation

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -113,6 +113,9 @@ func (c *Config) Validate() error {
 	if err := c.Staker.Validate(); err != nil {
 		return err
 	}
+	if err := c.SeqCoordinator.Validate(); err != nil {
+		return err
+	}
 	if c.TransactionStreamer.TrackBlockMetadataFrom != 0 && !c.BlockMetadataFetcher.Enable {
 		log.Warn("track-block-metadata-from is set but blockMetadata fetcher is not enabled")
 	}

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -155,6 +155,16 @@ var TestSeqCoordinatorConfig = SeqCoordinatorConfig{
 	Signer:                signature.DefaultSignVerifyConfig,
 }
 
+func (c *SeqCoordinatorConfig) Validate() error {
+	if !c.Enable {
+		return nil
+	}
+	if c.RedisUrl == "" {
+		return errors.New("seq-coordinator.redis-url is required when seq-coordinator is enabled")
+	}
+	return nil
+}
+
 func NewSeqCoordinator(
 	dataSigner signature.DataSignerFunc,
 	bpvalidator *contracts.AddressVerifier,


### PR DESCRIPTION
seq-coordinator.redis-url must be nonempty if the Sequencer Coordinator is being used.

We had https://github.com/OffchainLabs/nitro/issues/3441 which could've been avoided with this validation.

Resolves SUP-787