### PR TITLE
fix: Use context-aware HTTP request in DAS Rest client HealthCheck

### DIFF
--- a/daprovider/das/restful_client.go
+++ b/daprovider/das/restful_client.go
@@ -79,15 +79,19 @@ func (c *RestfulDasClient) GetByHash(ctx context.Context, hash common.Hash) ([]b
 }
 
 func (c *RestfulDasClient) HealthCheck(ctx context.Context) error {
-	res, err := http.Get(c.url + healthRequestPath)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("HTTP error with status %d returned by server: %s", res.StatusCode, http.StatusText(res.StatusCode))
-	}
-	return nil
+    req, err := http.NewRequestWithContext(ctx, "GET", c.url+healthRequestPath, nil)
+    if err != nil {
+        return err
+    }
+    res, err := http.DefaultClient.Do(req)
+    if err != nil {
+        return err
+    }
+    defer res.Body.Close()
+    if res.StatusCode != http.StatusOK {
+        return fmt.Errorf("HTTP error with status %d returned by server: %s", res.StatusCode, http.StatusText(res.StatusCode))
+    }
+    return nil
 }
 
 func (c *RestfulDasClient) ExpirationPolicy(ctx context.Context) (dasutil.ExpirationPolicy, error) {


### PR DESCRIPTION

- **Summary**: Replace `http.Get` with a context-aware request (`http.NewRequestWithContext` + `http.DefaultClient.Do`) in `daprovider/das/restful_client.go` to honor cancellation and timeouts.
- **Behavior**: `HealthCheck` now respects the provided `Context`; cancellation/deadline cleanly aborts the request. Response handling remains unchanged.
- **Rationale**: Prevents potential hangs during shutdown or transient network issues; improves robustness and resource management.