### PR TITLE
perf(threadsafe): optimize slice initialization by removing unnecessary allocation

### DIFF
--- a/bold/containers/threadsafe/slice.go
+++ b/bold/containers/threadsafe/slice.go
@@ -18,7 +18,7 @@ type Slice[V any] struct {
 }
 
 func NewSlice[V any]() *Slice[V] {
-	return &Slice[V]{items: make([]V, 0)}
+	return &Slice[V]{}
 }
 
 func (s *Slice[V]) Push(v V) {


### PR DESCRIPTION
Replace make([]V, 0) with zero value initialization in NewSlice constructor.

In Go, a nil slice and make([]T, 0) behave identically for all operations (len, cap, append, range), but nil slice avoids unnecessary memory allocation.

This is a standard Go optimization that improves memory efficiency without changing any behavior.