### PR TITLE
fix(server_common): invoke callback only when machine retrieval succeeds

### DIFF
--- a/validator/server_common/machine_loader.go
+++ b/validator/server_common/machine_loader.go
@@ -69,7 +69,7 @@ func (l *MachineLoader[M]) ForEachReadyMachine(runme func(*M)) {
 	for _, stat := range l.machines {
 		if stat.Ready() {
 			machine, err := stat.Current()
-			if err != nil {
+			if err == nil {
 				runme(machine)
 			}
 		}


### PR DESCRIPTION

- Summary: Ensure ForEachReadyMachine calls the callback only on successful machine retrieval.
- Problem: The callback was executed when stat.Current() returned an error (inverted condition), risking nil/invalid machine usage.
- Solution: Invert the condition to run the callback only if err == nil.
