### PR TITLE
Add cmd-line tool to simulate the l2pricing model

### DIFF
--- a/cmd/l2pricing-simulator/config.go
+++ b/cmd/l2pricing-simulator/config.go
@@ -1,0 +1,161 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/pflag"
+
+	"github.com/offchainlabs/nitro/arbos/l2pricing"
+	"github.com/offchainlabs/nitro/util/arbmath"
+)
+
+type Config interface {
+	AddFlags(*pflag.FlagSet)
+	Validate() error
+	Print(io.Writer)
+	ShouldExportCSV() bool
+	ShouldPrintLine(int) bool
+}
+
+func ParseConfig(config Config, args []string) error {
+	flags := pflag.NewFlagSet("l2pricing-simulator", pflag.ExitOnError)
+	config.AddFlags(flags)
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if err := config.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+type CommonConfig struct {
+	Verbose             bool
+	ExportCSV           bool
+	SequencerThroughput uint64
+	SurgeDemand         uint64
+	SurgeDuration       uint64
+	SurgeRamp           uint64
+}
+
+func (c *CommonConfig) AddFlags(flags *pflag.FlagSet) {
+	flags.BoolVarP(&c.Verbose, "verbose", "v", false, "If set, print all data points")
+	flags.BoolVar(&c.ExportCSV, "export-csv", false, "If set, print the output as csv")
+	flags.Uint64Var(&c.SequencerThroughput, "sequencer-throughput", 128_000_000, "Max sequencer throughput per second")
+	flags.Uint64Var(&c.SurgeDemand, "surge-gas", 200_000_000, "Amount of gas added to the backlog during peak surge")
+	flags.Uint64Var(&c.SurgeDuration, "surge-duration", 30, "Surge peak duration in seconds")
+	flags.Uint64Var(&c.SurgeRamp, "surge-ramp", 10, "Number of seconds surge takes to reach its peak")
+}
+
+func (c *CommonConfig) Print(w io.Writer) {
+	fmt.Fprintln(w, "Verbose:\t", c.Verbose)
+	fmt.Fprintln(w, "Sequencer Throughput:\t", toPrettyUint(c.SequencerThroughput))
+	fmt.Fprintln(w, "Surge demand:\t", toPrettyUint(c.SurgeDemand))
+	fmt.Fprintln(w, "Surge duration:\t", toPrettyUint(c.SurgeDuration))
+	fmt.Fprintln(w, "Surge ramp:\t", toPrettyUint(c.SurgeRamp))
+}
+
+func (c *CommonConfig) ShouldExportCSV() bool {
+	return c.ExportCSV
+}
+
+func (c *CommonConfig) Validate() error {
+	return nil
+}
+
+func (c *CommonConfig) Iterations() uint64 {
+	return c.SurgeDuration*2 + c.SurgeRamp*2 + 1
+}
+
+func (c *CommonConfig) ShouldPrintLine(i int) bool {
+	return c.Verbose || arbmath.SaturatingUCast[uint64](i)%(c.Iterations()/10) == 0
+}
+
+type LegacyConfig struct {
+	CommonConfig
+	InitialBacklog   uint64
+	SpeedLimit       uint64
+	Inertia          uint64
+	BacklogTolerance uint64
+}
+
+func (c *LegacyConfig) AddFlags(flags *pflag.FlagSet) {
+	c.CommonConfig.AddFlags(flags)
+	flags.Uint64Var(&c.InitialBacklog, "initial-backlog", 0, "Initial backlog")
+	flags.Uint64Var(&c.SpeedLimit, "speed-limit", l2pricing.InitialSpeedLimitPerSecondV6, "Speed limit per second")
+	flags.Uint64Var(&c.Inertia, "inertia", l2pricing.InitialPricingInertia, "Inertia")
+	flags.Uint64Var(&c.BacklogTolerance, "backlog-tolerance", l2pricing.InitialBacklogTolerance, "Backlog tolerance")
+}
+
+func (c *LegacyConfig) Print(w io.Writer) {
+	c.CommonConfig.Print(w)
+	fmt.Fprintln(w, "Initial backlog:\t", toPrettyUint(c.InitialBacklog))
+	fmt.Fprintln(w, "Speed limit:\t", toPrettyUint(c.SpeedLimit))
+	fmt.Fprintln(w, "Inertia:\t", c.Inertia)
+	fmt.Fprintln(w, "Backlog tolerance:\t", c.BacklogTolerance)
+}
+
+type ConstraintsConfig struct {
+	CommonConfig
+	Targets  []int64
+	Windows  []int64
+	Backlogs []int64
+}
+
+var DefaultConstraintConfig = ConstraintsConfig{
+	Targets: []int64{60_000_000, 41_000_000, 29_000_000, 20_000_000, 14_000_000, 10_000_000},
+	Windows: []int64{9, 52, 329, 2_105, 13_485, 86_400},
+}
+
+func (c *ConstraintsConfig) AddFlags(flags *pflag.FlagSet) {
+	c.CommonConfig.AddFlags(flags)
+	flags.Int64SliceVar(&c.Targets, "targets", DefaultConstraintConfig.Targets, "List of constraints' targets; previously speed-limit")
+	flags.Int64SliceVar(&c.Windows, "windows", DefaultConstraintConfig.Windows, "List of constraints' adjustment windows; previously inertia")
+	flags.Int64SliceVar(&c.Backlogs, "backlogs", DefaultConstraintConfig.Backlogs, "List of constraints' initial backlogs")
+}
+
+func (c *ConstraintsConfig) Print(w io.Writer) {
+	c.CommonConfig.Print(w)
+	fmt.Fprintln(w, "Number of constraints:\t", len(c.Targets))
+	for i := range len(c.Targets) {
+		var backlog int64
+		if i < len(c.Backlogs) {
+			backlog = c.Backlogs[i]
+		}
+		constraint := fmt.Sprintf("target=%v, window=%v, backlog=%v",
+			toPrettyInt(c.Targets[i]), toPrettyInt(c.Windows[i]), toPrettyInt(backlog))
+		fmt.Fprintf(w, "Constraint %v:\t%v\n", i, constraint)
+	}
+}
+
+func (c *ConstraintsConfig) Validate() error {
+	for _, target := range c.Targets {
+		if target < 0 {
+			return fmt.Errorf("invalid negative target")
+		}
+	}
+	for _, window := range c.Windows {
+		if window < 0 {
+			return fmt.Errorf("invalid negative adjustment window")
+		}
+	}
+	for _, backlog := range c.Backlogs {
+		if backlog < 0 {
+			return fmt.Errorf("invalid negative backlog")
+		}
+	}
+	if len(c.Targets) == 0 {
+		return fmt.Errorf("expected at least one constraint")
+	}
+	if len(c.Targets) != len(c.Windows) {
+		return fmt.Errorf("mismatch number of targets and adjustment-windows")
+	}
+	if len(c.Backlogs) > len(c.Targets) {
+		return fmt.Errorf("too many initial backlogs")
+	}
+	return nil
+}

--- a/cmd/l2pricing-simulator/gas.go
+++ b/cmd/l2pricing-simulator/gas.go
@@ -1,0 +1,50 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package main
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/params"
+)
+
+type GasSimulator struct {
+	CommonConfig
+	minGasTarget               uint64
+	prevUnnormSequencerBacklog uint64
+}
+
+func NewGasSimulator(config CommonConfig, minGasTarget uint64) *GasSimulator {
+	return &GasSimulator{config, minGasTarget, 0}
+}
+
+func (s *GasSimulator) compute(timestamp uint64, prevBaseFee *big.Int) uint64 {
+	// the surge increases linearly over 10 seconds, reaches its peak, and then decreases linearly
+	var unnormalizedDemand float64
+	if timestamp < s.SurgeRamp {
+		unnormalizedDemand = float64(timestamp*s.SurgeDemand) / float64(s.SurgeRamp)
+	} else if timestamp < s.SurgeRamp+s.SurgeDuration {
+		unnormalizedDemand = float64(s.SurgeDemand)
+	} else if timestamp < 2*s.SurgeRamp+s.SurgeDuration {
+		unnormalizedDemand = float64((2*s.SurgeRamp+s.SurgeDuration-timestamp-1)*s.SurgeDemand) / float64(s.SurgeRamp)
+	}
+	unnormalizedDemand = max(unnormalizedDemand, float64(s.minGasTarget))
+
+	// Compute all in float
+	prevUnnormSequencerBacklog := float64(s.prevUnnormSequencerBacklog)
+	unnormSeqBacklogAfterArrivals := prevUnnormSequencerBacklog + unnormalizedDemand
+	normalization := gweiToFloat(prevBaseFee)
+	unnormSeqThroughput := float64(s.SequencerThroughput) * normalization
+	unnormSeqOutput := min(unnormSeqBacklogAfterArrivals, unnormSeqThroughput)
+	unnormSeqBacklog := max(0, prevUnnormSequencerBacklog+unnormalizedDemand-unnormSeqThroughput)
+
+	s.prevUnnormSequencerBacklog = uint64(unnormSeqBacklog / normalization)
+	gasUsed := uint64(unnormSeqOutput / normalization)
+
+	return gasUsed
+}
+
+func gweiToFloat(value *big.Int) float64 {
+	return float64(value.Int64()) / params.GWei
+}

--- a/cmd/l2pricing-simulator/main.go
+++ b/cmd/l2pricing-simulator/main.go
@@ -1,0 +1,137 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+// l2pricing-simulator is a command-line tool that simulates the behavior of Nitro's l2 pricing algorithm.
+package main
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/offchainlabs/nitro/arbos/burn"
+	"github.com/offchainlabs/nitro/arbos/l2pricing"
+	"github.com/offchainlabs/nitro/arbos/storage"
+	"github.com/offchainlabs/nitro/util/arbmath"
+)
+
+var minBaseFee = big.NewInt(params.GWei)
+
+func newPricingState() (*l2pricing.L2PricingState, error) {
+	storage := storage.NewMemoryBacked(burn.NewSystemBurner(nil, false))
+	err := l2pricing.InitializeL2PricingState(storage)
+	if err != nil {
+		return nil, err
+	}
+	pricing := l2pricing.OpenL2PricingState(storage)
+	_ = pricing.SetMinBaseFeeWei(minBaseFee)
+	_ = pricing.SetBaseFeeWei(minBaseFee)
+	return pricing, nil
+}
+
+func runLegacyModel(args []string) error {
+	var config LegacyConfig
+	if err := ParseConfig(&config, args); err != nil {
+		return err
+	}
+
+	pricing, err := newPricingState()
+	if err != nil {
+		return err
+	}
+
+	_ = pricing.SetGasBacklog(config.InitialBacklog)
+	_ = pricing.SetSpeedLimitPerSecond(config.SpeedLimit)
+	_ = pricing.SetPricingInertia(config.Inertia)
+	_ = pricing.SetBacklogTolerance(config.BacklogTolerance)
+
+	gasSimulator := NewGasSimulator(config.CommonConfig, config.SpeedLimit)
+	results := []Result{}
+	for i := range config.Iterations() {
+		baseFee, _ := pricing.BaseFeeWei()
+		gas := gasSimulator.compute(i, baseFee)
+		_ = pricing.AddToGasPool(-arbmath.SaturatingCast[int64](gas), l2pricing.ArbosMultiConstraintsVersion)
+		pricing.UpdatePricingModel(1, l2pricing.ArbosMultiConstraintsVersion)
+		baseFee, _ = pricing.BaseFeeWei()
+		results = append(results, Result{
+			baseFee:  baseFee,
+			gasRatio: float64(gas) / float64(config.SpeedLimit),
+		})
+	}
+
+	printOutput(&config, results)
+	return nil
+}
+
+func runConstraintsModel(args []string) error {
+	var config ConstraintsConfig
+	if err := ParseConfig(&config, args); err != nil {
+		return err
+	}
+
+	pricing, err := newPricingState()
+	if err != nil {
+		return err
+	}
+
+	longTermWindow := uint64(0)
+	longTermTarget := uint64(0)
+	numConstraints := len(config.Targets)
+	for i := range numConstraints {
+		target := arbmath.SaturatingUCast[uint64](config.Targets[i])
+		window := arbmath.SaturatingUCast[uint64](config.Windows[i])
+		var backlog uint64
+		if i < len(config.Backlogs) {
+			backlog = arbmath.SaturatingUCast[uint64](config.Backlogs[i])
+		}
+		if err := pricing.AddConstraint(target, window, backlog); err != nil {
+			return fmt.Errorf("failed to add constraint: %w", err)
+		}
+		if window > longTermWindow {
+			longTermWindow = window
+			longTermTarget = target
+		}
+	}
+
+	gasSimulator := NewGasSimulator(config.CommonConfig, longTermTarget)
+
+	results := []Result{}
+	for i := range config.Iterations() {
+		baseFee, _ := pricing.BaseFeeWei()
+		gas := gasSimulator.compute(i, baseFee)
+		_ = pricing.AddToGasPool(-arbmath.SaturatingCast[int64](gas), l2pricing.ArbosMultiConstraintsVersion)
+		pricing.UpdatePricingModel(1, l2pricing.ArbosMultiConstraintsVersion)
+		baseFee, _ = pricing.BaseFeeWei()
+		results = append(results, Result{
+			baseFee:  baseFee,
+			gasRatio: float64(gas) / float64(longTermTarget),
+		})
+	}
+
+	printOutput(&config, results)
+	return nil
+}
+
+func main() {
+	args := os.Args
+	if len(args) < 2 {
+		fmt.Println("Usage: l2pricing-simulator [legacy|constraints] ...")
+		os.Exit(1)
+	}
+	var err error
+	switch strings.ToLower(args[1]) {
+	case "legacy":
+		err = runLegacyModel(args[2:])
+	case "constraints":
+		err = runConstraintsModel(args[2:])
+	default:
+		err = fmt.Errorf("unknown command '%s', valid commands are: legacy and constraints", args[1])
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/l2pricing-simulator/output.go
+++ b/cmd/l2pricing-simulator/output.go
@@ -1,0 +1,90 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package main
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"slices"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/ethereum/go-ethereum/params"
+)
+
+type Result struct {
+	baseFee  *big.Int
+	gasRatio float64
+}
+
+func printOutput(config Config, results []Result) {
+	if config.ShouldExportCSV() {
+		printCsvOutput(results)
+	} else {
+		printTextOutput(config, results)
+	}
+}
+
+func printCsvOutput(results []Result) {
+	fmt.Println("i,baseFee,gasRatio")
+	for i, result := range results {
+		fmt.Printf("%v,%v,%.3f\n", i, toGwei(result.baseFee), result.gasRatio)
+	}
+}
+
+func printTextOutput(config Config, results []Result) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+	config.Print(w)
+	w.Flush()
+
+	fmt.Println()
+
+	w = tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+	fmt.Fprintln(w, "i\tbaseFee\tgasRatio\t")
+	for i, result := range results {
+		if !config.ShouldPrintLine(i) {
+			continue
+		}
+		fmt.Fprintf(w, "%v\t", i)
+		fmt.Fprintf(w, "%v\t", toGwei(result.baseFee))
+		fmt.Fprintf(w, "%.3f\t", result.gasRatio)
+		fmt.Fprintln(w)
+	}
+	w.Flush()
+}
+
+func toGwei(wei *big.Int) string {
+	gweiDivisor := big.NewInt(params.GWei)
+	weiRat := new(big.Rat).SetInt(wei)
+	gweiDivisorRat := new(big.Rat).SetInt(gweiDivisor)
+	gweiRat := new(big.Rat).Quo(weiRat, gweiDivisorRat)
+	return gweiRat.FloatString(3)
+}
+
+func toPrettyUint(v uint64) string {
+	if v == 0 {
+		return "0"
+	}
+	parts := []string{}
+	for v >= 1000 {
+		parts = append(parts, fmt.Sprintf("%03d", v%1000))
+		v = v / 1000
+	}
+	if v > 0 {
+		parts = append(parts, fmt.Sprint(v))
+	}
+	slices.Reverse(parts)
+	return strings.Join(parts, ",")
+}
+
+func toPrettyInt(v int64) string {
+	if v == 0 {
+		return "0"
+	}
+	if v < 0 {
+		return "-" + toPrettyUint(uint64(-v))
+	}
+	return toPrettyUint(uint64(v))
+}


### PR DESCRIPTION
This tool is used to compare the Nitro implementation with the [Research team's simulations](https://colab.research.google.com/drive/1QWAULP2kDz3gGMmDBsoVPigQkfX5DCgz), so we can be sure Nitro behaves as we expect.

Close NIT-4047
