### PR TITLE
Also auto-enable EIP-7623 calldata price for sepolia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ arbos/testdata/*
 #other temporaries
 tmp/*
 .env
+go.work
+go.work.sum

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -392,6 +392,13 @@ func (state *ArbosState) UpgradeArbosVersion(
 			ensure(p.Save())
 			chainId, err := state.ChainId()
 			ensure(err)
+			// As of ArbOS v50, the parents of these chains have increased
+			// calldata pricing as part of EIP-7623.
+			// See: https://eips.ethereum.org/EIPS/eip-7623
+			var chainsWithIncreasedCalldataInParent = []*big.Int{
+				chaininfo.ArbitrumOneChainConfig().ChainID,
+				chaininfo.ArbitrumNovaChainConfig().ChainID,
+			}
 			if chainId.Cmp(chaininfo.ArbitrumOneChainConfig().ChainID) == 0 || chainId.Cmp(chaininfo.ArbitrumNovaChainConfig().ChainID) == 0 {
 				ensure(state.l1PricingState.SetCalldataPrice(big.NewInt(int64(params.TxCostFloorPerToken))))
 			} else {

--- a/cmd/chaininfo/chain_defaults.go
+++ b/cmd/chaininfo/chain_defaults.go
@@ -145,6 +145,9 @@ func ArbitrumNovaParams() params.ArbitrumChainParams {
 func ArbitrumRollupGoerliTestnetParams() params.ArbitrumChainParams {
 	return fetchArbitrumChainParams("goerli-rollup")
 }
+func ArbitrumRollupSepoliaTestnetParams() params.ArbitrumChainParams {
+	return fetchArbitrumChainParams("sepolia-rollup")
+}
 func ArbitrumDevTestParams() params.ArbitrumChainParams {
 	return fetchArbitrumChainParams("arb-dev-test")
 }
@@ -168,6 +171,9 @@ func ArbitrumNovaChainConfig() *params.ChainConfig {
 }
 func ArbitrumRollupGoerliTestnetChainConfig() *params.ChainConfig {
 	return fetchChainConfig("goerli-rollup")
+}
+func ArbitrumRollupSepoliaTestnetChainConfig() *params.ChainConfig {
+	return fetchChainConfig("sepolia-rollup")
 }
 func ArbitrumDevTestChainConfig() *params.ChainConfig {
 	return fetchChainConfig("arb-dev-test")

--- a/cmd/chaininfo/chain_defaults_test.go
+++ b/cmd/chaininfo/chain_defaults_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDefaultChainConfigsCopyCorrectly(t *testing.T) {
-	for _, chainName := range []string{"arb1", "nova", "goerli-rollup", "arb-dev-test", "anytrust-dev-test"} {
+	for _, chainName := range []string{"arb1", "nova", "goerli-rollup", "sepolia-rollup", "arb-dev-test", "anytrust-dev-test"} {
 		if !reflect.DeepEqual(DefaultChainConfigs[chainName], fetchChainConfig(chainName)) {
 			t.Fatalf("copy of %s default chain config mismatch", chainName)
 		}


### PR DESCRIPTION
This allows us to deploy the upgrade to ArbOS 50 on the sepolia-rollup chain and immediately begin estimating the correct values for what the parent chain will charge for calldata.

Closes: NIT-3835