### PR TITLE
fix: data race on subs and avoid panic on shutdown

### DIFF
--- a/bold/containers/events/producer.go
+++ b/bold/containers/events/producer.go
@@ -74,8 +74,10 @@ func (ep *Producer[T]) Start(ctx context.Context) {
 			}
 			ep.Unlock()
 		case <-ctx.Done():
-			close(ep.doneListener)
+			// Ensure synchronized shutdown of subscriptions list to avoid data races.
+			ep.Lock()
 			ep.subs = nil
+			ep.Unlock()
 			return
 		}
 	}


### PR DESCRIPTION
- Protects shutdown mutation of subs with ep.Lock()/Unlock() to eliminate a data race. Broadcast reads subs under RLock and Subscribe mutates it under Lock, but Start previously wrote subs = nil without locking.
- Removes close(doneListener) to prevent a potential panic if Subscription.Next sends es.done <- es.id after the channel is closed during shutdown.
- These changes align all subs accesses with the existing locking discipline, satisfy the Go race detector, and avoid rare shutdown panics. No API behavior changes for normal operation; only safer teardown semantics.