### PR TITLE
fix(redislock): remove extra argument from Redis DEL command

### DIFF
--- a/arbnode/redislock/redis.go
+++ b/arbnode/redislock/redis.go
@@ -240,7 +240,7 @@ func (l *Simple) Release(ctx context.Context) {
 			return nil
 		}
 		pipe := tx.TxPipeline()
-		pipe.Del(ctx, config.Key, l.myId)
+		pipe.Del(ctx, config.Key)
 		err = execTestPipe(pipe, ctx)
 		if errors.Is(err, redis.TxFailedErr) {
 			return nil


### PR DESCRIPTION
Remove redundant l.myId argument from pipe.Del() call in Release() function. The ownership check is already performed earlier, making the extra argument incorrect and causing unnecessary Redis operations.