### PR TITLE
docs: fix inverted comments in BoldMachine methods

### DIFF
--- a/validator/server_arb/bold_machine.go
+++ b/validator/server_arb/bold_machine.go
@@ -53,8 +53,8 @@ func (m *BoldMachine) GetStepCount() uint64 {
 	return m.inner.GetStepCount() + 1
 }
 
-// Hash returns the hash of the inner machine if the machine has not stepped,
-// otherwise it returns the hash of the zeroth step machine.
+// Hash returns the hash of the zeroth step machine if the machine has not stepped,
+// otherwise it returns the hash of the inner machine.
 func (m *BoldMachine) Hash() common.Hash {
 	if !m.hasStepped {
 		return m.zeroMachine.Hash()
@@ -74,8 +74,8 @@ func (m *BoldMachine) Freeze() {
 	m.zeroMachine.Freeze()
 }
 
-// Status returns the status of the inner machine if the machine has not
-// stepped, otherwise it returns the status of the zeroth step machine.
+// Status returns the status of the zeroth step machine if the machine has not
+// stepped, otherwise it returns the status of the inner machine.
 func (m *BoldMachine) Status() uint8 {
 	if !m.hasStepped {
 		return m.zeroMachine.Status()
@@ -101,8 +101,8 @@ func (m *BoldMachine) IsErrored() bool {
 	return m.inner.IsErrored()
 }
 
-// Step steps the inner machine if the machine has not stepped, otherwise it
-// steps the zeroth step machine.
+// Step steps the inner machine. If the machine has not yet stepped, the first
+// step is consumed to transition from the zeroth step, and remaining steps are applied.
 func (m *BoldMachine) Step(ctx context.Context, steps uint64) error {
 	if !m.hasStepped {
 		if steps == 0 {


### PR DESCRIPTION
Fixed three method comments in bold_machine.go that described opposite logic from actual code behavior.

Hash(), Status(), and Step() comments said they return inner machine when hasStepped=false and zeroMachine when true, but code does the reverse. Comments now match implementation.