### PR TITLE
chore: remove unused retrying flag from broadcast client

### DIFF
--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -137,9 +137,7 @@ type BroadcastClient struct {
 	conn        net.Conn
 	compression bool
 
-	retryCount atomic.Int64
-
-	retrying                        bool
+	retryCount                      atomic.Int64
 	shuttingDown                    bool
 	firstReconnectAttempt           bool
 	confirmedSequenceNumberListener chan arbutil.MessageIndex


### PR DESCRIPTION
drop the unused `retrying` field from `broadcastclient.BroadcastClient`, clean up `retryConnect` to stop writing to the removed flag while leaving retry logic intact