### PR TITLE
Do not always require CODECOV_TOKEN

### DIFF
--- a/.github/workflows/_codecov.yml
+++ b/.github/workflows/_codecov.yml
@@ -4,8 +4,8 @@ on:
   workflow_call:
     secrets:
       CODECOV_TOKEN:
-        required: true
-        description: Token to upload reports to Codecov.
+        required: false
+        description: Token to upload reports to Codecov. Required if `upload_report` is on.
     inputs:
       post_comment:
         description: 'Set to true to post a test summary comment on the PR.'


### PR DESCRIPTION
Previously the `_codecov` workflow required `CODECOV_TOKEN`. As a result, external fork PRs were failing, like https://github.com/OffchainLabs/nitro/pull/3847. However, we need this token only on merging to `master`.

This PR sets this secret as non-mandatory.

cc: @KolbyML 