### PR TITLE
Respect context cancellation in RestfulDasClient

### DIFF
--- a/daprovider/das/restful_client.go
+++ b/daprovider/das/restful_client.go
@@ -79,7 +79,12 @@ func (c *RestfulDasClient) GetByHash(ctx context.Context, hash common.Hash) ([]b
 }
 
 func (c *RestfulDasClient) HealthCheck(ctx context.Context) error {
-	res, err := http.Get(c.url + healthRequestPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url+healthRequestPath, nil)
+	if err != nil {
+		return err
+	}
+
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -91,7 +96,12 @@ func (c *RestfulDasClient) HealthCheck(ctx context.Context) error {
 }
 
 func (c *RestfulDasClient) ExpirationPolicy(ctx context.Context) (dasutil.ExpirationPolicy, error) {
-	res, err := http.Get(c.url + expirationPolicyRequestPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url+expirationPolicyRequestPath, nil)
+	if err != nil {
+		return -1, err
+	}
+
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
switch `HealthCheck` and `ExpirationPolicy` to context-aware HTTP requests; ensure DAS client requests terminate promptly on cancellation or deadlines

