### PR TITLE
Remove outdated TODO comment in clientmanager.go

### DIFF
--- a/wsbroadcastserver/clientmanager.go
+++ b/wsbroadcastserver/clientmanager.go
@@ -76,8 +76,6 @@ func (cm *ClientManager) registerClient(ctx context.Context, clientConnection *C
 		}
 	}()
 
-	// TODO:(clamb) the clientsTotalFailedRegisterCounter was deleted after backlog logic moved to ClientConnection. Should this metric be reintroduced or will it be ok to just delete completely given the behaviour has changed, ask Lee
-
 	if cm.config().ConnectionLimits.Enable && !cm.connectionLimiter.Register(clientConnection.clientIp) {
 		return fmt.Errorf("Connection limited %s", clientConnection.clientIp)
 	}


### PR DESCRIPTION


**Description:**

Removes an obsolete TODO comment in `registerClient` function that referenced a deleted metric (`clientsTotalFailedRegisterCounter`). The comment was asking whether to reintroduce this metric after backlog logic was moved to `ClientConnection`, but this is no longer relevant.

