### PR TITLE
Fix parent chain reader bug in creating smart contract wallet

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -835,6 +835,9 @@ func getStaker(
 			return nil, nil, common.Address{}, err
 		}
 		if config.Staker.UseSmartContractWallet {
+			if !l1Reader.Started() {
+				l1Reader.Start(ctx)
+			}
 			err = wallet.InitializeAndCreateSCW(ctx)
 		} else {
 			err = wallet.Initialize(ctx)
@@ -1469,7 +1472,7 @@ func (n *Node) Start(ctx context.Context) error {
 	if n.Staker != nil {
 		n.Staker.Start(ctx)
 	}
-	if n.L1Reader != nil {
+	if n.L1Reader != nil && !n.L1Reader.Started() {
 		n.L1Reader.Start(ctx)
 	}
 	if n.BroadcastClients != nil {


### PR DESCRIPTION
This PR fixes a bug where parent chain reader was not started before calling the initialization of smart contract wallet- which could lead to a crash during node startup.

Resolves NIT-3859