### PR TITLE
Bug-fix: identify already exists errors correctly while creating assertions

### DIFF
--- a/bold/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/bold/chain-abstraction/sol-implementation/assertion_chain.go
@@ -661,7 +661,7 @@ func (a *AssertionChain) createAndStakeOnAssertion(
 	})
 	opts := a.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx})
 	if createErr := handleCreateAssertionError(err, postState.GlobalState.BlockHash); createErr != nil {
-		if strings.Contains(err.Error(), "already exists") {
+		if strings.Contains(createErr.Error(), "already exists") {
 			assertionItem, err2 := a.GetAssertion(ctx, opts, protocol.AssertionHash{Hash: computedHash})
 			if err2 != nil {
 				return nil, err2


### PR DESCRIPTION
This PR fixes a bug where previously the errors while creating assertions were handled via `handleCreateAssertionError` but then checked for `already exists` string against `err` instead of `createErr`, thus missing them and ultimately leading to incorrect numbers in metrics- `arb_validator_poster_assertion_posted`, as we only increment this metric after successfully creating an assertion. 

eg: Assertions [on etherscan](https://etherscan.io/address/0x4DCeB440657f21083db8aDd07665f8ddBe1DCfc0#events) don't seem to match [nitro metrics](https://grafana.sso.arbitrum.io/goto/2LNEaW6NR?orgId=1)

Resolves NIT-4001