### PR TITLE
Remove the quadrupling of MaxPerBlockGasLimit

### DIFF
--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -34,7 +34,6 @@ import (
 	"github.com/offchainlabs/nitro/arbos/storage"
 	"github.com/offchainlabs/nitro/arbos/util"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
-	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/testhelpers/env"
 )
 
@@ -392,10 +391,6 @@ func (state *ArbosState) UpgradeArbosVersion(
 			ensure(p.UpgradeToArbosVersion(nextArbosVersion))
 			ensure(p.Save())
 			ensure(state.l2PricingState.SetMaxPerTxGasLimit(l2pricing.InitialPerTxGasLimitV50))
-			oldBlockGasLimit, err := state.l2PricingState.PerBlockGasLimit()
-			ensure(err)
-			newBlockGasLimit := arbmath.SaturatingUMul(oldBlockGasLimit, 4)
-			ensure(state.l2PricingState.SetMaxPerBlockGasLimit(newBlockGasLimit))
 		default:
 			return fmt.Errorf(
 				"the chain is upgrading to unsupported ArbOS version %v, %w",


### PR DESCRIPTION
We decided to make this change only as part of the upgrade contract or through some later action, and not to force it on everyone running the nitro software and upgrading to ArbOS 50.

Fixes: NIT-3908