### PR TITLE
refactor: remove redundant else clauses in BigMin and BigMax functions

### DIFF
--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -172,18 +172,16 @@ func BigGreaterThanOrEqual(first, second *big.Int) bool {
 func BigMin(first, second *big.Int) *big.Int {
 	if BigLessThan(first, second) {
 		return new(big.Int).Set(first)
-	} else {
-		return new(big.Int).Set(second)
 	}
+	return new(big.Int).Set(second)
 }
 
 // BigMax returns a clone of the maximum of two big integers
 func BigMax(first, second *big.Int) *big.Int {
 	if BigGreaterThan(first, second) {
 		return new(big.Int).Set(first)
-	} else {
-		return new(big.Int).Set(second)
 	}
+	return new(big.Int).Set(second)
 }
 
 // BigAdd add a huge to another


### PR DESCRIPTION
Refactor util/arbmath/math.go to remove unnecessary else blocks after return statements in BigMin() and BigMax() functions. This follows Go best practices and improves code readability by eliminating redundant conditional branches.

Changes:
- Removed else clause in BigMin() function after early return
- Removed else clause in BigMax() function after early return
- Logic remains functionally identical
All tests pass: syntax validation, formatting checks, and static analysis (golangci-lint) completed successfully.