### PR TITLE
fix: align Serialized AfterDelayedCount with struct field in delayed_seq_reorg_test.go

### DIFF
--- a/arbnode/delayed_seq_reorg_test.go
+++ b/arbnode/delayed_seq_reorg_test.go
@@ -84,7 +84,7 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 		Serialized:             serializedInitMsgBatch,
 	}
 	serializedUserMsgBatch := make([]byte, 40)
-	binary.BigEndian.PutUint64(serializedUserMsgBatch[32:], 2)
+	binary.BigEndian.PutUint64(serializedUserMsgBatch[32:], 3)
 	userMsgBatch := &SequencerInboxBatch{
 		BlockHash:              [32]byte{},
 		ParentChainBlockNumber: 0,
@@ -284,7 +284,7 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 		Serialized:             serializedInitMsgBatch,
 	}
 	serializedUserMsgBatch := make([]byte, 40)
-	binary.BigEndian.PutUint64(serializedUserMsgBatch[32:], 2)
+	binary.BigEndian.PutUint64(serializedUserMsgBatch[32:], 3)
 	userMsgBatch := &SequencerInboxBatch{
 		BlockHash:              [32]byte{},
 		ParentChainBlockNumber: 0,


### PR DESCRIPTION
The test had a logical inconsistency where the AfterDelayedCount value in the Serialized header (40-byte buffer) was set to 2, while the corresponding field in the SequencerInboxBatch struct was set to 3. The multiplexer reads the AfterDelayedCount from the Serialized header to determine how many delayed messages to process, so this mismatch meant the test was expecting 3 delayed messages but the multiplexer would only read 2 based on the header. This inconsistency could lead to incorrect test behavior or subtle bugs in test logic. The fix updates the binary.BigEndian.PutUint64 calls to write 