### PR TITLE
chore: remove unused min/max func

### DIFF
--- a/daprovider/das/aggregator_test.go
+++ b/daprovider/das/aggregator_test.go
@@ -145,20 +145,6 @@ func (w *WrapStore) Store(ctx context.Context, message []byte, timeout uint64) (
 	return nil, nil
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func enableLogging() {
 	glogger := log.NewGlogHandler(
 		log.NewTerminalHandler(io.Writer(os.Stderr), false))


### PR DESCRIPTION

Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 
