### PR TITLE
backport adding consensus v41 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -237,7 +237,7 @@ RUN ./download-machine.sh consensus-v31 0x260f5fa5c3176a856893642e149cf128b5a8de
 RUN ./download-machine.sh consensus-v32 0x184884e1eb9fefdc158f6c8ac912bb183bf3cf83f0090317e0bc4ac5860baa39
 #RUN ./download-machine.sh consensus-v40-rc.1 0x6dae396b0b7644a2d63b4b22e6452b767aa6a04b6778dadebdd74aa40f40a5c5
 #RUN ./download-machine.sh consensus-v40-rc.2 0xa8206be13d53e456c7ab061d94bab5b229d674ac57ffe7281216479a8820fcc0
-RUN ./download-machine.sh consensus-v42-rc.1 0x1be44d9f74056fc12af97ccbef7a2668bc5c946fe210505957b0a08b954b907f
+RUN ./download-machine.sh consensus-v41 0xa18d6266cef250802c3cb2bfefe947ea1aa9a32dd30a8d1dfc4568a8714d3a7a
 RUN ./download-machine.sh consensus-v50-alpha.1 0x28cfd8d81613ce4ebe750e77bfd95d6d95d4f53240488095a11c1ad3a494fa82
 RUN ./download-machine.sh consensus-v40 0xdb698a2576298f25448bc092e52cf13b1e24141c997135d70f217d674bbeb69a
 


### PR DESCRIPTION
Also removed deprecated v42-rc.1 since no one should ever use it
