### PR TITLE
fix(redislock): delete only the redis lock key on release

### DIFF
--- a/arbnode/redislock/redis.go
+++ b/arbnode/redislock/redis.go
@@ -240,7 +240,7 @@ func (l *Simple) Release(ctx context.Context) {
 			return nil
 		}
 		pipe := tx.TxPipeline()
-		pipe.Del(ctx, config.Key, l.myId)
+		pipe.Del(ctx, config.Key)
 		err = execTestPipe(pipe, ctx)
 		if errors.Is(err, redis.TxFailedErr) {
 			return nil


### PR DESCRIPTION
remove the extra argument to `DEL` so release deletes just the Redis lock key, prevents unnecessary attempts to delete a random per-node key