### PR TITLE
Close Badger DB after migration to prevent resource leak

### DIFF
--- a/daprovider/das/db_storage_service.go
+++ b/daprovider/das/db_storage_service.go
@@ -108,10 +108,15 @@ func NewDBStorageService(ctx context.Context, config *LocalDBStorageConfig, targ
 
 	if target != nil {
 		if err = ret.migrateTo(ctx, target); err != nil {
+			_ = ret.db.Close()
 			return nil, fmt.Errorf("error migrating local-db-storage to %s: %w", target, err)
 		}
 		if err = ret.setMigrated(); err != nil {
+			_ = ret.db.Close()
 			return nil, fmt.Errorf("error finalizing migration of local-db-storage to %s: %w", target, err)
+		}
+		if err := ret.db.Close(); err != nil {
+			return nil, fmt.Errorf("error closing db after migration: %w", err)
 		}
 		return nil, nil
 	}


### PR DESCRIPTION




Description:
- Summary: Ensure Badger DB is closed in the migration path of DBStorageService to avoid file descriptor leaks and stale locks.
- What changed: Added ret.db.Close() on both success and error paths when target != nil in daprovider/das/db_storage_service.go.
- Rationale: Previously, the DB was opened but not closed during migration, causing a real resource leak.
