### PR TITLE
Migrate to `wasm32-wasip1`

### DIFF
--- a/arbitrator/prover/test-cases/rust/.cargo/config.toml
+++ b/arbitrator/prover/test-cases/rust/.cargo/config.toml
@@ -1,7 +1,7 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
 
-[target.wasm32-wasi]
+[target.wasm32-wasip1]
 rustflags = [
   "-C", "target-cpu=mvp",
 ]

--- a/arbitrator/wasm-libraries/.cargo/config.toml
+++ b/arbitrator/wasm-libraries/.cargo/config.toml
@@ -3,7 +3,7 @@ rustflags = [
   "-C", "target-cpu=mvp",
 ]
 
-[target.wasm32-wasi]
+[target.wasm32-wasip1]
 rustflags = [
   "-C", "target-cpu=mvp",
 ]


### PR DESCRIPTION
Partially solves [NIT-3220](https://linear.app/offchain-labs/issue/NIT-3220/use-wasm32-wasip1-in-arbitrator-rust). The only usage of the old target `wasm32-wasi` is in the `wasmer` fork. However, this is to be 