### PR TITLE
chore: remove unnecessary allocation in emit_log function

### DIFF
--- a/arbitrator/arbutil/src/evm/req.rs
+++ b/arbitrator/arbutil/src/evm/req.rs
@@ -247,13 +247,12 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         self.last_return_data.clone().expect("missing return data")
     }
 
-    fn emit_log(&mut self, data: Vec<u8>, topics: u32) -> Result<()> {
-        // TODO: remove copy
-        let mut request = Vec::with_capacity(4 + data.len());
-        request.extend(topics.to_be_bytes());
-        request.extend(data);
+    fn emit_log(&mut self, mut data: Vec<u8>, topics: u32) -> Result<()> {
+        // Prepend topics by inserting at the beginning to avoid copying data
+        let topics_bytes = topics.to_be_bytes();
+        data.splice(0..0, topics_bytes);
 
-        let (res, _, _) = self.request(EvmApiMethod::EmitLog, request);
+        let (res, _, _) = self.request(EvmApiMethod::EmitLog, data);
         if !res.is_empty() {
             bail!(String::from_utf8(res).unwrap_or("malformed emit-log response".into()))
         }


### PR DESCRIPTION
Removes the TODO comment and eliminates an extra Vec allocation in `emit_log` by reusing the input data vector instead of creating a new request buffer. The topics bytes are now prepended directly to the existing data vector using splice.