### PR TITLE
fix: message count increment and clean up redundant `else`

### DIFF
--- a/arbnode/mel/extraction/messages_in_batch.go
+++ b/arbnode/mel/extraction/messages_in_batch.go
@@ -107,7 +107,7 @@ func messageFromSegment(
 			blockNumber += advancing
 		}
 		return nil, blockNumber, timestamp, nil
-	} else if kind == arbstate.BatchSegmentKindL2Message || kind == arbstate.BatchSegmentKindL2MessageBrotli {
+	} if kind == arbstate.BatchSegmentKindL2Message || kind == arbstate.BatchSegmentKindL2MessageBrotli {
 		segment = segment[1:]
 		msg := produceL2Message(
 			kind,
@@ -207,7 +207,7 @@ func extractDelayedMessageFromSegment(
 	}
 
 	// Increment the delayed messages read count in the mel state.
-	melState.DelayedMessagesRead += 1
+	melState.DelayedMessagesRead++
 
 	return &arbostypes.MessageWithMetadata{
 		Message:             delayed.Message,


### PR DESCRIPTION
I've updated the message counter to use the standard `++` operator for clarity.
Also removed unnecessary `else` blocks after `return` statements to simplify the flow.

Everything else remains unchanged.