### PR TITLE
Clarify Redis DAS signing key config

### DIFF
--- a/daprovider/das/redis_storage_service.go
+++ b/daprovider/das/redis_storage_service.go
@@ -40,7 +40,7 @@ func RedisConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultRedisConfig.Enable, "enable Redis caching of sequencer batch data")
 	f.String(prefix+".url", DefaultRedisConfig.Url, "Redis url")
 	f.Duration(prefix+".expiration", DefaultRedisConfig.Expiration, "Redis expiration")
-	f.String(prefix+".key-config", DefaultRedisConfig.KeyConfig, "Redis key config")
+	f.String(prefix+".key-config", DefaultRedisConfig.KeyConfig, "hex-encoded 32-byte signing key used to authenticate cached Redis entries")
 }
 
 type RedisStorageService struct {
@@ -57,7 +57,7 @@ func NewRedisStorageService(redisConfig RedisConfig, baseStorageService StorageS
 	}
 	signingKey := common.HexToHash(redisConfig.KeyConfig)
 	if signingKey == (common.Hash{}) {
-		return nil, errors.New("signing key file contents are not 32 bytes of hex")
+		return nil, errors.New("signing key must be a 32-byte hex value")
 	}
 	return &RedisStorageService{
 		baseStorageService: baseStorageService,


### PR DESCRIPTION
Clarifies that --redis.key-config expects a 32-byte hex signing key, not a file path, and makes the runtime error match that contract. The old text implied you should supply a filename, so newcomers would misconfigure Redis caching and only discover it via a misleading runtime failure.