### PR TITLE
fix: show correct value in redis database number error

### DIFF
--- a/util/redisutil/redisutil.go
+++ b/util/redisutil/redisutil.go
@@ -68,7 +68,7 @@ func parseFailoverRedisUrl(redisUrl string) (*redis.FailoverOptions, error) {
 		o.MasterName = f[0]
 		var err error
 		if o.DB, err = strconv.Atoi(f[1]); err != nil {
-			return nil, fmt.Errorf("redis: invalid database number: %q", f[0])
+			return nil, fmt.Errorf("redis: invalid database number: %q", f[1])
 		}
 	default:
 		return nil, fmt.Errorf("redis: invalid URL path: %s", u.Path)


### PR DESCRIPTION
Fixed misleading error message in parseFailoverRedisUrl. When parsing redis+sentinel URL with invalid database number (e.g. /mymaster/abc),the error was showing master name instead of the actual invalid value.

Before: "redis: invalid database number: "mymaster""
After:  "redis: invalid database number: "abc""

