### PR TITLE
fix: IP address string conversion in connection limiter

### DIFF
--- a/wsbroadcastserver/connectionlimiter.go
+++ b/wsbroadcastserver/connectionlimiter.go
@@ -85,7 +85,7 @@ func (l *ConnectionLimiter) getIpStringsAndLimits(ip net.IP) []ipStringAndLimit 
 	}
 
 	config := l.config()
-	result = append(result, ipStringAndLimit{string(ip), config.PerIpLimit})
+	result = append(result, ipStringAndLimit{ip.String(), config.PerIpLimit})
 
 	if isIpv6(ip) {
 		ipv6Slash48 := ip.Mask(net.CIDRMask(48, 128))


### PR DESCRIPTION

The connection limiter was using `string(ip)` to convert `net.IP` to string, which can produce incorrect representations of IP addresses, especially for IPv6.


- Replace `string(ip)` with `ip.String()` to ensure proper IP address formatting.

