### PR TITLE
avoid unnecessary warnings from sequencer expectedSurplus mechanism

### DIFF
--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -1422,10 +1422,16 @@ func (s *Sequencer) updateExpectedSurplus(ctx context.Context) (int64, error) {
 		backlogCost = backlogCallDataUnits * header.BaseFee.Int64()
 	case "BlobPrice":
 		if s.config().Dangerous.DisableBlobBaseFeeCheck {
-			log.Warn("expected surplus calculation is set to use blob price but --execution.sequencer.dangerous.disable-blob-base-fee-check is set, falling back to calldata price model")
+			if !s.expectedSurplusUpdated {
+				// only print notification once
+				log.Info("expected surplus calculation is set to use blob price but --execution.sequencer.dangerous.disable-blob-base-fee-check is set, falling back to calldata price model")
+			}
 			backlogCost = backlogCallDataUnits * header.BaseFee.Int64()
 		} else if header.BlobGasUsed == nil || header.ExcessBlobGas == nil {
-			log.Warn("expected surplus calculation is set to use blob price but latest parent chain header has BlobGasUsed or ExcessBlobGas as nil, falling back to calldata price model")
+			if !s.expectedSurplusUpdated {
+				// only print notification once
+				log.Info("expected surplus calculation is set to use blob price but latest parent chain header has BlobGasUsed or ExcessBlobGas as nil, falling back to calldata price model")
+			}
 			backlogCost = backlogCallDataUnits * header.BaseFee.Int64()
 		} else {
 			blobFeePerByte, err := s.parentChain.BlobFeePerByte(ctx, header)


### PR DESCRIPTION
Defaults make nodes print unnecessary warnings on many Orbit chains. Switch to Info, and settle for printing only once.