### PR TITLE
remove unused variable in express_lane_timeboost_test.go

### DIFF
--- a/system_tests/express_lane_timeboost_test.go
+++ b/system_tests/express_lane_timeboost_test.go
@@ -10,6 +10,5 @@ import (
 func TestBidValidatorAuctioneerRedisStream(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	redisURL := redisutil.CreateTestRedis(ctx, t)
-	_ = redisURL
+	_ = redisutil.CreateTestRedis(ctx, t)
 }


### PR DESCRIPTION
Eliminated unused 'redisURL' variable by using blank identifier directly in function call. Keeps the same functionality while removing compiler warning.