### PR TITLE
rpcclient: respect context cancellation during reconnect wait

### DIFF
--- a/util/rpcclient/rpcclient.go
+++ b/util/rpcclient/rpcclient.go
@@ -277,6 +277,9 @@ func (c *RpcClient) Start(ctx_in context.Context) error {
 		select {
 		case <-connTimeout:
 			return fmt.Errorf("timeout trying to connect lastError: %w", err)
+		case <-ctx_in.Done():
+			// Respect context cancellation during reconnect wait
+			return ctx_in.Err()
 		case <-time.After(time.Second):
 		}
 	}


### PR DESCRIPTION

### Summary
Handle context cancellation in `Start` reconnect loop to exit promptly when `ctx` is cancelled.

### Motivation
Previously, `Start` could hang until `ConnectionWait` elapsed even if the context was cancelled, slowing shutdown and tests.

### Changes
- Add `ctx_in.Done()` branch to the reconnect `select` after failed `DialOptions`.

