### PR TITLE
perf(arbutil): remove extra copy in EvmApiRequestor::emit_log

### DIFF
--- a/arbitrator/arbutil/src/evm/req.rs
+++ b/arbitrator/arbutil/src/evm/req.rs
@@ -248,10 +248,9 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
     }
 
     fn emit_log(&mut self, data: Vec<u8>, topics: u32) -> Result<()> {
-        // TODO: remove copy
-        let mut request = Vec::with_capacity(4 + data.len());
-        request.extend(topics.to_be_bytes());
-        request.extend(data);
+        let mut request = data;
+        let header = topics.to_be_bytes();
+        request.splice(0..0, header);
 
         let (res, _, _) = self.request(EvmApiMethod::EmitLog, request);
         if !res.is_empty() {


### PR DESCRIPTION

- Reuse the incoming Vec as the request buffer and prefix the 4-byte topics header in place (Vec::splice)
  instead of allocating a new Vec and copying.
- Preserves the EmitLog wire format expected by ARBoS (u32 topics BE, topics*32 bytes, then data).
- No behavior change; reduces allocation and copying; avoids unsafe code.