### PR TITLE
Add return error in case of missing code for SetProgramCached

### DIFF
--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -464,6 +464,9 @@ func (p Programs) SetProgramCached(
 		if err != nil {
 			return err
 		}
+		if len(code) == 0 {
+			return fmt.Errorf("code not found for codeHash: %x", codeHash)
+		}
 		cacheProgram(db, moduleHash, program, address, code, codeHash, params, debug, time, runCtx)
 	} else {
 		evictProgram(db, moduleHash, program.version, debug, runCtx, expired)


### PR DESCRIPTION
Fixes NIT-3284 

Add check against code existence since `Code()` does not return any errors. We could refactor `Code()` itself; however, that would go against `ContractCodeReader` interface definition for `Code()`. We could also add a `log.Warn` to `Code()` but thought to keep that part of the logic simple, which also keeps consistent with the other call sites of `Code()`, where [here](https://github.com/OffchainLabs/go-ethereum/blob/edd083e5055695d1f1bbf540e5aeb6dac03121c9/core/state/iterator.go#L147-L153) and [here](https://github.com/OffchainLabs/go-ethereum/blob/edd083e5055695d1f1bbf540e5aeb6dac03121c9/core/state/state_object.go#L537-L543) the caller also checks for missing code. To keep things simple and consistent we just add a check for missing code to `SetProgramCached`.