### PR TITLE
Centralize validator worker throttling in BlockValidator #NIT-3339

### DIFF
--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -80,7 +80,7 @@ type ThrottledValidationSpawner struct {
 func NewThrottledValidationSpawner(spawner validator.ValidationSpawner) *ThrottledValidationSpawner {
 	return &ThrottledValidationSpawner{
 		Spawner:   spawner,
-		Throttler: &WorkerThrottler{maxWorkers: spawner.WorkersCapacity()},
+		Throttler: &WorkerThrottler{maxWorkers: spawner.Capacity()},
 	}
 }
 
@@ -1357,12 +1357,12 @@ func (v *BlockValidator) Initialize(ctx context.Context) error {
 	for _, root := range moduleRoots {
 		if v.redisValidator != nil && validator.SpawnerSupportsModule(v.redisValidator, root) {
 			v.chosenValidator[root] = NewThrottledValidationSpawner(v.redisValidator)
-			log.Info("validator chosen", "WasmModuleRoot", root, "chosen", "redis", "maxWorkers", v.redisValidator.WorkersCapacity())
+			log.Info("validator chosen", "WasmModuleRoot", root, "chosen", "redis", "maxWorkers", v.redisValidator.Capacity())
 		} else {
 			for _, spawner := range v.execSpawners {
 				if validator.SpawnerSupportsModule(spawner, root) {
 					v.chosenValidator[root] = NewThrottledValidationSpawner(spawner)
-					log.Info("validator chosen", "WasmModuleRoot", root, "chosen", spawner.Name(), "maxWorkers", spawner.WorkersCapacity())
+					log.Info("validator chosen", "WasmModuleRoot", root, "chosen", spawner.Name(), "maxWorkers", spawner.Capacity())
 					break
 				}
 			}

--- a/validator/client/redis/producer.go
+++ b/validator/client/redis/producer.go
@@ -75,8 +75,8 @@ func ValidationClientConfigAddOptions(prefix string, f *pflag.FlagSet) {
 // ValidationClient implements validation client through redis streams.
 type ValidationClient struct {
 	stopwaiter.StopWaiter
-	config          *ValidationClientConfig
-	workersCapacity int
+	config   *ValidationClientConfig
+	capacity int
 	// producers stores moduleRoot to producer mapping.
 	producers   map[common.Hash]*pubsub.Producer[*validator.ValidationInput, validator.GoGlobalState]
 	redisClient redis.UniversalClient
@@ -92,10 +92,10 @@ func NewValidationClient(cfg *ValidationClientConfig) (*ValidationClient, error)
 		return nil, err
 	}
 	validationClient := &ValidationClient{
-		config:          cfg,
-		producers:       make(map[common.Hash]*pubsub.Producer[*validator.ValidationInput, validator.GoGlobalState]),
-		redisClient:     redisClient,
-		workersCapacity: int(cfg.Room),
+		config:      cfg,
+		producers:   make(map[common.Hash]*pubsub.Producer[*validator.ValidationInput, validator.GoGlobalState]),
+		redisClient: redisClient,
+		capacity:    int(cfg.Room),
 	}
 	return validationClient, nil
 }
@@ -169,6 +169,6 @@ func (c *ValidationClient) StylusArchs() []rawdb.WasmTarget {
 	return stylusArchs
 }
 
-func (c *ValidationClient) WorkersCapacity() int {
-	return int(c.workersCapacity)
+func (c *ValidationClient) Capacity() int {
+	return int(c.capacity)
 }

--- a/validator/interface.go
+++ b/validator/interface.go
@@ -18,7 +18,7 @@ type ValidationSpawner interface {
 	StylusArchs() []rawdb.WasmTarget
 	// This is a static number representing the maximum number of workers, should not change over time.
 	// block_validator uses this to size its worker pool.
-	WorkersCapacity() int
+	Capacity() int
 }
 
 type ValidationRun interface {

--- a/validator/server_arb/validator_spawner.go
+++ b/validator/server_arb/validator_spawner.go
@@ -214,7 +214,7 @@ func (v *ArbitratorSpawner) Launch(entry *validator.ValidationInput, moduleRoot 
 	return server_common.NewValRun(promise, moduleRoot)
 }
 
-func (v *ArbitratorSpawner) WorkersCapacity() int {
+func (v *ArbitratorSpawner) Capacity() int {
 	avail := v.config().Workers
 	if avail == 0 {
 		avail = util.GoMaxProcs()

--- a/validator/server_jit/spawner.go
+++ b/validator/server_jit/spawner.go
@@ -109,7 +109,7 @@ func (v *JitSpawner) Launch(entry *validator.ValidationInput, moduleRoot common.
 	return server_common.NewValRun(promise, moduleRoot)
 }
 
-func (v *JitSpawner) WorkersCapacity() int {
+func (v *JitSpawner) Capacity() int {
 	avail := v.config().Workers
 	if avail == 0 {
 		avail = util.GoMaxProcs()

--- a/validator/valnode/validation_api.go
+++ b/validator/valnode/validation_api.go
@@ -28,13 +28,13 @@ func (a *ValidationServerAPI) Name() string {
 	return a.spawner.Name()
 }
 
-func (a *ValidationServerAPI) WorkersCapacity() int {
-	return a.spawner.WorkersCapacity()
+func (a *ValidationServerAPI) Capacity() int {
+	return a.spawner.Capacity()
 }
 
 // This is for backwards compatibility, should be removed in the future.
 func (a *ValidationServerAPI) Room() int {
-	return a.spawner.WorkersCapacity()
+	return a.spawner.Capacity()
 }
 
 func (a *ValidationServerAPI) Validate(ctx context.Context, entry *server_api.InputJSON, moduleRoot common.Hash) (validator.GoGlobalState, error) {


### PR DESCRIPTION
 ## Summary

  - Refactors validator interface by replacing `Room()` method with `MaxAvailableWorkers()` to clarify that spawners report capacity rather than tracking current
  availability
  - Introduces `WorkerThrottler` in `BlockValidator` to centralize concurrency management across all validation spawners
  - Removes atomic counter tracking from individual spawners (ArbitratorSpawner, JitSpawner, ValidationClient, Redis client), simplifying their implementation
