### PR TITLE
fix: guard zero batchCount to prevent underflow

### DIFF
--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -233,6 +233,9 @@ func (t *InboxTracker) FindInboxBatchContainingMessage(pos arbutil.MessageIndex)
 	if err != nil {
 		return 0, false, err
 	}
+	if batchCount == 0 {
+		return 0, false, nil
+	}
 	low := uint64(0)
 	high := batchCount - 1
 	lastBatchMessageCount, err := t.GetBatchMessageCount(high)


### PR DESCRIPTION
Add an early return in InboxTracker.FindInboxBatchContainingMessage when sequencer batchCount is zero. Previously, the code computed high := batchCount - 1 unconditionally, which underflows for batchCount == 0 and attempts to read batch metadata at a huge index. This is incorrect and can surface during startup or snap-sync when no batches exist yet.

Callers across the codebase expect a “not found” outcome (found=false, no error) when a message isn’t contained in any batch or when there are no batches at all. By short-circuiting with (0, false, nil) for batchCount == 0, we:

- Prevent an unsigned underflow and invalid DB reads.
- Align behavior with consumer expectations (e.g., init reorg flow, node interface).
- Keep the binary search preconditions valid for the non-zero case without changing semantics.