### PR TITLE
Fix default runs value in aggregator tests (replace XOR with portable large default)

### DIFF
--- a/daprovider/das/aggregator_test.go
+++ b/daprovider/das/aggregator_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"os"
 	"strconv"
@@ -252,7 +253,8 @@ func initTest(t *testing.T) int {
 	}
 	rand.Seed(seed)
 
-	runs := 2 ^ 32
+	// Use a portable large default; avoid 2 ^ 32 (bitwise XOR), which yields 34
+	runs := math.MaxInt32
 	if len(*testflag.RunsFlag) > 0 {
 		var err error
 		runs, err = strconv.Atoi(*testflag.RunsFlag)


### PR DESCRIPTION


### Description
- **Problem**: `runs := 2 ^ 32` uses bitwise XOR, yielding `34` instead of 2^32, causing misleading defaults.
- **Change**: Replace with `runs := math.MaxInt32`, add `math` import, and a brief explanatory comment.
- **Rationale**: Keeps a large default value while remaining portable across 32- and 64-bit platforms.
- **Alternative considered**: `1 << 32` (not portable on 32-bit `int`).