### PR TITLE
chore: Add require-exhaustive-init linter to structs (1/n)

### DIFF
--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -37,6 +37,7 @@ type InboxBackend interface {
 	ReadDelayedInbox(seqNum uint64) (*arbostypes.L1IncomingMessage, error)
 }
 
+// lint:require-exhaustive-initialization
 type SequencerMessage struct {
 	MinTimestamp         uint64
 	MaxTimestamp         uint64
@@ -162,6 +163,7 @@ func ParseSequencerMessage(ctx context.Context, batchNum uint64, batchBlockHash 
 	return parsedMsg, nil
 }
 
+// lint:require-exhaustive-initialization
 type inboxMultiplexer struct {
 	backend                   InboxBackend
 	delayedMessagesRead       uint64

--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -179,10 +179,16 @@ type inboxMultiplexer struct {
 
 func NewInboxMultiplexer(backend InboxBackend, delayedMessagesRead uint64, dapReaders []daprovider.Reader, keysetValidationMode daprovider.KeysetValidationMode) arbostypes.InboxMultiplexer {
 	return &inboxMultiplexer{
-		backend:              backend,
-		delayedMessagesRead:  delayedMessagesRead,
-		dapReaders:           dapReaders,
-		keysetValidationMode: keysetValidationMode,
+		backend:                   backend,
+		delayedMessagesRead:       delayedMessagesRead,
+		dapReaders:                dapReaders,
+		cachedSequencerMessage:    nil,
+		cachedSequencerMessageNum: 0,
+		cachedSegmentNum:          0,
+		cachedSegmentTimestamp:    0,
+		cachedSegmentBlockNumber:  0,
+		cachedSubMessageNumber:    0,
+		keysetValidationMode:      keysetValidationMode,
 	}
 }
 

--- a/arbstate/inbox_fuzz_test.go
+++ b/arbstate/inbox_fuzz_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/offchainlabs/nitro/daprovider"
 )
 
+// lint:require-exhaustive-initialization
 type multiplexerBackend struct {
 	batchSeqNum           uint64
 	batch                 []byte

--- a/arbutil/finality_data.go
+++ b/arbutil/finality_data.go
@@ -5,6 +5,7 @@ package arbutil
 
 import "github.com/ethereum/go-ethereum/common"
 
+// lint:require-exhaustive-initialization
 type FinalityData struct {
 	MsgIdx    MessageIndex
 	BlockHash common.Hash

--- a/blocks_reexecutor/blocks_reexecutor.go
+++ b/blocks_reexecutor/blocks_reexecutor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
+// lint:require-exhaustive-initialization
 type Config struct {
 	Enable             bool   `koanf:"enable"`
 	Mode               string `koanf:"mode"`
@@ -87,6 +88,7 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Int(prefix+".trie-clean-limit", DefaultConfig.TrieCleanLimit, "memory allowance (MB) to use for caching trie nodes in memory")
 }
 
+// lint:require-exhaustive-initialization
 type BlocksReExecutor struct {
 	stopwaiter.StopWaiter
 	config       *Config

--- a/blocks_reexecutor/blocks_reexecutor.go
+++ b/blocks_reexecutor/blocks_reexecutor.go
@@ -71,7 +71,7 @@ var DefaultConfig = Config{
 	Blocks:             `[[0,0]]`, // execute from chain start to chain end
 	MinBlocksPerThread: 0,
 	TrieCleanLimit:     0,
-	blocks:             [][2]uint64{},
+	blocks:             nil,
 }
 
 var TestConfig = Config{

--- a/blocks_reexecutor/blocks_reexecutor.go
+++ b/blocks_reexecutor/blocks_reexecutor.go
@@ -65,18 +65,24 @@ func (c *Config) Validate() error {
 }
 
 var DefaultConfig = Config{
-	Enable: false,
-	Mode:   "random",
-	Room:   util.GoMaxProcs(),
-	Blocks: `[[0,0]]`, // execute from chain start to chain end
+	Enable:             false,
+	Mode:               "random",
+	Room:               util.GoMaxProcs(),
+	Blocks:             `[[0,0]]`, // execute from chain start to chain end
+	MinBlocksPerThread: 0,
+	TrieCleanLimit:     0,
+	blocks:             [][2]uint64{},
 }
 
 var TestConfig = Config{
-	Enable:         true,
-	Mode:           "full",
-	Blocks:         `[[0,0]]`, // execute from chain start to chain end
-	Room:           util.GoMaxProcs(),
-	TrieCleanLimit: 600,
+	Enable:             true,
+	Mode:               "full",
+	Blocks:             `[[0,0]]`, // execute from chain start to chain end
+	Room:               util.GoMaxProcs(),
+	TrieCleanLimit:     600,
+	MinBlocksPerThread: 0,
+
+	blocks: [][2]uint64{},
 }
 
 func ConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -164,15 +170,10 @@ func New(c *Config, blockchain *core.BlockChain, ethDb ethdb.Database, fatalErrC
 		Preimages: false,
 		HashDB:    &hashConfig,
 	}
-	blocksReExecutor := &BlocksReExecutor{
-		config:       c,
-		db:           state.NewDatabase(triedb.NewDatabase(ethDb, &trieConfig), nil),
-		blockchain:   blockchain,
-		blocks:       blocks,
-		done:         make(chan struct{}, c.Room),
-		fatalErrChan: fatalErrChan,
-	}
-	blocksReExecutor.stateFor = func(header *types.Header) (*state.StateDB, arbitrum.StateReleaseFunc, error) {
+
+	var blocksReExecutor *BlocksReExecutor
+
+	stateForFunc := func(header *types.Header) (*state.StateDB, arbitrum.StateReleaseFunc, error) {
 		blocksReExecutor.mutex.Lock()
 		defer blocksReExecutor.mutex.Unlock()
 		sdb, err := state.New(header.Root, blocksReExecutor.db)
@@ -181,6 +182,17 @@ func New(c *Config, blockchain *core.BlockChain, ethDb ethdb.Database, fatalErrC
 			return sdb, func() { blocksReExecutor.dereferenceRoot(header.Root) }, nil
 		}
 		return sdb, arbitrum.NoopStateRelease, err
+	}
+
+	blocksReExecutor = &BlocksReExecutor{
+		config:       c,
+		db:           state.NewDatabase(triedb.NewDatabase(ethDb, &trieConfig), nil),
+		blockchain:   blockchain,
+		stateFor:     stateForFunc,
+		blocks:       blocks,
+		done:         make(chan struct{}, c.Room),
+		fatalErrChan: fatalErrChan,
+		mutex:        sync.Mutex{},
 	}
 	return blocksReExecutor, nil
 }


### PR DESCRIPTION
Partial solution to https://github.com/OffchainLabs/nitro/issues/3121
Revives changes from https://github.com/OffchainLabs/nitro/pull/3445/ by @TropicalDog17. I opened a new PR and cherry-picked original commits to be able to make required changes and updates before merging. Github should preserve @TropicalDog17's contribution to the nitro repository.

[NIT-3240](https://linear.app/offchain-labs/issue/NIT-3240/use-the-struct-initialization-linter-more)