### PR TITLE
Investigate and fix flakey go-tests `Build` step

### DIFF
--- a/contracts-local/Makefile
+++ b/contracts-local/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build build-forge build-forge-sol build-forge-gas-dimensions build-forge-gas-dimensions-yul
 
 # Prevent parallel execution of targets, if the same compiler is used at the same time race conditions may occur
-.NOTPARALLEL
+.NOTPARALLEL:
 
 install:
 	forge install --no-git


### PR DESCRIPTION
resolves NIT-4098

```rust
2025-11-07T18:49:16.8075813Z FOUNDRY_PROFILE=gas-dimensions-yul forge build --skip *.sol
2025-11-07T18:49:17.1995799Z Compiling 1 files with Solc 0.8.17
2025-11-07T18:49:17.1999924Z Error: "/home/runner/.local/share/svm/0.8.17/solc-0.8.17": Text file busy (os error 26)
2025-11-07T18:49:17.2023624Z Compiling 22 files with Solc 0.8.30
2025-11-07T18:49:17.2025908Z make[1]: *** [Makefile:19: build-forge-gas-dimensions-yul] Error 1
2025-11-07T18:49:17.2026648Z make[1]: *** Waiting for unfinished jobs....
```

```rust
2025-11-07T21:48:46.1558497Z FOUNDRY_PROFILE=gas-dimensions-yul forge build --skip *.sol
2025-11-07T21:48:46.6298919Z Compiling 22 files with Solc 0.8.30
2025-11-07T21:48:46.6828727Z Compiling 63 files with Solc 0.8.17
2025-11-07T21:48:46.6832214Z Error: "/home/runner/.local/share/svm/0.8.17/solc-0.8.17": Text file busy (os error 26)
2025-11-07T21:48:46.6861935Z make[1]: *** [Makefile:14: build-forge-sol] Error 1
2025-11-07T21:48:46.6862703Z make[1]: *** Waiting for unfinished jobs....
2025-11-07T21:48:46.6946391Z Compiling 1 files with Solc 0.8.17
2025-11-07T21:48:46.7010374Z Solc 0.8.17 finished in 6.48ms
2025-11-07T21:48:46.7014908Z Compiler run successful!
```

So from my understanding the bug was that we were using the same solidity compiler in parallel building 2 separate things, which can lead to accessing resources which are already in use, which causes the compiler to panic.

# Solution

Mark the contracts-local makefile to run tasks sequentially, there are other solutions which could be done, but I don't think we would get any worth while benefit over the solution proposed in this PR

At the end of the day we just need to make sure that solidity compiler vX is used sequentially to my understanding

