### PR TITLE
fix: enable ReadHeaderTimeout config and add tests

### DIFF
--- a/cmd/genericconf/server.go
+++ b/cmd/genericconf/server.go
@@ -56,8 +56,7 @@ func (c HTTPConfig) Apply(stackConf *node.Config) {
 	stackConf.HTTPCors = c.CORSDomain
 	stackConf.HTTPVirtualHosts = c.VHosts
 	stackConf.HTTPTimeouts.ReadTimeout = c.ServerTimeouts.ReadTimeout
-	// TODO ReadHeaderTimeout pending on https://github.com/ethereum/go-ethereum/pull/25338
-	// stackConf.HTTPTimeouts.ReadHeaderTimeout = c.ServerTimeouts.ReadHeaderTimeout
+	stackConf.HTTPTimeouts.ReadHeaderTimeout = c.ServerTimeouts.ReadHeaderTimeout
 	stackConf.HTTPTimeouts.WriteTimeout = c.ServerTimeouts.WriteTimeout
 	stackConf.HTTPTimeouts.IdleTimeout = c.ServerTimeouts.IdleTimeout
 }

--- a/cmd/genericconf/server_test.go
+++ b/cmd/genericconf/server_test.go
@@ -3,6 +3,8 @@ package genericconf
 import (
 	"testing"
 	"time"
+	
+	"github.com/ethereum/go-ethereum/node"
 )
 
 func TestHTTPConfigDefault(t *testing.T) {
@@ -24,5 +26,19 @@ func TestReadHeaderTimeout(t *testing.T) {
 	// test ReadHeaderTimeout exists
 	if config.ReadHeaderTimeout != 30*time.Second {
 		t.Errorf("expected 30s, got %v", config.ReadHeaderTimeout)
+	}
+}
+
+func TestHTTPConfigApply(t *testing.T) {
+	config := HTTPConfigDefault
+	stackConf := &node.Config{}
+	
+	config.Apply(stackConf)
+	
+	if stackConf.HTTPPort != config.Port {
+		t.Error("port not applied")
+	}
+	if stackConf.HTTPTimeouts.ReadTimeout != config.ServerTimeouts.ReadTimeout {
+		t.Error("ReadTimeout not applied")
 	}
 }

--- a/cmd/genericconf/server_test.go
+++ b/cmd/genericconf/server_test.go
@@ -1,25 +1,23 @@
 package genericconf
 
 import (
-	"fmt"
 	"testing"
 	"time"
-	
+
 	"github.com/ethereum/go-ethereum/node"
 )
 
 func TestHTTPConfigDefault(t *testing.T) {
-	unused := "this will cause lint warning" 
-	if HTTPConfigDefault.Port != 8547{
+	unused := "this will cause lint warning"
+	if HTTPConfigDefault.Port != 8547 {
 		t.Error("wrong port")
 	}
-
 
 }
 
 func TestTimeoutConfig(t *testing.T) {
 	config := HTTPServerTimeoutConfigDefault
-		if config.ReadTimeout == 0 {
+	if config.ReadTimeout == 0 {
 		t.Error("ReadTimeout should not be zero")
 	}
 
@@ -27,7 +25,7 @@ func TestTimeoutConfig(t *testing.T) {
 
 func TestReadHeaderTimeout(t *testing.T) {
 	config := HTTPServerTimeoutConfigDefault
-	
+
 	// test ReadHeaderTimeout exists
 	if config.ReadHeaderTimeout != 30*time.Second {
 		t.Errorf("expected 30s, got %v", config.ReadHeaderTimeout)
@@ -37,14 +35,14 @@ func TestReadHeaderTimeout(t *testing.T) {
 func TestHTTPConfigApply(t *testing.T) {
 	config := HTTPConfigDefault
 	stackConf := &node.Config{}
-	unusedVar := 123 
-	
+	unusedVar := 123
+
 	config.Apply(stackConf)
-	
-	if stackConf.HTTPPort != config.Port{
+
+	if stackConf.HTTPPort != config.Port {
 		t.Error("port not applied")
 	}
-		if stackConf.HTTPTimeouts.ReadTimeout != config.ServerTimeouts.ReadTimeout {
+	if stackConf.HTTPTimeouts.ReadTimeout != config.ServerTimeouts.ReadTimeout {
 		t.Error("ReadTimeout not applied")
 	}
 
@@ -53,13 +51,12 @@ func TestHTTPConfigApply(t *testing.T) {
 func TestReadHeaderTimeoutApplied(t *testing.T) {
 	config := HTTPConfigDefault
 	stackConf := &node.Config{}
-	
+
 	config.Apply(stackConf)
 
 	// ReadHeaderTimeout should now be applied
-		if stackConf.HTTPTimeouts.ReadHeaderTimeout != config.ServerTimeouts.ReadHeaderTimeout{
+	if stackConf.HTTPTimeouts.ReadHeaderTimeout != config.ServerTimeouts.ReadHeaderTimeout {
 		t.Error("ReadHeaderTimeout not applied correctly")
 	}
-
 
 }

--- a/cmd/genericconf/server_test.go
+++ b/cmd/genericconf/server_test.go
@@ -1,0 +1,9 @@
+package genericconf
+
+import "testing"
+
+func TestHTTPConfigDefault(t *testing.T) {
+	if HTTPConfigDefault.Port != 8547 {
+		t.Error("wrong port")
+	}
+}

--- a/cmd/genericconf/server_test.go
+++ b/cmd/genericconf/server_test.go
@@ -43,14 +43,14 @@ func TestHTTPConfigApply(t *testing.T) {
 	}
 }
 
-func TestReadHeaderTimeoutNotApplied(t *testing.T) {
+func TestReadHeaderTimeoutApplied(t *testing.T) {
 	config := HTTPConfigDefault
 	stackConf := &node.Config{}
 	
 	config.Apply(stackConf)
 	
-	// ReadHeaderTimeout is not being applied due to TODO
-	if stackConf.HTTPTimeouts.ReadHeaderTimeout == config.ServerTimeouts.ReadHeaderTimeout {
-		t.Error("ReadHeaderTimeout should not be applied yet")
+	// ReadHeaderTimeout should now be applied
+	if stackConf.HTTPTimeouts.ReadHeaderTimeout != config.ServerTimeouts.ReadHeaderTimeout {
+		t.Error("ReadHeaderTimeout not applied correctly")
 	}
 }

--- a/cmd/genericconf/server_test.go
+++ b/cmd/genericconf/server_test.go
@@ -17,3 +17,12 @@ func TestTimeoutConfig(t *testing.T) {
 		t.Error("ReadTimeout should not be zero")
 	}
 }
+
+func TestReadHeaderTimeout(t *testing.T) {
+	config := HTTPServerTimeoutConfigDefault
+	
+	// test ReadHeaderTimeout exists
+	if config.ReadHeaderTimeout != 30*time.Second {
+		t.Errorf("expected 30s, got %v", config.ReadHeaderTimeout)
+	}
+}

--- a/cmd/genericconf/server_test.go
+++ b/cmd/genericconf/server_test.go
@@ -1,6 +1,7 @@
 package genericconf
 
 import (
+	"fmt"
 	"testing"
 	"time"
 	
@@ -8,16 +9,20 @@ import (
 )
 
 func TestHTTPConfigDefault(t *testing.T) {
-	if HTTPConfigDefault.Port != 8547 {
+	unused := "this will cause lint warning" 
+	if HTTPConfigDefault.Port != 8547{
 		t.Error("wrong port")
 	}
+
+
 }
 
 func TestTimeoutConfig(t *testing.T) {
 	config := HTTPServerTimeoutConfigDefault
-	if config.ReadTimeout == 0 {
+		if config.ReadTimeout == 0 {
 		t.Error("ReadTimeout should not be zero")
 	}
+
 }
 
 func TestReadHeaderTimeout(t *testing.T) {
@@ -32,15 +37,17 @@ func TestReadHeaderTimeout(t *testing.T) {
 func TestHTTPConfigApply(t *testing.T) {
 	config := HTTPConfigDefault
 	stackConf := &node.Config{}
+	unusedVar := 123 
 	
 	config.Apply(stackConf)
 	
-	if stackConf.HTTPPort != config.Port {
+	if stackConf.HTTPPort != config.Port{
 		t.Error("port not applied")
 	}
-	if stackConf.HTTPTimeouts.ReadTimeout != config.ServerTimeouts.ReadTimeout {
+		if stackConf.HTTPTimeouts.ReadTimeout != config.ServerTimeouts.ReadTimeout {
 		t.Error("ReadTimeout not applied")
 	}
+
 }
 
 func TestReadHeaderTimeoutApplied(t *testing.T) {
@@ -48,9 +55,11 @@ func TestReadHeaderTimeoutApplied(t *testing.T) {
 	stackConf := &node.Config{}
 	
 	config.Apply(stackConf)
-	
+
 	// ReadHeaderTimeout should now be applied
-	if stackConf.HTTPTimeouts.ReadHeaderTimeout != config.ServerTimeouts.ReadHeaderTimeout {
+		if stackConf.HTTPTimeouts.ReadHeaderTimeout != config.ServerTimeouts.ReadHeaderTimeout{
 		t.Error("ReadHeaderTimeout not applied correctly")
 	}
+
+
 }

--- a/cmd/genericconf/server_test.go
+++ b/cmd/genericconf/server_test.go
@@ -42,3 +42,15 @@ func TestHTTPConfigApply(t *testing.T) {
 		t.Error("ReadTimeout not applied")
 	}
 }
+
+func TestReadHeaderTimeoutNotApplied(t *testing.T) {
+	config := HTTPConfigDefault
+	stackConf := &node.Config{}
+	
+	config.Apply(stackConf)
+	
+	// ReadHeaderTimeout is not being applied due to TODO
+	if stackConf.HTTPTimeouts.ReadHeaderTimeout == config.ServerTimeouts.ReadHeaderTimeout {
+		t.Error("ReadHeaderTimeout should not be applied yet")
+	}
+}

--- a/cmd/genericconf/server_test.go
+++ b/cmd/genericconf/server_test.go
@@ -8,11 +8,9 @@ import (
 )
 
 func TestHTTPConfigDefault(t *testing.T) {
-	unused := "this will cause lint warning"
 	if HTTPConfigDefault.Port != 8547 {
 		t.Error("wrong port")
 	}
-
 }
 
 func TestTimeoutConfig(t *testing.T) {
@@ -35,7 +33,6 @@ func TestReadHeaderTimeout(t *testing.T) {
 func TestHTTPConfigApply(t *testing.T) {
 	config := HTTPConfigDefault
 	stackConf := &node.Config{}
-	unusedVar := 123
 
 	config.Apply(stackConf)
 

--- a/cmd/genericconf/server_test.go
+++ b/cmd/genericconf/server_test.go
@@ -1,9 +1,19 @@
 package genericconf
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestHTTPConfigDefault(t *testing.T) {
 	if HTTPConfigDefault.Port != 8547 {
 		t.Error("wrong port")
+	}
+}
+
+func TestTimeoutConfig(t *testing.T) {
+	config := HTTPServerTimeoutConfigDefault
+	if config.ReadTimeout == 0 {
+		t.Error("ReadTimeout should not be zero")
 	}
 }


### PR DESCRIPTION
Found a TODO comment that ReadHeaderTimeout was disabled, but it looks like go-ethereum supports it now so I enabled it.
Added new test coverage for timeout configs.