### PR TITLE
fix: regex to correctly detect “i/o timeout” in TxForwarder

### DIFF
--- a/execution/gethexec/forwarder.go
+++ b/execution/gethexec/forwarder.go
@@ -117,7 +117,7 @@ func NewForwarder(targets []string, config *ForwarderConfig) *TxForwarder {
 		targets:               targets,
 		timeout:               config.ConnectionTimeout,
 		transport:             transport,
-		tryNewForwarderErrors: regexp.MustCompile(`(?i)(^http:|^json:|^i/0|timeout exceeded|no such host)`),
+		tryNewForwarderErrors: regexp.MustCompile(`(?i)(^http:|^json:|^i/o|timeout exceeded|no such host)`),
 	}
 }
 


### PR DESCRIPTION

- **What**: Correct a typo in the error-matching regex in `execution/gethexec/forwarder.go` (`^i/0` → `^i/o`) to reliably detect `i/o timeout`.
- **Why**: The typo prevented proper classification of transient network timeouts, potentially blocking failover/retry logic and reducing resilience.
- **Impact**: Improves robustness of transaction forwarding under intermittent network issues; no behavior change beyond correct matching.
