### PR TITLE
fix: add initialization check to Redis ValidationClient.WasmModuleRoo…

### DIFF
--- a/validator/client/redis/producer.go
+++ b/validator/client/redis/producer.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 
@@ -126,6 +127,9 @@ func (c *ValidationClient) Initialize(ctx context.Context, moduleRoots []common.
 }
 
 func (c *ValidationClient) WasmModuleRoots() ([]common.Hash, error) {
+	if len(c.moduleRoots) == 0 && len(c.producers) == 0 {
+		return nil, errors.New("validation client not initialized")
+	}
 	return c.moduleRoots, nil
 }
 


### PR DESCRIPTION
Add state validation to WasmModuleRoots() method to return error when client is not initialized. This ensures consistency with ValidationSpawner interface contract and prevents nil slice returns that could cause issues in calling code.

The method now checks if both moduleRoots and producers are empty before returning the slice, maintaining the same pattern used by other implementations.