### PR TITLE
redislock: replace time.Tick with time.NewTicker to prevent timer leak

### DIFF
--- a/arbnode/redislock/redis.go
+++ b/arbnode/redislock/redis.go
@@ -146,7 +146,9 @@ func (l *Simple) AttemptLockAndPeriodicallyRefreshIt(ctx context.Context, releas
 
 	refreshLock := func() {
 		defer l.Release(ctx)
-		refreshTick := time.Tick(l.config().RefreshDuration)
+		// Use a managed ticker to avoid leaking a global time.Ticker
+		ticker := time.NewTicker(l.config().RefreshDuration)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-release:
@@ -159,7 +161,7 @@ func (l *Simple) AttemptLockAndPeriodicallyRefreshIt(ctx context.Context, releas
 					return
 				case <-ctx.Done():
 					return
-				case <-refreshTick:
+				case <-ticker.C:
 					gotLock, err := l.attemptLock(ctx)
 					if err != nil {
 						log.Error("attemptLock returned error during refresh: %w", err)


### PR DESCRIPTION


Description:
### Summary
Replace `time.Tick` with a managed `time.NewTicker` in `redislock` refresh loop and stop it on exit to prevent leaking timers when the goroutine terminates.

### Motivation
`time.Tick` cannot be stopped and leaks its underlying ticker. In long‑running processes with restarted refresh goroutines, this can accumulate timers and degrade performance.

### Changes
- Create a `time.NewTicker(l.config().RefreshDuration)` and `defer ticker.Stop()`.
- Switch the select case from `refreshTick` to `ticker.C`.


