### PR TITLE
Optimize Rust caching for CI using Swatinem/rust-cache

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -32,6 +32,16 @@ runs:
       id: install-rust
       uses: ./.github/actions/install-rust
 
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: "true"
+        workspaces: "arbitrator"
+        cache-directories: |
+          arbitrator/wasm-libraries/target/
+          arbitrator/wasm-libraries/soft-float/
+          target/
+
     - name: Setup Foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
@@ -47,18 +57,6 @@ runs:
       with:
         path: ~/.cache/go-build
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-
-    - name: Cache Rust build
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/
-          arbitrator/target/
-          arbitrator/wasm-libraries/target/
-          arbitrator/wasm-libraries/soft-float/
-          target/etc/initial-machine-cache/
-          /home/runner/.rustup/toolchains/
-        key: ${{ runner.os }}-cargo-${{ steps.install-rust.outputs.version }}-${{ hashFiles('arbitrator/Cargo.lock') }}
 
     - name: Cache cbrotli
       id: cache-cbrotli


### PR DESCRIPTION
Resolves NIT-3887

If we look at the CI from my other PR https://github.com/OffchainLabs/nitro/pull/4044

<img width="1281" height="69" alt="image" src="https://github.com/user-attachments/assets/252ff44f-2832-4430-9aa1-8f9b4f7e22be" />
<img width="1281" height="69" alt="image" src="https://github.com/user-attachments/assets/424abbff-d0f4-4ce5-aec0-fda5098b0b0b" />
<img width="1281" height="69" alt="image" src="https://github.com/user-attachments/assets/adaf1372-0a3c-45eb-9cce-2f73e345ca99" />
<img width="1281" height="69" alt="image" src="https://github.com/user-attachments/assets/561ae4ba-7bb2-4f6a-8dbf-b393f33e7cf4" />
<img width="1281" height="69" alt="image" src="https://github.com/user-attachments/assets/c8ecca1c-8378-47e9-b73f-287613ac936a" />
etc



On runs on this PR I get ^

On other PR's when I rerun CI I get 3 minute build times https://github.com/OffchainLabs/nitro/actions/runs/19184038879/job/54864755393 which seems to indicate the cache works within the same PR, but not across PR's which is a problem. The first build is slow, but with a build cache the first build in each PR shouldn't be slow