### PR TITLE
test: correct default runs to 1<<32 in aggregator_test 

### DIFF
--- a/daprovider/das/aggregator_test.go
+++ b/daprovider/das/aggregator_test.go
@@ -256,7 +256,7 @@ func initTest(t *testing.T) int {
 	}
 	rand.Seed(seed)
 
-	runs := 2 ^ 32
+	runs := 1 << 32
 	if len(*testflag.RunsFlag) > 0 {
 		var err error
 		runs, err = strconv.Atoi(*testflag.RunsFlag)


### PR DESCRIPTION


Description:
- Summary: Replace incorrect XOR expression (2 ^ 32) with the intended exponent-equivalent bit shift (1 << 32) for the default runs value in aggregator_test.
- Rationale: 2 ^ 32 in Go is bitwise XOR (resulting in 34), not exponentiation. This was misleading and could affect future changes if bounds are adjusted.
- Changes:
  - Set runs default to 1 << 32 in daprovider/das/aggregator_test.go.
