### PR TITLE
fix: WithMockBridge to actually enable mock bridge

### DIFF
--- a/bold/testing/setup/rollup_stack.go
+++ b/bold/testing/setup/rollup_stack.go
@@ -203,7 +203,7 @@ func WithSafeFastConfirmation() Opt {
 
 func WithMockBridge() Opt {
 	return func(setup *ChainSetup) {
-		setup.useMockBridge = false
+		setup.useMockBridge = true
 	}
 }
 


### PR DESCRIPTION
The option WithMockBridge was inverted and set useMockBridge = false, which disabled the mock bridge. This caused a semantic mismatch with callers and tests that expect WithMockBridge() to deploy mocks. The deploy path already uses useMockBridge to choose between mocksgen.DeployBridgeStub (mock) and bridgegen.DeployBridge (real), so setting it to true here aligns the option name with behavior and avoids ABI mismatches in tests and deployments.