### PR TITLE
Store blobs locally post fusaka + disk reader

### DIFF
--- a/util/headerreader/blob_client.go
+++ b/util/headerreader/blob_client.go
@@ -252,21 +252,33 @@ func (b *BlobClient) getBlobs(ctx context.Context, slot uint64, versionedHashes 
 	}
 
 	output := make([]kzg4844.Blob, len(response))
+	computedHashes := make([]common.Hash, len(response))
+
 	for i, blobData := range response {
 		if len(blobData) != len(output[i]) {
 			return nil, fmt.Errorf("blob at index %d has incorrect length %d, expected %d", i, len(blobData), len(output[i]))
 		}
 		copy(output[i][:], blobData)
 
+		// Compute commitment and versioned hash for validation and storage
+		commitment, err := kzg4844.BlobToCommitment(&output[i])
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute commitment for blob %d: %w", i, err)
+		}
+		computedHashes[i] = blobs.CommitmentToVersionedHash(commitment)
+
+		// Validate against provided hashes if present
 		if len(versionedHashes) > 0 {
-			commitment, err := kzg4844.BlobToCommitment(&output[i])
-			if err != nil {
-				return nil, fmt.Errorf("failed to compute commitment for blob %d: %w", i, err)
+			if computedHashes[i] != versionedHashes[i] {
+				return nil, fmt.Errorf("blob %d versioned hash mismatch: expected %s, got %s", i, versionedHashes[i].Hex(), computedHashes[i].Hex())
 			}
-			computedHash := blobs.CommitmentToVersionedHash(commitment)
-			if computedHash != versionedHashes[i] {
-				return nil, fmt.Errorf("blob %d versioned hash mismatch: expected %s, got %s", i, versionedHashes[i].Hex(), computedHash.Hex())
-			}
+		}
+	}
+
+	// Save blobs to disk in version 1 format if blobDirectory is configured
+	if b.blobDirectory != "" {
+		if err := saveBlobsV1ToDisk(output, computedHashes, slot, b.blobDirectory); err != nil {
+			return nil, err
 		}
 	}
 
@@ -282,6 +294,13 @@ type blobResponseItem struct {
 	Blob            hexutil.Bytes        `json:"blob"`
 	KzgCommitment   hexutil.Bytes        `json:"kzg_commitment"`
 	KzgProof        hexutil.Bytes        `json:"kzg_proof"`
+}
+
+// blobStorageV1 represents the version 1 blob storage format.
+// Stores blobs as a map from versioned hash to blob data for fast lookups.
+type blobStorageV1 struct {
+	Version int                      `json:"version"`
+	Data    map[string]hexutil.Bytes `json:"data"`
 }
 
 func (b *BlobClient) blobSidecars(ctx context.Context, slot uint64, versionedHashes []common.Hash) ([]kzg4844.Blob, error) {
@@ -362,7 +381,7 @@ func (b *BlobClient) blobSidecars(ctx context.Context, slot uint64, versionedHas
 	}
 
 	if b.blobDirectory != "" {
-		if err := saveBlobDataToDisk(rawData, slot, b.blobDirectory); err != nil {
+		if err := saveBlobsV0ToDisk(rawData, slot, b.blobDirectory); err != nil {
 			return nil, err
 		}
 	}
@@ -370,7 +389,8 @@ func (b *BlobClient) blobSidecars(ctx context.Context, slot uint64, versionedHas
 	return output, nil
 }
 
-func saveBlobDataToDisk(rawData json.RawMessage, slot uint64, blobDirectory string) error {
+// saveBlobsV0ToDisk saves blobs in version 0 format (legacy blob_sidecars format)
+func saveBlobsV0ToDisk(rawData json.RawMessage, slot uint64, blobDirectory string) error {
 	filePath := path.Join(blobDirectory, fmt.Sprint(slot))
 	file, err := os.Create(filePath)
 	if err != nil {
@@ -386,6 +406,168 @@ func saveBlobDataToDisk(rawData json.RawMessage, slot uint64, blobDirectory stri
 	}
 	file.Close()
 	return nil
+}
+
+// saveBlobsV1ToDisk saves blobs in version 1 format (versioned hash -> blob map)
+func saveBlobsV1ToDisk(blobs []kzg4844.Blob, versionedHashes []common.Hash, slot uint64, blobDirectory string) error {
+	if len(blobs) != len(versionedHashes) {
+		return fmt.Errorf("mismatch between number of blobs (%d) and versioned hashes (%d)", len(blobs), len(versionedHashes))
+	}
+
+	// Build map from versioned hash to blob data
+	blobMap := make(map[string]hexutil.Bytes, len(blobs))
+	for i := range blobs {
+		hashStr := versionedHashes[i].Hex()
+		blobMap[hashStr] = blobs[i][:]
+	}
+
+	storage := blobStorageV1{
+		Version: 1,
+		Data:    blobMap,
+	}
+
+	jsonData, err := json.Marshal(storage)
+	if err != nil {
+		return fmt.Errorf("unable to marshal blobs into JSON: %w", err)
+	}
+
+	filePath := path.Join(blobDirectory, fmt.Sprint(slot))
+	if err := os.WriteFile(filePath, jsonData, 0600); err != nil {
+		return fmt.Errorf("failed to write blob data to disk: %w", err)
+	}
+
+	return nil
+}
+
+// ReadBlobsFromDisk reads blobs from disk storage and returns them in the order of the requested versioned hashes.
+// Supports both version 0 (blob_sidecars) and version 1 (hash map) formats.
+// Returns error if any requested blob is not found.
+func ReadBlobsFromDisk(blobDirectory string, slot uint64, versionedHashes []common.Hash) ([]kzg4844.Blob, error) {
+	if len(versionedHashes) == 0 {
+		return nil, fmt.Errorf("versionedHashes cannot be empty")
+	}
+
+	filePath := path.Join(blobDirectory, fmt.Sprint(slot))
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("blob file not found for slot %d: %w", slot, err)
+		}
+		return nil, fmt.Errorf("failed to read blob file for slot %d: %w", slot, err)
+	}
+
+	version, err := detectBlobFileFormat(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect blob file format for slot %d: %w", slot, err)
+	}
+
+	switch version {
+	case 0:
+		return readBlobsV0(data, versionedHashes)
+	case 1:
+		return readBlobsV1(data, versionedHashes)
+	default:
+		return nil, fmt.Errorf("unsupported blob storage version: %d", version)
+	}
+}
+
+// detectBlobFileFormat detects the storage format version.
+// Returns 0 for old format (blob_sidecars), 1 for new format (hash map).
+func detectBlobFileFormat(data []byte) (int, error) {
+	var versionCheck struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal(data, &versionCheck); err != nil {
+		return 0, fmt.Errorf("failed to parse blob file: %w", err)
+	}
+	return versionCheck.Version, nil
+}
+
+// readBlobsV1 reads blobs from version 1 format (versioned hash -> blob map)
+func readBlobsV1(data []byte, versionedHashes []common.Hash) ([]kzg4844.Blob, error) {
+	var storage blobStorageV1
+	if err := json.Unmarshal(data, &storage); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal version 1 blob storage: %w", err)
+	}
+
+	// Lookup each requested hash and maintain order
+	result := make([]kzg4844.Blob, len(versionedHashes))
+	for i, hash := range versionedHashes {
+		hashStr := hash.Hex()
+		blobData, found := storage.Data[hashStr]
+		if !found {
+			return nil, fmt.Errorf("blob not found for versioned hash %s", hashStr)
+		}
+		if len(blobData) != len(result[i]) {
+			return nil, fmt.Errorf("blob has incorrect length %d, expected %d for hash %s", len(blobData), len(result[i]), hashStr)
+		}
+		copy(result[i][:], blobData)
+
+		// Validate blob matches its versioned hash
+		commitment, err := kzg4844.BlobToCommitment(&result[i])
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute commitment for blob at hash %s: %w", hashStr, err)
+		}
+		computedHash := blobs.CommitmentToVersionedHash(commitment)
+		if computedHash != hash {
+			return nil, fmt.Errorf("blob validation failed: computed hash %s does not match requested hash %s", computedHash.Hex(), hashStr)
+		}
+	}
+
+	return result, nil
+}
+
+// readBlobsV0 reads blobs from version 0 format (blob_sidecars array)
+func readBlobsV0(data []byte, versionedHashes []common.Hash) ([]kzg4844.Blob, error) {
+	// Parse the old format wrapped in fullResult
+	var full fullResult[[]blobResponseItem]
+	if err := json.Unmarshal(data, &full); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal version 0 blob storage: %w", err)
+	}
+
+	// Build a map from versioned hash to blob by computing hashes from commitments.
+	// We're doing this because the old format (directly serializing the "data" field
+	// from response from the old blob_sidecars endpoint) doesn't have the versioned hash.
+	blobMap := make(map[common.Hash]kzg4844.Blob)
+	for _, item := range full.Data {
+		// Compute versioned hash from stored KZG commitment
+		if len(item.KzgCommitment) != len(kzg4844.Commitment{}) {
+			return nil, fmt.Errorf("invalid KZG commitment length: %d, expected %d", len(item.KzgCommitment), len(kzg4844.Commitment{}))
+		}
+		var storedCommitment kzg4844.Commitment
+		copy(storedCommitment[:], item.KzgCommitment)
+		versionedHash := blobs.CommitmentToVersionedHash(storedCommitment)
+
+		// Copy blob data
+		if len(item.Blob) != len(kzg4844.Blob{}) {
+			return nil, fmt.Errorf("invalid blob length: %d, expected %d", len(item.Blob), len(kzg4844.Blob{}))
+		}
+		var blob kzg4844.Blob
+		copy(blob[:], item.Blob)
+
+		// Validate blob matches the stored commitment
+		computedCommitment, err := kzg4844.BlobToCommitment(&blob)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute commitment for blob: %w", err)
+		}
+		if computedCommitment != storedCommitment {
+			return nil, fmt.Errorf("blob validation failed: computed commitment does not match stored commitment for versioned hash %s", versionedHash.Hex())
+		}
+
+		blobMap[versionedHash] = blob
+	}
+
+	// Lookup each requested hash and maintain order
+	result := make([]kzg4844.Blob, len(versionedHashes))
+	for i, hash := range versionedHashes {
+		blob, found := blobMap[hash]
+		if !found {
+			return nil, fmt.Errorf("blob not found for versioned hash %s", hash.Hex())
+		}
+		result[i] = blob
+	}
+
+	return result, nil
 }
 
 type genesisResponse struct {

--- a/util/headerreader/blob_client_test.go
+++ b/util/headerreader/blob_client_test.go
@@ -5,26 +5,153 @@ package headerreader
 
 import (
 	"encoding/json"
-	"io"
+	"math/rand"
 	"os"
 	"path"
 	"reflect"
+	"slices"
+	"strings"
 	"testing"
 
-	"github.com/r3labs/diff/v3"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 
+	"github.com/offchainlabs/nitro/util/blobs"
 	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 
-func TestSaveBlobsToDisk(t *testing.T) {
+// createTestBlobs creates test blobs and their versioned hashes
+func createTestBlobs(count int) ([]kzg4844.Blob, []common.Hash, error) {
+	testData := make([]byte, count*blobs.BlobEncodableData)
+	r := rand.New(rand.NewSource(1))
+	_, err := r.Read(testData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	testBlobs, err := blobs.EncodeBlobs(testData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	_, versionedHashes, err := blobs.ComputeCommitmentsAndHashes(testBlobs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return testBlobs, versionedHashes, nil
+}
+
+func TestSaveBlobsV1ToDisk(t *testing.T) {
+	testBlobs, versionedHashes, err := createTestBlobs(3)
+	Require(t, err)
+
+	testDir := t.TempDir()
+	slot := uint64(12345)
+
+	err = saveBlobsV1ToDisk(testBlobs, versionedHashes, slot, testDir)
+	Require(t, err)
+
+	filePath := path.Join(testDir, "12345")
+	data, err := os.ReadFile(filePath)
+	Require(t, err)
+
+	var storage blobStorageV1
+	err = json.Unmarshal(data, &storage)
+	Require(t, err)
+
+	if storage.Version != 1 {
+		t.Errorf("expected version 1, got %d", storage.Version)
+	}
+
+	if len(storage.Data) != len(testBlobs) {
+		t.Errorf("expected %d blobs, got %d", len(testBlobs), len(storage.Data))
+	}
+
+	for i, hash := range versionedHashes {
+		blobData, found := storage.Data[hash.Hex()]
+		if !found {
+			t.Errorf("blob not found for hash %s", hash.Hex())
+			continue
+		}
+		if !reflect.DeepEqual([]byte(blobData), testBlobs[i][:]) {
+			t.Errorf("blob data mismatch for index %d", i)
+		}
+	}
+}
+
+func TestReadBlobsV1FromDisk(t *testing.T) {
+	testBlobs, versionedHashes, err := createTestBlobs(3)
+	Require(t, err)
+
+	testDir := t.TempDir()
+	slot := uint64(12345)
+
+	err = saveBlobsV1ToDisk(testBlobs, versionedHashes, slot, testDir)
+	Require(t, err)
+
+	readBlobs, err := ReadBlobsFromDisk(testDir, slot, versionedHashes)
+	Require(t, err)
+
+	if len(readBlobs) != len(testBlobs) {
+		t.Fatalf("expected %d blobs, got %d", len(testBlobs), len(readBlobs))
+	}
+
+	for i := range testBlobs {
+		if readBlobs[i] != testBlobs[i] {
+			t.Errorf("blob mismatch at index %d", i)
+		}
+	}
+}
+
+func TestReadBlobsV1OrderPreservation(t *testing.T) {
+	testBlobs, versionedHashes, err := createTestBlobs(3)
+	Require(t, err)
+
+	testDir := t.TempDir()
+	slot := uint64(12345)
+
+	err = saveBlobsV1ToDisk(testBlobs, versionedHashes, slot, testDir)
+	Require(t, err)
+
+	// Read in reverse order
+	reversedHashes := slices.Clone(versionedHashes)
+	slices.Reverse(reversedHashes)
+
+	readBlobs, err := ReadBlobsFromDisk(testDir, slot, reversedHashes)
+	Require(t, err)
+
+	// Verify blobs are in reversed order
+	for i := range testBlobs {
+		expectedIdx := len(testBlobs) - 1 - i
+		if readBlobs[i] != testBlobs[expectedIdx] {
+			t.Errorf("blob at index %d does not match expected blob at index %d", i, expectedIdx)
+		}
+	}
+}
+
+func TestSaveBlobsV0ToDisk(t *testing.T) {
+	testDir := t.TempDir()
+	slot := uint64(5)
+
+	testBlobs, _, err := createTestBlobs(2)
+	Require(t, err)
+
+	commitment1, err := kzg4844.BlobToCommitment(&testBlobs[0])
+	Require(t, err)
+	commitment2, err := kzg4844.BlobToCommitment(&testBlobs[1])
+	Require(t, err)
+
+	// Create V0 format response with real blobs and commitments
 	response := []blobResponseItem{{
 		BlockRoot:       "a",
 		Index:           0,
 		Slot:            5,
 		BlockParentRoot: "a0",
 		ProposerIndex:   9,
-		Blob:            []byte{1},
-		KzgCommitment:   []byte{1},
+		Blob:            testBlobs[0][:],
+		KzgCommitment:   commitment1[:],
 		KzgProof:        []byte{1},
 	}, {
 		BlockRoot:       "a",
@@ -32,30 +159,248 @@ func TestSaveBlobsToDisk(t *testing.T) {
 		Slot:            5,
 		BlockParentRoot: "a0",
 		ProposerIndex:   10,
-		Blob:            []byte{2},
-		KzgCommitment:   []byte{2},
+		Blob:            testBlobs[1][:],
+		KzgCommitment:   commitment2[:],
 		KzgProof:        []byte{2},
 	}}
-	testDir := t.TempDir()
+
 	rawData, err := json.Marshal(response)
 	Require(t, err)
-	err = saveBlobDataToDisk(rawData, 5, testDir)
+	err = saveBlobsV0ToDisk(rawData, slot, testDir)
 	Require(t, err)
 
 	filePath := path.Join(testDir, "5")
-	file, err := os.Open(filePath)
+	data, err := os.ReadFile(filePath)
 	Require(t, err)
-	defer file.Close()
 
-	data, err := io.ReadAll(file)
-	Require(t, err)
 	var full fullResult[[]blobResponseItem]
 	err = json.Unmarshal(data, &full)
 	Require(t, err)
-	if !reflect.DeepEqual(full.Data, response) {
-		changelog, err := diff.Diff(full.Data, response)
-		Require(t, err)
-		Fail(t, "blob data saved to disk does not match actual blob data", changelog)
+
+	if len(full.Data) != len(response) {
+		t.Fatalf("expected %d blob items, got %d", len(response), len(full.Data))
+	}
+
+	for i := range response {
+		if !reflect.DeepEqual(full.Data[i], response[i]) {
+			t.Errorf("blob item %d mismatch", i)
+		}
+	}
+}
+
+func TestReadBlobsV0FromDisk(t *testing.T) {
+	testDir := t.TempDir()
+	slot := uint64(5)
+
+	testBlobs, _, err := createTestBlobs(2)
+	Require(t, err)
+
+	commitment1, err := kzg4844.BlobToCommitment(&testBlobs[0])
+	Require(t, err)
+	commitment2, err := kzg4844.BlobToCommitment(&testBlobs[1])
+	Require(t, err)
+
+	hash1 := blobs.CommitmentToVersionedHash(commitment1)
+	hash2 := blobs.CommitmentToVersionedHash(commitment2)
+	versionedHashes := []common.Hash{hash1, hash2}
+
+	// Create V0 format response with real blobs and commitments
+	response := []blobResponseItem{{
+		BlockRoot:       "a",
+		Index:           0,
+		Slot:            5,
+		BlockParentRoot: "a0",
+		ProposerIndex:   9,
+		Blob:            testBlobs[0][:],
+		KzgCommitment:   commitment1[:],
+		KzgProof:        []byte{1},
+	}, {
+		BlockRoot:       "a",
+		Index:           1,
+		Slot:            5,
+		BlockParentRoot: "a0",
+		ProposerIndex:   10,
+		Blob:            testBlobs[1][:],
+		KzgCommitment:   commitment2[:],
+		KzgProof:        []byte{2},
+	}}
+
+	rawData, err := json.Marshal(response)
+	Require(t, err)
+	err = saveBlobsV0ToDisk(rawData, slot, testDir)
+	Require(t, err)
+
+	// Read old format blobs using new reader
+	readBlobs, err := ReadBlobsFromDisk(testDir, slot, versionedHashes)
+	Require(t, err)
+
+	if len(readBlobs) != 2 {
+		t.Fatalf("expected 2 blobs, got %d", len(readBlobs))
+	}
+
+	if readBlobs[0] != testBlobs[0] {
+		t.Errorf("blob 0 mismatch")
+	}
+	if readBlobs[1] != testBlobs[1] {
+		t.Errorf("blob 1 mismatch")
+	}
+}
+
+func TestDetectBlobFileFormat(t *testing.T) {
+	// Test version 1 format
+	v1Data := blobStorageV1{
+		Version: 1,
+		Data:    make(map[string]hexutil.Bytes),
+	}
+	v1JSON, err := json.Marshal(v1Data)
+	Require(t, err)
+
+	version, err := detectBlobFileFormat(v1JSON)
+	Require(t, err)
+	if version != 1 {
+		t.Errorf("expected version 1, got %d", version)
+	}
+
+	// Test version 0 format (no version field)
+	v0Data := fullResult[[]blobResponseItem]{
+		Data: []blobResponseItem{},
+	}
+	v0JSON, err := json.Marshal(v0Data)
+	Require(t, err)
+
+	version, err = detectBlobFileFormat(v0JSON)
+	Require(t, err)
+	if version != 0 {
+		t.Errorf("expected version 0, got %d", version)
+	}
+}
+
+func TestReadBlobsFromDiskErrors(t *testing.T) {
+	testDir := t.TempDir()
+
+	// Test missing file
+	_, err := ReadBlobsFromDisk(testDir, 99999, []common.Hash{common.HexToHash("0x123")})
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+
+	// Test empty versioned hashes
+	_, err = ReadBlobsFromDisk(testDir, 12345, []common.Hash{})
+	if err == nil {
+		t.Error("expected error for empty versioned hashes")
+	}
+
+	// Test missing blob in V1 format
+	testBlobs, versionedHashes, err := createTestBlobs(2)
+	Require(t, err)
+
+	slot := uint64(12345)
+	err = saveBlobsV1ToDisk(testBlobs, versionedHashes, slot, testDir)
+	Require(t, err)
+
+	// Try to read with a hash that doesn't exist
+	wrongHash := common.HexToHash("0xdeadbeef")
+	_, err = ReadBlobsFromDisk(testDir, slot, []common.Hash{wrongHash})
+	if err == nil {
+		t.Error("expected error for missing blob")
+	}
+}
+
+func TestReadBlobsV1ValidationFailure(t *testing.T) {
+	testDir := t.TempDir()
+	slot := uint64(12345)
+
+	// Create two valid blobs
+	testBlobs, versionedHashes, err := createTestBlobs(2)
+	Require(t, err)
+
+	// Save them normally
+	err = saveBlobsV1ToDisk(testBlobs, versionedHashes, slot, testDir)
+	Require(t, err)
+
+	// Manually corrupt the file by swapping blob data between two hashes
+	filePath := path.Join(testDir, "12345")
+	data, err := os.ReadFile(filePath)
+	Require(t, err)
+
+	var storage blobStorageV1
+	err = json.Unmarshal(data, &storage)
+	Require(t, err)
+
+	// Swap the blob data for the two hashes (so hash doesn't match blob)
+	hash0Str := versionedHashes[0].Hex()
+	hash1Str := versionedHashes[1].Hex()
+	storage.Data[hash0Str], storage.Data[hash1Str] = storage.Data[hash1Str], storage.Data[hash0Str]
+
+	// Write corrupted data back
+	corruptedData, err := json.Marshal(storage)
+	Require(t, err)
+	err = os.WriteFile(filePath, corruptedData, 0600)
+	Require(t, err)
+
+	// Try to read - should fail validation
+	_, err = ReadBlobsFromDisk(testDir, slot, versionedHashes)
+	if err == nil {
+		t.Error("expected validation error for corrupted blob")
+	}
+	if err != nil && !strings.Contains(err.Error(), "blob validation failed") {
+		t.Errorf("expected validation error, got: %v", err)
+	}
+}
+
+func TestReadBlobsV0ValidationFailure(t *testing.T) {
+	testDir := t.TempDir()
+	slot := uint64(5)
+
+	// Create two valid blobs
+	testBlobs, _, err := createTestBlobs(2)
+	Require(t, err)
+
+	// Compute commitments
+	commitment1, err := kzg4844.BlobToCommitment(&testBlobs[0])
+	Require(t, err)
+	commitment2, err := kzg4844.BlobToCommitment(&testBlobs[1])
+	Require(t, err)
+
+	// Create V0 format but with swapped blobs (blob1 with commitment2 and vice versa)
+	response := []blobResponseItem{{
+		BlockRoot:       "a",
+		Index:           0,
+		Slot:            5,
+		BlockParentRoot: "a0",
+		ProposerIndex:   9,
+		Blob:            testBlobs[1][:], // Wrong blob for this commitment
+		KzgCommitment:   commitment1[:],
+		KzgProof:        []byte{1},
+	}, {
+		BlockRoot:       "a",
+		Index:           1,
+		Slot:            5,
+		BlockParentRoot: "a0",
+		ProposerIndex:   10,
+		Blob:            testBlobs[0][:], // Wrong blob for this commitment
+		KzgCommitment:   commitment2[:],
+		KzgProof:        []byte{2},
+	}}
+
+	// Save corrupted data
+	rawData, err := json.Marshal(response)
+	Require(t, err)
+	err = saveBlobsV0ToDisk(rawData, slot, testDir)
+	Require(t, err)
+
+	// Compute expected versioned hashes
+	hash1 := blobs.CommitmentToVersionedHash(commitment1)
+	hash2 := blobs.CommitmentToVersionedHash(commitment2)
+	versionedHashes := []common.Hash{hash1, hash2}
+
+	// Try to read - should fail validation
+	_, err = ReadBlobsFromDisk(testDir, slot, versionedHashes)
+	if err == nil {
+		t.Error("expected validation error for corrupted blob")
+	}
+	if err != nil && !strings.Contains(err.Error(), "blob validation failed") {
+		t.Errorf("expected validation error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
The Ethereum Fusaka fork introduced /eth/v1/beacon/blobs as a replacement for the legacy /eth/v1/beacon/blob_sidecars endpoint. Nitro's getBlobs() function fetches from the new endpoint but was not saving blobs to disk.

The legacy blobSidecars() function saves blobs in "Version 0" format with full metadata (commitments, proofs, block roots). The new endpoint returns only blob data, requiring a minimal storage format optimized for hash-based lookups.

Additionally, there was no ReadBlobsFromDisk() function - blobs could be saved but not read back. This commit adds the reader for testing and to enable a future beacon endpoint emulator that we may add.

Storage Format V1 (new):
- Stores blobs as versioned hash -> blob map
- File: {blob-directory}/{slot}
- Format: {"version": 1, "data": {"0xHASH": "0xBLOB", ...}}
- Used by getBlobs() when fetching from /eth/v1/beacon/blobs

Storage Format V0 (legacy, backward compatible):
- Stores blob_sidecars array with full metadata
- Format: {"data": [{"blob": "0x...", "kzg_commitment": "0x...", "kzg_proof": "0x...", ...}]}
- Used by blobSidecars() when fetching from legacy endpoint
- Still readable for backward compatibility

ReadBlobsFromDisk() (new):
- Reads blobs from disk, transparently handling V0 or V1 format
- Auto-detects version via presence of "version" field
- Validates blob integrity:
  * V1: Computes commitment -> versioned hash, verifies match to key
  * V0: Computes commitment from blob, verifies match to stored commitment
- No migration needed - both formats coexist

Renamed functions for clarity:
- saveBlobDataToDisk -> saveBlobsV0ToDisk (legacy format)
- Added saveBlobsV1ToDisk (new format)

Testing improvements:
- Updated createTestBlobs() to use production blobs.EncodeBlobs()
- All tests now use real KZG blobs with valid commitments
- Added TestReadBlobsV1ValidationFailure and TestReadBlobsV0ValidationFailure
- Renamed existing tests to indicate format (e.g., TestSaveBlobsV0ToDisk)

NIT-4113