### PR TITLE
Fix flaky failures of TestEthSyncing

### DIFF
--- a/system_tests/eth_sync_test.go
+++ b/system_tests/eth_sync_test.go
@@ -66,9 +66,14 @@ func TestEthSyncing(t *testing.T) {
 	}
 	for testClientB.ConsensusNode.TxStreamer.ExecuteNextMsg(ctx) {
 	}
-	time.Sleep(time.Second * 2)
-	progress, err = testClientB.Client.SyncProgress(ctx)
-	Require(t, err)
+	for range 10 {
+		progress, err = testClientB.Client.SyncProgress(ctx)
+		Require(t, err)
+		if progress == nil {
+			break
+		}
+		time.Sleep(time.Second)
+	}
 	if progress != nil {
 		Fatal(t, "eth_syncing did not return nil but should have")
 	}


### PR DESCRIPTION
This PR modifies `TestEthSyncing` to not rely on time delays- this is an attempt to make it less flaky in various test modes.
Verified that `TestEthSyncing` passes both in pathdb and default-A test modes.

Resolves NIT-4104