### PR TITLE
Fix some tests

### DIFF
--- a/util/testhelpers/github/releases.go
+++ b/util/testhelpers/github/releases.go
@@ -33,7 +33,7 @@ func getAuthGitClient(ctx context.Context) *github.Client {
 func NitroReleases(ctx context.Context) ([]*github.RepositoryRelease, error) {
 	client := getAuthGitClient(ctx)
 	opts := &github.ListOptions{
-		PerPage: 50,
+		PerPage: 100,
 	}
 	releases, _, err := client.Repositories.ListReleases(ctx, "OffchainLabs", "nitro", opts)
 	return releases, err

--- a/util/testhelpers/github/releases_test.go
+++ b/util/testhelpers/github/releases_test.go
@@ -13,8 +13,8 @@ func TestReleases(t *testing.T) {
 	if len(rels) == 0 {
 		t.Error("No releases found")
 	}
-	if len(rels) != 50 {
-		t.Errorf("Expected 50 releases, got %d", len(rels))
+	if len(rels) != 100 {
+		t.Errorf("Expected 100 releases, got %d", len(rels))
 	}
 }
 


### PR DESCRIPTION
The tests which use the releases package were failing because we have had more than 50 non-prerelease releases since the last consensus release, and it was only fetching the first 50 pages from the GitHub API.
