### PR TITLE
fix(docs): correct zero value documentation in ADR example

### DIFF
--- a/docs/decisions/0001-avoid-primitive-constraint-types.md
+++ b/docs/decisions/0001-avoid-primitive-constraint-types.md
@@ -16,8 +16,6 @@ positive values. For example:
 
 ```go
 // Pos64 is a type which represents a positive uint64.
-//
-// The "zero" value of Pos64 is 1.
 type Pos64 struct {
 	uint64
 }
@@ -44,7 +42,7 @@ func MustPos64(v uint64) Pos64 {
 
 // Val returns the value of the Pos64.
 func (p Pos64) Val() uint64 {
-	// The zero value of Pos64 is 1.
+	// Handle invalid zero value by returning 1 as a safe default.
 	if p.uint64 == 0 {
 		return 1
 	}


### PR DESCRIPTION
Remove incorrect claim that Pos64 zero value equals 1, which is impossible in Go. 

And updated Val() method comment to describe handling of invalid state rather than zero value semantics.