### PR TITLE
Move fallback to batch poster

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1682,8 +1682,8 @@ func (b *BatchPoster) MaybePostSequencerBatch(ctx context.Context) (bool, error)
 			return false, fmt.Errorf("%w: batch position changed from %v to %v while creating batch", storage.ErrStorageRace, batchPosition, actualBatchPosition)
 		}
 		// #nosec G115
-		sequencerMsg, err = b.dapWriter.Store(ctx, sequencerMsg, uint64(time.Now().Add(config.DASRetentionPeriod).Unix()), config.DisableDapFallbackStoreDataOnChain)
-		if err != nil {
+		sequencerMsg, err = b.dapWriter.Store(ctx, sequencerMsg, uint64(time.Now().Add(config.DASRetentionPeriod).Unix()))
+		if err != nil && config.DisableDapFallbackStoreDataOnChain {
 			batchPosterDAFailureCounter.Inc(1)
 			return false, err
 		}

--- a/daprovider/daclient/daclient.go
+++ b/daprovider/daclient/daclient.go
@@ -93,10 +93,9 @@ func (c *Client) Store(
 	ctx context.Context,
 	message []byte,
 	timeout uint64,
-	disableFallbackStoreDataOnChain bool,
 ) ([]byte, error) {
 	var storeResult StoreResult
-	if err := c.CallContext(ctx, &storeResult, "daprovider_store", hexutil.Bytes(message), hexutil.Uint64(timeout), disableFallbackStoreDataOnChain); err != nil {
+	if err := c.CallContext(ctx, &storeResult, "daprovider_store", hexutil.Bytes(message), hexutil.Uint64(timeout)); err != nil {
 		return nil, fmt.Errorf("error returned from daprovider_store rpc method, err: %w", err)
 	}
 	return storeResult.SerializedDACert, nil

--- a/daprovider/das/dasserver/dasserver.go
+++ b/daprovider/das/dasserver/dasserver.go
@@ -195,9 +195,8 @@ func (s *Server) Store(
 	ctx context.Context,
 	message hexutil.Bytes,
 	timeout hexutil.Uint64,
-	disableFallbackStoreDataOnChain bool,
 ) (*daclient.StoreResult, error) {
-	serializedDACert, err := s.writer.Store(ctx, message, uint64(timeout), disableFallbackStoreDataOnChain)
+	serializedDACert, err := s.writer.Store(ctx, message, uint64(timeout))
 	if err != nil {
 		return nil, err
 	}

--- a/daprovider/das/dasutil/dasutil.go
+++ b/daprovider/das/dasutil/dasutil.go
@@ -77,19 +77,12 @@ type writerForDAS struct {
 	dasWriter DASWriter
 }
 
-func (d *writerForDAS) Store(ctx context.Context, message []byte, timeout uint64, disableFallbackStoreDataOnChain bool) ([]byte, error) {
+func (d *writerForDAS) Store(ctx context.Context, message []byte, timeout uint64) ([]byte, error) {
 	cert, err := d.dasWriter.Store(ctx, message, timeout)
-	if errors.Is(err, ErrBatchToDasFailed) {
-		if disableFallbackStoreDataOnChain {
-			return nil, errors.New("unable to batch to DAS and fallback storing data on chain is disabled")
-		}
-		log.Warn("Falling back to storing data on chain", "err", err)
-		return message, nil
-	} else if err != nil {
+	if err != nil {
 		return nil, err
-	} else {
-		return Serialize(cert), nil
 	}
+	return Serialize(cert), nil
 }
 
 var (

--- a/daprovider/writer.go
+++ b/daprovider/writer.go
@@ -14,6 +14,5 @@ type Writer interface {
 		ctx context.Context,
 		message []byte,
 		timeout uint64,
-		disableFallbackStoreDataOnChain bool,
 	) ([]byte, error)
 }


### PR DESCRIPTION
closes NIT-3897

A direct follow-up will be to unify `writer.go:Writer` interface with `dasutil:DASWriter` one. I didn't want to do it in this PR to avoid obfuscating main semantic change.