### PR TITLE
Update Codecov workflow to use download-artifact v6

### DIFF
--- a/.github/workflows/_codecov.yml
+++ b/.github/workflows/_codecov.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download JUnit reports
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           pattern: junit-reports-*
           path: downloaded-reports/


### PR DESCRIPTION
bump actions/download-artifact from v5 to v6 in .github/workflows/_codecov.yml
keeps the Codecov job aligned with the latest GitHub Actions release