### PR TITLE
Fix panic in limitedMarshal.String() for small ArgLogLimit values

### DIFF
--- a/util/rpcclient/rpcclient.go
+++ b/util/rpcclient/rpcclient.go
@@ -116,10 +116,13 @@ func (m limitedMarshal) String() string {
 	}
 	// #nosec G115
 	limit := int(m.limit)
-	if m.limit <= 0 || len(str) <= limit {
+	if limit <= 0 || len(str) <= limit {
 		return str
 	}
-	prefix := str[:m.limit/2-1]
+	if limit < 4 {
+		return str[:limit]
+	}
+	prefix := str[:limit/2-1]
 	postfix := str[len(str)-limit/2+1:]
 	return fmt.Sprintf("%v..%v", prefix, postfix)
 }


### PR DESCRIPTION

### Problem
The `limitedMarshal.String()` method in `util/rpcclient/rpcclient.go` can panic when `ArgLogLimit` is set to small values (1-3). The expression `limit/2-1` becomes negative, causing a slice bounds panic when accessing `str[:limit/2-1]`.

### Solution
Added a guard clause to handle small limit values by returning a simple prefix truncation instead of the complex prefix/postfix logic.

