### PR TITLE
fix: Propagate context to external signer in DataPoster signer

### DIFF
--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -191,7 +191,7 @@ func NewDataPoster(ctx context.Context, opts *DataPosterOpts) (*DataPoster, erro
 		dp.auth = &bind.TransactOpts{
 			From: sender,
 			Signer: func(address common.Address, tx *types.Transaction) (*types.Transaction, error) {
-				return signer(context.TODO(), address, tx)
+				return signer(ctx, address, tx)
 			},
 		}
 	}


### PR DESCRIPTION

- **Summary**: Replace `context.TODO()` with the constructor-provided `ctx` in `bind.TransactOpts.Signer` (file `arbnode/dataposter/data_poster.go`) so sign requests respect cancellation and deadlines.
- **Behavior**: Signing now honors the provided `Context`; functional behavior remains unchanged.
- **Rationale**: Avoids potential hangs during shutdown or network stalls; improves robustness and resource handling.
