### PR TITLE
Remove Unused Hash Import from Operator Module

### DIFF
--- a/arbitrator/arbutil/src/operator.rs
+++ b/arbitrator/arbutil/src/operator.rs
@@ -3,7 +3,6 @@
 
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
-use std::hash::Hash;
 use wasmparser::Operator;
 
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]


### PR DESCRIPTION
Drop the unused std::hash::Hash import from arbitrator/arbutil/src/operator.rs
Keep imports limited to what the module actually references, silencing the unused import warning and tightening the module’s surface area