### PR TITLE
Guard FillInBatchGasFields calls when InboxReader is not set

### DIFF
--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -338,10 +338,12 @@ func (t *InboxTracker) legacyGetDelayedMessageAndAccumulator(ctx context.Context
 		return nil, common.Hash{}, err
 	}
 
-	err = msg.FillInBatchGasFields(func(batchNum uint64) ([]byte, error) {
-		data, _, err := t.txStreamer.inboxReader.GetSequencerMessageBytes(ctx, batchNum)
-		return data, err
-	})
+	if t.txStreamer.inboxReader != nil {
+		err = msg.FillInBatchGasFields(func(batchNum uint64) ([]byte, error) {
+			data, _, err := t.txStreamer.inboxReader.GetSequencerMessageBytes(ctx, batchNum)
+			return data, err
+		})
+	}
 
 	return msg, acc, err
 }
@@ -371,10 +373,12 @@ func (t *InboxTracker) GetDelayedMessageAccumulatorAndParentChainBlockNumber(ctx
 		return msg, acc, 0, err
 	}
 
-	err = msg.FillInBatchGasFields(func(batchNum uint64) ([]byte, error) {
-		data, _, err := t.txStreamer.inboxReader.GetSequencerMessageBytes(ctx, batchNum)
-		return data, err
-	})
+	if t.txStreamer.inboxReader != nil {
+		err = msg.FillInBatchGasFields(func(batchNum uint64) ([]byte, error) {
+			data, _, err := t.txStreamer.inboxReader.GetSequencerMessageBytes(ctx, batchNum)
+			return data, err
+		})
+	}
 	if err != nil {
 		return msg, acc, 0, err
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -482,14 +482,19 @@ func (s *TransactionStreamer) GetMessage(msgIdx arbutil.MessageIndex) (*arbostyp
 		return nil, err
 	}
 
-	err = message.Message.FillInBatchGasFields(func(batchNum uint64) ([]byte, error) {
-		ctx, err := s.GetContextSafe()
-		if err != nil {
-			return nil, err
-		}
-		data, _, err := s.inboxReader.GetSequencerMessageBytes(ctx, batchNum)
-		return data, err
-	})
+	if s.inboxReader != nil {
+		err = message.Message.FillInBatchGasFields(func(batchNum uint64) ([]byte, error) {
+			ctx, err := s.GetContextSafe()
+			if err != nil {
+				return nil, err
+			}
+			data, _, err := s.inboxReader.GetSequencerMessageBytes(ctx, batchNum)
+			return data, err
+		})
+	} else {
+		// Without an inbox reader, we can't fetch batch data; skip best-effort filling.
+		// err remains nil here intentionally.
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Prevent potential nil-deref when calling FillInBatchGasFields for BatchPostingReport messages before InboxReader is initialized.
- TransactionStreamer.GetMessage and InboxTracker delayed message readers now conditionally call FillInBatchGasFields only if an InboxReader is present; otherwise they skip best-effort gas stats filling.
- This change is necessary because FillInBatchGasFields requires a batch data fetcher; passing a closure that dereferences a nil InboxReader can crash in tests or atypical initialization sequences where SetInboxReaders hasn’t been called yet. Skipping is safe: gas fields are best-effort and other paths already tolerate their absence.