### PR TITLE
Detailed batch post report

### DIFF
--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -32,7 +32,7 @@ var ArbRetryableTxAddress common.Address
 var ArbSysAddress common.Address
 var InternalTxStartBlockMethodID [4]byte
 var InternalTxBatchPostingReportMethodID [4]byte
-var InternalTxDetailedBatchPostingReportMethodID [4]byte
+var InternalTxBatchPostingReportV2MethodID [4]byte
 var RedeemScheduledEventID common.Hash
 var L2ToL1TransactionEventID common.Hash
 var L2ToL1TxEventID common.Hash

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -32,6 +32,7 @@ var ArbRetryableTxAddress common.Address
 var ArbSysAddress common.Address
 var InternalTxStartBlockMethodID [4]byte
 var InternalTxBatchPostingReportMethodID [4]byte
+var InternalTxDetailedBatchPostingReportMethodID [4]byte
 var RedeemScheduledEventID common.Hash
 var L2ToL1TransactionEventID common.Hash
 var L2ToL1TxEventID common.Hash
@@ -186,7 +187,8 @@ func ProduceBlock(
 	exposeMultiGas bool,
 ) (*types.Block, types.Receipts, error) {
 	chainConfig := chainContext.Config()
-	txes, err := ParseL2Transactions(message, chainConfig.ChainID)
+	lastArbosVersion := types.DeserializeHeaderExtraInformation(lastBlockHeader).ArbOSFormatVersion
+	txes, err := ParseL2Transactions(message, chainConfig.ChainID, lastArbosVersion)
 	if err != nil {
 		log.Warn("error parsing incoming message", "err", err)
 		txes = types.Transactions{}

--- a/arbos/incomingmessage_test.go
+++ b/arbos/incomingmessage_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 )
@@ -38,7 +39,7 @@ func TestSerializeAndParseL1Message(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	txes, err := ParseL2Transactions(newMsg, chainId)
+	txes, err := ParseL2Transactions(newMsg, chainId, params.MaxDebugArbosVersionSupported)
 	if err != nil {
 		t.Error(err)
 	}

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -117,27 +117,48 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 		}
 		batchTimestamp := util.SafeMapGet[*big.Int](inputs, "batchTimestamp")
 		batchPosterAddress := util.SafeMapGet[common.Address](inputs, "batchPosterAddress")
+		batchDataGas := util.SafeMapGet[uint64](inputs, "batchDataGas")
+		l1BaseFeeWei := util.SafeMapGet[*big.Int](inputs, "l1BaseFeeWei")
+
+		l1p := state.L1PricingState()
+		perBatchGas, err := l1p.PerBatchGasCost()
+		if err != nil {
+			log.Warn("L1Pricing PerBatchGas failed", "err", err)
+		}
+		gasSpent := arbmath.SaturatingAdd(perBatchGas, arbmath.SaturatingCast[int64](batchDataGas))
+		weiSpent := arbmath.BigMulByUint(l1BaseFeeWei, arbmath.SaturatingUCast[uint64](gasSpent))
+		err = l1p.UpdateForBatchPosterSpending(
+			evm.StateDB,
+			evm,
+			state.ArbOSVersion(),
+			batchTimestamp.Uint64(),
+			evm.Context.Time,
+			batchPosterAddress,
+			weiSpent,
+			l1BaseFeeWei,
+			util.TracingDuringEVM,
+		)
+		if err != nil {
+			log.Warn("L1Pricing UpdateForSequencerSpending failed", "err", err)
+		}
+		return nil
+	case InternalTxDetailedBatchPostingReportMethodID:
+		inputs, err := util.UnpackInternalTxDataDetailedBatchPostingReport(tx.Data)
+		if err != nil {
+			return err
+		}
+		batchTimestamp := util.SafeMapGet[*big.Int](inputs, "batchTimestamp")
+		batchPosterAddress := util.SafeMapGet[common.Address](inputs, "batchPosterAddress")
 		batchCalldataLength := util.SafeMapGet[uint64](inputs, "batchCalldataLength")
 		batchCalldataNonZeros := util.SafeMapGet[uint64](inputs, "batchCalldataNonZeros")
-		batchLegacyGas := util.SafeMapGet[uint64](inputs, "batchLegacyGas")
 		batchExtraGas := util.SafeMapGet[uint64](inputs, "batchExtraGas")
 		l1BaseFeeWei := util.SafeMapGet[*big.Int](inputs, "l1BaseFeeWei")
 
-		var gasSpent uint64
-		if batchCalldataLength == ^uint64(0) {
-			if state.ArbOSVersion() >= params.ArbosVersion_50 {
-				return fmt.Errorf("missing batch calldata stats for arbos >= 50")
-			}
-			gasSpent = batchLegacyGas
-		} else {
-			gasSpent = arbostypes.LegacyCostForStats(&arbostypes.BatchDataStats{
-				Length:   batchCalldataLength,
-				NonZeros: batchCalldataNonZeros,
-			})
-			if batchLegacyGas != ^uint64(0) && batchLegacyGas != gasSpent {
-				log.Error("legacy gas doesn't fit local compute", "local", gasSpent, "legacy", batchLegacyGas, "timestamp", batchTimestamp)
-			}
-		}
+		gasSpent := arbostypes.LegacyCostForStats(&arbostypes.BatchDataStats{
+			Length:   batchCalldataLength,
+			NonZeros: batchCalldataNonZeros,
+		})
+
 		gasSpent = arbmath.SaturatingUAdd(gasSpent, batchExtraGas)
 
 		l1p := state.L1PricingState()
@@ -172,9 +193,10 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 			util.TracingDuringEVM,
 		)
 		if err != nil {
-			log.Warn("L1Pricing UpdateForSequencerSpending failed", "err", err)
+			log.Warn("L1Pricing UpdateForSequencerSpending failed (detailed report)", "err", err)
 		}
 		return nil
+
 	default:
 		return fmt.Errorf("unknown internal tx method selector: %v", hex.EncodeToString(tx.Data[:4]))
 	}

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -142,8 +142,8 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 			log.Warn("L1Pricing UpdateForSequencerSpending failed", "err", err)
 		}
 		return nil
-	case InternalTxDetailedBatchPostingReportMethodID:
-		inputs, err := util.UnpackInternalTxDataDetailedBatchPostingReport(tx.Data)
+	case InternalTxBatchPostingReportV2MethodID:
+		inputs, err := util.UnpackInternalTxDataBatchPostingReportV2(tx.Data)
 		if err != nil {
 			return err
 		}
@@ -193,7 +193,7 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 			util.TracingDuringEVM,
 		)
 		if err != nil {
-			log.Warn("L1Pricing UpdateForSequencerSpending failed (detailed report)", "err", err)
+			log.Warn("L1Pricing UpdateForSequencerSpending failed (v2 report)", "err", err)
 		}
 		return nil
 

--- a/arbos/parse_l2.go
+++ b/arbos/parse_l2.go
@@ -371,8 +371,8 @@ func parseSubmitRetryableMessage(rd io.Reader, header *arbostypes.L1IncomingMess
 	return types.NewTx(tx), err
 }
 
-// if lastArbosVersion is under 50: we'll create a nondetailed batch-posting report
-// arbos-50+ can parse both legacy and detailed batch posting report, so it's o.k. that we rely on previous block
+// if lastArbosVersion is under 50: we'll create a legacy batch-posting report
+// arbos-50+ can parse both legacy and v2 batch posting report, so it's o.k. that we rely on previous block
 func createBatchPostingReportTransaction(rd io.Reader, chainId *big.Int, lastArbosVersion uint64, batchDataStats *arbostypes.BatchDataStats, legacyBatchGas *uint64) (*types.Transaction, error) {
 	batchTimestamp, batchPosterAddr, _, batchNum, l1BaseFee, extraGas, err := arbostypes.ParseBatchPostingReportMessageFields(rd)
 	if err != nil {
@@ -404,7 +404,7 @@ func createBatchPostingReportTransaction(rd io.Reader, chainId *big.Int, lastArb
 		if batchDataStats == nil {
 			return nil, fmt.Errorf("no gas data stats in a batch posting report post arbos 50")
 		}
-		data, err = util.PackInternalTxDataDetailedBatchPostingReport(
+		data, err = util.PackInternalTxDataBatchPostingReportV2(
 			batchTimestamp, batchPosterAddr, batchNum, batchDataStats.Length, batchDataStats.NonZeros, extraGas, l1BaseFee,
 		)
 		if err != nil {

--- a/arbos/parse_l2.go
+++ b/arbos/parse_l2.go
@@ -12,13 +12,15 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbos/util"
 	"github.com/offchainlabs/nitro/util/arbmath"
 )
 
-func ParseL2Transactions(msg *arbostypes.L1IncomingMessage, chainId *big.Int) (types.Transactions, error) {
+// note: lastArbosVersion is arbos version in previous block, not current!
+func ParseL2Transactions(msg *arbostypes.L1IncomingMessage, chainId *big.Int, lastArbosVersion uint64) (types.Transactions, error) {
 	if len(msg.L2msg) > arbostypes.MaxL2MessageSize {
 		// ignore the message if l2msg is too large
 		return nil, errors.New("message too large")
@@ -70,7 +72,7 @@ func ParseL2Transactions(msg *arbostypes.L1IncomingMessage, chainId *big.Int) (t
 		log.Debug("ignoring rollup event message")
 		return types.Transactions{}, nil
 	case arbostypes.L1MessageType_BatchPostingReport:
-		tx, err := parseBatchPostingReportMessage(bytes.NewReader(msg.L2msg), chainId, msg.BatchDataStats, msg.LegacyBatchGasCost)
+		tx, err := createBatchPostingReportTransaction(bytes.NewReader(msg.L2msg), chainId, lastArbosVersion, msg.BatchDataStats, msg.LegacyBatchGasCost)
 		if err != nil {
 			return nil, err
 		}
@@ -369,28 +371,47 @@ func parseSubmitRetryableMessage(rd io.Reader, header *arbostypes.L1IncomingMess
 	return types.NewTx(tx), err
 }
 
-func parseBatchPostingReportMessage(rd io.Reader, chainId *big.Int, batchDataStats *arbostypes.BatchDataStats, legacyBatchGas *uint64) (*types.Transaction, error) {
+// if lastArbosVersion is under 50: we'll create a nondetailed batch-posting report
+// arbos-50+ can parse both legacy and detailed batch posting report, so it's o.k. that we rely on previous block
+func createBatchPostingReportTransaction(rd io.Reader, chainId *big.Int, lastArbosVersion uint64, batchDataStats *arbostypes.BatchDataStats, legacyBatchGas *uint64) (*types.Transaction, error) {
 	batchTimestamp, batchPosterAddr, _, batchNum, l1BaseFee, extraGas, err := arbostypes.ParseBatchPostingReportMessageFields(rd)
 	if err != nil {
 		return nil, err
 	}
-	legacyGas := ^uint64(0)
-	callDataLen := ^uint64(0)
-	callDataNonZeros := ^uint64(0)
-
+	var legacyGas uint64
 	if batchDataStats != nil {
-		callDataLen = batchDataStats.Length
-		callDataNonZeros = batchDataStats.NonZeros
-	}
-	if legacyBatchGas != nil {
+		legacyGas = arbostypes.LegacyCostForStats(batchDataStats)
+		if legacyBatchGas != nil && *legacyBatchGas != legacyGas {
+			log.Error("legacy gas doesn't fit local compute", "local", legacyGas, "legacy", legacyBatchGas, "timestamp", batchTimestamp)
+		}
+	} else {
+		if legacyBatchGas == nil {
+			return nil, fmt.Errorf("no gas data field in a batch posting report")
+		}
 		legacyGas = *legacyBatchGas
 	}
-	data, err := util.PackInternalTxDataBatchPostingReport(
-		batchTimestamp, batchPosterAddr, batchNum, callDataLen, callDataNonZeros, legacyGas, extraGas, l1BaseFee,
-	)
-	if err != nil {
-		return nil, err
+
+	var data []byte
+	if lastArbosVersion < params.ArbosVersion_50 {
+		batchGas := arbmath.SaturatingUAdd(legacyGas, extraGas)
+		data, err = util.PackInternalTxDataBatchPostingReport(
+			batchTimestamp, batchPosterAddr, batchNum, batchGas, l1BaseFee,
+		)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		if batchDataStats == nil {
+			return nil, fmt.Errorf("no gas data stats in a batch posting report post arbos 50")
+		}
+		data, err = util.PackInternalTxDataDetailedBatchPostingReport(
+			batchTimestamp, batchPosterAddr, batchNum, batchDataStats.Length, batchDataStats.NonZeros, extraGas, l1BaseFee,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	return types.NewTx(&types.ArbitrumInternalTx{
 		ChainId: chainId,
 		Data:    data,

--- a/arbos/util/util.go
+++ b/arbos/util/util.go
@@ -27,7 +27,9 @@ var ParseL2ToL1TxLog func(*types.Log) (*precompilesgen.ArbSysL2ToL1Tx, error)
 var PackInternalTxDataStartBlock func(...interface{}) ([]byte, error)
 var UnpackInternalTxDataStartBlock func([]byte) (map[string]interface{}, error)
 var PackInternalTxDataBatchPostingReport func(...interface{}) ([]byte, error)
+var PackInternalTxDataDetailedBatchPostingReport func(...interface{}) ([]byte, error)
 var UnpackInternalTxDataBatchPostingReport func([]byte) (map[string]interface{}, error)
+var UnpackInternalTxDataDetailedBatchPostingReport func([]byte) (map[string]interface{}, error)
 var PackArbRetryableTxRedeem func(...interface{}) ([]byte, error)
 
 func init() {
@@ -45,6 +47,7 @@ func init() {
 	acts := precompilesgen.ArbosActsABI
 	PackInternalTxDataStartBlock, UnpackInternalTxDataStartBlock = NewCallParser(acts, "startBlock")
 	PackInternalTxDataBatchPostingReport, UnpackInternalTxDataBatchPostingReport = NewCallParser(acts, "batchPostingReport")
+	PackInternalTxDataDetailedBatchPostingReport, UnpackInternalTxDataDetailedBatchPostingReport = NewCallParser(acts, "detailedBatchPostingReport")
 	PackArbRetryableTxRedeem, _ = NewCallParser(precompilesgen.ArbRetryableTxABI, "redeem")
 }
 

--- a/arbos/util/util.go
+++ b/arbos/util/util.go
@@ -27,9 +27,9 @@ var ParseL2ToL1TxLog func(*types.Log) (*precompilesgen.ArbSysL2ToL1Tx, error)
 var PackInternalTxDataStartBlock func(...interface{}) ([]byte, error)
 var UnpackInternalTxDataStartBlock func([]byte) (map[string]interface{}, error)
 var PackInternalTxDataBatchPostingReport func(...interface{}) ([]byte, error)
-var PackInternalTxDataDetailedBatchPostingReport func(...interface{}) ([]byte, error)
+var PackInternalTxDataBatchPostingReportV2 func(...interface{}) ([]byte, error)
 var UnpackInternalTxDataBatchPostingReport func([]byte) (map[string]interface{}, error)
-var UnpackInternalTxDataDetailedBatchPostingReport func([]byte) (map[string]interface{}, error)
+var UnpackInternalTxDataBatchPostingReportV2 func([]byte) (map[string]interface{}, error)
 var PackArbRetryableTxRedeem func(...interface{}) ([]byte, error)
 
 func init() {
@@ -47,7 +47,7 @@ func init() {
 	acts := precompilesgen.ArbosActsABI
 	PackInternalTxDataStartBlock, UnpackInternalTxDataStartBlock = NewCallParser(acts, "startBlock")
 	PackInternalTxDataBatchPostingReport, UnpackInternalTxDataBatchPostingReport = NewCallParser(acts, "batchPostingReport")
-	PackInternalTxDataDetailedBatchPostingReport, UnpackInternalTxDataDetailedBatchPostingReport = NewCallParser(acts, "detailedBatchPostingReport")
+	PackInternalTxDataBatchPostingReportV2, UnpackInternalTxDataBatchPostingReportV2 = NewCallParser(acts, "batchPostingReportV2")
 	PackArbRetryableTxRedeem, _ = NewCallParser(precompilesgen.ArbRetryableTxABI, "redeem")
 }
 

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -457,18 +457,20 @@ func (s *ExecutionEngine) resequenceReorgedMessages(messages []*arbostypes.Messa
 			log.Warn("skipping non-standard sequencer message found from reorg", "header", header)
 			continue
 		}
-		txes, err := arbos.ParseL2Transactions(msg.Message, s.bc.Config().ChainID)
+		lastArbosVersion := types.DeserializeHeaderExtraInformation(lastBlockHeader).ArbOSFormatVersion
+		txes, err := arbos.ParseL2Transactions(msg.Message, s.bc.Config().ChainID, lastArbosVersion)
 		if err != nil {
 			log.Warn("failed to parse sequencer message found from reorg", "err", err)
 			continue
 		}
 		hooks := arbos.NoopSequencingHooks(txes)
 		hooks.DiscardInvalidTxsEarly = true
-		_, err = s.sequenceTransactionsWithBlockMutex(msg.Message.Header, hooks, nil)
+		block, err := s.sequenceTransactionsWithBlockMutex(msg.Message.Header, hooks, nil)
 		if err != nil {
 			log.Error("failed to re-sequence old user message removed by reorg", "err", err)
 			return
 		}
+		lastBlockHeader = block.Header()
 	}
 }
 

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -470,7 +470,9 @@ func (s *ExecutionEngine) resequenceReorgedMessages(messages []*arbostypes.Messa
 			log.Error("failed to re-sequence old user message removed by reorg", "err", err)
 			return
 		}
-		lastBlockHeader = block.Header()
+		if block != nil {
+			lastBlockHeader = block.Header()
+		}
 	}
 }
 

--- a/gethhook/geth_test.go
+++ b/gethhook/geth_test.go
@@ -127,7 +127,7 @@ func RunMessagesThroughAPI(t *testing.T, msgs [][]byte, statedb *state.StateDB) 
 		if err != nil {
 			t.Error(err)
 		}
-		txes, err := arbos.ParseL2Transactions(msg, chainId)
+		txes, err := arbos.ParseL2Transactions(msg, chainId, params.MaxDebugArbosVersionSupported)
 		if err != nil {
 			t.Error(err)
 		}

--- a/precompiles/ArbosActs.go
+++ b/precompiles/ArbosActs.go
@@ -19,6 +19,6 @@ func (con ArbosActs) BatchPostingReport(c ctx, evm mech, batchTimestamp huge, ba
 	return con.CallerNotArbOSError()
 }
 
-func (con ArbosActs) DetailedBatchPostingReport(c ctx, evm mech, batchTimestamp huge, batchPosterAddress addr, batchNumber uint64, batchCallDataLength uint64, batchCallDataNonZeros uint64, batchExtraGas uint64, l1BaseFeeWei huge) error {
+func (con ArbosActs) BatchPostingReportV2(c ctx, evm mech, batchTimestamp huge, batchPosterAddress addr, batchNumber uint64, batchCallDataLength uint64, batchCallDataNonZeros uint64, batchExtraGas uint64, l1BaseFeeWei huge) error {
 	return con.CallerNotArbOSError()
 }

--- a/precompiles/ArbosActs.go
+++ b/precompiles/ArbosActs.go
@@ -15,6 +15,10 @@ func (con ArbosActs) StartBlock(c ctx, evm mech, l1BaseFee huge, l1BlockNumber, 
 	return con.CallerNotArbOSError()
 }
 
-func (con ArbosActs) BatchPostingReport(c ctx, evm mech, batchTimestamp huge, batchPosterAddress addr, batchNumber uint64, batchCallDataLength uint64, batchCallDataNonZeros uint64, batchLegacyGas uint64, batchExtraGas uint64, l1BaseFeeWei huge) error {
+func (con ArbosActs) BatchPostingReport(c ctx, evm mech, batchTimestamp huge, batchPosterAddress addr, batchNumber uint64, batchGas uint64, l1BaseFeeWei huge) error {
+	return con.CallerNotArbOSError()
+}
+
+func (con ArbosActs) DetailedBatchPostingReport(c ctx, evm mech, batchTimestamp huge, batchPosterAddress addr, batchNumber uint64, batchCallDataLength uint64, batchCallDataNonZeros uint64, batchExtraGas uint64, l1BaseFeeWei huge) error {
 	return con.CallerNotArbOSError()
 }

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -633,7 +633,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 	ArbosActs := insert(MakePrecompile(precompilesgen.ArbosActsMetaData, &ArbosActs{Address: types.ArbosAddress}))
 	arbos.InternalTxStartBlockMethodID = ArbosActs.GetMethodID("StartBlock")
 	arbos.InternalTxBatchPostingReportMethodID = ArbosActs.GetMethodID("BatchPostingReport")
-	arbos.InternalTxDetailedBatchPostingReportMethodID = ArbosActs.GetMethodID("DetailedBatchPostingReport")
+	arbos.InternalTxBatchPostingReportV2MethodID = ArbosActs.GetMethodID("BatchPostingReportV2")
 
 	ArbOwner.methodsByName["SetCalldataPriceIncrease"].arbosVersion = params.ArbosVersion_40
 	ArbOwnerPublic.methodsByName["IsCalldataPriceIncreaseEnabled"].arbosVersion = params.ArbosVersion_40

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -633,6 +633,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 	ArbosActs := insert(MakePrecompile(precompilesgen.ArbosActsMetaData, &ArbosActs{Address: types.ArbosAddress}))
 	arbos.InternalTxStartBlockMethodID = ArbosActs.GetMethodID("StartBlock")
 	arbos.InternalTxBatchPostingReportMethodID = ArbosActs.GetMethodID("BatchPostingReport")
+	arbos.InternalTxDetailedBatchPostingReportMethodID = ArbosActs.GetMethodID("DetailedBatchPostingReport")
 
 	ArbOwner.methodsByName["SetCalldataPriceIncrease"].arbosVersion = params.ArbosVersion_40
 	ArbOwnerPublic.methodsByName["IsCalldataPriceIncreaseEnabled"].arbosVersion = params.ArbosVersion_40

--- a/precompiles/precompile_test.go
+++ b/precompiles/precompile_test.go
@@ -183,7 +183,7 @@ func TestPrecompilesPerArbosVersion(t *testing.T) {
 	// Each new precompile contract and each method on new or existing precompile
 	// contracts should be counted.
 	expectedNewEntriesPerArbosVersion := map[uint64]int{
-		0:                      98,
+		0:                      99,
 		params.ArbosVersion_5:  3,
 		params.ArbosVersion_10: 2,
 		params.ArbosVersion_11: 4,

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -196,7 +196,14 @@ func TestCustomSolidityErrors(t *testing.T) {
 		"arbosActs.StartBlock",
 	)
 
-	_, customError = arbosActs.BatchPostingReport(&auth, big.NewInt(0), common.Address{}, 0, 0, 0, 0, 0, big.NewInt(0))
+	_, customError = arbosActs.BatchPostingReport(&auth, big.NewInt(0), common.Address{}, 0, 0, big.NewInt(0))
+	ensure(
+		customError,
+		"CallerNotArbOS()",
+		"arbosActs.BatchPostingReport",
+	)
+
+	_, customError = arbosActs.DetailedBatchPostingReport(&auth, big.NewInt(0), common.Address{}, 0, 0, 0, 0, big.NewInt(0))
 	ensure(
 		customError,
 		"CallerNotArbOS()",

--- a/system_tests/precompile_test.go
+++ b/system_tests/precompile_test.go
@@ -203,11 +203,11 @@ func TestCustomSolidityErrors(t *testing.T) {
 		"arbosActs.BatchPostingReport",
 	)
 
-	_, customError = arbosActs.DetailedBatchPostingReport(&auth, big.NewInt(0), common.Address{}, 0, 0, 0, 0, big.NewInt(0))
+	_, customError = arbosActs.BatchPostingReportV2(&auth, big.NewInt(0), common.Address{}, 0, 0, 0, 0, big.NewInt(0))
 	ensure(
 		customError,
 		"CallerNotArbOS()",
-		"arbosActs.BatchPostingReport",
+		"arbosActs.BatchPostingReportV2",
 	)
 }
 

--- a/system_tests/retryable_test.go
+++ b/system_tests/retryable_test.go
@@ -102,7 +102,7 @@ func retryableSetup(t *testing.T, modifyNodeConfig ...func(*NodeBuilder)) (
 			if !msgTypes[message.Message.Header.Kind] {
 				continue
 			}
-			txs, err := arbos.ParseL2Transactions(message.Message, chaininfo.ArbitrumDevTestChainConfig().ChainID)
+			txs, err := arbos.ParseL2Transactions(message.Message, chaininfo.ArbitrumDevTestChainConfig().ChainID, params.MaxDebugArbosVersionSupported)
 			Require(t, err)
 			for _, tx := range txs {
 				if txTypes[tx.Type()] {


### PR DESCRIPTION
fixes: NIT-3909

pulls in: https://github.com/OffchainLabs/nitro-precompile-interfaces/pull/18

This separates batch poster into two messages, one that is that is backward-compatible and one that isn't.
The non backward-compatible version will only be created past arbos50.
