### PR TITLE
Fix ValidationInput exhaustive initialization

### DIFF
--- a/system_tests/validation_mock_test.go
+++ b/system_tests/validation_mock_test.go
@@ -238,10 +238,17 @@ func TestValidationServerAPI(t *testing.T) {
 	}
 
 	valInput := validator.ValidationInput{
-		StartState: startState,
+		Id:            0,
+		HasDelayedMsg: false,
+		DelayedMsgNr:  0,
 		Preimages: daprovider.PreimagesMap{
 			arbutil.Keccak256PreimageType: globalstateToTestPreimages(endState),
 		},
+		UserWasms:  make(map[rawdb.WasmTarget]map[common.Hash][]byte),
+		BatchInfo:  []validator.BatchInfo{},
+		DelayedMsg: []byte{},
+		StartState: startState,
+		DebugChain: false,
 	}
 	valRun := client.Launch(&valInput, mockWasmModuleRoots[0])
 	res, err := valRun.Await(ctx)
@@ -300,10 +307,17 @@ func TestValidationClientRoom(t *testing.T) {
 	}
 
 	valInput := validator.ValidationInput{
-		StartState: startState,
+		Id:            0,
+		HasDelayedMsg: false,
+		DelayedMsgNr:  0,
 		Preimages: daprovider.PreimagesMap{
 			arbutil.Keccak256PreimageType: globalstateToTestPreimages(endState),
 		},
+		UserWasms:  make(map[rawdb.WasmTarget]map[common.Hash][]byte),
+		BatchInfo:  []validator.BatchInfo{},
+		DelayedMsg: []byte{},
+		StartState: startState,
+		DebugChain: false,
 	}
 
 	valRuns := make([]validator.ValidationRun, 0, 4)
@@ -365,7 +379,17 @@ func TestExecutionKeepAlive(t *testing.T) {
 	err = clientShortTO.Start(ctx)
 	Require(t, err)
 
-	valInput := validator.ValidationInput{}
+	valInput := validator.ValidationInput{
+		Id:            0,
+		HasDelayedMsg: false,
+		DelayedMsgNr:  0,
+		Preimages:     daprovider.PreimagesMap{},
+		UserWasms:     make(map[rawdb.WasmTarget]map[common.Hash][]byte),
+		BatchInfo:     []validator.BatchInfo{},
+		DelayedMsg:    []byte{},
+		StartState:    validator.GoGlobalState{},
+		DebugChain:    false,
+	}
 	runDefault, err := clientDefault.CreateExecutionRun(mockWasmModuleRoots[0], &valInput, false).Await(ctx)
 	Require(t, err)
 	runShortTO, err := clientShortTO.CreateExecutionRun(mockWasmModuleRoots[0], &valInput, false).Await(ctx)

--- a/validator/server_api/json.go
+++ b/validator/server_api/json.go
@@ -128,6 +128,8 @@ func ValidationInputFromJson(entry *InputJSON) (*validator.ValidationInput, erro
 		StartState:    entry.StartState,
 		Preimages:     preimages,
 		UserWasms:     make(map[rawdb.WasmTarget]map[common.Hash][]byte),
+		BatchInfo:     nil,
+		DelayedMsg:    nil,
 		DebugChain:    entry.DebugChain,
 	}
 	delayed, err := base64.StdEncoding.DecodeString(entry.DelayedMsgB64)

--- a/validator/validation_entry.go
+++ b/validator/validation_entry.go
@@ -12,6 +12,7 @@ type BatchInfo struct {
 	Data   []byte
 }
 
+// lint:require-exhaustive-initialization
 type ValidationInput struct {
 	Id            uint64
 	HasDelayedMsg bool


### PR DESCRIPTION
Per maintainer feedback on PR #3923, this fixes ValidationInput to use exhaustive initialization.

All 4 ValidationInput initializations now explicitly initialize all 9 fields:
- system_tests/validation_mock_test.go (3 initializations)
- validator/server_api/json.go (1 initialization)

This is 1 of 16 structs from the original PR, addressing them incrementally as recommended.

Addresses #3121