### PR TITLE
Revert https://github.com/OffchainLabs/nitro/pull/3487

### DIFF
--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -631,6 +631,11 @@ func Precompiles() map[addr]ArbosPrecompile {
 	arbos.InternalTxStartBlockMethodID = ArbosActs.GetMethodID("StartBlock")
 	arbos.InternalTxBatchPostingReportMethodID = ArbosActs.GetMethodID("BatchPostingReport")
 
+	for _, contract := range contracts {
+		precompile := contract.Precompile()
+		arbosState.PrecompileMinArbOSVersions[precompile.address] = precompile.arbosVersion
+	}
+
 	ArbOwner.methodsByName["SetCalldataPriceIncrease"].arbosVersion = params.ArbosVersion_40
 	ArbOwnerPublic.methodsByName["IsCalldataPriceIncreaseEnabled"].arbosVersion = params.ArbosVersion_40
 
@@ -642,15 +647,11 @@ func Precompiles() map[addr]ArbosPrecompile {
 	ArbOwner.methodsByName["IsNativeTokenOwner"].arbosVersion = params.ArbosVersion_41
 	ArbOwner.methodsByName["GetAllNativeTokenOwners"].arbosVersion = params.ArbosVersion_41
 
-	ArbNativeTokenManager := insert(MakePrecompile(pgen.ArbNativeTokenManagerMetaData, &ArbNativeTokenManager{Address: types.ArbNativeTokenManagerAddress}))
+	_, ArbNativeTokenManager := MakePrecompile(pgen.ArbNativeTokenManagerMetaData, &ArbNativeTokenManager{Address: types.ArbNativeTokenManagerAddress})
 	ArbNativeTokenManager.arbosVersion = params.ArbosVersion_41
 	ArbNativeTokenManager.methodsByName["MintNativeToken"].arbosVersion = params.ArbosVersion_41
 	ArbNativeTokenManager.methodsByName["BurnNativeToken"].arbosVersion = params.ArbosVersion_41
-
-	for _, contract := range contracts {
-		precompile := contract.Precompile()
-		arbosState.PrecompileMinArbOSVersions[precompile.address] = precompile.arbosVersion
-	}
+	insert(ArbNativeTokenManager.address, ArbNativeTokenManager)
 
 	return contracts
 }

--- a/system_tests/arbos_upgrade_test.go
+++ b/system_tests/arbos_upgrade_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
@@ -90,7 +89,7 @@ func checkArbOSVersion(t *testing.T, testClient *TestClient, expectedVersion uin
 	state, err := arbosState.OpenSystemArbosState(statedb, nil, true)
 	Require(t, err, "could not open ArbOS state", scenario)
 	if state.ArbOSVersion() != expectedVersion {
-		t.Fatalf("%s: expected ArbOS version %v, got %v", scenario, expectedVersion, state.ArbOSVersion())
+		t.Errorf("%s: expected ArbOS version %v, got %v", scenario, expectedVersion, state.ArbOSVersion())
 	}
 
 }
@@ -194,121 +193,6 @@ func TestArbos11To32UpgradeWithMcopy(t *testing.T) {
 	Require(t, err)
 	if blockSeq.Hash() != blockReplica.Hash() {
 		t.Errorf("expected sequencer and replica to have same block hash, got %v and %v", blockSeq.Hash(), blockReplica.Hash())
-	}
-}
-
-func TestArbNativeTokenManagerInArbos32To41Upgrade(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	initialVersion := uint64(32)
-	finalVersion := uint64(41)
-
-	arbOSInit := &params.ArbOSInit{
-		NativeTokenSupplyManagementEnabled: true,
-	}
-	builder := NewNodeBuilder(ctx).
-		DefaultConfig(t, true).
-		WithArbOSVersion(initialVersion).
-		WithArbOSInit(arbOSInit)
-	builder.execConfig.TxPreChecker.Strictness = gethexec.TxPreCheckerStrictnessLikelyCompatible
-	cleanup := builder.Build(t)
-	defer cleanup()
-
-	authOwner := builder.L2Info.GetDefaultTransactOpts("Owner", ctx)
-	authOwner.GasLimit = 32000000
-
-	// makes Owner a chain owner
-	arbDebug, err := precompilesgen.NewArbDebug(types.ArbDebugAddress, builder.L2.Client)
-	Require(t, err)
-	tx, err := arbDebug.BecomeChainOwner(&authOwner)
-	Require(t, err)
-	_, err = EnsureTxSucceeded(ctx, builder.L2.Client, tx)
-	Require(t, err)
-
-	checkArbOSVersion(t, builder.L2, initialVersion, "")
-
-	arbOwner, err := precompilesgen.NewArbOwner(types.ArbOwnerAddress, builder.L2.Client)
-	Require(t, err)
-
-	callOpts := &bind.CallOpts{Context: ctx}
-
-	nativeTokenOwnerName := "NativeTokenOwner"
-	builder.L2Info.GenerateAccount(nativeTokenOwnerName)
-	nativeTokenOwnerAddr := builder.L2Info.GetAddress(nativeTokenOwnerName)
-
-	// checks that IsNativeTokenOwner doesn't exist in ArbOwner before upgrade
-	_, err = arbOwner.IsNativeTokenOwner(callOpts, nativeTokenOwnerAddr)
-	if err == nil || !strings.Contains(err.Error(), "execution reverted") {
-		t.Fatalf("expected IsNativeTokenOwner to fail before upgrade, got %v", err)
-	}
-
-	// schedule arbos upgrade
-	tx, err = arbOwner.ScheduleArbOSUpgrade(&authOwner, finalVersion, 0)
-	Require(t, err)
-	_, err = builder.L2.EnsureTxSucceeded(tx)
-	Require(t, err)
-
-	// checks upgrade worked
-	var data []byte
-	for i := range 10 {
-		for range 100 {
-			data = append(data, byte(i))
-		}
-	}
-	tx = builder.L2Info.PrepareTx("Owner", "Owner", builder.L2Info.TransferGas, big.NewInt(1e12), data)
-	err = builder.L2.Client.SendTransaction(ctx, tx)
-	Require(t, err)
-	_, err = builder.L2.EnsureTxSucceeded(tx)
-	Require(t, err)
-	checkArbOSVersion(t, builder.L2, finalVersion, "")
-
-	// checks that IsNativeTokenOwner works after upgrade
-	_, err = arbOwner.IsNativeTokenOwner(callOpts, nativeTokenOwnerAddr)
-	Require(t, err)
-
-	// adds native token owner
-	tx, err = arbOwner.AddNativeTokenOwner(&authOwner, nativeTokenOwnerAddr)
-	Require(t, err)
-	_, err = builder.L2.EnsureTxSucceeded(tx)
-
-	// funds the native token owner
-	tx = builder.L2Info.PrepareTx("Owner", nativeTokenOwnerName, builder.L2Info.TransferGas, big.NewInt(500000000000000000), nil)
-	err = builder.L2.Client.SendTransaction(ctx, tx)
-	Require(t, err)
-	_, err = builder.L2.EnsureTxSucceeded(tx)
-	Require(t, err)
-
-	arbNativeTokenManager, err := precompilesgen.NewArbNativeTokenManager(types.ArbNativeTokenManagerAddress, builder.L2.Client)
-	Require(t, err)
-
-	// checks minting
-	nativeTokenOwnerABI, err := precompilesgen.ArbNativeTokenManagerMetaData.GetAbi()
-	Require(t, err)
-	mintTopic := nativeTokenOwnerABI.Events["NativeTokenMinted"].ID
-	authNativeTokenOwner := builder.L2Info.GetDefaultTransactOpts(nativeTokenOwnerName, ctx)
-	authNativeTokenOwner.GasLimit = 32000000
-	toMint := big.NewInt(100)
-	tx, err = arbNativeTokenManager.MintNativeToken(&authNativeTokenOwner, toMint)
-	Require(t, err)
-	receipt, err := builder.L2.EnsureTxSucceeded(tx)
-	Require(t, err)
-	mintLogged := false
-	for _, log := range receipt.Logs {
-		if log.Topics[0] == mintTopic {
-			mintLogged = true
-			parsedLog, err := arbNativeTokenManager.ParseNativeTokenMinted(*log)
-			Require(t, err)
-			if parsedLog.To != nativeTokenOwnerAddr {
-				t.Fatal("expected mint to be to", nativeTokenOwnerAddr, "got", parsedLog.To)
-			}
-			if parsedLog.Amount.Cmp(toMint) != 0 {
-				t.Fatal("expected mint amount to be", toMint, "got", parsedLog.Amount)
-			}
-		}
-	}
-	if !mintLogged {
-		t.Fatal("expected mint event to be logged")
 	}
 }
 


### PR DESCRIPTION
Revert "Merge pull request #3487 from OffchainLabs/fix_arbos41_arbnativetokenmanager_upgrade"

This reverts commit 7d58f8e4425b609de0a7a185fdbaae8ef66e82ff, reversing changes made to 21835b96fe1ddcb1c18a72563066cbfadf5471a0.