### PR TITLE
Backport Remove pre sylus validation (#3785)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -342,17 +342,21 @@ ENTRYPOINT [ "/usr/local/bin/nitro" , "--validation.wasm.allowed-wasm-module-roo
 
 USER user
 
+# The nitro-node-validator is needed in case some modifications are needed in arbitrator or jit API.
+# That was the case when enabling arbos30.
+# We no longer support pre-arbos-30 wasmmoduleroots (newer wasmmoduleroots can execute old blocks)
+# We keep the code (commented out), and the docker-target, for use in case such an update is needed again.
 FROM nitro-node AS nitro-node-validator
-USER root
-COPY --from=nitro-legacy /usr/local/bin/nitro-val /home/user/nitro-legacy/bin/nitro-val
-COPY --from=nitro-legacy /usr/local/bin/jit /home/user/nitro-legacy/bin/jit
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update && \
-    apt-get install -y xxd netcat-traditional && \
-    rm -rf /var/lib/apt/lists/* /usr/share/doc/* /var/cache/ldconfig/aux-cache /usr/lib/python3.9/__pycache__/ /usr/lib/python3.9/*/__pycache__/ /var/log/*
-COPY scripts/split-val-entry.sh /usr/local/bin
-ENTRYPOINT [ "/usr/local/bin/split-val-entry.sh" ]
-USER user
+# USER root
+# COPY --from=nitro-legacy /usr/local/bin/nitro-val /home/user/nitro-legacy/bin/nitro-val
+# COPY --from=nitro-legacy /usr/local/bin/jit /home/user/nitro-legacy/bin/jit
+# RUN export DEBIAN_FRONTEND=noninteractive && \
+#     apt-get update && \
+#     apt-get install -y xxd netcat-traditional && \
+#     rm -rf /var/lib/apt/lists/* /usr/share/doc/* /var/cache/ldconfig/aux-cache /usr/lib/python3.9/__pycache__/ /usr/lib/python3.9/*/__pycache__/ /var/log/*
+# COPY scripts/split-val-entry.sh /usr/local/bin
+# ENTRYPOINT [ "/usr/local/bin/split-val-entry.sh" ]
+# USER user
 
 FROM nitro-node-validator AS nitro-node-dev
 USER root

--- a/validator/client/validation_client.go
+++ b/validator/client/validation_client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
-	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/offchainlabs/nitro/util/containers"
 	"github.com/offchainlabs/nitro/util/rpcclient"
@@ -70,12 +69,7 @@ func (c *ValidationClient) Start(ctx context.Context) error {
 	}
 	var stylusArchs []rawdb.WasmTarget
 	if err := c.client.CallContext(ctx, &stylusArchs, server_api.Namespace+"_stylusArchs"); err != nil {
-		var rpcError rpc.Error
-		ok := errors.As(err, &rpcError)
-		if !ok || rpcError.ErrorCode() != -32601 {
-			return fmt.Errorf("could not read stylus arch from server: %w", err)
-		}
-		stylusArchs = []rawdb.WasmTarget{rawdb.WasmTarget("pre-stylus")} // invalid, will fail if trying to validate block with stylus
+		return fmt.Errorf("could not read stylus arch from server: %w", err)
 	} else {
 		if len(stylusArchs) == 0 {
 			return fmt.Errorf("could not read stylus archs from validation server")


### PR DESCRIPTION
remove support for pre-stylus validation
pre-stylus validation is no longer needed, and does create problems.
fail if stylus support not found instead of assuming pre-stylus
dockerfile changes
