### PR TITLE
refactor(wsbroadcastserver): simplify ClientConnection Name; remove duplicate IP

### DIFF
--- a/wsbroadcastserver/clientconnection.go
+++ b/wsbroadcastserver/clientconnection.go
@@ -80,7 +80,7 @@ func NewClientConnection(
 		clientIp:        connectingIP,
 		desc:            desc,
 		creation:        time.Now(),
-		Name:            fmt.Sprintf("%s@%s-%d", connectingIP, conn.RemoteAddr(), rand.Intn(10)),
+		Name:            fmt.Sprintf("%s-%d", conn.RemoteAddr(), rand.Intn(10)),
 		clientAction:    clientAction,
 		requestedSeqNum: requestedSeqNum,
 		out:             make(chan message, maxSendQueue),


### PR DESCRIPTION


## Description:
- Summary: Use only RemoteAddr with a short suffix for ClientConnection.Name instead of "IP@RemoteAddr-<n>".
- Rationale: connectingIP duplicates the IP already present in RemoteAddr; removal reduces log noise and simplifies parsing.

