### PR TITLE
Avoid logging Redis cache misses as errors in DAS RedisStorageService

### DIFF
--- a/daprovider/das/redis_storage_service.go
+++ b/daprovider/das/redis_storage_service.go
@@ -84,6 +84,10 @@ func (rs *RedisStorageService) verifyMessageSignature(data []byte) ([]byte, erro
 
 func (rs *RedisStorageService) getVerifiedData(ctx context.Context, key common.Hash) ([]byte, error) {
 	data, err := rs.client.Get(ctx, string(key.Bytes())).Bytes()
+	if errors.Is(err, redis.Nil) {
+        // Cache miss is expected and should not be logged as an error
+        return nil, err
+    }
 	if err != nil {
 		log.Error("das.RedisStorageService.getVerifiedData", "err", err)
 		return nil, err


### PR DESCRIPTION
This change treats Redis cache misses (redis.Nil) in getVerifiedData as expected behavior rather than errors, preventing noisy false-error logs and improving observability. Functionality remains the same—on a miss we fall back to the base storage and populate the cache—only the logging severity is adjusted.