### PR TITLE
Remove unreachable batch poster verification in system test

### DIFF
--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -182,33 +182,6 @@ func testBatchPosterParallel(t *testing.T, useRedis bool, useRedisLock bool) {
 		}
 	}
 
-	// TODO: factor this out in separate test case and skip it or delete this
-	// code entirely.
-	// I've locally confirmed that this passes when the clique period is set to 1.
-	// However, setting the clique period to 1 slows everything else (including the L1 deployment for this test) down to a crawl.
-	if false {
-		// Make sure the batch poster is able to post multiple batches in one block
-		endL1Block, err := builder.L1.Client.BlockNumber(ctx)
-		Require(t, err)
-		seqInbox, err := arbnode.NewSequencerInbox(builder.L1.Client, builder.L2.ConsensusNode.DeployInfo.SequencerInbox, 0)
-		Require(t, err)
-		batches, err := seqInbox.LookupBatchesInRange(ctx, new(big.Int).SetUint64(startL1Block), new(big.Int).SetUint64(endL1Block))
-		Require(t, err)
-		var foundMultipleInBlock bool
-		for i := range batches {
-			if i == 0 {
-				continue
-			}
-			if batches[i-1].ParentChainBlockNumber == batches[i].ParentChainBlockNumber {
-				foundMultipleInBlock = true
-				break
-			}
-		}
-
-		if !foundMultipleInBlock {
-			Fatal(t, "only found one batch per block")
-		}
-	}
 
 	l2balance, err := testClientB.Client.BalanceAt(ctx, builder.L2Info.GetAddress("User2"), nil)
 	Require(t, err)


### PR DESCRIPTION
Drop the if false block in TestBatchPoster that could never execute and only carried TODO notes. Remove redundant code path to keep the system test focused on real coverage and avoid confusing reviewers.