### PR TITLE
Return False When Checking if Deposit Tx Type Has Poster Costs

### DIFF
--- a/arbos/l1pricing/l1pricing_test.go
+++ b/arbos/l1pricing/l1pricing_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbos/burn"
@@ -30,6 +31,32 @@ func TestL1PriceUpdate(t *testing.T) {
 	priceEstimate, err := ps.PricePerUnit()
 	Require(t, err)
 	if priceEstimate.Cmp(initialPriceEstimate) != 0 {
+		Fail(t)
+	}
+}
+
+func Test_getPosterUnitsWithoutCache(t *testing.T) {
+	depositorAddr := common.HexToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
+	txData := &types.ArbitrumDepositTx{
+		From:  depositorAddr,
+		To:    common.Address{},
+		Value: big.NewInt(1),
+	}
+	tx := types.NewTx(types.TxData(txData))
+	pricingState := &L1PricingState{}
+	posterAddr := common.Address{}
+	// Only txs that come from the batch poster address will be checked for a poster cost.
+	units := pricingState.getPosterUnitsWithoutCache(tx, posterAddr, 11)
+	if units != 0 {
+		Fail(t)
+	}
+
+	// This can never happen in prod, but even if the batch poster sends a
+	// deposit tx, the poster costs should still be 0.
+	posterAddr = BatchPosterAddress
+	// Only txs that come from the batch poster address will be checked for a poster cost.
+	units = pricingState.getPosterUnitsWithoutCache(tx, posterAddr, 11)
+	if units != 0 {
 		Fail(t)
 	}
 }

--- a/arbos/util/util.go
+++ b/arbos/util/util.go
@@ -244,6 +244,8 @@ func TxTypeHasPosterCosts(txType byte) bool {
 		fallthrough
 	case types.ArbitrumSubmitRetryableTxType:
 		return false
+	case types.ArbitrumDepositTxType:
+		return false
 	}
 	return true
 }


### PR DESCRIPTION
Resolves NIT-3076

Post ArbOS50 we want to ensure that deposit tx types have a poster cost of 0. To do this, we have a function named `TxTypeHasPosterCosts` which we modify to return false. This is NOT a consensus breaking change because the function `TxTypeHasPosterCosts` is only called in one place:

```go
func (ps *L1PricingState) getPosterUnitsWithoutCache(tx *types.Transaction, posterAddr common.Address, brotliCompressionLevel uint64) uint64 {

	if posterAddr != BatchPosterAddress {
		return 0
	}
	txBytes, merr := tx.MarshalBinary()
	txType := tx.Type()
	if !util.TxTypeHasPosterCosts(txType) || merr != nil {
		return 0
	}

	l1Bytes, err := byteCountAfterBrotliLevel(txBytes, brotliCompressionLevel)
	if err != nil {
		panic(fmt.Sprintf("failed to compress tx: %v", err))
	}
	return l1Bytes * params.TxDataNonZeroGasEIP2028
}
```
which will only be called if the tx was posted by the batch poster. However, the batch poster will never submit an Arbitrum deposit tx, so we will never call this code path in a version pre or post ArbOS 50