### PR TITLE
chore: update golangci-lint-action from v8 to v9

### DIFF
--- a/.github/workflows/_fast.yml
+++ b/.github/workflows/_fast.yml
@@ -23,7 +23,7 @@ jobs:
         run: make -j8 build-node-deps
 
       - name: GolangCI Lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.5
 

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: make -j build-node-deps
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           skip-cache: true


### PR DESCRIPTION
Bumped golangci-lint-action from v8 to v9 in CI workflows