### PR TITLE
Avoid Cloning Revert Payload in UserOutcome Display

### DIFF
--- a/arbitrator/arbutil/src/evm/user.rs
+++ b/arbitrator/arbutil/src/evm/user.rs
@@ -69,7 +69,10 @@ impl Display for UserOutcome {
             OutOfInk => write!(f, "out of ink"),
             OutOfStack => write!(f, "out of stack"),
             Revert(data) => {
-                let text = String::from_utf8(data.clone()).unwrap_or_else(|_| hex::encode(data));
+                let text = match std::str::from_utf8(data) {
+                    Ok(s) => s.to_owned(),
+                    Err(_) => hex::encode(data),
+                };
                 write!(f, "revert {text}")
             }
         }


### PR DESCRIPTION
remove the data.clone() allocation in Display for UserOutcome::Revert decode the byte slice directly as UTF-8, or fall back to hex::encode on error preserve existing output while skipping an unnecessary heap clone