### PR TITLE
Add min nitro versions field to sequencer feed

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -47,8 +47,8 @@ import (
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/staker"
 	"github.com/offchainlabs/nitro/staker/bold"
-	"github.com/offchainlabs/nitro/staker/legacy"
-	"github.com/offchainlabs/nitro/staker/multi_protocol"
+	legacystaker "github.com/offchainlabs/nitro/staker/legacy"
+	multiprotocolstaker "github.com/offchainlabs/nitro/staker/multi_protocol"
 	"github.com/offchainlabs/nitro/staker/validatorwallet"
 	"github.com/offchainlabs/nitro/util/containers"
 	"github.com/offchainlabs/nitro/util/contracts"
@@ -449,7 +449,7 @@ func getBroadcastServer(
 			}
 			maybeDataSigner = dataSigner
 		}
-		broadcastServer = broadcaster.NewBroadcaster(func() *wsbroadcastserver.BroadcasterConfig { return &configFetcher.Get().Feed.Output }, l2ChainId, fatalErrChan, maybeDataSigner)
+		broadcastServer = broadcaster.NewBroadcaster(func() *wsbroadcastserver.BroadcasterConfig { return &configFetcher.Get().Feed.Output }, l2ChainId, fatalErrChan, maybeDataSigner, config.Feed.MinNitroVersions...)
 	}
 	return broadcastServer, nil
 }

--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -42,11 +42,15 @@ var (
 var TransactionStreamerBlockCreationStopped = errors.New("block creation stopped in transaction streamer")
 
 type FeedConfig struct {
-	Output wsbroadcastserver.BroadcasterConfig `koanf:"output" reload:"hot"`
-	Input  Config                              `koanf:"input" reload:"hot"`
+	Output           wsbroadcastserver.BroadcasterConfig `koanf:"output" reload:"hot"`
+	Input            Config                              `koanf:"input" reload:"hot"`
+	MinNitroVersions []int                               `koanf:"min-nitro-versions"`
 }
 
 func (fc *FeedConfig) Validate() error {
+	if len(fc.MinNitroVersions) > 0 && len(fc.MinNitroVersions) != 3 {
+		return fmt.Errorf("--node.feed.min-nitro-versions int array has to be exactly of length 3 but its length is: %d", len(fc.MinNitroVersions))
+	}
 	return fc.Output.Validate()
 }
 
@@ -57,11 +61,13 @@ func FeedConfigAddOptions(prefix string, f *pflag.FlagSet, feedInputEnable bool,
 	if feedOutputEnable {
 		wsbroadcastserver.BroadcasterConfigAddOptions(prefix+".output", f)
 	}
+	f.IntSlice(prefix+".min-nitro-versions", FeedConfigDefault.MinNitroVersions, "minimum nitro versions decided by the feed source such that info/warn/error logs would be logged by feed readers if their node version is lower than values given here respectively. Only accept int array of length 3")
 }
 
 var FeedConfigDefault = FeedConfig{
-	Output: wsbroadcastserver.DefaultBroadcasterConfig,
-	Input:  DefaultConfig,
+	Output:           wsbroadcastserver.DefaultBroadcasterConfig,
+	Input:            DefaultConfig,
+	MinNitroVersions: []int{},
 }
 
 type Config struct {

--- a/broadcaster/message/message.go
+++ b/broadcaster/message/message.go
@@ -40,6 +40,10 @@ type BroadcastFeedMessage struct {
 	Signature      []byte                         `json:"signature"`
 	BlockMetadata  common.BlockMetadata           `json:"blockMetadata,omitempty"`
 
+	// Represents minimum nitro versions such that any node reading from the feed would log an info or
+	// warn or error log message if its node version is lower than the corresponding value of the array
+	MinNitroVersions *[3]int `json:"minNitroVersions,omitempty"`
+
 	CumulativeSumMsgSize uint64 `json:"-"`
 }
 

--- a/cmd/chaininfo/chain_info.go
+++ b/cmd/chaininfo/chain_info.go
@@ -15,6 +15,9 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
+// NITRO_NODE_VERSION needs to be updated every time a new nitro release is published
+const NITRO_NODE_VERSION int = 0
+
 //go:embed arbitrum_chain_info.json
 var DefaultChainsInfoBytes []byte
 

--- a/util/testhelpers/testhelpers.go
+++ b/util/testhelpers/testhelpers.go
@@ -119,6 +119,19 @@ func (h *LogHandler) WasLogged(pattern string) bool {
 	return false
 }
 
+func (h *LogHandler) WasLoggedAtLevel(pattern string, lvl slog.Level) bool {
+	re, err := regexp.Compile(pattern)
+	RequireImpl(h.t, err)
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+	for _, record := range h.records {
+		if record.Level == lvl && re.MatchString(record.Message) {
+			return true
+		}
+	}
+	return false
+}
+
 func newLogHandler(t *testing.T) *LogHandler {
 	return &LogHandler{
 		t:               t,


### PR DESCRIPTION
This PR adds a new optional field to the `BroadcastFeedMessage` called `minNitroVersions` that is an array of 3 integers representing required minimum nitro node versions- meaning the recipient of this feed message would log an `Info` message if its node version is lower than the first value in `MinNitroVersions` array, would log a `Warn` message if its lower than the second value and an `Error` message if its lower than the third value. 

Version of the nitro node is the new constant defined in chaininfo package `NITRO_NODE_VERSION` currently equal to 0. As one can see this constant can be updated at each nitro release to track the version of the nitro node.

Feed source can set the `minNitroVersions`  field via the config option 
```
--node.feed.min-nitro-versions = <INT_ARRAY_OF_SIZE_3>
```

Resolves NIT-3441