### PR TITLE
[NIT-4130] Enhance state management in StopWaiterSafe

### DIFF
--- a/util/stopwaiter/state/state.go
+++ b/util/stopwaiter/state/state.go
@@ -25,6 +25,7 @@ func (s *InternalState) Unlock() {
 type LockedInternalState struct {
 	Started   bool
 	Stopped   bool
+	Name      string
 	ctx       context.Context
 	parentCtx context.Context
 	StopFunc  func()


### PR DESCRIPTION
Analogous changes as in #3981 - we move mutex-guarded fields into a separate struct with private data accessible only via locking mechanism.

I will try to find out if we can come up with some generic utility for this kind of state management.