### PR TITLE
fix: correct error aggregation for multi-target compile results

### DIFF
--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -232,7 +232,7 @@ func activateProgramInternal(
 	for i := 0; i < expectedResults; i++ {
 		res := <-results
 		if res.err != nil {
-			err = errors.Join(res.err, fmt.Errorf("%s:%w", res.target, err))
+			err = errors.Join(err, fmt.Errorf("%s: %w", res.target, res.err))
 		} else {
 			asmMap[res.target] = res.asm
 		}


### PR DESCRIPTION
Correct error accumulation in activateProgramInternal: join the accumulator with the current target’s error and tag it properly. This aligns with errors.Join usage elsewhere (dbconv, arbosState, stylus_tracer) and prevents misleading wrapped-nil entries and mislabelled targets in logs.