### PR TITLE
fix: AutoDepositTokenForStaking should be no-op when already stake

### DIFF
--- a/bold/chain-abstraction/sol-implementation/assertion_chain_test.go
+++ b/bold/chain-abstraction/sol-implementation/assertion_chain_test.go
@@ -594,9 +594,9 @@ func Test_autoDepositFunds_SkipsIfAlreadyStaked(t *testing.T) {
 	evenBiggerBalance := new(big.Int).Add(oldBalance, big.NewInt(100))
 	require.NoError(t, setupCfg.Chains[0].AutoDepositTokenForStaking(ctx, evenBiggerBalance))
 
-	// Check that we our balance does not increase if we try to auto-deposit again given we are
-	// already staked as a validator. In fact, expect it decreased.
+	// Check that our balance does not change if we try to auto-deposit again given we are
+	// already staked as a validator.
 	newBalance, err = erc20.BalanceOf(&bind.CallOpts{}, account.AccountAddr)
 	require.NoError(t, err)
-	require.True(t, oldBalance.Cmp(newBalance) > 0)
+	require.Equal(t, oldBalance, newBalance)
 }


### PR DESCRIPTION
The test ‘Test_autoDepositFunds_SkipsIfAlreadyStaked’ incorrectly expected the stake token balance to decrease on a second auto-deposit call after the validator was already staked. According to the implementation of AutoDepositTokenForStaking and its documentation, the function is a no-op when already staked. This change:
- Fixes the comment grammar.
- Updates the assertion to verify the balance remains unchanged rather than decreasing.
This aligns the test with the intended contract semantics and prevents false positives that contradict production behavior.