### PR TITLE
confighelpers: remove unreachable return after os.Exit in DumpConfig

### DIFF
--- a/cmd/util/confighelpers/configuration.go
+++ b/cmd/util/confighelpers/configuration.go
@@ -315,5 +315,4 @@ func DumpConfig(k *koanf.Koanf, extraOverrideFields map[string]interface{}) erro
 
 	fmt.Println(string(c))
 	os.Exit(0)
-	return fmt.Errorf("Unreachable")
 }


### PR DESCRIPTION


Seasoned backend engineer focused on Go and distributed systems; contributor to performance, reliability, and developer tooling across L2/blockchain infrastructure.