### PR TITLE
Fix timer leaks in transaction streamer retry logic

### DIFF
--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1063,17 +1063,19 @@ func (s *TransactionStreamer) WriteMessageFromSequencer(
 		if s.insertionMutex.TryLock() {
 			return true
 		}
-		lockTick := time.Tick(5 * time.Millisecond)
-		lockTimeout := time.After(50 * time.Millisecond)
+		lockTicker := time.NewTicker(5 * time.Millisecond)
+		defer lockTicker.Stop()
+		lockTimeout := time.NewTimer(50 * time.Millisecond)
+		defer lockTimeout.Stop()
 		for {
 			select {
-			case <-lockTimeout:
+			case <-lockTimeout.C:
 				return false
 			default:
 				select {
-				case <-lockTimeout:
+				case <-lockTimeout.C:
 					return false
-				case <-lockTick:
+				case <-lockTicker.C:
 					if s.insertionMutex.TryLock() {
 						return true
 					}


### PR DESCRIPTION

**Problem:**
- Using `time.Tick()` and repeated `time.After()` in the hot retry loop
- `time.Tick()` cannot be stopped, creating potential timer leaks
- Multiple `time.After()` calls accumulate timers if not properly managed

**Solution:**
- Replaced `time.Tick(5ms)` with `time.NewTicker(5ms)` + proper `defer Stop()`
- Replaced `time.After(50ms)` with `time.NewTimer(50ms)` + proper `defer Stop()`
- Updated select statements to read from timer channels (`.C`)

