### PR TITLE
fix(server_common, wsbroadcastserver): correct machine callback condition and add write deadline

### DIFF
--- a/wsbroadcastserver/clientconnection.go
+++ b/wsbroadcastserver/clientconnection.go
@@ -325,6 +325,9 @@ func (cc *ClientConnection) writeRaw(p []byte) error {
 	cc.ioMutex.Lock()
 	defer cc.ioMutex.Unlock()
 
+	_ = cc.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	defer cc.conn.SetWriteDeadline(time.Time{})
+	
 	_, err := cc.conn.Write(p)
 
 	return err


### PR DESCRIPTION


### Description
- **Summary**: Ensure `ForEachReadyMachine` invokes callback only on successful machine retrieval; add bounded write deadline for client writes.
- **Problem**:
  - `validator/server_common/machine_loader.go`: callback executed when `stat.Current()` returned an error.
  - `wsbroadcastserver/clientconnection.go`: `conn.Write` could block indefinitely on slow/stalled clients.
- **Solution**:
  - Invert condition to call callback only if `err == nil`.
  - Set and reset a write deadline (`10s`) around `conn.Write`.
