### PR TITLE
Update CI to use migrated repo execution-spec-tests -> execution-specs

### DIFF
--- a/.github/workflows/runExecutionSpecTests.sh
+++ b/.github/workflows/runExecutionSpecTests.sh
@@ -20,7 +20,7 @@ sleep 10
 
 # Run execution spec tests
 git clone https://github.com/OffchainLabs/execution-specs.git
-cd execution-spec-tests
+cd execution-specs
 curl -LsSf https://astral.sh/uv/install.sh | sh
 uv python install 3.11
 uv python pin 3.11


### PR DESCRIPTION
resolves NIT-4060

Recently the EF's STEEL team combined the execution-spec-tests and execution-specs into one repo, this PR updates our execution-spec-tests CI to use the new github repo