### PR TITLE
authenticate with dockerhub

### DIFF
--- a/.github/workflows/_go-tests.yml
+++ b/.github/workflows/_go-tests.yml
@@ -11,12 +11,17 @@ jobs:
       fail-fast: false
       matrix:
         test-mode: [defaults, pathdb, challenge, stylus, l3challenge]
-    services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
+
     steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start redis
+        docker run -d -p 6379: 6379 redis:latest
+
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/_go-tests.yml
+++ b/.github/workflows/_go-tests.yml
@@ -20,7 +20,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start redis
-        docker run -d -p 6379:6379 redis:latest
+        run: docker run -d -p 6379:6379 redis:latest
 
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/_go-tests.yml
+++ b/.github/workflows/_go-tests.yml
@@ -20,7 +20,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start redis
-        docker run -d -p 6379: 6379 redis:latest
+        docker run -d -p 6379:6379 redis:latest
 
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Start registgry
+      - name: Start registry
         docker run -d -p 5000:5000 registry:2
 
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,14 +16,17 @@ jobs:
   docker:
     name: Docker build
     runs-on: arbitrator-ci
-    services:
-      # local registry
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
 
     steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start registgry
+        docker run -d -p 5000:5000 registry:2
+
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start registry
-        run: docker run -d -p 5000:5000 registry:2
+        run: docker run -d -p 5000:5000 registry:2.8
 
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start registry
-        docker run -d -p 5000:5000 registry:2
+        run: docker run -d -p 5000:5000 registry:2
 
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -27,7 +27,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start redis
-        docker run -d -p 6379: 6379 redis:latest
+        docker run -d -p 6379:6379 redis:latest
 
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -27,7 +27,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start redis
-        docker run -d -p 6379:6379 redis:latest
+        run: docker run -d -p 6379:6379 redis:latest
 
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -14,18 +14,21 @@ jobs:
     name: Scheduled tests
     runs-on: arbitrator-ci
 
-    services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
-
     strategy:
       fail-fast: false
       matrix:
         test-mode: [legacychallenge, long, challenge, l3challenge, execution-spec-tests]
 
     steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start redis
+        docker run -d -p 6379: 6379 redis:latest
+
       - name: Checkout
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
any images in `services:` are downloaded before any authentication steps are run, so manually starting images after authenticating with dockerhub to avoid rate limiting
