### PR TITLE
docs: fix LICENSE file link in el-proxy main.go

### DIFF
--- a/cmd/el-proxy/main.go
+++ b/cmd/el-proxy/main.go
@@ -1,5 +1,5 @@
 // Copyright 2025, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/nitro/blob/master/LICENSE
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
 
 // el-proxy is an example implementation of a Timeboost Express Lane proxy
 // and should only be used for testing purposes. It listens for


### PR DESCRIPTION
Updated outdated LICENSE URL comment to the correct file path.

