### PR TITLE
Make TestEthSyncing not flaky

### DIFF
--- a/arbnode/consensus_execution_syncer.go
+++ b/arbnode/consensus_execution_syncer.go
@@ -28,6 +28,10 @@ var DefaultConsensusExecutionSyncerConfig = ConsensusExecutionSyncerConfig{
 	SyncInterval: 300 * time.Millisecond,
 }
 
+var TestConsensusExecutionSyncerConfig = ConsensusExecutionSyncerConfig{
+	SyncInterval: TestSyncMonitorConfig.MsgLag / 2,
+}
+
 // We don't define a Test config. For most tests we want the Syncer to behave
 // the same as in production.
 

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -208,6 +208,7 @@ func ConfigDefaultL1NonSequencerTest() *Config {
 	config.SeqCoordinator.Enable = false
 	config.BlockValidator = staker.TestBlockValidatorConfig
 	config.SyncMonitor = TestSyncMonitorConfig
+	config.ConsensusExecutionSyncer = TestConsensusExecutionSyncerConfig
 	config.Staker = legacystaker.TestL1ValidatorConfig
 	config.Staker.Enable = false
 	config.BlockValidator.ValidationServerConfigs = []rpcclient.ClientConfig{{URL: ""}}
@@ -227,6 +228,7 @@ func ConfigDefaultL2Test() *Config {
 	config.SeqCoordinator.Signer.ECDSA.Dangerous.AcceptMissing = true
 	config.Staker = legacystaker.TestL1ValidatorConfig
 	config.SyncMonitor = TestSyncMonitorConfig
+	config.ConsensusExecutionSyncer = TestConsensusExecutionSyncerConfig
 	config.Staker.Enable = false
 	config.BlockValidator.ValidationServerConfigs = []rpcclient.ClientConfig{{URL: ""}}
 	config.TransactionStreamer = DefaultTransactionStreamerConfig


### PR DESCRIPTION
This PR fixes an issue in `TestEthSyncing` where previously it was flaky due to how `SyncProgress` was tested, i.e the `ConsensusExecutionSyncer`'s SyncInterval was 300 milliseconds where as the consensus sync monitor's MsgLag was 10 milliseconds, meaning some times execution (where the `SyncProgress` call is answered) didn't timely receive the updates from `ConsensusExecutionSyncer` thus causing the flakiness. We fix it by making `SyncInterval` in tests default to half of `MsgLag` and also increase the number of txs from 1 to 5 so that execution's syncMonitor doesn't return synced as true incorrectly. because we return [built+1 >= syncTarget](https://github.com/OffchainLabs/nitro/blob/56f5c6de4c81b0c57123ed0956b5ecdf69d0057b/execution/gethexec/sync_monitor.go#L216) and this can be misleading when only one consensus is not synced with execution by the first tx!

Resolves NIT-4000