### PR TITLE
Fix out of bounds config access in dataposter

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -1226,7 +1226,10 @@ func (p *DataPoster) Start(ctxIn context.Context) {
 			log.Warn("failed to update tx poster nonce", "err", err)
 		}
 		now := time.Now()
-		nextCheck := now.Add(arbmath.MinInt(p.config().ReplacementTimes[0], p.config().BlobTxReplacementTimes[0]))
+		nextCheck := now.Add(p.config().ReplacementTimes[0])
+		if len(p.config().BlobTxReplacementTimes) > 0 {
+			nextCheck = now.Add(arbmath.MinInt(p.config().ReplacementTimes[0], p.config().BlobTxReplacementTimes[0]))
+		}
 		maxTxsToRbf := p.config().MaxMempoolTransactions
 		if maxTxsToRbf == 0 {
 			maxTxsToRbf = 512
@@ -1412,6 +1415,12 @@ func (c *DataPosterConfig) Validate() error {
 		// Valid values
 	default:
 		return fmt.Errorf("invalid enable-cell-proofs value %q (valid: \"\", \"auto\", \"force-enable\", \"force-disable\")", c.EnableCellProofs)
+	}
+	if len(c.ReplacementTimes) == 0 {
+		return fmt.Errorf("replacement-times must have at least one value")
+	}
+	if c.Post4844Blobs && len(c.BlobTxReplacementTimes) == 0 {
+		return fmt.Errorf("blob-tx-replacement-times must have at least one value when post-4844-blobs is enabled")
 	}
 	return nil
 }


### PR DESCRIPTION
The DataPoster was panicking with an out of bounds access into the `BlobTxReplacementTimes` slice when used by Validators. In [a recent change](https://github.com/OffchainLabs/nitro/commit/34561ddfffaf565e6d7ca280bee76b3e2ac5a482) we set all blob related parameters in the DataPosterConfig to nil/empty when used from a Validator context, since blob txs should never be used by the Validator to post its assertions. The line fixed in this commit was trying to schedule the next iteration of the tx replacement loop to be at least the minimum of the lowest blob or normal tx replacement time, even if there were no `BlobTxReplacementTimes`.

This PR also adds basic configuration validation that `BlobTxReplacementTimes` is nonempty when blob txs are enabled, and that `ReplacementTimes` is always nonempty.

As some background, we use a sparser blob tx replacement schedule because replacing blob txs is more expensive due to requiring a larger escalation of price (2x  vs 1.1x increase). This is an intentional implementation detail included by execution clients to limit spammy potentially large replacement txs.