### PR TITLE
fix: correct error message formatting in blockchain and genesis generator

### DIFF
--- a/execution/gethexec/blockchain.go
+++ b/execution/gethexec/blockchain.go
@@ -152,11 +152,11 @@ func WriteOrTestGenblock(chainDb ethdb.Database, cacheConfig *core.BlockChainCon
 	if blockNumber > 0 {
 		prevHash = rawdb.ReadCanonicalHash(chainDb, blockNumber-1)
 		if prevHash == EmptyHash {
-			return fmt.Errorf("block number %d not found in database", chainDb)
+			return fmt.Errorf("block number %d not found in database", blockNumber-1)
 		}
 		prevHeader := rawdb.ReadHeader(chainDb, prevHash, blockNumber-1)
 		if prevHeader == nil {
-			return fmt.Errorf("block header for block %d not found in database", chainDb)
+			return fmt.Errorf("block header for block %d not found in database", blockNumber-1)
 		}
 		timestamp = prevHeader.Time
 	}


### PR DESCRIPTION
The error messages were using chainDb (database object) instead of blockNumber-1 
in fmt.Errorf format strings with %d placeholder, which is incorrect because:

1. chainDb is an interface type (ethdb.Database), not an integer
2. The %d format specifier expects an integer value
3. This causes misleading error messages that show database object address 
   instead of the actual block number that was not found
4. The same error was duplicated in both blockchain.go and genesis-generator.go
   due to code copying

Changes:
- execution/gethexec/blockchain.go: lines 155, 159
- cmd/genesis-generator/genesis-generator.go: lines 129, 133
