### PR TITLE
Separate batch write and stream to avoid node halt edge case

### DIFF
--- a/arbnode/delayed_seq_reorg_test.go
+++ b/arbnode/delayed_seq_reorg_test.go
@@ -64,7 +64,7 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 			},
 		},
 	}
-	err = tracker.AddDelayedMessages([]*DelayedInboxMessage{initMsgDelayed, userDelayed, userDelayed2})
+	_, _, err = tracker.AddDelayedMessages([]*DelayedInboxMessage{initMsgDelayed, userDelayed, userDelayed2})
 	Require(t, err)
 
 	serializedInitMsgBatch := make([]byte, 40)
@@ -149,7 +149,10 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 			},
 		},
 	}
-	err = tracker.AddDelayedMessages([]*DelayedInboxMessage{userDelayedModified})
+	batch, prevMessageCount, err := tracker.AddDelayedMessages([]*DelayedInboxMessage{userDelayedModified})
+	Require(t, err)
+
+	err = tracker.ReorgAtAndEndBatch(batch, prevMessageCount)
 	Require(t, err)
 
 	// userMsgBatch, and emptyBatch will be reorged out
@@ -264,7 +267,7 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 			},
 		},
 	}
-	err = tracker.AddDelayedMessages([]*DelayedInboxMessage{initMsgDelayed, userDelayed, userDelayed2})
+	_, _, err = tracker.AddDelayedMessages([]*DelayedInboxMessage{initMsgDelayed, userDelayed, userDelayed2})
 	Require(t, err)
 
 	serializedInitMsgBatch := make([]byte, 40)
@@ -350,7 +353,7 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 			},
 		},
 	}
-	err = tracker.AddDelayedMessages([]*DelayedInboxMessage{userDelayed2, userDelayed3})
+	_, _, err = tracker.AddDelayedMessages([]*DelayedInboxMessage{userDelayed2, userDelayed3})
 	Require(t, err)
 
 	msgCount, err = streamer.GetMessageCount()
@@ -380,7 +383,10 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 			},
 		},
 	}
-	err = tracker.AddDelayedMessages([]*DelayedInboxMessage{userDelayed2Modified})
+	batch, prevMessageCount, err := tracker.AddDelayedMessages([]*DelayedInboxMessage{userDelayed2Modified})
+	Require(t, err)
+
+	err = tracker.ReorgAtAndEndBatch(batch, prevMessageCount)
 	Require(t, err)
 
 	msgCount, err = streamer.GetMessageCount()

--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -50,9 +50,10 @@ type SequencerMessage struct {
 const MaxDecompressedLen int = 1024 * 1024 * 16 // 16 MiB
 const maxZeroheavyDecompressedLen = 101*MaxDecompressedLen/100 + 64
 const MaxSegmentsPerSequencerMessage = 100 * 1024
+const L1HeaderSize = 40
 
 func ParseSequencerMessage(ctx context.Context, batchNum uint64, batchBlockHash common.Hash, data []byte, dapReaders *daprovider.ReaderRegistry, keysetValidationMode daprovider.KeysetValidationMode) (*SequencerMessage, error) {
-	if len(data) < 40 {
+	if len(data) < L1HeaderSize {
 		return nil, errors.New("sequencer message missing L1 header")
 	}
 	parsedMsg := &SequencerMessage{
@@ -63,7 +64,7 @@ func ParseSequencerMessage(ctx context.Context, batchNum uint64, batchBlockHash 
 		AfterDelayedMessages: binary.BigEndian.Uint64(data[32:40]),
 		Segments:             [][]byte{},
 	}
-	payload := data[40:]
+	payload := data[L1HeaderSize:]
 
 	// Stage 0: Check if our node is out of date and we don't understand this batch type
 	// If the parent chain sequencer inbox smart contract authenticated this batch,


### PR DESCRIPTION
Fixes [NIT-4065](https://linear.app/offchain-labs/issue/NIT-4065/dont-read-a-batch-posting-report-if-you-cannot-read-the-batch-posted)

The first solution attempt to fix the issue was to swap `AddDelayedMessages`  with `AddSequencerBatches` calls inside `addMessages`. But by doing so `InboxReader` thinks we we need to reorg due to `delayedMessagesMismatch`  and such check happens [here](https://github.com/OffchainLabs/nitro/blob/master/arbnode/inbox_tracker.go#L745-L754): it can't find the first batch (idx `0`) accumulator. To be more specific we try to find an entry in the DB with key `rlpDelayedMessagePrefix + seqNum`  but it fails to do so. The one responsible for creating such entry is `AddDelayedMessages` [here](https://github.com/OffchainLabs/nitro/blob/master/arbnode/inbox_tracker.go#L513-L521) which is why just swapping those 2 calls won't cut it. Then I had an idea, this PR, in an attempt to "force" the issue, I tried separating the steps of batch writing and batch streaming into 2 functions so instead of having:
```go
AddDelayedMessages
>>> write batch to DB
>>> stream batch
AddSequencerBatches
```
we would have:
```go
AddDelayedMessages
>>> write batch to DB
AddSequencerBatches
>>> stream batch
```
So [here](https://github.com/OffchainLabs/nitro/blob/master/arbnode/inbox_tracker.go#L626-L628), instead of returning `ReorgAtAndEndBatch` we return `batch` and `prevMessageCount` and "defer" that call to after `AddSequencerBatches` call, becoming something like:
```go
batch, prevMessageCount, err := r.tracker.AddDelayedMessages(delayedMessages)
err = r.tracker.AddSequencerBatches(ctx, r.client, sequencerBatches)
err = r.tracker.ReorgAtAndEndBatch(batch, prevMessageCount) // << calls `txStreamer.ReorgAtAndEndBatch`
```
so even though we didn't swap `AddDelayedMessages`  with `AddSequencerBatches`  if blobs or batch metadata read fails then we never stream the batches, and that fixed the above test at least. Looking at the rest of the code I think that's okay as I couldn't find any other assumptions about `AddSequencerBatches` being the one responsible for streaming the batches; now, if `AddSequencerBatches` return `batches == nil` then we never do.