### PR TITLE
fix: prevent HTTP response body leaks in restful DAS client

### DIFF
--- a/daprovider/das/restful_client.go
+++ b/daprovider/das/restful_client.go
@@ -79,6 +79,7 @@ func (c *RestfulDasClient) HealthCheck(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("HTTP error with status %d returned by server: %s", res.StatusCode, http.StatusText(res.StatusCode))
 	}
@@ -90,6 +91,7 @@ func (c *RestfulDasClient) ExpirationPolicy(ctx context.Context) (dasutil.Expira
 	if err != nil {
 		return -1, err
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return -1, err
 	}


### PR DESCRIPTION
Added missing defer res.Body.Close() calls in HealthCheck and ExpirationPolicy methods. Without these, HTTP response bodies weren't being closed properly, causing resource leaks that could degrade performance under load

This follows Go's standard practice of always closing HTTP response bodiesto prevent file descriptor and memory leaks