### PR TITLE
update arbdb schema version to 2

### DIFF
--- a/arbnode/db-schema/schema.go
+++ b/arbnode/db-schema/schema.go
@@ -26,4 +26,4 @@ var (
 	HeadMelStateBlockNumKey     []byte = []byte("_headMelStateBlockNum")        // contains the latest computed MEL state's parent chain block number
 )
 
-const CurrentDbSchemaVersion uint64 = 1
+const CurrentDbSchemaVersion uint64 = 2

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -333,6 +333,10 @@ func checkArbDbSchemaVersion(arbDb ethdb.Database) error {
 			// No database updates are necessary for database format version 0->1.
 			// This version adds a new format for delayed messages in the inbox tracker,
 			// but it can still read the old format for old messages.
+		case 1:
+			// No database updates are necessary for database format version 1->0.
+			// This version adds a new optional field to L1IncomingMessages,
+			// but it can still read the old format for old messages.
 		default:
 			return fmt.Errorf("unsupported database format version %v", version)
 		}


### PR DESCRIPTION
This accounts for the changes in L1IncomingMessage. Intended to prevent anyone trying to bring up an old node with new database.