### PR TITLE
Fix broadcast client shutdown deadlock

### DIFF
--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -196,7 +196,10 @@ func (bc *BroadcastClient) Start(ctxIn context.Context) {
 				errors.Is(err, ErrIncorrectChainId) ||
 				errors.Is(err, ErrMissingFeedServerVersion) ||
 				errors.Is(err, ErrIncorrectFeedServerVersion) {
-				bc.fatalErrChan <- fmt.Errorf("failed connecting to server feed due to %w", err)
+				select {
+				case bc.fatalErrChan <- fmt.Errorf("failed connecting to server feed due to %w", err):
+				case <-ctx.Done():
+				}
 				return
 			}
 			if err == nil {
@@ -491,7 +494,11 @@ func (bc *BroadcastClient) startBackgroundReader(earlyFrameData io.Reader) {
 						}
 					}
 					if res.ConfirmedSequenceNumberMessage != nil && bc.confirmedSequenceNumberListener != nil {
-						bc.confirmedSequenceNumberListener <- res.ConfirmedSequenceNumberMessage.SequenceNumber
+						select {
+						case bc.confirmedSequenceNumberListener <- res.ConfirmedSequenceNumberMessage.SequenceNumber:
+						case <-ctx.Done():
+							return
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Add context-aware escape hatches to channel sends in broadcast client to prevent goroutines from blocking indefinitely during shutdown. When the context is cancelled, goroutines can now exit cleanly instead of waiting forever on full channel buffers that will never be drained.

This should fix https://github.com/OffchainLabs/nitro/issues/3850