### PR TITLE
Interpolate the RUN_URL in Slack notification

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -122,5 +122,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
-            "text": "⚠️ CI job failed! ${RUN_URL}",
+            {
+              "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
+              "text": "⚠️ CI job failed! ${{ env.RUN_URL }}",
+            }


### PR DESCRIPTION
The RUN_URL needs to be interpolated by the github actions framework. This doesn't happen if without the double braces. Also, the action expects valid JSON input, so even more braces are applied to the payload argument.

Fixes: NIT-3924