### PR TITLE
[NIT-4107] Update GenesisBlockNum to first nitro block in chain info

### DIFF
--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -37,7 +37,7 @@
         "DataAvailabilityCommittee": false,
         "InitialArbOSVersion": 6,
         "InitialChainOwner": "0xd345e41ae2cb00311956aa7109fc801ae8c81a52",
-        "GenesisBlockNum": 0
+        "GenesisBlockNum": 22207818
       }
     },
     "rollup": {


### PR DESCRIPTION
Based on https://www.notion.so/arbitrum/When-was-Arbitrum-One-upgraded-from-Classic-to-Nitro-0892200359bb41b6b378b8a21cc86401#e6fbdf509e814461b021de4878b7bd96