### PR TITLE
Remove redundant Background context initialization in poster_test

### DIFF
--- a/bold/assertions/poster_test.go
+++ b/bold/assertions/poster_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestPostAssertion(t *testing.T) {
-	ctx := context.Background()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	chainSetup, chalManager, assertionManager, stateManager := setupAssertionPosting(t)


### PR DESCRIPTION
The test created a context.Background() and immediately shadowed it with context.WithCancel(context.Background()). The initial Background context was unused and provided no benefit. Removing it simplifies the code, matches project-wide usage patterns, and avoids confusion about which context is actually used.