### PR TITLE
Replace ArbosVersion field in feed with ArbosVersionBefore

### DIFF
--- a/arbos/arbostypes/messagewithmeta.go
+++ b/arbos/arbostypes/messagewithmeta.go
@@ -21,10 +21,10 @@ type MessageWithMetadata struct {
 
 // lint:require-exhaustive-initialization
 type MessageWithMetadataAndBlockInfo struct {
-	MessageWithMeta MessageWithMetadata
-	BlockHash       *common.Hash
-	BlockMetadata   common.BlockMetadata
-	ArbOSVersion    uint64
+	MessageWithMeta    MessageWithMetadata
+	BlockHash          *common.Hash
+	BlockMetadata      common.BlockMetadata
+	ArbOSVersionBefore uint64
 }
 
 var EmptyTestMessageWithMetadata = MessageWithMetadata{

--- a/broadcastclient/broadcastclient_test.go
+++ b/broadcastclient/broadcastclient_test.go
@@ -53,10 +53,10 @@ func TestReceiveMessages(t *testing.T) {
 
 func testMessage() arbostypes.MessageWithMetadataAndBlockInfo {
 	return arbostypes.MessageWithMetadataAndBlockInfo{
-		MessageWithMeta: arbostypes.TestMessageWithMetadataAndRequestId,
-		BlockHash:       nil,
-		BlockMetadata:   nil,
-		ArbOSVersion:    0,
+		MessageWithMeta:    arbostypes.TestMessageWithMetadataAndRequestId,
+		BlockHash:          nil,
+		BlockMetadata:      nil,
+		ArbOSVersionBefore: 0,
 	}
 }
 

--- a/broadcastclients/broadcastclients_test.go
+++ b/broadcastclients/broadcastclients_test.go
@@ -49,10 +49,10 @@ func (ts *MockTransactionStreamer) AddBroadcastMessages(feedMessages []*message.
 
 func testMessage() arbostypes.MessageWithMetadataAndBlockInfo {
 	return arbostypes.MessageWithMetadataAndBlockInfo{
-		MessageWithMeta: arbostypes.EmptyTestMessageWithMetadata,
-		BlockHash:       nil,
-		BlockMetadata:   nil,
-		ArbOSVersion:    0,
+		MessageWithMeta:    arbostypes.EmptyTestMessageWithMetadata,
+		BlockHash:          nil,
+		BlockMetadata:      nil,
+		ArbOSVersionBefore: 0,
 	}
 }
 

--- a/broadcaster/broadcaster.go
+++ b/broadcaster/broadcaster.go
@@ -44,7 +44,7 @@ func (b *Broadcaster) NewBroadcastFeedMessage(
 	sequenceNumber arbutil.MessageIndex,
 ) (*m.BroadcastFeedMessage, error) {
 	message := messageWithInfo.MessageWithMeta
-	if messageWithInfo.ArbOSVersion < params.ArbosVersion_50 && message.Message != nil {
+	if messageWithInfo.ArbOSVersionBefore < params.ArbosVersion_50 && message.Message != nil {
 		message.Message.BatchDataStats = nil
 	}
 
@@ -61,12 +61,12 @@ func (b *Broadcaster) NewBroadcastFeedMessage(
 	}
 
 	return &m.BroadcastFeedMessage{
-		SequenceNumber: sequenceNumber,
-		Message:        message,
-		BlockHash:      messageWithInfo.BlockHash,
-		Signature:      messageSignature,
-		BlockMetadata:  messageWithInfo.BlockMetadata,
-		ArbOSVersion:   messageWithInfo.ArbOSVersion,
+		SequenceNumber:     sequenceNumber,
+		Message:            message,
+		BlockHash:          messageWithInfo.BlockHash,
+		Signature:          messageSignature,
+		BlockMetadata:      messageWithInfo.BlockMetadata,
+		ArbOSVersionBefore: messageWithInfo.ArbOSVersionBefore,
 	}, nil
 }
 

--- a/broadcaster/broadcaster_test.go
+++ b/broadcaster/broadcaster_test.go
@@ -63,10 +63,10 @@ func (p *messageCountPredicate) Error() string {
 
 func testMessage() arbostypes.MessageWithMetadataAndBlockInfo {
 	return arbostypes.MessageWithMetadataAndBlockInfo{
-		MessageWithMeta: arbostypes.EmptyTestMessageWithMetadata,
-		BlockHash:       nil,
-		BlockMetadata:   nil,
-		ArbOSVersion:    0,
+		MessageWithMeta:    arbostypes.EmptyTestMessageWithMetadata,
+		BlockHash:          nil,
+		BlockMetadata:      nil,
+		ArbOSVersionBefore: 0,
 	}
 }
 
@@ -132,14 +132,14 @@ func TestBatchDataStatsIsIncludedBasedOnArbOSVersion(t *testing.T) {
 	message.MessageWithMeta.Message.BatchDataStats = batchDataStats
 
 	// For ArbOS versions >= 50, BatchDataStats should be preserved
-	message.ArbOSVersion = params.ArbosVersion_50
+	message.ArbOSVersionBefore = params.ArbosVersion_50
 	feedMsg, err := b.NewBroadcastFeedMessage(message, sequenceNumber)
 	Require(t, err)
 	require.Equal(t, batchDataStats, feedMsg.Message.Message.BatchDataStats)
 	require.Equal(t, signMessage(t, message, sequenceNumber, signer), feedMsg.Signature)
 
 	// For ArbOS versions < 50, BatchDataStats should be nil
-	message.ArbOSVersion = params.ArbosVersion_41
+	message.ArbOSVersionBefore = params.ArbosVersion_41
 	feedMsg, err = b.NewBroadcastFeedMessage(message, sequenceNumber)
 	Require(t, err)
 	require.Nil(t, feedMsg.Message.Message.BatchDataStats)

--- a/broadcaster/message/message.go
+++ b/broadcaster/message/message.go
@@ -34,12 +34,12 @@ type BroadcastMessage struct {
 }
 
 type BroadcastFeedMessage struct {
-	SequenceNumber arbutil.MessageIndex           `json:"sequenceNumber"`
-	Message        arbostypes.MessageWithMetadata `json:"message"`
-	BlockHash      *common.Hash                   `json:"blockHash,omitempty"`
-	Signature      []byte                         `json:"signature"`
-	BlockMetadata  common.BlockMetadata           `json:"blockMetadata,omitempty"`
-	ArbOSVersion   uint64                         `json:"arbOSVersion,omitempty"`
+	SequenceNumber     arbutil.MessageIndex           `json:"sequenceNumber"`
+	Message            arbostypes.MessageWithMetadata `json:"message"`
+	BlockHash          *common.Hash                   `json:"blockHash,omitempty"`
+	Signature          []byte                         `json:"signature"`
+	BlockMetadata      common.BlockMetadata           `json:"blockMetadata,omitempty"`
+	ArbOSVersionBefore uint64                         `json:"arbOSVersionBefore,omitempty"`
 
 	CumulativeSumMsgSize uint64 `json:"-"`
 }

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -646,10 +646,10 @@ func (s *ExecutionEngine) sequenceTransactionsWithBlockMutex(header *arbostypes.
 	blockMetadata := s.blockMetadataFromBlock(block, timeboostedTxs)
 
 	msgWithInfo := arbostypes.MessageWithMetadataAndBlockInfo{
-		MessageWithMeta: msgWithMeta,
-		BlockHash:       &msgResult.BlockHash,
-		BlockMetadata:   blockMetadata,
-		ArbOSVersion:    types.DeserializeHeaderExtraInformation(block.Header()).ArbOSFormatVersion,
+		MessageWithMeta:    msgWithMeta,
+		BlockHash:          &msgResult.BlockHash,
+		BlockMetadata:      blockMetadata,
+		ArbOSVersionBefore: types.DeserializeHeaderExtraInformation(lastBlockHeader).ArbOSFormatVersion,
 	}
 
 	_, err = s.consensus.WriteMessageFromSequencer(msgIdx, msgWithInfo).Await(s.GetContext())
@@ -732,10 +732,10 @@ func (s *ExecutionEngine) sequenceDelayedMessageWithBlockMutex(message *arbostyp
 	}
 
 	msgWithInfo := arbostypes.MessageWithMetadataAndBlockInfo{
-		MessageWithMeta: messageWithMeta,
-		BlockHash:       &msgResult.BlockHash,
-		BlockMetadata:   s.blockMetadataFromBlock(block, nil),
-		ArbOSVersion:    types.DeserializeHeaderExtraInformation(block.Header()).ArbOSFormatVersion,
+		MessageWithMeta:    messageWithMeta,
+		BlockHash:          &msgResult.BlockHash,
+		BlockMetadata:      s.blockMetadataFromBlock(block, nil),
+		ArbOSVersionBefore: types.DeserializeHeaderExtraInformation(currentHeader).ArbOSFormatVersion,
 	}
 
 	_, err = s.consensus.WriteMessageFromSequencer(msgIdx, msgWithInfo).Await(s.GetContext())


### PR DESCRIPTION
In this PR we fix an issue introduced in https://github.com/OffchainLabs/nitro/pull/3853 where we populate the feed with a new field- `ArbosVersion` but this cannot be calculated in `getMessageWithMetadataAndBlockInfo` before we execute the current block thus causing a lot of spam warnings! Hence its logically sound to instead replace it with `ArbosVersionBefore`

Resolves NIT-4035