### PR TITLE
Use the t.TempDir() for L1 data directory

### DIFF
--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -84,7 +84,7 @@ import (
 	"github.com/offchainlabs/nitro/util/signature"
 	"github.com/offchainlabs/nitro/util/testhelpers"
 	"github.com/offchainlabs/nitro/util/testhelpers/env"
-	"github.com/offchainlabs/nitro/util/testhelpers/flag"
+	testflag "github.com/offchainlabs/nitro/util/testhelpers/flag"
 	"github.com/offchainlabs/nitro/util/testhelpers/github"
 	"github.com/offchainlabs/nitro/validator/inputs"
 	"github.com/offchainlabs/nitro/validator/server_api"
@@ -1413,7 +1413,7 @@ func createTestL1BlockChain(t *testing.T, l1info info, withClientWrapper bool) (
 	if l1info == nil {
 		l1info = NewL1TestInfo(t)
 	}
-	stackConfig := testhelpers.CreateStackConfigForTest("")
+	stackConfig := testhelpers.CreateStackConfigForTest(t.TempDir())
 	l1info.GenerateAccount("Faucet")
 
 	chainConfig := chaininfo.ArbitrumDevTestChainConfig()


### PR DESCRIPTION
Before this change all of the L1 nodes created by the builder shared the same working data directory. This means that if parallel tests that relied on the state of L1 had bad timing, they could clobber each other's local databases.

This should significantly improve CI test stability. On the downside, it does make it a bit slower to run tests because each testcase ends up initializing a completely isolated L1 node. Them's the breaks.

Fixes: NIT-3886