### PR TITLE
fix: Ensure file is always closed when saving blobs to disk

### DIFF
--- a/util/headerreader/blob_client.go
+++ b/util/headerreader/blob_client.go
@@ -374,6 +374,7 @@ func saveBlobDataToDisk(rawData json.RawMessage, slot uint64, blobDirectory stri
 		return fmt.Errorf("could not create file to store fetched blobs")
 	}
 	full := fullResult[json.RawMessage]{Data: rawData}
+	defer file.Close()
 	fullbytes, err := json.Marshal(full)
 	if err != nil {
 		return fmt.Errorf("unable to marshal data into bytes while attempting to store fetched blobs")
@@ -381,7 +382,6 @@ func saveBlobDataToDisk(rawData json.RawMessage, slot uint64, blobDirectory stri
 	if _, err := file.Write(fullbytes); err != nil {
 		return fmt.Errorf("failed to write blob data to disk")
 	}
-	file.Close()
 	return nil
 }
 


### PR DESCRIPTION

- **Summary**: Add `defer file.Close()` in `saveBlobDataToDisk` (`util/headerreader/blob_client.go`) to guarantee file descriptor release on all paths.
- **Behavior**: No functional change to blob saving; ensures cleanup on marshal/write errors.
- **Rationale**: Prevents file descriptor leaks that can lead to “too many open files” under failure or high-load scenarios; improves robustness.
