### PR TITLE
Implement Execution/Consensus interface over RPC

### DIFF
--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos/l2pricing"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
+	"github.com/offchainlabs/nitro/consensus"
 	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/execution/gethexec"
 	"github.com/offchainlabs/nitro/statetransfer"
@@ -88,11 +89,11 @@ func (w *execClientWrapper) SetFinalityData(
 	return containers.NewReadyPromise(struct{}{}, nil)
 }
 
-func (w *execClientWrapper) DigestMessage(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*execution.MessageResult] {
+func (w *execClientWrapper) DigestMessage(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*consensus.MessageResult] {
 	return containers.NewReadyPromise(w.ExecutionEngine.DigestMessage(num, msg, msgForPrefetch))
 }
 
-func (w *execClientWrapper) Reorg(count arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*execution.MessageResult] {
+func (w *execClientWrapper) Reorg(count arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*consensus.MessageResult] {
 	return containers.NewReadyPromise(w.ExecutionEngine.Reorg(count, newMessages, oldMessages))
 }
 
@@ -100,7 +101,7 @@ func (w *execClientWrapper) HeadMessageIndex() containers.PromiseInterface[arbut
 	return containers.NewReadyPromise(w.ExecutionEngine.HeadMessageIndex())
 }
 
-func (w *execClientWrapper) ResultAtMessageIndex(pos arbutil.MessageIndex) containers.PromiseInterface[*execution.MessageResult] {
+func (w *execClientWrapper) ResultAtMessageIndex(pos arbutil.MessageIndex) containers.PromiseInterface[*consensus.MessageResult] {
 	return containers.NewReadyPromise(w.ExecutionEngine.ResultAtMessageIndex(pos))
 }
 

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/offchainlabs/nitro/broadcastclient"
 	"github.com/offchainlabs/nitro/broadcaster"
 	m "github.com/offchainlabs/nitro/broadcaster/message"
+	"github.com/offchainlabs/nitro/consensus"
 	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/staker"
 	"github.com/offchainlabs/nitro/util/arbmath"
@@ -1029,7 +1030,7 @@ func (s *TransactionStreamer) ExpectChosenSequencer() error {
 func (s *TransactionStreamer) WriteMessageFromSequencer(
 	msgIdx arbutil.MessageIndex,
 	msgWithMeta arbostypes.MessageWithMetadata,
-	msgResult execution.MessageResult,
+	msgResult consensus.MessageResult,
 	blockMetadata common.BlockMetadata,
 ) error {
 	if err := s.ExpectChosenSequencer(); err != nil {
@@ -1242,11 +1243,11 @@ func (s *TransactionStreamer) BlockMetadataAtMessageIndex(msgIdx arbutil.Message
 	return blockMetadata, nil
 }
 
-func (s *TransactionStreamer) ResultAtMessageIndex(msgIdx arbutil.MessageIndex) (*execution.MessageResult, error) {
+func (s *TransactionStreamer) ResultAtMessageIndex(msgIdx arbutil.MessageIndex) (*consensus.MessageResult, error) {
 	key := dbKey(messageResultPrefix, uint64(msgIdx))
 	data, err := s.db.Get(key)
 	if err == nil {
-		var msgResult execution.MessageResult
+		var msgResult consensus.MessageResult
 		err = rlp.DecodeBytes(data, &msgResult)
 		if err == nil {
 			return &msgResult, nil
@@ -1280,7 +1281,7 @@ func (s *TransactionStreamer) ResultAtMessageIndex(msgIdx arbutil.MessageIndex) 
 	return msgResult, nil
 }
 
-func (s *TransactionStreamer) checkResult(msgIdx arbutil.MessageIndex, msgResult *execution.MessageResult, msgAndBlockInfo *arbostypes.MessageWithMetadataAndBlockInfo) {
+func (s *TransactionStreamer) checkResult(msgIdx arbutil.MessageIndex, msgResult *consensus.MessageResult, msgAndBlockInfo *arbostypes.MessageWithMetadataAndBlockInfo) {
 	if msgAndBlockInfo.BlockHash == nil {
 		return
 	}
@@ -1312,7 +1313,7 @@ func (s *TransactionStreamer) checkResult(msgIdx arbutil.MessageIndex, msgResult
 
 func (s *TransactionStreamer) storeResult(
 	msgIdx arbutil.MessageIndex,
-	msgResult execution.MessageResult,
+	msgResult consensus.MessageResult,
 	batch ethdb.Batch,
 ) error {
 	msgResultBytes, err := rlp.EncodeToBytes(msgResult)

--- a/consensus/interface.go
+++ b/consensus/interface.go
@@ -1,0 +1,50 @@
+package consensus
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/util/containers"
+)
+
+const RPCNamespace = "nitroconsensus"
+
+var ErrSequencerInsertLockTaken = errors.New("insert lock taken")
+
+type MessageResult struct {
+	BlockHash common.Hash
+	SendRoot  common.Hash
+}
+
+type InboxBatch struct {
+	BatchNum uint64
+	Found    bool
+}
+
+// not implemented in execution, used as input
+// BatchFetcher is required for any execution node
+type BatchFetcher interface {
+	FindInboxBatchContainingMessage(message arbutil.MessageIndex) containers.PromiseInterface[InboxBatch]
+	GetBatchParentChainBlock(seqNum uint64) containers.PromiseInterface[uint64]
+}
+
+type ConsensusInfo interface {
+	Synced() containers.PromiseInterface[bool]
+	FullSyncProgressMap() containers.PromiseInterface[map[string]interface{}]
+	SyncTargetMessageCount() containers.PromiseInterface[arbutil.MessageIndex]
+	BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[common.BlockMetadata]
+}
+
+type ConsensusSequencer interface {
+	WriteMessageFromSequencer(msgIdx arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult MessageResult, blockMetadata common.BlockMetadata) containers.PromiseInterface[struct{}]
+	ExpectChosenSequencer() containers.PromiseInterface[struct{}]
+}
+
+type FullConsensusClient interface {
+	BatchFetcher
+	ConsensusInfo
+	ConsensusSequencer
+}

--- a/consensus/rpcclient/client.go
+++ b/consensus/rpcclient/client.go
@@ -1,0 +1,132 @@
+package consensusrpcclient
+
+import (
+	"context"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/node"
+
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/consensus"
+	"github.com/offchainlabs/nitro/util/containers"
+	"github.com/offchainlabs/nitro/util/rpcclient"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
+)
+
+type ConsensusRpcClient struct {
+	stopwaiter.StopWaiter
+	client *rpcclient.RpcClient
+}
+
+func NewConsensusRpcClient(config rpcclient.ClientConfigFetcher, stack *node.Node) *ConsensusRpcClient {
+	return &ConsensusRpcClient{
+		client: rpcclient.NewRpcClient(config, stack),
+	}
+}
+
+func (c *ConsensusRpcClient) Start(ctx_in context.Context) error {
+	c.StopWaiter.Start(ctx_in, c)
+	ctx := c.GetContext()
+	return c.client.Start(ctx)
+}
+
+func convertError(err error) error {
+	if err == nil {
+		return nil
+	}
+	errStr := err.Error()
+	if strings.Contains(errStr, consensus.ErrSequencerInsertLockTaken.Error()) {
+		return consensus.ErrSequencerInsertLockTaken
+	}
+	return err
+}
+
+func (c *ConsensusRpcClient) FindInboxBatchContainingMessage(message arbutil.MessageIndex) containers.PromiseInterface[consensus.InboxBatch] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (consensus.InboxBatch, error) {
+		var res consensus.InboxBatch
+		err := c.client.CallContext(ctx, &res, consensus.RPCNamespace+"_findInboxBatchContainingMessage", message)
+		if err != nil {
+			return consensus.InboxBatch{BatchNum: 0, Found: false}, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ConsensusRpcClient) GetBatchParentChainBlock(seqNum uint64) containers.PromiseInterface[uint64] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (uint64, error) {
+		var res uint64
+		err := c.client.CallContext(ctx, &res, consensus.RPCNamespace+"_getBatchParentChainBlock", seqNum)
+		if err != nil {
+			return 0, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ConsensusRpcClient) Synced() containers.PromiseInterface[bool] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (bool, error) {
+		var res bool
+		err := c.client.CallContext(ctx, &res, consensus.RPCNamespace+"_synced")
+		if err != nil {
+			return false, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ConsensusRpcClient) FullSyncProgressMap() containers.PromiseInterface[map[string]interface{}] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (map[string]interface{}, error) {
+		var res map[string]interface{}
+		err := c.client.CallContext(ctx, &res, consensus.RPCNamespace+"_fullSyncProgressMap")
+		if err != nil {
+			return nil, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ConsensusRpcClient) SyncTargetMessageCount() containers.PromiseInterface[arbutil.MessageIndex] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (arbutil.MessageIndex, error) {
+		var res arbutil.MessageIndex
+		err := c.client.CallContext(ctx, &res, consensus.RPCNamespace+"_syncTargetMessageCount")
+		if err != nil {
+			return 0, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ConsensusRpcClient) BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[common.BlockMetadata] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (common.BlockMetadata, error) {
+		var res common.BlockMetadata
+		err := c.client.CallContext(ctx, &res, consensus.RPCNamespace+"_blockMetadataAtMessageIndex", msgIdx)
+		if err != nil {
+			return nil, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ConsensusRpcClient) WriteMessageFromSequencer(msgIdx arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult consensus.MessageResult, blockMetadata common.BlockMetadata) containers.PromiseInterface[struct{}] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (struct{}, error) {
+		var res struct{}
+		err := c.client.CallContext(ctx, &res, consensus.RPCNamespace+"_writeMessageFromSequencer", msgIdx, msgWithMeta, msgResult, blockMetadata)
+		if err != nil {
+			return struct{}{}, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ConsensusRpcClient) ExpectChosenSequencer() containers.PromiseInterface[struct{}] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (struct{}, error) {
+		var res struct{}
+		err := c.client.CallContext(ctx, &res, consensus.RPCNamespace+"_expectChosenSequencer")
+		if err != nil {
+			return struct{}{}, convertError(err)
+		}
+		return res, nil
+	})
+}

--- a/consensus/rpcserver/server.go
+++ b/consensus/rpcserver/server.go
@@ -1,0 +1,53 @@
+package consensusrpcserver
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/consensus"
+)
+
+type ConsensusRpcServer struct {
+	consensus consensus.FullConsensusClient
+}
+
+func NewConsensusRpcServer(consensus consensus.FullConsensusClient) *ConsensusRpcServer {
+	return &ConsensusRpcServer{consensus}
+}
+
+func (a *ConsensusRpcServer) FindInboxBatchContainingMessage(ctx context.Context, message arbutil.MessageIndex) (consensus.InboxBatch, error) {
+	return a.consensus.FindInboxBatchContainingMessage(message).Await(ctx)
+}
+
+func (a *ConsensusRpcServer) GetBatchParentChainBlock(ctx context.Context, seqNum uint64) (uint64, error) {
+	return a.consensus.GetBatchParentChainBlock(seqNum).Await(ctx)
+}
+
+func (a *ConsensusRpcServer) Synced(ctx context.Context) (bool, error) {
+	return a.consensus.Synced().Await(ctx)
+}
+
+func (a *ConsensusRpcServer) FullSyncProgressMap(ctx context.Context) (map[string]interface{}, error) {
+	return a.consensus.FullSyncProgressMap().Await(ctx)
+}
+
+func (a *ConsensusRpcServer) SyncTargetMessageCount(ctx context.Context) (arbutil.MessageIndex, error) {
+	return a.consensus.SyncTargetMessageCount().Await(ctx)
+}
+
+func (a *ConsensusRpcServer) BlockMetadataAtMessageIndex(ctx context.Context, msgIdx arbutil.MessageIndex) (common.BlockMetadata, error) {
+	return a.consensus.BlockMetadataAtMessageIndex(msgIdx).Await(ctx)
+}
+
+func (a *ConsensusRpcServer) WriteMessageFromSequencer(ctx context.Context, msgIdx arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult consensus.MessageResult, blockMetadata common.BlockMetadata) error {
+	_, err := a.consensus.WriteMessageFromSequencer(msgIdx, msgWithMeta, msgResult, blockMetadata).Await(ctx)
+	return err
+}
+
+func (a *ConsensusRpcServer) ExpectChosenSequencer(ctx context.Context) error {
+	_, err := a.consensus.ExpectChosenSequencer().Await(ctx)
+	return err
+}

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -29,6 +29,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbos/programs"
 	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/consensus"
 	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/util"
@@ -469,10 +470,10 @@ func (n *ExecutionNode) StopAndWait() {
 	// }
 }
 
-func (n *ExecutionNode) DigestMessage(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*execution.MessageResult] {
+func (n *ExecutionNode) DigestMessage(num arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*consensus.MessageResult] {
 	return containers.NewReadyPromise(n.ExecEngine.DigestMessage(num, msg, msgForPrefetch))
 }
-func (n *ExecutionNode) Reorg(newHeadMsgIdx arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*execution.MessageResult] {
+func (n *ExecutionNode) Reorg(newHeadMsgIdx arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*consensus.MessageResult] {
 	return containers.NewReadyPromise(n.ExecEngine.Reorg(newHeadMsgIdx, newMessages, oldMessages))
 }
 func (n *ExecutionNode) HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex] {
@@ -484,7 +485,7 @@ func (n *ExecutionNode) NextDelayedMessageNumber() (uint64, error) {
 func (n *ExecutionNode) SequenceDelayedMessage(message *arbostypes.L1IncomingMessage, delayedSeqNum uint64) error {
 	return n.ExecEngine.SequenceDelayedMessage(message, delayedSeqNum)
 }
-func (n *ExecutionNode) ResultAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[*execution.MessageResult] {
+func (n *ExecutionNode) ResultAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[*consensus.MessageResult] {
 	return containers.NewReadyPromise(n.ExecEngine.ResultAtMessageIndex(msgIdx))
 }
 func (n *ExecutionNode) ArbOSVersionForMessageIndex(msgIdx arbutil.MessageIndex) (uint64, error) {
@@ -526,7 +527,7 @@ func (n *ExecutionNode) ForwardTo(url string) error {
 	}
 }
 
-func (n *ExecutionNode) SetConsensusClient(consensus execution.FullConsensusClient) {
+func (n *ExecutionNode) SetConsensusClient(consensus consensus.FullConsensusClient) {
 	n.ExecEngine.SetConsensus(consensus)
 	n.SyncMonitor.SetConsensusInfo(consensus)
 }

--- a/execution/gethexec/sync_monitor.go
+++ b/execution/gethexec/sync_monitor.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/execution"
+	"github.com/offchainlabs/nitro/consensus"
 )
 
 type SyncMonitorConfig struct {
@@ -32,7 +32,7 @@ func SyncMonitorConfigAddOptions(prefix string, f *flag.FlagSet) {
 
 type SyncMonitor struct {
 	config    *SyncMonitorConfig
-	consensus execution.ConsensusInfo
+	consensus consensus.ConsensusInfo
 	exec      *ExecutionEngine
 }
 
@@ -110,7 +110,7 @@ func (s *SyncMonitor) Synced(ctx context.Context) bool {
 	return false
 }
 
-func (s *SyncMonitor) SetConsensusInfo(consensus execution.ConsensusInfo) {
+func (s *SyncMonitor) SetConsensusInfo(consensus consensus.ConsensusInfo) {
 	s.consensus = consensus
 }
 

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -10,16 +10,14 @@ import (
 
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/consensus"
 	"github.com/offchainlabs/nitro/util/containers"
 )
 
+const RPCNamespace = "nitroexecution"
+
 type MaintenanceStatus struct {
 	IsRunning bool `json:"isRunning"`
-}
-
-type MessageResult struct {
-	BlockHash common.Hash
-	SendRoot  common.Hash
 }
 
 type RecordResult struct {
@@ -29,20 +27,15 @@ type RecordResult struct {
 	UserWasms state.UserWasms
 }
 
-type InboxBatch struct {
-	BatchNum uint64
-	Found    bool
-}
-
 var ErrRetrySequencer = errors.New("please retry transaction")
 var ErrSequencerInsertLockTaken = errors.New("insert lock taken")
 
 // always needed
 type ExecutionClient interface {
-	DigestMessage(msgIdx arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*MessageResult]
-	Reorg(msgIdxOfFirstMsgToAdd arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*MessageResult]
+	DigestMessage(msgIdx arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*consensus.MessageResult]
+	Reorg(msgIdxOfFirstMsgToAdd arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*consensus.MessageResult]
 	HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex]
-	ResultAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[*MessageResult]
+	ResultAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[*consensus.MessageResult]
 	MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) containers.PromiseInterface[uint64]
 	BlockNumberToMessageIndex(blockNum uint64) containers.PromiseInterface[arbutil.MessageIndex]
 	SetFinalityData(ctx context.Context, safeFinalityData *arbutil.FinalityData, finalizedFinalityData *arbutil.FinalityData, validatedFinalityData *arbutil.FinalityData) containers.PromiseInterface[struct{}]
@@ -83,29 +76,4 @@ type ExecutionSequencer interface {
 // needed for batch poster
 type ExecutionBatchPoster interface {
 	ArbOSVersionForMessageIndex(msgIdx arbutil.MessageIndex) (uint64, error)
-}
-
-// not implemented in execution, used as input
-// BatchFetcher is required for any execution node
-type BatchFetcher interface {
-	FindInboxBatchContainingMessage(message arbutil.MessageIndex) containers.PromiseInterface[InboxBatch]
-	GetBatchParentChainBlock(seqNum uint64) containers.PromiseInterface[uint64]
-}
-
-type ConsensusInfo interface {
-	Synced() containers.PromiseInterface[bool]
-	FullSyncProgressMap() containers.PromiseInterface[map[string]interface{}]
-	SyncTargetMessageCount() containers.PromiseInterface[arbutil.MessageIndex]
-	BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[common.BlockMetadata]
-}
-
-type ConsensusSequencer interface {
-	WriteMessageFromSequencer(msgIdx arbutil.MessageIndex, msgWithMeta arbostypes.MessageWithMetadata, msgResult MessageResult, blockMetadata common.BlockMetadata) containers.PromiseInterface[struct{}]
-	ExpectChosenSequencer() containers.PromiseInterface[struct{}]
-}
-
-type FullConsensusClient interface {
-	BatchFetcher
-	ConsensusInfo
-	ConsensusSequencer
 }

--- a/execution/rpcclient/client.go
+++ b/execution/rpcclient/client.go
@@ -1,0 +1,155 @@
+package executionrpcclient
+
+import (
+	"context"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/node"
+
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/consensus"
+	"github.com/offchainlabs/nitro/execution"
+	"github.com/offchainlabs/nitro/util/containers"
+	"github.com/offchainlabs/nitro/util/rpcclient"
+	"github.com/offchainlabs/nitro/util/stopwaiter"
+)
+
+type ExecutionRpcClient struct {
+	stopwaiter.StopWaiter
+	client *rpcclient.RpcClient
+}
+
+func NewExecutionRpcClient(config rpcclient.ClientConfigFetcher, stack *node.Node) *ExecutionRpcClient {
+	return &ExecutionRpcClient{
+		client: rpcclient.NewRpcClient(config, stack),
+	}
+}
+
+func (c *ExecutionRpcClient) Start(ctx_in context.Context) error {
+	c.StopWaiter.Start(ctx_in, c)
+	ctx := c.GetContext()
+	return c.client.Start(ctx)
+}
+
+func convertError(err error) error {
+	if err == nil {
+		return nil
+	}
+	errStr := err.Error()
+	if strings.Contains(errStr, execution.ErrRetrySequencer.Error()) {
+		return execution.ErrRetrySequencer
+	}
+	return err
+}
+
+// ExecutionClient methods
+
+func (c *ExecutionRpcClient) DigestMessage(msgIdx arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) containers.PromiseInterface[*consensus.MessageResult] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (*consensus.MessageResult, error) {
+		var res consensus.MessageResult
+		err := c.client.CallContext(ctx, &res, execution.RPCNamespace+"_digestMessage", msgIdx, msg, msgForPrefetch)
+		if err != nil {
+			return nil, convertError(err)
+		}
+		return &res, nil
+	})
+}
+
+func (c *ExecutionRpcClient) Reorg(msgIdxOfFirstMsgToAdd arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) containers.PromiseInterface[[]*consensus.MessageResult] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) ([]*consensus.MessageResult, error) {
+		var res []*consensus.MessageResult
+		err := c.client.CallContext(ctx, res, execution.RPCNamespace+"_reorg", msgIdxOfFirstMsgToAdd, newMessages, oldMessages)
+		if err != nil {
+			return nil, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ExecutionRpcClient) HeadMessageIndex() containers.PromiseInterface[arbutil.MessageIndex] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (arbutil.MessageIndex, error) {
+		var res arbutil.MessageIndex
+		err := c.client.CallContext(ctx, &res, execution.RPCNamespace+"_headMessageIndex")
+		if err != nil {
+			return 0, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ExecutionRpcClient) ResultAtMessageIndex(msgIdx arbutil.MessageIndex) containers.PromiseInterface[*consensus.MessageResult] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (*consensus.MessageResult, error) {
+		var res *consensus.MessageResult
+		err := c.client.CallContext(ctx, &res, execution.RPCNamespace+"_resultAtMessageIndex", msgIdx)
+		if err != nil {
+			return nil, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ExecutionRpcClient) MessageIndexToBlockNumber(messageNum arbutil.MessageIndex) containers.PromiseInterface[uint64] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (uint64, error) {
+		var res uint64
+		err := c.client.CallContext(ctx, &res, execution.RPCNamespace+"_messageIndexToBlockNumber", messageNum)
+		if err != nil {
+			return 0, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ExecutionRpcClient) BlockNumberToMessageIndex(blockNum uint64) containers.PromiseInterface[arbutil.MessageIndex] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (arbutil.MessageIndex, error) {
+		var res arbutil.MessageIndex
+		err := c.client.CallContext(ctx, &res, execution.RPCNamespace+"_blockNumberToMessageIndex", blockNum)
+		if err != nil {
+			return 0, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ExecutionRpcClient) SetFinalityData(ctx context.Context, safeFinalityData *arbutil.FinalityData, finalizedFinalityData *arbutil.FinalityData, validatedFinalityData *arbutil.FinalityData) containers.PromiseInterface[struct{}] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (struct{}, error) {
+		err := c.client.CallContext(ctx, nil, execution.RPCNamespace+"_setFinalityData", safeFinalityData, finalizedFinalityData, validatedFinalityData)
+		return struct{}{}, convertError(err)
+	})
+}
+
+func (c *ExecutionRpcClient) MarkFeedStart(to arbutil.MessageIndex) containers.PromiseInterface[struct{}] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (struct{}, error) {
+		err := c.client.CallContext(ctx, nil, execution.RPCNamespace+"_markFeedStart", to)
+		return struct{}{}, convertError(err)
+	})
+}
+
+func (c *ExecutionRpcClient) TriggerMaintenance() containers.PromiseInterface[struct{}] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (struct{}, error) {
+		err := c.client.CallContext(ctx, nil, execution.RPCNamespace+"_triggerMaintenance")
+		return struct{}{}, convertError(err)
+	})
+}
+
+func (c *ExecutionRpcClient) ShouldTriggerMaintenance() containers.PromiseInterface[bool] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (bool, error) {
+		var res bool
+		err := c.client.CallContext(ctx, &res, execution.RPCNamespace+"_shouldTriggerMaintenance")
+		if err != nil {
+			return false, convertError(err)
+		}
+		return res, nil
+	})
+}
+
+func (c *ExecutionRpcClient) MaintenanceStatus() containers.PromiseInterface[*execution.MaintenanceStatus] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (*execution.MaintenanceStatus, error) {
+		var res *execution.MaintenanceStatus
+		err := c.client.CallContext(ctx, &res, execution.RPCNamespace+"_maintenanceStatus")
+		if err != nil {
+			return nil, convertError(err)
+		}
+		return res, nil
+	})
+}

--- a/execution/rpcserver/server.go
+++ b/execution/rpcserver/server.go
@@ -1,0 +1,67 @@
+package executionrpcserver
+
+import (
+	"context"
+
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/consensus"
+	"github.com/offchainlabs/nitro/execution"
+)
+
+type ExecutionRpcServer struct {
+	executionClient execution.ExecutionClient
+}
+
+func NewExecutionRpcServer(executionClient execution.ExecutionClient) *ExecutionRpcServer {
+	return &ExecutionRpcServer{executionClient}
+}
+
+// ExecutionClient methods
+
+func (c *ExecutionRpcServer) DigestMessage(ctx context.Context, msgIdx arbutil.MessageIndex, msg *arbostypes.MessageWithMetadata, msgForPrefetch *arbostypes.MessageWithMetadata) (*consensus.MessageResult, error) {
+	return c.executionClient.DigestMessage(msgIdx, msg, msgForPrefetch).Await(ctx)
+}
+
+func (c *ExecutionRpcServer) Reorg(ctx context.Context, msgIdxOfFirstMsgToAdd arbutil.MessageIndex, newMessages []arbostypes.MessageWithMetadataAndBlockInfo, oldMessages []*arbostypes.MessageWithMetadata) ([]*consensus.MessageResult, error) {
+	return c.executionClient.Reorg(msgIdxOfFirstMsgToAdd, newMessages, oldMessages).Await(ctx)
+}
+
+func (c *ExecutionRpcServer) HeadMessageIndex(ctx context.Context) (arbutil.MessageIndex, error) {
+	return c.executionClient.HeadMessageIndex().Await(ctx)
+}
+
+func (c *ExecutionRpcServer) ResultAtMessageIndex(ctx context.Context, msgIdx arbutil.MessageIndex) (*consensus.MessageResult, error) {
+	return c.executionClient.ResultAtMessageIndex(msgIdx).Await(ctx)
+}
+
+func (c *ExecutionRpcServer) MessageIndexToBlockNumber(ctx context.Context, messageNum arbutil.MessageIndex) (uint64, error) {
+	return c.executionClient.MessageIndexToBlockNumber(messageNum).Await(ctx)
+}
+
+func (c *ExecutionRpcServer) BlockNumberToMessageIndex(ctx context.Context, blockNum uint64) (arbutil.MessageIndex, error) {
+	return c.executionClient.BlockNumberToMessageIndex(blockNum).Await(ctx)
+}
+
+func (c *ExecutionRpcServer) SetFinalityData(ctx context.Context, safeFinalityData *arbutil.FinalityData, finalizedFinalityData *arbutil.FinalityData, validatedFinalityData *arbutil.FinalityData) error {
+	_, err := c.executionClient.SetFinalityData(ctx, safeFinalityData, finalizedFinalityData, validatedFinalityData).Await(ctx)
+	return err
+}
+
+func (c *ExecutionRpcServer) MarkFeedStart(ctx context.Context, to arbutil.MessageIndex) error {
+	_, err := c.executionClient.MarkFeedStart(to).Await(ctx)
+	return err
+}
+
+func (c *ExecutionRpcServer) TriggerMaintenance(ctx context.Context) error {
+	_, err := c.executionClient.TriggerMaintenance().Await(ctx)
+	return err
+}
+
+func (c *ExecutionRpcServer) ShouldTriggerMaintenance(ctx context.Context) (bool, error) {
+	return c.executionClient.ShouldTriggerMaintenance().Await(ctx)
+}
+
+func (c *ExecutionRpcServer) MaintenanceStatus(ctx context.Context) (*execution.MaintenanceStatus, error) {
+	return c.executionClient.MaintenanceStatus().Await(ctx)
+}

--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/offchainlabs/nitro/arbnode/resourcemanager"
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/execution"
+	"github.com/offchainlabs/nitro/consensus"
 	"github.com/offchainlabs/nitro/util"
 	"github.com/offchainlabs/nitro/util/containers"
 	"github.com/offchainlabs/nitro/util/rpcclient"
@@ -374,7 +374,7 @@ func NewBlockValidator(
 		if err != nil {
 			return nil, err
 		}
-		res := &execution.MessageResult{}
+		res := &consensus.MessageResult{}
 		if messageCount > 0 {
 			res, err = streamer.ResultAtMessageIndex(messageCount - 1)
 			if err != nil {
@@ -558,7 +558,7 @@ func GlobalStateToMsgCount(tracker InboxTrackerInterface, streamer TransactionSt
 	if processed < count {
 		return false, 0, nil
 	}
-	res := &execution.MessageResult{}
+	res := &consensus.MessageResult{}
 	if count > 0 {
 		res, err = streamer.ResultAtMessageIndex(count - 1)
 		if err != nil {
@@ -1361,7 +1361,7 @@ func (v *BlockValidator) checkLegacyValid() error {
 		return nil
 	}
 
-	result := &execution.MessageResult{}
+	result := &consensus.MessageResult{}
 	if msgCount > 0 {
 		result, err = v.streamer.ResultAtMessageIndex(msgCount - 1)
 		if err != nil {

--- a/staker/bold/bold_state_provider.go
+++ b/staker/bold/bold_state_provider.go
@@ -20,7 +20,7 @@ import (
 	"github.com/offchainlabs/nitro/bold/containers/option"
 	l2stateprovider "github.com/offchainlabs/nitro/bold/layer2-state-provider"
 	"github.com/offchainlabs/nitro/bold/state-commitments/history"
-	"github.com/offchainlabs/nitro/execution"
+	"github.com/offchainlabs/nitro/consensus"
 	"github.com/offchainlabs/nitro/staker"
 	challengecache "github.com/offchainlabs/nitro/staker/challenge-cache"
 	"github.com/offchainlabs/nitro/validator"
@@ -216,7 +216,7 @@ func (s *BOLDStateProvider) StatesInBatchRange(
 		if ctx.Err() != nil {
 			return nil, nil, ctx.Err()
 		}
-		executionResult := &execution.MessageResult{}
+		executionResult := &consensus.MessageResult{}
 		if pos > 0 {
 			executionResult, err = s.inboxStreamer.ResultAtMessageIndex(pos - 1)
 			if err != nil {
@@ -279,7 +279,7 @@ func (s *BOLDStateProvider) findGlobalStateFromMessageCountAndBatch(count arbuti
 			return validator.GoGlobalState{}, fmt.Errorf("message count %v is past end of batch %v message count %v", count, batchIndex, batchMsgCount)
 		}
 	}
-	res := &execution.MessageResult{}
+	res := &consensus.MessageResult{}
 	if count > 0 {
 		res, err = s.inboxStreamer.ResultAtMessageIndex(count - 1)
 		if err != nil {
@@ -440,7 +440,7 @@ func (s *BOLDStateProvider) virtualState(msgNum arbutil.MessageIndex, limit l2st
 		return gs, fmt.Errorf("could not get limitMsgCount at %d: %w", limit, err)
 	}
 	if msgNum >= limitMsgCount {
-		result := &execution.MessageResult{}
+		result := &consensus.MessageResult{}
 		if limitMsgCount > 0 {
 			result, err = s.inboxStreamer.ResultAtMessageIndex(limitMsgCount - 1)
 			if err != nil {

--- a/staker/legacy/block_challenge_backend.go
+++ b/staker/legacy/block_challenge_backend.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/execution"
+	"github.com/offchainlabs/nitro/consensus"
 	"github.com/offchainlabs/nitro/solgen/go/challenge_legacy_gen"
 	"github.com/offchainlabs/nitro/staker"
 	"github.com/offchainlabs/nitro/validator"
@@ -120,7 +120,7 @@ func (b *BlockChallengeBackend) FindGlobalStateFromMessageCount(count arbutil.Me
 			return validator.GoGlobalState{}, errors.New("findBatchFromMessageCount returned bad batch")
 		}
 	}
-	res := &execution.MessageResult{}
+	res := &consensus.MessageResult{}
 	if count > 0 {
 		res, err = b.streamer.ResultAtMessageIndex(count - 1)
 		if err != nil {

--- a/staker/legacy/l1_validator.go
+++ b/staker/legacy/l1_validator.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/execution"
+	"github.com/offchainlabs/nitro/consensus"
 	"github.com/offchainlabs/nitro/solgen/go/rollup_legacy_gen"
 	"github.com/offchainlabs/nitro/staker"
 	"github.com/offchainlabs/nitro/staker/txbuilder"
@@ -350,7 +350,7 @@ func (v *L1Validator) generateNodeAction(
 				return nil, false, errors.New("batch not found on L1")
 			}
 		}
-		execResult := &execution.MessageResult{}
+		execResult := &consensus.MessageResult{}
 		if validatedCount > 0 {
 			execResult, err = v.txStreamer.ResultAtMessageIndex(validatedCount - 1)
 			if err != nil {

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbutil"
+	"github.com/offchainlabs/nitro/consensus"
 	"github.com/offchainlabs/nitro/daprovider"
 	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/util/rpcclient"
@@ -66,7 +67,7 @@ type TransactionStreamerInterface interface {
 	BlockValidatorRegistrer
 	GetProcessedMessageCount() (arbutil.MessageIndex, error)
 	GetMessage(msgIdx arbutil.MessageIndex) (*arbostypes.MessageWithMetadata, error)
-	ResultAtMessageIndex(msgIdx arbutil.MessageIndex) (*execution.MessageResult, error)
+	ResultAtMessageIndex(msgIdx arbutil.MessageIndex) (*consensus.MessageResult, error)
 	PauseReorgs()
 	ResumeReorgs()
 	ChainConfig() *params.ChainConfig
@@ -412,7 +413,7 @@ func (v *StatelessBlockValidator) ValidationEntryRecord(ctx context.Context, e *
 	return nil
 }
 
-func BuildGlobalState(res execution.MessageResult, pos GlobalStatePosition) validator.GoGlobalState {
+func BuildGlobalState(res consensus.MessageResult, pos GlobalStatePosition) validator.GoGlobalState {
 	return validator.GoGlobalState{
 		BlockHash:  res.BlockHash,
 		SendRoot:   res.SendRoot,
@@ -449,7 +450,7 @@ func (v *StatelessBlockValidator) CreateReadyValidationEntry(ctx context.Context
 		return nil, err
 	}
 	var prevDelayed uint64
-	prevResult := &execution.MessageResult{}
+	prevResult := &consensus.MessageResult{}
 	if pos > 0 {
 		prev, err := v.streamer.GetMessage(pos - 1)
 		if err != nil {

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/offchainlabs/nitro/broadcastclient"
 	"github.com/offchainlabs/nitro/broadcaster/backlog"
 	"github.com/offchainlabs/nitro/broadcaster/message"
-	"github.com/offchainlabs/nitro/execution"
+	"github.com/offchainlabs/nitro/consensus"
 	"github.com/offchainlabs/nitro/execution/gethexec"
 	"github.com/offchainlabs/nitro/relay"
 	"github.com/offchainlabs/nitro/util/signature"
@@ -152,7 +152,7 @@ func compareAllMsgResultsFromConsensusAndExecution(
 	ctx context.Context,
 	testClient *TestClient,
 	testScenario string,
-) *execution.MessageResult {
+) *consensus.MessageResult {
 	execHeadMsgIdx, err := testClient.ExecNode.HeadMessageIndex().Await(context.Background())
 	Require(t, err)
 	consensusHeadMsgIdx, err := testClient.ConsensusNode.TxStreamer.GetHeadMessageIndex()
@@ -164,7 +164,7 @@ func compareAllMsgResultsFromConsensusAndExecution(
 		)
 	}
 
-	var lastResult *execution.MessageResult
+	var lastResult *consensus.MessageResult
 	for msgIdx := arbutil.MessageIndex(0); msgIdx <= consensusHeadMsgIdx; msgIdx++ {
 		resultExec, err := testClient.ExecNode.ResultAtMessageIndex(arbutil.MessageIndex(msgIdx)).Await(ctx)
 		Require(t, err)


### PR DESCRIPTION
This PR is for NIT-2567

I have implemented the JSON-RPC interface for the consensus and execution layer.

I setup a basic cli-arg setup has ``--node.interconnect`` which has 2 options
- `direct` the default uses the pre-existing interfaces
- `jsonrpc` runs the Consensus and Execution interfaces over a json rpc

I run `direct` and it works fine.

`jsonrpc` fails with `"failed to create node                    err="not connected"` which to fix this I assume we need to ensure 
- the client is connecting to the right jsonrpc server
- start the clients after the server is started

^ so basically ensuring the server's are running and properly connect before trying to use the interfaces

In terms of scope `Have configuration to use existing interface or new RPC interface` I set things up with this in mind. In the future I assume that we will allow users to specify running exclusively the consensus side so that a different execution layer client can be chosen, but to my knowledge that task was out of scope of this issue/pr and will definitely require some re-arranging and refactoring of how things are initialized.

So I believe this Issue is more of a V1 before we add more complexity to how the node is initialized.

If anybody has any questions feel free to ask me