### PR TITLE
fix: replace deprecated Arbitrum Snapshot URL with active space link

### DIFF
--- a/cmd/conf/init.go
+++ b/cmd/conf/init.go
@@ -48,7 +48,7 @@ var InitConfigDefault = InitConfig{
 	Force:                         false,
 	Url:                           "",
 	Latest:                        "",
-	LatestBase:                    "https://snapshot.arbitrum.foundation/",
+	LatestBase:                    "https://snapshot.org/#/arbitrumfoundation.eth",
 	ValidateChecksum:              true,
 	DownloadPath:                  "",
 	DownloadPoll:                  time.Minute,


### PR DESCRIPTION


## **Description**

This PR updates the obsolete Snapshot URL (`snapshot.arbitrum.foundation`) in `cmd/conf/init.go` and replaces it with the current, functional Arbitrum DAO Snapshot space:

```
https://snapshot.org/#/arbitrumfoundation.eth
```


