### PR TITLE
Backport Correct the order TransactionStreamer and PopulateFeedBacklog (#3812)

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1373,14 +1373,6 @@ func (n *Node) Start(ctx context.Context) error {
 			return fmt.Errorf("error initializing feed broadcast server: %w", err)
 		}
 	}
-	if n.InboxTracker != nil && n.BroadcastServer != nil {
-		// Even if the sequencer coordinator will populate this backlog,
-		// we want to make sure it's populated before any clients connect.
-		err = n.InboxTracker.PopulateFeedBacklog(n.BroadcastServer)
-		if err != nil {
-			return fmt.Errorf("error populating feed backlog on startup: %w", err)
-		}
-	}
 	err = n.TxStreamer.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("error starting transaction streamer: %w", err)
@@ -1389,6 +1381,14 @@ func (n *Node) Start(ctx context.Context) error {
 		err = n.InboxReader.Start(ctx)
 		if err != nil {
 			return fmt.Errorf("error starting inbox reader: %w", err)
+		}
+	}
+	if n.InboxTracker != nil && n.BroadcastServer != nil {
+		// Even if the sequencer coordinator will populate this backlog,
+		// we want to make sure it's populated before any clients connect.
+		err = n.InboxTracker.PopulateFeedBacklog(n.BroadcastServer)
+		if err != nil {
+			return fmt.Errorf("error populating feed backlog on startup: %w", err)
 		}
 	}
 	// must init broadcast server before trying to sequence anything


### PR DESCRIPTION
The TransactionStreamer and InboxReader are now needed by PopulateFeedBacklog as
of c6bd24a becuase the GetMessage implementation in the transaction streamer
needs the InboxReader to have been started so it can get the blobs associated
with a message.

This is problematic becuase during initialization of the node
PopulateFeedBacklog uses the transaction streamer to get messages which were
stored in the database when there is a backlog.

Fixes: NIT-3997