### PR TITLE
fix: use structured logging format instead of printf-style in log.Warn calls

### DIFF
--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -476,7 +476,7 @@ func (c *SeqCoordinator) chosenOneRelease(ctx context.Context) error {
 	// got error - was it still released?
 	current, err := c.CurrentChosenSequencer(ctx)
 	if err != nil {
-		log.Warn("unable to verify sequencer release status due to Redis error: %v", err)
+		log.Warn("unable to verify sequencer release status due to Redis error", "err", err)
 		return releaseErr
 	}
 	if current != c.config.Url() {

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -517,7 +517,7 @@ func validateOrUpgradeWasmerSerializeVersion(db ethdb.Database) error {
 			}
 		}
 		if versionInDB != WasmerSerializeVersion {
-			log.Warn("Detected wasmer serialize version %v, expected version %v - removing old wasm entries", versionInDB, WasmerSerializeVersion)
+			log.Warn("Detected wasmer serialize version mismatch - removing old wasm entries", "versionInDB", versionInDB, "expectedVersion", WasmerSerializeVersion)
 			prefixes := rawdb.WasmPrefixesExceptWavm()
 			if err := deleteWasmEntries(db, prefixes, false, 0); err != nil {
 				return fmt.Errorf("Failed to purge wasm entries: %w", err)

--- a/validator/client/redis/producer.go
+++ b/validator/client/redis/producer.go
@@ -115,7 +115,7 @@ func (c *ValidationClient) Initialize(ctx context.Context, moduleRoots []common.
 		p, err := pubsub.NewProducer[*validator.ValidationInput, validator.GoGlobalState](
 			c.redisClient, server_api.RedisStreamForRoot(c.config.StreamPrefix, mr), &c.config.ProducerConfig)
 		if err != nil {
-			log.Warn("failed init redis for %v: %w", mr, err)
+			log.Warn("failed init redis", "moduleRoot", mr, "err", err)
 			continue
 		}
 		p.Start(c.GetContext())


### PR DESCRIPTION
Found 3 log.Warn calls using printf-style formatting (%v, %w) instead of go-ethereum's structured logging key-value pairs.

This caused malformed output where placeholders stayed as literal text:
  WARN failed init redis for %v: %w    0xabc123="connection refused"

Instead of proper structured logging:
  WARN failed init redis    moduleRoot=0xabc123 err="connection refused"
