### PR TITLE
[NIT-3755] Serialization order of the chain config in the init message changes the genesis block hash

### DIFF
--- a/arbos/arbostypes/incomingmessage.go
+++ b/arbos/arbostypes/incomingmessage.go
@@ -278,8 +278,7 @@ type ParsedInitMessage struct {
 	InitialL1BaseFee *big.Int
 
 	// These may be nil
-	ChainConfig           *params.ChainConfig
-	SerializedChainConfig []byte
+	ChainConfig *params.ChainConfig
 }
 
 // The initial L1 pricing basefee starts at 50 GWei unless set in the init message
@@ -300,7 +299,7 @@ func (msg *L1IncomingMessage) ParseInitMessage() (*ParsedInitMessage, error) {
 	var chainId *big.Int
 	if len(msg.L2msg) == 32 {
 		chainId = new(big.Int).SetBytes(msg.L2msg[:32])
-		return &ParsedInitMessage{chainId, basefee, nil, nil}, nil
+		return &ParsedInitMessage{chainId, basefee, nil}, nil
 	}
 	if len(msg.L2msg) > 32 {
 		chainId = new(big.Int).SetBytes(msg.L2msg[:32])
@@ -323,7 +322,7 @@ func (msg *L1IncomingMessage) ParseInitMessage() (*ParsedInitMessage, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse init message, err: %w, message data: %v", err, string(msg.L2msg))
 			}
-			return &ParsedInitMessage{chainId, basefee, &chainConfig, serializedChainConfig}, nil
+			return &ParsedInitMessage{chainId, basefee, &chainConfig}, nil
 		}
 	}
 	return nil, fmt.Errorf("invalid init message data %v", string(msg.L2msg))

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -885,17 +885,15 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 					return chainDb, nil, fmt.Errorf("incompatible chain config read from init message in L1 inbox: %w", err)
 				}
 			}
-			log.Info("Read serialized chain config from init message", "json", string(parsedInitMessage.SerializedChainConfig))
 		} else {
 			serializedChainConfig, err := json.Marshal(chainConfig)
 			if err != nil {
 				return chainDb, nil, err
 			}
 			parsedInitMessage = &arbostypes.ParsedInitMessage{
-				ChainId:               chainConfig.ChainID,
-				InitialL1BaseFee:      arbostypes.DefaultInitialL1BaseFee,
-				ChainConfig:           chainConfig,
-				SerializedChainConfig: serializedChainConfig,
+				ChainId:          chainConfig.ChainID,
+				InitialL1BaseFee: arbostypes.DefaultInitialL1BaseFee,
+				ChainConfig:      chainConfig,
 			}
 			log.Warn("Created fake init message as L1Reader is disabled and serialized chain config from init message is not available", "json", string(serializedChainConfig))
 		}

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -1683,13 +1683,11 @@ func createNonL1BlockChainWithStackConfig(
 
 	initReader := statetransfer.NewMemoryInitDataReader(&info.ArbInitData)
 	if initMessage == nil {
-		serializedChainConfig, err := json.Marshal(chainConfig)
 		Require(t, err)
 		initMessage = &arbostypes.ParsedInitMessage{
-			ChainId:               chainConfig.ChainID,
-			InitialL1BaseFee:      arbostypes.DefaultInitialL1BaseFee,
-			ChainConfig:           chainConfig,
-			SerializedChainConfig: serializedChainConfig,
+			ChainId:          chainConfig.ChainID,
+			InitialL1BaseFee: arbostypes.DefaultInitialL1BaseFee,
+			ChainConfig:      chainConfig,
 		}
 	}
 	coreCacheConfig := gethexec.DefaultCacheConfigFor(&execConfig.Caching)

--- a/system_tests/genesis_block_test.go
+++ b/system_tests/genesis_block_test.go
@@ -62,10 +62,9 @@ func computeGenesisBlockHash(t *testing.T, serializedChainConfig []byte) common.
 	require.NoError(t, err)
 
 	parsedInitMessage := &arbostypes.ParsedInitMessage{
-		ChainId:               chainConfig.ChainID,
-		InitialL1BaseFee:      big.NewInt(1000000000),
-		ChainConfig:           &chainConfig,
-		SerializedChainConfig: serializedChainConfig,
+		ChainId:          chainConfig.ChainID,
+		InitialL1BaseFee: big.NewInt(1000000000),
+		ChainConfig:      &chainConfig,
 	}
 
 	genesisBlock := generateGenesisBlock(

--- a/system_tests/state_fuzz_test.go
+++ b/system_tests/state_fuzz_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -142,15 +141,10 @@ func FuzzStateTransition(f *testing.F) {
 		}
 		chainDb := rawdb.NewMemoryDatabase()
 		chainConfig := chaininfo.ArbitrumDevTestChainConfig()
-		serializedChainConfig, err := json.Marshal(chainConfig)
-		if err != nil {
-			panic(err)
-		}
 		initMessage := &arbostypes.ParsedInitMessage{
-			ChainId:               chainConfig.ChainID,
-			InitialL1BaseFee:      arbostypes.DefaultInitialL1BaseFee,
-			ChainConfig:           chainConfig,
-			SerializedChainConfig: serializedChainConfig,
+			ChainId:          chainConfig.ChainID,
+			InitialL1BaseFee: arbostypes.DefaultInitialL1BaseFee,
+			ChainConfig:      chainConfig,
 		}
 		options := core.DefaultConfig().WithStateScheme(env.GetTestStateScheme())
 		stateRoot, err := arbosState.InitializeArbosInDatabase(


### PR DESCRIPTION
# Problem

Since we write the serialization bytes directly to the initial storage: https://github.com/OffchainLabs/nitro/blob/master/arbos/arbosState/arbosstate.go#L242, two different, but equivalent serializations of the chain config yield different genesis blocks.

# Proposed solution

Just before the storage write, we reserialize the config. Since `json.Marshall` is deterministic, it will always result in a unified serialization. In case we get different bytes than the ones passed in the init message, we log a warning.

With this we no longer need the serialized version of chain config in the init message - field removed.

We also revert https://github.com/OffchainLabs/nitro/pull/3636 (introducing this 'problem' also to out cmd).

# Potential problems

This is not backwards compatible and might break recomputing existing deployments.
