### PR TITLE
Include msg.SetCodeAuthorizations field when constructing arbitrum.TransactionArgs

### DIFF
--- a/execution/nodeInterface/NodeInterface.go
+++ b/execution/nodeInterface/NodeInterface.go
@@ -507,6 +507,7 @@ func (n NodeInterface) messageArgs(
 		Value:                (*hexutil.Big)(value),
 		Nonce:                (*hexutil.Uint64)(&nonce),
 		Data:                 (*hexutil.Bytes)(&data),
+		AuthorizationList:    msg.SetCodeAuthorizations,
 	}
 	if !contractCreation {
 		args.To = &to


### PR DESCRIPTION
Fixes: NIT-3757

Earlier Authorizations list from 7702 transactions is not accounted towards the total cost, this pr makes sure that to include msg.SetCodeAuthorizations field when constructing arbitrum.TransactionArgs