### PR TITLE
feat(validator): add configurable jit executable path via CLI flag

### DIFF
--- a/validator/server_jit/machine_loader.go
+++ b/validator/server_jit/machine_loader.go
@@ -18,15 +18,24 @@ type JitMachineConfig struct {
 	ProverBinPath        string
 	JitCranelift         bool
 	WasmMemoryUsageLimit int
+	JitPath              string
 }
 
 var DefaultJitMachineConfig = JitMachineConfig{
 	JitCranelift:         true,
 	ProverBinPath:        "replay.wasm",
 	WasmMemoryUsageLimit: 4294967296,
+	JitPath:              "", // Empty string means use default path resolution
 }
 
-func getJitPath() (string, error) {
+func getJitPath(configPath string) (string, error) {
+	// If a custom path is provided, use it directly
+	if configPath != "" {
+		_, err := os.Stat(configPath)
+		return configPath, err
+	}
+
+	// Fall back to original logic for auto-detection
 	var jitBinary string
 	executable, err := os.Executable()
 	if err == nil {
@@ -55,7 +64,7 @@ type JitMachineLoader struct {
 }
 
 func NewJitMachineLoader(config *JitMachineConfig, locator *server_common.MachineLocator, maxExecutionTime time.Duration, fatalErrChan chan error) (*JitMachineLoader, error) {
-	jitPath, err := getJitPath()
+	jitPath, err := getJitPath(config.JitPath)
 	if err != nil {
 		return nil, err
 	}

--- a/validator/server_jit/spawner.go
+++ b/validator/server_jit/spawner.go
@@ -21,6 +21,7 @@ type JitSpawnerConfig struct {
 	Workers          int           `koanf:"workers" reload:"hot"`
 	Cranelift        bool          `koanf:"cranelift"`
 	MaxExecutionTime time.Duration `koanf:"max-execution-time" reload:"hot"`
+	JitPath          string        `koanf:"jit-path"`
 
 	// TODO: change WasmMemoryUsageLimit to a string and use resourcemanager.ParseMemLimit
 	WasmMemoryUsageLimit int `koanf:"wasm-memory-usage-limit"`
@@ -33,6 +34,7 @@ var DefaultJitSpawnerConfig = JitSpawnerConfig{
 	Cranelift:            true,
 	WasmMemoryUsageLimit: 4294967296, // 2^32 WASM memory limit
 	MaxExecutionTime:     time.Minute * 10,
+	JitPath:              "", // Empty string means use default path resolution
 }
 
 func JitSpawnerConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -40,6 +42,7 @@ func JitSpawnerConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Bool(prefix+".cranelift", DefaultJitSpawnerConfig.Cranelift, "use Cranelift instead of LLVM when validating blocks using the jit-accelerated block validator")
 	f.Int(prefix+".wasm-memory-usage-limit", DefaultJitSpawnerConfig.WasmMemoryUsageLimit, "if memory used by a jit wasm exceeds this limit, a warning is logged")
 	f.Duration(prefix+".max-execution-time", DefaultJitSpawnerConfig.MaxExecutionTime, "if execution time used by a jit wasm exceeds this limit, a rpc error is returned")
+	f.String(prefix+".jit-path", DefaultJitSpawnerConfig.JitPath, "path to jit executable, if empty, attempts to find jit executable relative to nitro binary or in PATH")
 }
 
 type JitSpawner struct {
@@ -55,6 +58,7 @@ func NewJitSpawner(locator *server_common.MachineLocator, config JitSpawnerConfi
 	machineConfig := DefaultJitMachineConfig
 	machineConfig.JitCranelift = config().Cranelift
 	machineConfig.WasmMemoryUsageLimit = config().WasmMemoryUsageLimit
+	machineConfig.JitPath = config().JitPath
 	maxExecutionTime := config().MaxExecutionTime
 	loader, err := NewJitMachineLoader(&machineConfig, locator, maxExecutionTime, fatalErrChan)
 	if err != nil {


### PR DESCRIPTION
## Description

### Problem
The jit executable path is currently hardcoded and auto-detected relative to the nitro binary, causing issues in DAP environments and custom setups where the path detection fails.

### Solution
Added `--validation.jit.jit-path` CLI flag to allow users to specify a custom jit executable path while maintaining backward compatibility.

### Changes
- Added `JitPath` field to `JitMachineConfig` and `JitSpawnerConfig`
- Modified `getJitPath()` to accept optional custom path parameter
- Added CLI flag `--validation.jit.jit-path` with proper configuration binding
- Falls back to original auto-detection when no custom path is provided

### Usage
```bash
# Custom path
nitro-val --validation.jit.jit-path="/path/to/jit"

# Default behavior (unchanged)
nitro-val
```

### Files Modified
- `validator/server_jit/machine_loader.go`
- `validator/server_jit/spawner.go`

Fixes #3254