### PR TITLE
fix: ParseMemLimit to accept numbers without suffix as bytes

### DIFF
--- a/arbnode/resourcemanager/resource_management.go
+++ b/arbnode/resourcemanager/resource_management.go
@@ -76,7 +76,7 @@ func ParseMemLimit(limitStr string) (int, error) {
 		limit <<= 30
 	case "T", "TB":
 		limit <<= 40
-	case "B":
+	case "B", "": // Support empty suffix for bytes (default unit)
 	default:
 		return 0, fmt.Errorf("unsupported memory limit suffix string %s", s)
 	}


### PR DESCRIPTION


Fixes `ParseMemLimit` function to properly handle numeric values without unit suffixes by treating them as bytes (the default unit).

