### PR TITLE
fix: broken links (404) across codebase

### DIFF
--- a/arbitrator/wasm-libraries/user-host-trait/src/lib.rs
+++ b/arbitrator/wasm-libraries/user-host-trait/src/lib.rs
@@ -456,7 +456,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
     /// `read_return_data` hostio. The semantics are equivalent to that of the EVM's [`CREATE`]
     /// opcode, which notably includes the exact address returned.
     ///
-/// [`Deploying Stylus Programs`]: https://developer.arbitrum.io/
+    /// [`Deploying Stylus Programs`]: https://developer.arbitrum.io/
     /// [`CREATE`]: https://www.evm.codes/#f0
     fn create1(
         &mut self,
@@ -511,7 +511,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
     /// via the `read_return_data` hostio. The semantics are equivalent to that of the EVM's
     /// `[CREATE2`] opcode, which notably includes the exact address returned.
     ///
-/// [`Deploying Stylus Programs`]: https://developer.arbitrum.io/
+    /// [`Deploying Stylus Programs`]: https://developer.arbitrum.io/
     /// [`CREATE2`]: https://www.evm.codes/#f5
     fn create2(
         &mut self,
@@ -818,7 +818,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
     /// [`Ink and Gas`] for more information on Stylus's compute pricing.
     ///
     /// [`GAS`]: https://www.evm.codes/#5a
-/// [`Ink and Gas`]: https://developer.arbitrum.io/
+    /// [`Ink and Gas`]: https://developer.arbitrum.io/
     fn evm_ink_left(&mut self) -> Result<Ink, Self::Err> {
         self.buy_ink(hostio::EVM_INK_LEFT_BASE_INK)?;
         let ink = self.ink_ready()?;


### PR DESCRIPTION

This PR fixes broken external links (404 errors) found throughout the codebase, improving documentation reliability and developer experience.

