### PR TITLE
Run pebble database tests in Nightly CI Builds

### DIFF
--- a/.github/workflows/gotestsum.sh
+++ b/.github/workflows/gotestsum.sh
@@ -12,6 +12,7 @@ tags=""
 run=""
 skip=""
 test_state_scheme=""
+test_database_engine=""
 junitfile=""
 log=true
 race=false
@@ -47,6 +48,12 @@ while [[ $# -gt 0 ]]; do
       shift
       check_missing_value $# "$1" "--test_state_scheme"
       test_state_scheme=$1
+      shift
+      ;;
+    --test_database_engine)
+      shift
+      check_missing_value $# "$1" "--test_database_engine"
+      test_database_engine=$1
       shift
       ;;
     --race)
@@ -128,6 +135,10 @@ if [ "$test_state_scheme" != "" ]; then
     cmd="$cmd -args -- --test_state_scheme=$test_state_scheme --test_loglevel=8"
 else
     cmd="$cmd -args -- --test_loglevel=8" # Use error log level, which is the value 8 in the slog level enum for tests.
+fi
+
+if [ "$test_database_engine" != "" ]; then
+    cmd="$cmd --test_database_engine=$test_database_engine"
 fi
 
 if [ "$log" == true ]; then

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-mode: [legacychallenge, long, challenge, l3challenge, execution-spec-tests]
+        test-mode: [legacychallenge, long, challenge, l3challenge, execution-spec-tests, pebble]
 
     steps:
       - name: Checkout
@@ -84,6 +84,11 @@ jobs:
       - name: run execution spec tests
         if: matrix.test-mode == 'execution-spec-tests'
         run: ${{ github.workspace }}/.github/workflows/runExecutionSpecTests.sh
+
+      - name: run tests with pebble db
+        if: matrix.test-mode == 'pebble'
+        run: |
+          ${{ github.workspace }}/.github/workflows/gotestsum.sh --timeout 90m --test_database_engine pebble        
 
       - name: Archive detailed run log
         uses: actions/upload-artifact@v5

--- a/cmd/nitro/init_test.go
+++ b/cmd/nitro/init_test.go
@@ -418,6 +418,7 @@ func TestOpenInitializeChainDbIncompatibleStateScheme(t *testing.T) {
 	defer cancel()
 
 	stackConfig := testhelpers.CreateStackConfigForTest(t.TempDir())
+	stackConfig.DBEngine = rawdb.DBPebble
 	stack, err := node.New(stackConfig)
 	Require(t, err)
 	defer stack.Close()
@@ -685,6 +686,7 @@ func TestOpenInitializeChainDbEmptyInit(t *testing.T) {
 	defer cancel()
 
 	stackConfig := testhelpers.CreateStackConfigForTest(t.TempDir())
+	stackConfig.DBEngine = rawdb.DBPebble
 	stack, err := node.New(stackConfig)
 	Require(t, err)
 	defer stack.Close()

--- a/system_tests/archival_path_scheme_test.go
+++ b/system_tests/archival_path_scheme_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccessingPathSchemeState(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithDatabase(rawdb.DBPebble)
 
 	// This test is PathScheme specific, it shouldn't be run with HashScheme
 	builder.RequireScheme(t, rawdb.PathScheme)
@@ -56,7 +56,7 @@ func TestAccessingPathSchemeState(t *testing.T) {
 func TestAccessingPathSchemeArchivalState(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithDatabase(rawdb.DBPebble)
 	builder.execConfig.Caching.Archive = true
 	builder.execConfig.Caching.StateHistory = 2
 

--- a/system_tests/block_validator_test.go
+++ b/system_tests/block_validator_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/redisutil"
-	"github.com/offchainlabs/nitro/util/testhelpers/flag"
+	testflag "github.com/offchainlabs/nitro/util/testhelpers/flag"
 	"github.com/offchainlabs/nitro/util/testhelpers/github"
 	"github.com/offchainlabs/nitro/validator/client/redis"
 )

--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -568,7 +568,7 @@ func createTestNodeOnL1ForBoldProtocol(
 	nodeConfig.BatchPoster.DataPoster.MaxMempoolTransactions = 18
 	fatalErrChan := make(chan error, 10)
 	withoutClientWrapper := false
-	l1info, l1client, l1backend, l1stack, _, _ = createTestL1BlockChain(t, nil, withoutClientWrapper)
+	l1info, l1client, l1backend, l1stack, _, _ = createTestL1BlockChain(t, nil, withoutClientWrapper, testhelpers.CreateStackConfigForTest(""))
 	var l2chainDb ethdb.Database
 	var l2arbDb ethdb.Database
 	var l2blockchain *core.BlockChain
@@ -636,8 +636,10 @@ func createTestNodeOnL1ForBoldProtocol(
 
 	execConfig := ExecConfigDefaultNonSequencerTest(t, rawdb.HashScheme)
 	Require(t, execConfig.Validate())
+	stackConfig := testhelpers.CreateStackConfigForTest("")
+	stackConfig.DBEngine = rawdb.DBPebble
 	initMessage := getInitMessage(ctx, t, l1client, addresses)
-	_, l2stack, l2chainDb, l2arbDb, l2blockchain = createNonL1BlockChainWithStackConfig(t, l2info, "", chainConfig, nil, initMessage, nil, execConfig)
+	_, l2stack, l2chainDb, l2arbDb, l2blockchain = createNonL1BlockChainWithStackConfig(t, l2info, "", chainConfig, nil, initMessage, stackConfig, execConfig)
 	var sequencerTxOptsPtr *bind.TransactOpts
 	var dataSigner signature.DataSignerFunc
 	if isSequencer {
@@ -848,6 +850,7 @@ func create2ndNodeWithConfigForBoldProtocol(
 	nodeConfig.BatchPoster.DataPoster.MaxMempoolTransactions = 18
 	if stackConfig == nil {
 		stackConfig = testhelpers.CreateStackConfigForTest(t.TempDir())
+		stackConfig.DBEngine = rawdb.DBPebble
 	}
 	l2stack, err := node.New(stackConfig)
 	Require(t, err)

--- a/system_tests/fees_test.go
+++ b/system_tests/fees_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
@@ -33,7 +34,7 @@ func TestSequencerFeePaid(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithDatabase(rawdb.DBPebble)
 	cleanup := builder.Build(t)
 	defer cleanup()
 
@@ -135,7 +136,7 @@ func testSequencerPriceAdjustsFrom(t *testing.T, initialEstimate uint64) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithDatabase(rawdb.DBPebble)
 	builder.nodeConfig.DelayedSequencer.FinalizeDistance = 1
 	cleanup := builder.Build(t)
 	defer cleanup()

--- a/system_tests/finality_data_test.go
+++ b/system_tests/finality_data_test.go
@@ -36,7 +36,7 @@ func TestFinalizedBlocksMovedToAncients(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithDatabase(rawdb.DBPebble)
 	// The procedure that periodically pushes finality data, from consensus to execution,
 	// will not be able to get finalized/safe block numbers since UseFinalityData is false.
 	// Therefore, with UseFinalityData set to false, ExecutionEngine will not be able to move data to ancients by itself,

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/offchainlabs/nitro/arbnode"
@@ -299,7 +300,7 @@ func TestRedisForwarderFallbackNoRedis(t *testing.T) {
 			ipcPath:              fallbackIpcPath,
 			redisUrl:             redisUrl,
 			enableSecCoordinator: false,
-		})
+		}).WithDatabase(rawdb.DBPebble)
 	cleanup := builder.Build(t)
 	defer cleanup()
 	fallbackClient := builder.L2.Client

--- a/system_tests/multigas_dump_test.go
+++ b/system_tests/multigas_dump_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/core/rawdb"
 )
 
 // TestMultigasDataFromReceipts spins up an L2 node with ancd checks if multigas data is present in receipts
@@ -44,7 +46,7 @@ func TestMultigasDataCanBeDisabled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, false).WithDatabase(rawdb.DBPebble)
 	builder.execConfig.ExposeMultiGas = false
 	cleanup := builder.Build(t)
 	defer cleanup()

--- a/system_tests/program_gas_test.go
+++ b/system_tests/program_gas_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers/logger"
@@ -275,7 +276,7 @@ func TestProgramKeccakCost(t *testing.T) {
 func setupGasCostTest(t *testing.T) *NodeBuilder {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithDatabase(rawdb.DBPebble)
 	cleanup := builder.Build(t)
 	t.Cleanup(cleanup)
 	return builder

--- a/system_tests/pruning_test.go
+++ b/system_tests/pruning_test.go
@@ -44,7 +44,7 @@ func testPruning(t *testing.T, mode string, pruneParallelStorageTraversal bool) 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithDatabase(rawdb.DBPebble)
 	// PathScheme prunes the state trie by itself, so only HashScheme should be tested
 	builder.RequireScheme(t, rawdb.HashScheme)
 

--- a/system_tests/recreatestate_rpc_test.go
+++ b/system_tests/recreatestate_rpc_test.go
@@ -170,7 +170,7 @@ func TestRecreateStateForRPCBigEnoughDepthLimit(t *testing.T) {
 func TestRecreateStateForRPCDepthLimitExceeded(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithTakeOwnership(false)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithDatabase(rawdb.DBPebble).WithTakeOwnership(false)
 	builder.RequireScheme(t, rawdb.HashScheme)
 	builder.execConfig.RPC.MaxRecreateStateDepth = int64(200)
 	builder.execConfig.Sequencer.MaxBlockSpeed = 0
@@ -335,7 +335,7 @@ func testSkippingSavingStateAndRecreatingAfterRestart(t *testing.T, cacheConfig 
 	maxRecreateStateDepth := int64(30 * 1000 * 1000)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, false).WithDatabase(rawdb.DBPebble)
 
 	builder.execConfig.RPC.MaxRecreateStateDepth = maxRecreateStateDepth
 	builder.execConfig.Sequencer.MaxBlockSpeed = 0

--- a/system_tests/retryable_test.go
+++ b/system_tests/retryable_test.go
@@ -268,6 +268,7 @@ func TestSubmitRetryableImmediateSuccess(t *testing.T) {
 func testSubmitRetryableEmptyEscrow(t *testing.T, arbosVersion uint64) {
 	builder, delayedInbox, lookupL2Tx, ctx, teardown := retryableSetup(t, func(builder *NodeBuilder) {
 		builder.WithArbOSVersion(arbosVersion)
+		builder.WithDatabase(rawdb.DBPebble)
 	})
 	defer teardown()
 
@@ -510,7 +511,9 @@ func insertRetriables(
 }
 
 func TestSubmitManyRetryableFailThenRetry(t *testing.T) {
-	builder, delayedInbox, lookupL2Tx, ctx, teardown := retryableSetup(t)
+	builder, delayedInbox, lookupL2Tx, ctx, teardown := retryableSetup(t, func(b *NodeBuilder) {
+		b.WithDatabase(rawdb.DBPebble)
+	})
 	defer teardown()
 	infraFeeAddr, networkFeeAddr := setupFeeAddresses(t, ctx, builder)
 	elevateL2Basefee(t, ctx, builder)
@@ -1294,7 +1297,9 @@ func TestL1FundedUnsignedTransaction(t *testing.T) {
 }
 
 func TestRetryableSubmissionAndRedeemFees(t *testing.T) {
-	builder, delayedInbox, lookupL2Tx, ctx, teardown := retryableSetup(t)
+	builder, delayedInbox, lookupL2Tx, ctx, teardown := retryableSetup(t, func(b *NodeBuilder) {
+		b.WithDatabase(rawdb.DBPebble)
+	})
 	defer teardown()
 	infraFeeAddr, networkFeeAddr := setupFeeAddresses(t, ctx, builder)
 

--- a/system_tests/revalidation_test.go
+++ b/system_tests/revalidation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
@@ -22,7 +23,8 @@ func TestRevalidationForSpecifiedRange(t *testing.T) {
 	var transferGas = util.NormalizeL2GasForL1GasInitial(800_000, params.GWei) // include room for aggregator L1 costs
 
 	// 1st node with sequencer, stays up all the time.
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).DontParalellise()
+	databaseEngine := rawdb.DBPebble
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).DontParalellise().WithDatabase(databaseEngine)
 	builder.nodeConfig.BlockValidator.Enable = true
 	builder.L2Info = NewBlockChainTestInfo(
 		t,
@@ -36,6 +38,7 @@ func TestRevalidationForSpecifiedRange(t *testing.T) {
 	// This node will be stopped in middle.
 	testDir := t.TempDir()
 	nodeBStack := testhelpers.CreateStackConfigForTest(testDir)
+	nodeBStack.DBEngine = databaseEngine
 	nodeBConfig := builder.nodeConfig
 	nodeBConfig.BatchPoster.Enable = false
 	nodeBParams := &SecondNodeParams{

--- a/system_tests/seq_nonce_test.go
+++ b/system_tests/seq_nonce_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/offchainlabs/nitro/util/arbmath"
@@ -24,7 +25,7 @@ func TestSequencerParallelNonces(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, false).WithDatabase(rawdb.DBPebble)
 	builder.takeOwnership = false
 	builder.execConfig.Sequencer.NonceFailureCacheExpiry = time.Minute
 	cleanup := builder.Build(t)
@@ -127,7 +128,7 @@ func TestSequencerNonceHandling(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithDatabase(rawdb.DBPebble)
 	builder.execConfig.Sequencer.MaxBlockSpeed = time.Second
 	builder.execConfig.Sequencer.NonceFailureCacheExpiry = 4 * time.Second
 	cleanup := builder.Build(t)

--- a/system_tests/seqcompensation_test.go
+++ b/system_tests/seqcompensation_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/offchainlabs/nitro/arbos/l1pricing"
@@ -18,7 +19,7 @@ import (
 func TestSequencerCompensation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithDatabase(rawdb.DBPebble)
 	cleanup := builder.Build(t)
 	defer cleanup()
 

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -439,7 +440,7 @@ func TestPopulateFeedBacklog(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithDatabase(rawdb.DBPebble)
 	builder.BuildL1(t)
 
 	userAccount := "User2"

--- a/system_tests/snap_sync_test.go
+++ b/system_tests/snap_sync_test.go
@@ -28,7 +28,8 @@ func TestSnapSync(t *testing.T) {
 	var transferGas = util.NormalizeL2GasForL1GasInitial(800_000, params.GWei) // include room for aggregator L1 costs
 
 	// 1st node with sequencer, stays up all the time.
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).DontParalellise()
+	databaseEngine := rawdb.DBPebble
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).DontParalellise().WithDatabase(databaseEngine)
 	// only supported for hash scheme
 	builder.RequireScheme(t, rawdb.HashScheme)
 	builder.L2Info = NewBlockChainTestInfo(
@@ -43,6 +44,7 @@ func TestSnapSync(t *testing.T) {
 	// This node will be stopped in middle and arbitrumdata will be deleted.
 	testDir := t.TempDir()
 	nodeBStack := testhelpers.CreateStackConfigForTest(testDir)
+	nodeBStack.DBEngine = databaseEngine
 	nodeBConfig := builder.nodeConfig
 	nodeBConfig.BatchPoster.Enable = false
 	nodeBParams := &SecondNodeParams{

--- a/system_tests/staterecovery_test.go
+++ b/system_tests/staterecovery_test.go
@@ -19,7 +19,7 @@ import (
 func TestRecreateMissingStates(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true).WithDatabase(rawdb.DBPebble)
 	builder.RequireScheme(t, rawdb.HashScheme)
 	builder.execConfig.Caching.Archive = true
 	builder.execConfig.Caching.MaxNumberOfBlocksToSkipStateSaving = 16

--- a/system_tests/timeboost_test.go
+++ b/system_tests/timeboost_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
@@ -922,7 +923,7 @@ func TestTimeboostBulkBlockMetadataAPI(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder := NewNodeBuilder(ctx).DefaultConfig(t, false).DontParalellise()
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, false).DontParalellise().WithDatabase(rawdb.DBPebble)
 	builder.nodeConfig.TransactionStreamer.TrackBlockMetadataFrom = 1
 	builder.execConfig.BlockMetadataApiCacheSize = 0 // Caching is disabled
 	cleanup := builder.Build(t)

--- a/util/testhelpers/env/env.go
+++ b/util/testhelpers/env/env.go
@@ -7,8 +7,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/offchainlabs/nitro/util/testhelpers/flag"
+	testflag "github.com/offchainlabs/nitro/util/testhelpers/flag"
 )
+
+const MemoryDB = "in-memory"
 
 // There are two CI steps, one to run tests using the path state scheme, and one to run tests using the hash state scheme.
 // An environment variable controls that behavior.
@@ -19,4 +21,22 @@ func GetTestStateScheme() string {
 	}
 	log.Debug("test state scheme", "testStateScheme", stateScheme)
 	return stateScheme
+}
+
+func GetTestDatabaseEngine() string {
+	engineFlag := *testflag.DatabaseEngineFlag
+	databaseEngine := MemoryDB
+
+	switch engineFlag {
+	case rawdb.DBLeveldb, rawdb.DBPebble, MemoryDB:
+		databaseEngine = engineFlag
+	default:
+		log.Warn("invalid test database engine flag; using default",
+			"provided", engineFlag,
+			"default", MemoryDB,
+		)
+	}
+
+	log.Debug("test database scheme", "testDatabaseEngine", databaseEngine)
+	return databaseEngine
 }

--- a/util/testhelpers/flag/flag.go
+++ b/util/testhelpers/flag/flag.go
@@ -9,6 +9,7 @@ import (
 var (
 	fs                                            = flag.NewFlagSet("test", flag.ExitOnError)
 	StateSchemeFlag                               = fs.String("test_state_scheme", "", "State scheme to use for tests")
+	DatabaseEngineFlag                            = fs.String("test_database_engine", "", "Database engine to use for tests")
 	RedisFlag                                     = fs.String("test_redis", "", "Redis URL for testing")
 	RecordBlockInputsEnable                       = fs.Bool("recordBlockInputs.enable", false, "Whether to record block inputs as a json file")
 	RecordBlockInputsWithSlug                     = fs.String("recordBlockInputs.WithSlug", "", "Slug directory for validationInputsWriter")

--- a/util/testhelpers/stackconfig.go
+++ b/util/testhelpers/stackconfig.go
@@ -5,6 +5,8 @@ package testhelpers
 
 import (
 	"github.com/ethereum/go-ethereum/node"
+
+	"github.com/offchainlabs/nitro/util/testhelpers/env"
 )
 
 func CreateStackConfigForTest(dataDir string) *node.Config {
@@ -26,6 +28,6 @@ func CreateStackConfigForTest(dataDir string) *node.Config {
 	stackConf.P2P.NoDial = true
 	stackConf.P2P.ListenAddr = ""
 	stackConf.P2P.NAT = nil
-	stackConf.DBEngine = "leveldb"
+	stackConf.DBEngine = env.GetTestDatabaseEngine()
 	return &stackConf
 }


### PR DESCRIPTION
Replaces https://github.com/OffchainLabs/nitro/pull/3915  this PR uses a branch from origin instead of my remote branch. I will use the origin branch going forward.

Resolves NIT-3501

This PR
- makes "in-memory" the default database for system_tests
- you can set which database engine is used with the `--test-database-engine` flag
- adds a nightly ci test runner which runs all system_tests using the pebble database engine