### PR TITLE
Fix: Return proper error on non-200 in RestfulDasClient.ExpirationPolicy

### DIFF
--- a/daprovider/das/restful_client.go
+++ b/daprovider/das/restful_client.go
@@ -93,11 +93,11 @@ func (c *RestfulDasClient) ExpirationPolicy(ctx context.Context) (dasutil.Expira
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return -1, err
+		return -1, fmt.Errorf("HTTP error with status %d returned by server: %s", res.StatusCode, http.StatusText(res.StatusCode))
 	}
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return -1, fmt.Errorf("HTTP error with status %d returned by server: %s", res.StatusCode, http.StatusText(res.StatusCode))
+		return -1, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	var response RestfulDasServerResponse


### PR DESCRIPTION


### Description
- Ensure ExpirationPolicy returns a meaningful error on non-200 responses instead of (-1, nil).
- Improve body read error to a wrapped, descriptive error.

- **Why**: Prevents silent failure and inconsistent behavior across DAS client methods.
- **Scope**: Single function in `daprovider/das/restful_client.go`.

