### PR TITLE
Fail instead of panic when building second node if first node was not built with L1

### DIFF
--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -951,7 +951,7 @@ func (b *NodeBuilder) Build2ndNode(t *testing.T, params *SecondNodeParams) (*Tes
 	if b.L2 == nil {
 		t.Fatal("builder did not previously built an L2 Node")
 	}
-	if b.withL1 && b.L1 == nil {
+	if b.L1 == nil {
 		t.Fatal("builder did not previously built an L1 Node")
 	}
 	return build2ndNode(

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -949,10 +949,10 @@ func build2ndNode(
 func (b *NodeBuilder) Build2ndNode(t *testing.T, params *SecondNodeParams) (*TestClient, func()) {
 	DontWaitAndRun(b.ctx, 1, t.Name())
 	if b.L2 == nil {
-		t.Fatal("builder did not previously built an L2 Node")
+		t.Fatal("builder did not previously build an L2 Node")
 	}
 	if b.L1 == nil {
-		t.Fatal("builder did not previously built an L1 Node")
+		t.Fatal("builder did not previously build an L1 Node")
 	}
 	return build2ndNode(
 		t,


### PR DESCRIPTION
Fixes: NIT-3689