### PR TITLE
fix: Enable EIP7883 and EIP7823 for Arbos50

### DIFF
--- a/gethhook/geth-hook.go
+++ b/gethhook/geth-hook.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/precompiles"
@@ -65,10 +64,9 @@ func init() {
 			precompileErrors[[4]byte(errABI.ID.Bytes())] = errABI
 		}
 
+		// Arbos is a special case, Arbos handles versioning of precompiles internally, versioning of Ethereum/non-Arbos precompiles must be handled externally
 		var wrapped vm.AdvancedPrecompile = ArbosPrecompileWrapper{precompile}
-		if precompile.Precompile().ArbosVersion() < params.ArbosVersion_Stylus {
-			vm.PrecompiledContractsBeforeArbOS30[addr] = wrapped
-		}
+		vm.PrecompiledContractsBeforeArbOS30[addr] = wrapped
 		vm.PrecompiledContractsStartingFromArbOS30[addr] = wrapped
 		vm.PrecompiledContractsStartingFromArbOS50[addr] = wrapped
 	}


### PR DESCRIPTION
# problem

fixes NIT-3996

EIP7883 and EIP7823 are initially enabled for Arbos50, but then at the end Arbos50's precompiles are overridden by the Arbos30 precompiles. I found this while finishing up the work on porting the execution-spec-tests to Arbitrum.

# solution

Don't override the Arbos50 precompiles with the Arbos30 precompiles

I found our precompile initialization code to be a little confusing, so I defined it into 3 sections
- pre-Arbos30 precompiles
- Arbos30 precompiles
- Arbos50 precompiles

hopefully this organization helps, it looks like investing in the execution-spec-tests is already paying dividends!