### PR TITLE
Port: Fix backward incompatible data-streaming protocol change

### DIFF
--- a/daprovider/data_streaming/receiver.go
+++ b/daprovider/data_streaming/receiver.go
@@ -86,7 +86,7 @@ func NewDefaultDataStreamReceiver(verifier *PayloadVerifier) *DataStreamReceiver
 // StartStreamingResult is expected by DataStreamer to be returned by the endpoint responsible for the StartReceiving method.
 // lint:require-exhaustive-initialization
 type StartStreamingResult struct {
-	MessageId hexutil.Uint64 `json:"MessageId,omitempty"`
+	MessageId hexutil.Uint64 `json:"BatchId,omitempty"` // For compatibility reasons we keep the old name "BatchId"
 }
 
 func (dsr *DataStreamReceiver) StartReceiving(ctx context.Context, timestamp, nChunks, chunkSize, totalSize, timeout uint64, signature []byte) (*StartStreamingResult, error) {


### PR DESCRIPTION
https://github.com/OffchainLabs/nitro/pull/3625 introduced a backwards incompatible change: `*_StartChunkedStore` returns a struct with another field name (`MessageId` instead of `BatchId`). This PR fixes this.

backports #3801 to v3.8.x