### PR TITLE
chore: fix typos across codebase

### DIFF
--- a/arbos/arbosState/initialize.go
+++ b/arbos/arbosState/initialize.go
@@ -140,7 +140,7 @@ func InitializeArbosInDatabase(db ethdb.Database, cacheConfig *core.CacheConfig,
 		return common.Hash{}, err
 	}
 
-	log.Info("addresss table import complete")
+	log.Info("address table import complete")
 
 	retryableReader, err := initData.GetRetryableDataReader()
 	if err != nil {

--- a/bold/assertions/manager.go
+++ b/bold/assertions/manager.go
@@ -172,7 +172,7 @@ func WithPollingInterval(t time.Duration) Opt {
 	}
 }
 
-// WithConfirmationInterval overrides the default a confiramtion interval.
+// WithConfirmationInterval overrides the default a confirmation interval.
 //
 // This is the interval the assertion manager will wait between attempts to
 // persist information about which assertions can be confirmed to the parent

--- a/bold/assertions/sync.go
+++ b/bold/assertions/sync.go
@@ -445,7 +445,7 @@ func (m *Manager) maybePostRivalAssertionAndChallenge(
 // Attempt to post a rival assertion based on the last agreed with ancestor
 // of a given assertion.
 //
-// If this parent assertion already has a rival we agree with that arleady exists
+// If this parent assertion already has a rival we agree with that already exists
 // then this function will return that assertion.
 func (m *Manager) maybePostRivalAssertion(
 	ctx context.Context,

--- a/bold/challenge-manager/manager.go
+++ b/bold/challenge-manager/manager.go
@@ -145,7 +145,7 @@ func New(
 	m.assertionManager.SetRivalHandler(m)
 	log.Info("Setting up challenge manager",
 		"name", m.name,
-		"addreess", m.chain.StakerAddress(),
+		"address", m.chain.StakerAddress(),
 		"rollup", m.chain.RollupAddress())
 	return m, nil
 }

--- a/bold/layer2-state-provider/history_commitment_provider.go
+++ b/bold/layer2-state-provider/history_commitment_provider.go
@@ -61,7 +61,7 @@ type ProofCollector interface {
 //
 // To determine the exact block from which to collect the machine hashes, the
 // collector needs to know the `FromState` which contains the batch and position
-// within that batch of the first messsage to which the rival assertions are
+// within that batch of the first message to which the rival assertions are
 // committing. In addiiton, the collector needs to know the
 // `BlockChallengeHeight` (which is a relative index within the range of blocks
 // to which the rival assertions are committing where they first diverge.)

--- a/bold/layer2-state-provider/provider.go
+++ b/bold/layer2-state-provider/provider.go
@@ -63,7 +63,7 @@ type ExecutionProvider interface {
 	// Produces the L2 execution state to assert to after the previous assertion
 	// state.
 	// Returns either the state at the batch count maxInboxCount (PosInBatch=0) or
-	// the state LayerZeroHeights.BlockChallengeHeight blokcs after
+	// the state LayerZeroHeights.BlockChallengeHeight blocks after
 	// previousGlobalState, whichever is an earlier state.
 	ExecutionStateAfterPreviousState(ctx context.Context, maxInboxCount uint64, previousGlobalState protocol.GoGlobalState) (*protocol.ExecutionState, error)
 }

--- a/bold/state-commitments/history/history_commitment.go
+++ b/bold/state-commitments/history/history_commitment.go
@@ -91,7 +91,7 @@ func newCommitter() *historyCommitter {
 //
 // Without this type, it would be impossible to distinguish between a hash which
 // has not been found and a hash which is the value of common.Hash{}.
-// That's because the lastLeafProver's postions map is initialized with pointers
+// That's because the lastLeafProver's positions map is initialized with pointers
 // to common.Hash{} values in a pre-allocated slice.
 type soughtHash struct {
 	found bool

--- a/broadcaster/backlog/backlog_test.go
+++ b/broadcaster/backlog/backlog_test.go
@@ -216,7 +216,7 @@ func TestDelete(t *testing.T) {
 		{
 			"EmptyBacklog",
 			[]arbutil.MessageIndex{},
-			0, // no segements in backlog so nothing to delete
+			0, // no segments in backlog so nothing to delete
 			0,
 			0,
 			0,

--- a/daprovider/das/local_file_storage_service.go
+++ b/daprovider/das/local_file_storage_service.go
@@ -566,7 +566,7 @@ type trieLayout struct {
 
 	// Anything changing the layout (pruning, adding files) must go through
 	// this mutex.
-	// Pruning the entire history at statup of Arb Nova as of 2024-06-12 takes
+	// Pruning the entire history at startup of Arb Nova as of 2024-06-12 takes
 	// 5s on my laptop, so the overhead of pruning after startup should be neglibile.
 	writeMutex sync.Mutex
 }

--- a/daprovider/util.go
+++ b/daprovider/util.go
@@ -26,7 +26,7 @@ type BlobReader interface {
 type PreimagesMap map[arbutil.PreimageType]map[common.Hash][]byte
 
 // PreimageRecorder is used to add (key,value) pair to the map accessed by key = ty of a bigger map, preimages.
-// If ty doesn't exist as a key in the preimages map, then it is intialized to map[common.Hash][]byte and then (key,value) pair is added
+// If ty doesn't exist as a key in the preimages map, then it is initialized to map[common.Hash][]byte and then (key,value) pair is added
 type PreimageRecorder func(key common.Hash, value []byte, ty arbutil.PreimageType)
 
 // RecordPreimagesTo takes in preimages map and returns a function that can be used

--- a/docs/decisions/0001-avoid-primitive-constraint-types.md
+++ b/docs/decisions/0001-avoid-primitive-constraint-types.md
@@ -81,7 +81,7 @@ is too prone to bugs introduced by refactoring.
 ### Status Quo: check the constraint in multiple places
 
 * Good, because it is what the code is already doing
-* Good, because when a funciton becomes public, the constraint holds
+* Good, because when a function becomes public, the constraint holds
 * Good, because when a function moves to another file or package, the constraint holds
 * Bad, because it means the check may need to be repeated. DRY
 

--- a/linters/testdata/src/pointercheck/pointercheck.go
+++ b/linters/testdata/src/pointercheck/pointercheck.go
@@ -9,7 +9,7 @@ type A struct {
 // pointerCmp compares pointers, sometimes inside
 func pointerCmp() {
 	a, b := &A{}, &A{}
-	// Simple comparions.
+	// Simple comparisons.
 	if a != b {
 		fmt.Println("Not Equal")
 	}

--- a/relay/relay_stress_test.go
+++ b/relay/relay_stress_test.go
@@ -147,7 +147,7 @@ func largeBacklogRelayTestImpl(t *testing.T, numClients, backlogSize, l2MsgSize 
 		defer client.StopOnly()
 	}
 
-	// wait for all clients to atleast connect once
+	// wait for all clients to at least connect once
 	connectDeadlineTimer := time.NewTicker(connectDeadline)
 	defer connectDeadlineTimer.Stop()
 	select {

--- a/staker/bold/bold_state_provider.go
+++ b/staker/bold/bold_state_provider.go
@@ -429,7 +429,7 @@ func (s *BOLDStateProvider) messageNum(md *l2stateprovider.AssociatedAssertionMe
 // current batch. In that case, the chalHeight will be a block in the virtual
 // padding of the history commitment of this validator.
 //
-// If there is an Option.Some() retrun value, it means that callers don't need
+// If there is an Option.Some() return value, it means that callers don't need
 // to actually step through a machine to produce a series of hashes, because all
 // of the hashes can just be "virtual" copies of a single machine in the
 // FINISHED state's hash.

--- a/system_tests/bold_new_challenge_test.go
+++ b/system_tests/bold_new_challenge_test.go
@@ -116,7 +116,7 @@ func (s *incorrectBlockStateProvider) CollectMachineHashes(
 			honestHashes = append(honestHashes, s.evilMachineHash)
 		}
 	} else if uint64(cfg.BlockChallengeHeight) >= s.wrongAtBlockHeight {
-		panic(fmt.Sprintf("challenge occured at block height %v at or after wrongAtBlockHeight %v", cfg.BlockChallengeHeight, s.wrongAtBlockHeight))
+		panic(fmt.Sprintf("challenge occurred at block height %v at or after wrongAtBlockHeight %v", cfg.BlockChallengeHeight, s.wrongAtBlockHeight))
 	}
 	return honestHashes, nil
 }

--- a/system_tests/outbox_test.go
+++ b/system_tests/outbox_test.go
@@ -231,7 +231,7 @@ func TestOutboxProofs(t *testing.T) {
 				Require(t, err, "couldn't get logs")
 			}
 
-			t.Log("Querried for", len(query), "positions", query)
+			t.Log("Queried for", len(query), "positions", query)
 			t.Log("Found", len(logs), "logs for proof", provable.leaf, "of", treeSize)
 
 			known := make(map[merkletree.LevelAndLeaf]common.Hash) // all values in the tree we know

--- a/system_tests/retryable_test.go
+++ b/system_tests/retryable_test.go
@@ -1143,7 +1143,7 @@ func TestDepositETH(t *testing.T) {
 
 	l1tx, err := delayedInbox.DepositEth439370b1(&txOpts)
 	if err != nil {
-		t.Fatalf("DepositEth0() unexected error: %v", err)
+		t.Fatalf("DepositEth0() unexpected error: %v", err)
 	}
 
 	l1Receipt, err := builder.L1.EnsureTxSucceeded(l1tx)

--- a/system_tests/seq_coordinator_test.go
+++ b/system_tests/seq_coordinator_test.go
@@ -110,7 +110,7 @@ func TestRedisSeqCoordinatorPriorities(t *testing.T) {
 			}
 			if trySequencing(nodeNum) {
 				if succeeded >= 0 {
-					t.Fatal("sequnced succeeded in parallel",
+					t.Fatal("sequenced succeeded in parallel",
 						"index1:", succeeded, "debug", testNodes[succeeded].ConsensusNode.SeqCoordinator.DebugPrint(),
 						"index2:", nodeNum, "debug", node.SeqCoordinator.DebugPrint(),
 						"now", time.Now().UnixMilli())

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -640,7 +640,7 @@ func TestTimeboostExpressLaneTransactionHandling(t *testing.T) {
 			t.Fatalf("unexpected error string returned: %s", failErr.Error())
 		}
 	}
-	checkFailErr("context deadline exceeded") // tx will be rejected with nonce too high error so wont appear in a block
+	checkFailErr("context deadline exceeded") // tx will be rejected with nonce too high error so won't appear in a block
 
 	wg.Add(1)
 	go func(w *sync.WaitGroup) {


### PR DESCRIPTION
**Description**

1. `addresss` → `address`
2. `confiramtion` → `confirmation`
3. `arleady` → `already`
4. `addreess` → `address`
5. `messsage` → `message`
6. `blokcs` → `blocks`
7. `segements` → `segments`
8. `statup` → `startup`
9. `intialized` → `initialized`
10. `funciton` → `function`
11. `comparions` → `comparisons`
12. `atleast` → `at least`
13. `retrun` → `return`
14. `occured` → `occurred`
15. `Querried` → `Queried`
16. `unexected` → `unexpected`
17. `postions` → `positions`
18. `sequnced` → `sequenced`
19. `wont` → `won't`