### PR TITLE
fix: add defer file.Close() to prevent resource leak in saveBlobDataToDisk

### DIFF
--- a/util/headerreader/blob_client.go
+++ b/util/headerreader/blob_client.go
@@ -373,6 +373,7 @@ func saveBlobDataToDisk(rawData json.RawMessage, slot uint64, blobDirectory stri
 	if err != nil {
 		return fmt.Errorf("could not create file to store fetched blobs")
 	}
+	defer file.Close()
 	full := fullResult[json.RawMessage]{Data: rawData}
 	fullbytes, err := json.Marshal(full)
 	if err != nil {
@@ -381,7 +382,6 @@ func saveBlobDataToDisk(rawData json.RawMessage, slot uint64, blobDirectory stri
 	if _, err := file.Write(fullbytes); err != nil {
 		return fmt.Errorf("failed to write blob data to disk")
 	}
-	file.Close()
 	return nil
 }
 


### PR DESCRIPTION
Fixed potential file descriptor leak when file.Write() fails. The file.Close() call was unreachable after error returns, potentially causing "too many open files" errors over time.

Added defer file.Close() immediately after file creation to guarantee cleanup regardless of function exit path.

Reference: https://go.dev/doc/effective_go#defer