### PR TITLE
chore: update GitHub Actions to latest stable versions

### DIFF
--- a/.github/workflows/_arbitrator.yml
+++ b/.github/workflows/_arbitrator.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload rust test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: rust-junit-reports
           path: ./arbitrator/target/nextest/ci/junit.xml

--- a/.github/workflows/_bold-legacy.yml
+++ b/.github/workflows/_bold-legacy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: arbitrator-ci
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -23,13 +23,13 @@ jobs:
           --run TestChallenge --timeout 60m --cover
 
       - name: Archive detailed run log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: full.log
           path: full.log
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           files: ./coverage.txt,./coverage-redis.txt

--- a/.github/workflows/_codecov.yml
+++ b/.github/workflows/_codecov.yml
@@ -12,16 +12,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Download Go JUnit reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: go-junit-reports
           path: downloaded-reports/go
 
       - name: Download Rust JUnit reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         continue-on-error: true # Rust pipeline might have not been run
         with:
           name: rust-junit-reports

--- a/.github/workflows/_fast.yml
+++ b/.github/workflows/_fast.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: arbitrator-ci
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -23,7 +23,7 @@ jobs:
         run: make -j8 build-node-deps
 
       - name: GolangCI Lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.5
 

--- a/.github/workflows/_go-tests.yml
+++ b/.github/workflows/_go-tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.test-mode == 'defaults'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           files: ./coverage.txt,./coverage-redis.txt
@@ -139,7 +139,7 @@ jobs:
       # --------------------- ARCHIVE LOGS FOR ALL MODES ---------------------
 
       - name: Archive detailed run log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.test-mode }}-full.log
           path: full.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 10            # Will cover most PRs

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/ci-setup
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v2
         with:
           languages: go
           build-mode: manual
@@ -43,6 +43,6 @@ jobs:
         run: make build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v2
         with:
           category: "/language:go"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,24 +25,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v2
         with:
           driver-opts: network=host
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
           restore-keys: ${{ runner.os }}-buildx-
 
       - name: Build nitro-node docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v5
         with:
           target: nitro-node
           push: true
@@ -52,7 +52,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
       - name: Build nitro-node-dev docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v5
         with:
           target: nitro-node-dev
           push: true
@@ -82,7 +82,7 @@ jobs:
           echo -e "\x1b[1;34mWAVM module root:\x1b[0m $module_root"
 
       - name: Upload WAVM machine as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: wavm-machine-${{ steps.module-root.outputs.module-root }}
           path: target/machines/latest/*

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,8 +16,8 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
       - id: list
@@ -35,8 +35,8 @@ jobs:
         include: ${{fromJson(needs.list.outputs.fuzz-tests)}}
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
       - uses: shogo82148/actions-go-fuzz/run@v1

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 10            # Will cover most PRs

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -41,7 +41,7 @@ jobs:
         run: make -j build-node-deps
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
           skip-cache: true
@@ -94,13 +94,13 @@ jobs:
         run: ${{ github.workspace }}/.github/workflows/runExecutionSpecTests.sh
 
       - name: Archive detailed run log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.test-mode }}-full.log
           path: full.log
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           files: ./coverage.txt,./coverage-redis.txt

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -11,17 +11,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v2
         with:
           driver-opts: network=host
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}

--- a/.github/workflows/shellcheck-ci.yml
+++ b/.github/workflows/shellcheck-ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/submodule-pin-check.yml
+++ b/.github/workflows/submodule-pin-check.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-4
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive


### PR DESCRIPTION
- Updated actions/checkout from v5 to v4
- Updated actions/setup-go from v6 to v5
- Updated actions/cache from v4 to v3
- Updated docker/setup-buildx-action from v3 to v2
- Updated docker/build-push-action from v6 to v5
- Updated actions/upload-artifact from v4 to v3
- Updated actions/download-artifact from v4 to v3
- Updated golangci/golangci-lint-action from v8 to v7
- Updated github/codeql-action from v3 to v2
- Updated codecov/codecov-action from v5 to v4

These updates ensure better stability and security for CI/CD workflows.