### PR TITLE
chore: remove unused params from OpenRetryableState and Keepalive

### DIFF
--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -87,7 +87,7 @@ func OpenArbosState(stateDB vm.StateDB, burner burn.Burner) (*ArbosState, error)
 		networkFeeAccount:      backingStorage.OpenStorageBackedAddress(uint64(networkFeeAccountOffset)),
 		l1PricingState:         l1pricing.OpenL1PricingState(backingStorage.OpenCachedSubStorage(l1PricingSubspace), arbosVersion),
 		l2PricingState:         l2pricing.OpenL2PricingState(backingStorage.OpenCachedSubStorage(l2PricingSubspace)),
-		retryableState:         retryables.OpenRetryableState(backingStorage.OpenCachedSubStorage(retryablesSubspace), stateDB),
+		retryableState:         retryables.OpenRetryableState(backingStorage.OpenCachedSubStorage(retryablesSubspace)),
 		addressTable:           addressTable.Open(backingStorage.OpenCachedSubStorage(addressTableSubspace)),
 		chainOwners:            addressSet.OpenAddressSet(backingStorage.OpenCachedSubStorage(chainOwnerSubspace)),
 		nativeTokenOwners:      addressSet.OpenAddressSet(backingStorage.OpenCachedSubStorage(nativeTokenOwnerSubspace)),

--- a/arbos/retryable_test.go
+++ b/arbos/retryable_test.go
@@ -87,7 +87,7 @@ func TestRetryableLifecycle(t *testing.T) {
 	setTime((timestampAtCreation + timeoutAtCreation) / 2)
 	for _, id := range ids {
 		window := currentTime + lifetime
-		newTimeout, err := retryableState.Keepalive(id, currentTime, window, lifetime)
+		newTimeout, err := retryableState.Keepalive(id, currentTime, window)
 		Require(t, err, "failed to extend the retryable's lifetime")
 		proveReapingDoesNothing()
 		if newTimeout != timeoutAtCreation+lifetime {
@@ -95,7 +95,7 @@ func TestRetryableLifecycle(t *testing.T) {
 		}
 
 		// prove we need to wait before keepalive can succeed again
-		_, err = retryableState.Keepalive(id, currentTime, window, lifetime)
+		_, err = retryableState.Keepalive(id, currentTime, window)
 		if err == nil {
 			Fail(t, "keepalive should have failed")
 		}

--- a/arbos/retryables/retryable.go
+++ b/arbos/retryables/retryable.go
@@ -36,7 +36,7 @@ func InitializeRetryableState(sto *storage.Storage) error {
 	return storage.InitializeQueue(sto.OpenCachedSubStorage(timeoutQueueKey))
 }
 
-func OpenRetryableState(sto *storage.Storage, statedb vm.StateDB) *RetryableState {
+func OpenRetryableState(sto *storage.Storage) *RetryableState {
 	return &RetryableState{
 		sto,
 		storage.OpenQueue(sto.OpenCachedSubStorage(timeoutQueueKey)),
@@ -217,8 +217,7 @@ func (retryable *Retryable) CalldataSize() (uint64, error) {
 func (rs *RetryableState) Keepalive(
 	ticketId common.Hash,
 	currentTimestamp,
-	limitBeforeAdd,
-	timeToAdd uint64,
+	limitBeforeAdd uint64,
 ) (uint64, error) {
 	retryable, err := rs.OpenRetryable(ticketId, currentTimestamp)
 	if err != nil {

--- a/precompiles/ArbRetryableTx.go
+++ b/precompiles/ArbRetryableTx.go
@@ -170,7 +170,7 @@ func (con ArbRetryableTx) Keepalive(c ctx, evm mech, ticketId bytes32) (huge, er
 
 	currentTime := evm.Context.Time
 	window := currentTime + retryables.RetryableLifetimeSeconds
-	newTimeout, err := retryableState.Keepalive(ticketId, currentTime, window, retryables.RetryableLifetimeSeconds)
+	newTimeout, err := retryableState.Keepalive(ticketId, currentTime, window)
 	if err != nil {
 		return big.NewInt(0), err
 	}


### PR DESCRIPTION
Removed the unused vm.StateDB parameter from OpenRetryableState and the unused timeToAdd parameter from RetryableState.Keepalive, and updated all call sites. These parameters were never read and created API ambiguity. Keepalive is specified to add exactly one lifetime period (RetryableLifetimeSeconds), and the state DB is not needed to construct RetryableState. This change simplifies the API, prevents confusion for callers, and aligns implementation with the documented behavior of the precompile and tests.