### PR TITLE
Port - remove lock when setting finality data (#3916)

### DIFF
--- a/execution/gethexec/sync_monitor.go
+++ b/execution/gethexec/sync_monitor.go
@@ -278,9 +278,6 @@ func (s *SyncMonitor) SetFinalityData(
 	finalizedFinalityData *arbutil.FinalityData,
 	validatedFinalityData *arbutil.FinalityData,
 ) error {
-	s.exec.createBlocksMutex.Lock()
-	defer s.exec.createBlocksMutex.Unlock()
-
 	finalizedBlockHeader, err := s.getFinalityBlockHeader(
 		s.config.FinalizedBlockWaitForBlockValidator,
 		validatedFinalityData,


### PR DESCRIPTION
backport #3916

lock is not needed as blockhash is anyway included so it cannot be reorged