### PR TITLE
Handle error returned by ExecEngine.Start in ExecutionNode.Start

### DIFF
--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -431,7 +431,9 @@ func (n *ExecutionNode) Start(ctx context.Context) error {
 	// if err != nil {
 	// 	return fmt.Errorf("error starting geth stack: %w", err)
 	// }
-	n.ExecEngine.Start(ctx)
+	if err := n.ExecEngine.Start(ctx); err != nil {
+		return fmt.Errorf("error starting execution engine: %w", err)
+	}
 	err := n.TxPublisher.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("error starting transaction puiblisher: %w", err)


### PR DESCRIPTION

## Summary
  - Ensure ExecutionNode.Start fails fast if ExecEngine.Start returns an error.

- Changes
  - Add error handling around ExecEngine.Start(ctx) in execution/gethexec/node.go.
  - Return a wrapped error to surface startup failures clearly.

- Rationale
  - Avoids launching the node in a partially initialized state.
  - Improves debuggability and reliability by not swallowing critical startup errors.

