### PR TITLE
chore(system_tests): remove redundant batchNum assignment

### DIFF
--- a/system_tests/inbox_blob_failure_test.go
+++ b/system_tests/inbox_blob_failure_test.go
@@ -251,8 +251,7 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 		t.Logf("PASS: Follower is fully synced")
 	}
 
-	// Prevent unused variable warning
-	_ = batchNum
+
 }
 
 // Build2ndNodeWithBlobReader builds a second node with a custom blob reader.


### PR DESCRIPTION
Remove the unused batchNum assignment helper in system_tests/inbox_blob_failure_test.go. Keep the code lean: batchNum already participates in logging and metadata checks, so no warning suppression is needed.