### PR TITLE
Add legacy validator back for split validator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -321,7 +321,7 @@ USER user
 WORKDIR /home/user/
 ENTRYPOINT [ "/usr/local/bin/nitro" ]
 
-FROM offchainlabs/nitro-node:v2.3.4-rc.5-b4cc111 AS nitro-legacy
+FROM offchainlabs/nitro-node:v3.7.6-c0fe95e AS nitro-legacy
 
 FROM nitro-node-slim AS nitro-node
 USER root
@@ -356,10 +356,12 @@ USER user
 # We keep the code (commented out), and the docker-target, for use in case such an update is needed again.
 FROM nitro-node AS nitro-node-validator
 USER root
+COPY --from=nitro-legacy /usr/local/bin/nitro-val /home/user/nitro-legacy/bin/nitro-val
+COPY --from=nitro-legacy /usr/local/bin/jit /home/user/nitro-legacy/bin/jit
 RUN export DEBIAN_FRONTEND=noninteractive && \
-     apt-get update && \
-     apt-get install -y xxd netcat-traditional && \
-     rm -rf /var/lib/apt/lists/* /usr/share/doc/* /var/cache/ldconfig/aux-cache /usr/lib/python3.9/__pycache__/ /usr/lib/python3.9/*/__pycache__/ /var/log/*
+    apt-get update && \
+    apt-get install -y xxd netcat-traditional && \
+    rm -rf /var/lib/apt/lists/* /usr/share/doc/* /var/cache/ldconfig/aux-cache /usr/lib/python3.9/__pycache__/ /usr/lib/python3.9/*/__pycache__/ /var/log/*
 COPY scripts/split-val-entry.sh /usr/local/bin
 ENTRYPOINT [ "/usr/local/bin/split-val-entry.sh" ]
 USER user

--- a/scripts/split-val-entry.sh
+++ b/scripts/split-val-entry.sh
@@ -2,15 +2,22 @@
 
 xxd -l 32 -ps -c 40 /dev/urandom > /tmp/nitro-val.jwt
 
+legacyvalopts=()
 latestvalopts=()
 while [[ $1 == "--val-options"* ]]; do
+    setlegacy=true
     setlatest=true
     if [[ $1 == "--val-options-legacy" ]]; then
         setlatest=false
-        echo "warning! legacy validator options set and will have no effect"
+    fi
+    if [[ $1 == "--val-options-latest" ]]; then
+        setlegacy=false
     fi
     shift
     while [[ "$1" != "--" ]] && [[ $# -gt 0 ]]; do
+        if $setlegacy; then
+            legacyvalopts=( "${legacyvalopts[@]}" "$1" )
+        fi
         if $setlatest; then
             latestvalopts=( "${latestvalopts[@]}" "$1" )
         fi
@@ -24,12 +31,13 @@ echo launching validation servers
 # add their port to wait loop
 # edit validation-server-configs-list to include the other nodes
 /usr/local/bin/nitro-val --file-logging.enable=false --auth.addr 127.0.0.10 --auth.origins 127.0.0.1 --auth.jwtsecret /tmp/nitro-val.jwt --auth.port 52000 "${latestvalopts[@]}" &
-# shellcheck disable=SC2043
-for port in 52000; do
+/home/user/nitro-legacy/bin/nitro-val --file-logging.enable=false --auth.addr 127.0.0.10 --auth.origins 127.0.0.1 --auth.jwtsecret /tmp/nitro-val.jwt --auth.port 52001 --validation.wasm.root-path /home/user/nitro-legacy/machines "${legacyvalopts[@]}" &
+for port in 52000 52001; do
     while ! nc -w1 -z 127.0.0.10 $port; do
         echo waiting for validation port $port
         sleep 1
     done
 done
 echo launching nitro-node
-exec /usr/local/bin/nitro --validation.wasm.allowed-wasm-module-roots /home/user/target/machines --node.block-validator.validation-server-configs-list='[{"jwtsecret":"/tmp/nitro-val.jwt","url":"ws://127.0.0.10:52000"}]' "$@"
+exec /usr/local/bin/nitro --validation.wasm.allowed-wasm-module-roots /home/user/nitro-legacy/machines,/home/user/target/machines --node.block-validator.validation-server-configs-list='[{"jwtsecret":"/tmp/nitro-val.jwt","url":"ws://127.0.0.10:52000"}, {"jwtsecret":"/tmp/nitro-val.jwt","url":"ws://127.0.0.10:52001"}]' "$@"
+


### PR DESCRIPTION
Pre-stylus legacy validator was no longer needed, so was removed from split validator.  Similar split validator functionality is desired for ArbOS50, so adding it back in.
