### PR TITLE
remove lock when setting finality data

### DIFF
--- a/execution/gethexec/sync_monitor.go
+++ b/execution/gethexec/sync_monitor.go
@@ -277,9 +277,6 @@ func (s *SyncMonitor) SetFinalityData(
 	finalizedFinalityData *arbutil.FinalityData,
 	validatedFinalityData *arbutil.FinalityData,
 ) error {
-	s.exec.createBlocksMutex.Lock()
-	defer s.exec.createBlocksMutex.Unlock()
-
 	finalizedBlockHeader, err := s.getFinalityBlockHeader(
 		s.config.FinalizedBlockWaitForBlockValidator,
 		validatedFinalityData,


### PR DESCRIPTION
fixes: nit-4046
fixes: nit-3498

lock is not needed as blockhash is anyway included so it cannot be reorged