### PR TITLE
Remove outdated TODO comments in extra transaction checks

### DIFF
--- a/arbos/extra_transaction_checks.go
+++ b/arbos/extra_transaction_checks.go
@@ -23,7 +23,7 @@ func extraPreTxFilter(
 	sender common.Address,
 	l1Info *L1Info,
 ) error {
-	// TODO: implement additional pre-transaction checks
+	// No additional pre-transaction checks configured
 	return nil
 }
 
@@ -39,6 +39,6 @@ func extraPostTxFilter(
 	l1Info *L1Info,
 	result *core.ExecutionResult,
 ) error {
-	// TODO: implement additional post-transaction checks
+	// No additional post-transaction checks configured
 	return nil
 }


### PR DESCRIPTION

## Summary
Remove misleading TODO comments in `arbos/extra_transaction_checks.go` that incorrectly suggested unimplemented functionality.

## Rationale
The TODO comments were misleading since these functions are already implemented and actively used in `arbos/block_processor.go`. The functions work as intended - providing empty stubs for additional transaction checks that can be extended by chain operators.

