### PR TITLE
Add test for blob fetch failure race condition

### DIFF
--- a/system_tests/inbox_blob_failure_test.go
+++ b/system_tests/inbox_blob_failure_test.go
@@ -230,8 +230,10 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 		checkBlockNum = seqBlockNum
 	}
 
+	// #nosec G115
 	seqBlock, err := builder.L2.Client.BlockByNumber(ctx, big.NewInt(int64(checkBlockNum)))
 	Require(t, err)
+	// #nosec G115
 	follBlock, err := testClientB.Client.BlockByNumber(ctx, big.NewInt(int64(checkBlockNum)))
 	Require(t, err)
 


### PR DESCRIPTION
Test verifies that follower can recover and continue syncing after blob fetch failures cause temporary desync. Includes failingBlobReader wrapper to simulate blob DA failures and validates recovery by comparing final block hashes between sequencer and follower.

This attempts to reproduce the issue described in NIT-4065. Notably it doesn't seem to be able to reproduce it.