### PR TITLE
Optimize DivCeil to reuse the computed quotient

### DIFF
--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -394,10 +394,11 @@ func SaturatingNeg[T Signed](value T) T {
 
 // Integer division but rounding up
 func DivCeil[T Unsigned](value, divisor T) T {
+	quotient := value / divisor
 	if value%divisor == 0 {
-		return value / divisor
+		return quotient
 	}
-	return value/divisor + 1
+	return quotient + 1
 }
 
 // ApproxExpBasisPoints return the Maclaurin series approximation of e^x, where


### PR DESCRIPTION
cache the result of value / divisor inside DivCeil, reuse the cached quotient to eliminate a second identical division, keep function behaviour unchanged while reducing redundant work