### PR TITLE
Remove unused Debug import from arbutil operator module

### DIFF
--- a/arbitrator/arbutil/src/operator.rs
+++ b/arbitrator/arbutil/src/operator.rs
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
 
 use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 use wasmparser::Operator;
 


### PR DESCRIPTION
cleaned up arbitrator/arbutil/src/operator.rs by removing the unused std::fmt::Debug import
eliminates unnecessary compiler noise while keeping the module behavior unchanged