### PR TITLE
Remove Double Account Creation in BoLD Challenge Tests

### DIFF
--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -37,12 +37,12 @@ import (
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/l2pricing"
 	"github.com/offchainlabs/nitro/arbstate"
-	"github.com/offchainlabs/nitro/bold/chain-abstraction"
-	"github.com/offchainlabs/nitro/bold/chain-abstraction/sol-implementation"
-	"github.com/offchainlabs/nitro/bold/challenge-manager"
+	protocol "github.com/offchainlabs/nitro/bold/chain-abstraction"
+	solimpl "github.com/offchainlabs/nitro/bold/chain-abstraction/sol-implementation"
+	challengemanager "github.com/offchainlabs/nitro/bold/challenge-manager"
 	modes "github.com/offchainlabs/nitro/bold/challenge-manager/types"
-	"github.com/offchainlabs/nitro/bold/layer2-state-provider"
-	"github.com/offchainlabs/nitro/bold/testing"
+	l2stateprovider "github.com/offchainlabs/nitro/bold/layer2-state-provider"
+	challenge_testing "github.com/offchainlabs/nitro/bold/testing"
 	"github.com/offchainlabs/nitro/bold/testing/setup"
 	butil "github.com/offchainlabs/nitro/bold/util"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
@@ -557,9 +557,6 @@ func createTestNodeOnL1ForBoldProtocol(
 		l2info = NewArbTestInfo(t, chainConfig.ChainID)
 	}
 
-	l1info.GenerateAccount("RollupOwner")
-	l1info.GenerateAccount("Sequencer")
-	l1info.GenerateAccount("User")
 	l1info.GenerateAccount("Asserter")
 	l1info.GenerateAccount("EvilAsserter")
 


### PR DESCRIPTION
A change was introduced 6 days ago which added default blockchain test info accounts, but our bold challenge tests were trying to create the same accounts leading to errors. We did not catch this immediately, as nightly is the only target that runs these challenge tests