### PR TITLE
Multigas: remove hardcoded value in TestMultigasStylus_GetBytes32

### DIFF
--- a/system_tests/multigas_stylus_program_test.go
+++ b/system_tests/multigas_stylus_program_test.go
@@ -43,8 +43,8 @@ func TestMultigasStylus_GetBytes32(t *testing.T) {
 	require.Equal(t, params.WarmStorageReadCostEIP2929, receipt.MultiGasUsed.Get(multigas.ResourceKindComputation))
 
 	// TODO(NIT-3552): after instrumenting intrinsic gas and gasChargingHook this difference should be zero
-	gasDifference := params.TxGas + uint64(516)
-	require.Equal(t, receipt.GasUsed, receipt.MultiGasUsed.SingleGas()+gasDifference)
+	// require.Equal(t, receipt.GasUsed, receipt.MultiGasUsed.SingleGas()+params.TxGas)
+	require.GreaterOrEqual(t, receipt.GasUsed, receipt.MultiGasUsed.SingleGas())
 
 	// TODO(NIT-3793, NIT-3793, NIT-3795): Once all WASM operations are instrumented, WasmComputation
 	// should be derived as the residual from SingleGas instead of asserted directly.


### PR DESCRIPTION
Fix up `TestMultigasStylus_GetBytes32` after merging https://github.com/OffchainLabs/go-ethereum/pull/538

Remove hardcoded value until STF is fully instrumented