### PR TITLE
docs: clarify optimistic state write behavior in Arbitrum Nitro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<br />
+<br />> Note: Arbitrum Nitro performs state writes optimistically during execution.
+> Final state is confirmed only after dispute resolution completes on L1.
+
 <p align="center">
   <a href="https://arbitrum.io/">
     <img src="https://arbitrum.io/assets/arbitrum/logo_color.png" alt="Logo" width="80" height="80">


### PR DESCRIPTION
This PR adds a short clarification to the documentation describing how
Arbitrum Nitro performs optimistic state writes during execution.

The note explains that although state updates appear immediately during
L2 execution, final state is only confirmed after the L1 dispute resolution
process completes.

This helps integrators understand execution semantics when building on top
of Nitro. Documentation-only change, no code modifications.
