### PR TITLE
fix: Remove private key from logs in nitro CLI

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -94,7 +94,8 @@ func addUnlockWallet(accountManager *accounts.Manager, walletConf *genericconf.W
 
 		devAddr = crypto.PubkeyToAddress(devPrivKey.PublicKey)
 
-		log.Info("Dev node funded private key", "priv", walletConf.PrivateKey)
+		// Do not log private keys
+        log.Info("Dev node funded key loaded")
 		log.Info("Funded public address", "addr", devAddr)
 	}
 


### PR DESCRIPTION

Summary: Stop logging the dev private key in cmd/nitro/nitro.go. Replace the sensitive log entry with a neutral message.
Why: Logging private keys is a critical security issue (risk of key exposure in CI logs, user terminals, or aggregated log backends).
