### PR TITLE
Remove dead code in ReferenceDA certificate

### DIFF
--- a/daprovider/referenceda/certificate.go
+++ b/daprovider/referenceda/certificate.go
@@ -93,25 +93,3 @@ func (c *Certificate) RecoverSigner() (common.Address, error) {
 
 	return crypto.PubkeyToAddress(*pubKey), nil
 }
-
-// ValidateWithContract checks if the certificate is signed by a trusted signer using the contract
-// TODO: Uncomment the following once we have merged customda contracts changes.
-/*
-func (c *Certificate) ValidateWithContract(validator *ospgen.ReferenceDAProofValidator, opts *bind.CallOpts) error {
-	signer, err := c.RecoverSigner()
-	if err != nil {
-		return err
-	}
-
-	isTrusted, err := validator.TrustedSigners(opts, signer)
-	if err != nil {
-		return fmt.Errorf("failed to check trusted signer: %w", err)
-	}
-
-	if !isTrusted {
-		return fmt.Errorf("certificate signed by untrusted signer: %s", signer.Hex())
-	}
-
-	return nil
-    }
-*/


### PR DESCRIPTION

**Description**
- Remove obsolete TODO referencing custom-da contract changes.
- Delete the commented-out `ValidateWithContract` implementation in `daprovider/referenceda/certificate.go`.

**Rationale**
The commented block and TODO created the impression of unfinished work and added noise for reviewers and maintainers without providing value.

