### PR TITLE
Enable ArbOS 50 in system tests

### DIFF
--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -170,7 +170,7 @@
         "EnableArbOS": true,
         "AllowDebugPrecompiles": true,
         "DataAvailabilityCommittee": false,
-        "InitialArbOSVersion": 40,
+        "InitialArbOSVersion": 50,
         "InitialChainOwner": "0x0000000000000000000000000000000000000000",
         "GenesisBlockNum": 0
       }
@@ -263,8 +263,7 @@
     "chain-name": "stylus-testnet",
     "sequencer-url": "https://stylus-testnet-sequencer.arbitrum.io/rpc",
     "feed-url": "wss://stylus-testnet.arbitrum.io/feed",
-    "chain-config":
-    {
+    "chain-config": {
       "chainId": 23011913,
       "homesteadBlock": 0,
       "daoForkBlock": null,
@@ -280,13 +279,11 @@
       "muirGlacierBlock": 0,
       "berlinBlock": 0,
       "londonBlock": 0,
-      "clique":
-      {
+      "clique": {
         "period": 0,
         "epoch": 0
       },
-      "arbitrum":
-      {
+      "arbitrum": {
         "EnableArbOS": true,
         "AllowDebugPrecompiles": false,
         "DataAvailabilityCommittee": false,
@@ -295,8 +292,7 @@
         "GenesisBlockNum": 0
       }
     },
-    "rollup":
-    {
+    "rollup": {
       "bridge": "0x35aa95ac4747D928E2Cd42FE4461F6D9d1826346",
       "inbox": "0xe1e3b1CBaCC870cb6e5F4Bdf246feB6eB5cD351B",
       "sequencer-inbox": "0x00A0F15b79d1D3e5991929FaAbCF2AA65623530c",

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -367,6 +367,7 @@ func TestBatchPosterLargeTx(t *testing.T) {
 	defer cancel()
 
 	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder.takeOwnership = true
 	builder.execConfig.Sequencer.MaxTxDataSize = 110000
 	cleanup := builder.Build(t)
 	defer cleanup()
@@ -380,7 +381,6 @@ func TestBatchPosterLargeTx(t *testing.T) {
 	gas := builder.L2Info.TransferGas + 2000*uint64(len(data))
 
 	auth := builder.L2Info.GetDefaultTransactOpts("Owner", ctx)
-	becomeChainOwner(t, ctx, auth, builder.L2.Client)
 	arbOwner, err := pgen.NewArbOwner(types.ArbOwnerAddress, builder.L2.Client)
 	Require(t, err)
 	tx, err := arbOwner.SetMaxTxGasLimit(&auth, gas)

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/offchainlabs/nitro/arbnode/dataposter"
 	"github.com/offchainlabs/nitro/arbnode/dataposter/externalsignertest"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
+	pgen "github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/solgen/go/upgrade_executorgen"
 	"github.com/offchainlabs/nitro/util/redisutil"
 )
@@ -376,9 +377,19 @@ func TestBatchPosterLargeTx(t *testing.T) {
 	data := make([]byte, 100000)
 	_, err := rand.Read(data)
 	Require(t, err)
+	gas := builder.L2Info.TransferGas + 2000*uint64(len(data))
+
+	auth := builder.L2Info.GetDefaultTransactOpts("Owner", ctx)
+	becomeChainOwner(t, ctx, auth, builder.L2.Client)
+	arbOwner, err := pgen.NewArbOwner(types.ArbOwnerAddress, builder.L2.Client)
+	Require(t, err)
+	tx, err := arbOwner.SetMaxTxGasLimit(&auth, gas)
+	Require(t, err)
+	_, err = EnsureTxSucceeded(ctx, builder.L2.Client, tx)
+	Require(t, err)
+
 	faucetAddr := builder.L2Info.GetAddress("Faucet")
-	gas := builder.L2Info.TransferGas + 20000*uint64(len(data))
-	tx := builder.L2Info.PrepareTxTo("Faucet", &faucetAddr, gas, common.Big0, data)
+	tx = builder.L2Info.PrepareTxToCustomGas("Faucet", &faucetAddr, gas, common.Big0, data)
 	err = builder.L2.Client.SendTransaction(ctx, tx)
 	Require(t, err)
 	receiptA, err := builder.L2.EnsureTxSucceeded(tx)

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -764,6 +764,10 @@ func (b *NodeBuilder) BuildL2OnL1(t *testing.T) func() {
 		b.addresses,
 	)
 
+	if b.takeOwnership {
+		becomeChainOwner(t, b.ctx, b.L2Info.GetDefaultTransactOpts("Owner", b.ctx), b.L2.Client)
+	}
+
 	return func() {
 		b.L2.cleanup()
 		if b.L1 != nil && b.L1.cleanup != nil {
@@ -818,17 +822,7 @@ func (b *NodeBuilder) BuildL2(t *testing.T) func() {
 	b.L2.Client = ClientForStack(t, b.L2.Stack)
 
 	if b.takeOwnership {
-		debugAuth := b.L2Info.GetDefaultTransactOpts("Owner", b.ctx)
-
-		// make auth a chain owner
-		arbdebug, err := precompilesgen.NewArbDebug(common.HexToAddress("0xff"), b.L2.Client)
-		Require(t, err, "failed to deploy ArbDebug")
-
-		tx, err := arbdebug.BecomeChainOwner(&debugAuth)
-		Require(t, err, "failed to deploy ArbDebug")
-
-		_, err = EnsureTxSucceeded(b.ctx, b.L2.Client, tx)
-		Require(t, err)
+		becomeChainOwner(t, b.ctx, b.L2Info.GetDefaultTransactOpts("Owner", b.ctx), b.L2.Client)
 	}
 
 	StartWatchChanErr(t, b.ctx, fatalErrChan, b.L2.ConsensusNode)

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -2125,3 +2125,13 @@ func populateMachineDir(t *testing.T, cr *github.ConsensusRelease) string {
 	Require(t, err)
 	return machineDir
 }
+
+func becomeChainOwner(t *testing.T, ctx context.Context, opts bind.TransactOpts, client *ethclient.Client) {
+	t.Helper()
+	arbdebug, err := precompilesgen.NewArbDebug(types.ArbDebugAddress, client)
+	Require(t, err, "failed to deploy ArbDebug")
+	tx, err := arbdebug.BecomeChainOwner(&opts)
+	Require(t, err, "failed to deploy ArbDebug")
+	_, err = EnsureTxSucceeded(ctx, client, tx)
+	Require(t, err)
+}

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -414,12 +414,12 @@ func TestGasAccountingParams(t *testing.T) {
 	ctx := builder.ctx
 
 	speedLimit := uint64(18)
-	txGasLimit := uint64(19)
+	blockGasLimit := uint64(19)
 	tx, err := arbOwner.SetSpeedLimit(&auth, speedLimit)
 	Require(t, err)
 	_, err = builder.L2.EnsureTxSucceeded(tx)
 	Require(t, err)
-	tx, err = arbOwner.SetMaxTxGasLimit(&auth, txGasLimit)
+	tx, err = arbOwner.SetMaxBlockGasLimit(&auth, blockGasLimit)
 	Require(t, err)
 	_, err = builder.L2.EnsureTxSucceeded(tx)
 	Require(t, err)
@@ -430,12 +430,12 @@ func TestGasAccountingParams(t *testing.T) {
 		Fatal(t, "expected speed limit to be", speedLimit, "got", arbGasInfoSpeedLimit)
 	}
 	// #nosec G115
-	if arbGasInfoPoolSize.Cmp(big.NewInt(int64(txGasLimit))) != 0 {
-		Fatal(t, "expected pool size to be", txGasLimit, "got", arbGasInfoPoolSize)
+	if arbGasInfoPoolSize.Cmp(big.NewInt(int64(blockGasLimit))) != 0 {
+		Fatal(t, "expected pool size to be", blockGasLimit, "got", arbGasInfoPoolSize)
 	}
 	// #nosec G115
-	if arbGasInfoTxGasLimit.Cmp(big.NewInt(int64(txGasLimit))) != 0 {
-		Fatal(t, "expected tx gas limit to be", txGasLimit, "got", arbGasInfoTxGasLimit)
+	if arbGasInfoTxGasLimit.Cmp(big.NewInt(int64(blockGasLimit))) != 0 {
+		Fatal(t, "expected tx gas limit to be", blockGasLimit, "got", arbGasInfoTxGasLimit)
 	}
 }
 

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -1057,6 +1057,7 @@ func testMemory(t *testing.T, jit bool) {
 	Require(t, err)
 
 	ensure(arbOwner.SetInkPrice(&auth, 1e4))
+	ensure(arbOwner.SetMaxBlockGasLimit(&auth, 34000000))
 	ensure(arbOwner.SetMaxTxGasLimit(&auth, 34000000))
 
 	memoryAddr := deployWasm(t, ctx, auth, l2client, watFile("memory"))
@@ -1092,7 +1093,7 @@ func testMemory(t *testing.T, jit bool) {
 	args := argsForMulticall(vm.CALL, memoryAddr, nil, []byte{126, 50})
 	args = multicallAppend(args, vm.CALL, memoryAddr, []byte{126, 80})
 
-	tx := l2info.PrepareTxTo("Owner", &multiAddr, 1e9, nil, args)
+	tx := l2info.PrepareTxToCustomGas("Owner", &multiAddr, 33000000, nil, args)
 	receipt := ensure(tx, l2client.SendTransaction(ctx, tx))
 	gasCost := receipt.GasUsedForL2()
 	memCost := model.GasCost(128, 0, 0) + model.GasCost(126, 2, 128)
@@ -1102,6 +1103,7 @@ func testMemory(t *testing.T, jit bool) {
 	}
 
 	// check that we'd normally run out of gas
+	ensure(arbOwner.SetMaxBlockGasLimit(&auth, 32000000))
 	ensure(arbOwner.SetMaxTxGasLimit(&auth, 32000000))
 	expectFailure(multiAddr, args, oneEth)
 

--- a/system_tests/retryable_test.go
+++ b/system_tests/retryable_test.go
@@ -581,7 +581,7 @@ func TestSubmitManyRetryableFailThenRetry(t *testing.T) {
 	}
 
 	l2FaucetTxOpts := builder.L2Info.GetDefaultTransactOpts("Faucet", ctx)
-	l2FaucetTxOpts.GasLimit = uint64(1e8)
+	l2FaucetTxOpts.GasLimit = l2pricing.InitialPerTxGasLimitV50
 	l2FaucetAddress := builder.L2Info.GetAddress("Faucet")
 	colors.PrintBlue("L2 Faucet   ", l2FaucetAddress)
 	var addressesToCreate []common.Address

--- a/system_tests/storage_trie_test.go
+++ b/system_tests/storage_trie_test.go
@@ -44,7 +44,6 @@ func TestStorageTrie(t *testing.T) {
 	defer cleanup()
 
 	ownerTxOpts := builder.L2Info.GetDefaultTransactOpts("Owner", ctx)
-	becomeChainOwner(t, ctx, ownerTxOpts, builder.L2.Client)
 	arbOwner, err := pgen.NewArbOwner(types.ArbOwnerAddress, builder.L2.Client)
 	Require(t, err)
 	tx, err := arbOwner.SetMaxTxGasLimit(&ownerTxOpts, 33000000)

--- a/system_tests/test_info.go
+++ b/system_tests/test_info.go
@@ -228,6 +228,15 @@ func (b *BlockchainTestInfo) PrepareTx(from, to string, gas uint64, value *big.I
 func (b *BlockchainTestInfo) PrepareTxTo(
 	from string, to *common.Address, gas uint64, value *big.Int, data []byte,
 ) *types.Transaction {
+	// After arbos_50 l2 txs consuming more than 32,000,000 in compute gas are rejected, this makes
+	// sure our current tests pass and we shouldnt reach compute gas consumption of 32,000,000 anyway
+	gas = min(gas, l2pricing.InitialPerTxGasLimitV50)
+	return b.PrepareTxToCustomGas(from, to, gas, value, data)
+}
+
+func (b *BlockchainTestInfo) PrepareTxToCustomGas(
+	from string, to *common.Address, gas uint64, value *big.Int, data []byte,
+) *types.Transaction {
 	b.T.Helper()
 	info := b.GetInfoWithPrivKey(from)
 	txNonce := info.Nonce.Add(1) - 1


### PR DESCRIPTION
This PR makes it that nitro system_tests are run with ArbOS 50