### PR TITLE
prover: remove unnecessary wasm exports

### DIFF
--- a/arbitrator/prover/src/lib.rs
+++ b/arbitrator/prover/src/lib.rs
@@ -124,6 +124,7 @@ pub unsafe extern "C" fn free_rust_bytes(vec: RustBytes) {
 }
 
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_load_machine(
     binary_path: *const c_char,
     library_paths: *const *const c_char,
@@ -212,11 +213,13 @@ pub fn str_to_c_string(text: &str) -> *mut libc::c_char {
 }
 
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_free_machine(mach: *mut Machine) {
     drop(Box::from_raw(mach));
 }
 
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_clone_machine(mach: *mut Machine) -> *mut Machine {
     let new_mach = (*mach).clone();
     Box::into_raw(Box::new(new_mach))
@@ -255,6 +258,7 @@ pub unsafe extern "C" fn arbitrator_step(
 }
 
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_add_inbox_message(
     mach: *mut Machine,
     inbox_identifier: u64,
@@ -274,6 +278,7 @@ pub unsafe extern "C" fn arbitrator_add_inbox_message(
 
 /// Adds a user program to the machine's known set of wasms.
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_add_user_wasm(
     mach: *mut Machine,
     module: *const u8,
@@ -312,6 +317,7 @@ pub unsafe extern "C" fn arbitrator_step_until_host_io(
 }
 
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_serialize_state(
     mach: *const Machine,
     path: *const c_char,
@@ -330,6 +336,7 @@ pub unsafe extern "C" fn arbitrator_serialize_state(
 }
 
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_deserialize_and_replace_state(
     mach: *mut Machine,
     path: *const c_char,
@@ -348,6 +355,7 @@ pub unsafe extern "C" fn arbitrator_deserialize_and_replace_state(
 }
 
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_get_num_steps(mach: *const Machine) -> u64 {
     (*mach).get_steps()
 }
@@ -377,16 +385,19 @@ const_assert_eq!(
 
 /// Returns one of ARBITRATOR_MACHINE_STATUS_*
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_get_status(mach: *const Machine) -> u8 {
     (*mach).get_status() as u8
 }
 
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_global_state(mach: *mut Machine) -> GlobalState {
     (*mach).get_global_state()
 }
 
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_set_global_state(mach: *mut Machine, gs: GlobalState) {
     (*mach).set_global_state(gs);
 }
@@ -451,16 +462,19 @@ pub unsafe extern "C" fn arbitrator_set_preimage_resolver(
 }
 
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_set_context(mach: *mut Machine, context: u64) {
     (*mach).set_context(context);
 }
 
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_hash(mach: *mut Machine) -> Bytes32 {
     (*mach).hash()
 }
 
 #[no_mangle]
+#[cfg(feature = "native")]
 pub unsafe extern "C" fn arbitrator_module_root(mach: *mut Machine) -> Bytes32 {
     (*mach).get_modules_root()
 }


### PR DESCRIPTION
prover's unnecessary exports add lots of dependencies to user_host which imports it. They are only required for native and not when compiling to wasm.

With rust 1.89.0 it added a call to wasi's fd_tell function, which made machine loading fail.
We could stub fd_tell along with other wasis - but really, no need to.