### PR TITLE
Add More Types to Timeboost Bid Hashes for Replay Protection

### DIFF
--- a/timeboost/types.go
+++ b/timeboost/types.go
@@ -43,13 +43,17 @@ func (b *Bid) ToEIP712Hash(domainSeparator [32]byte) (common.Hash, error) {
 			{Name: "round", Type: "uint64"},
 			{Name: "expressLaneController", Type: "address"},
 			{Name: "amount", Type: "uint256"},
+			{Name: "chainId", Type: "uint256"},
+			{Name: "auctionContractAddress", Type: "address"},
 		},
 	}
 
 	message := apitypes.TypedDataMessage{
-		"round":                 big.NewInt(0).SetUint64(b.Round),
-		"expressLaneController": [20]byte(b.ExpressLaneController),
-		"amount":                b.Amount,
+		"round":                  big.NewInt(0).SetUint64(b.Round),
+		"expressLaneController":  [20]byte(b.ExpressLaneController),
+		"amount":                 b.Amount,
+		"chainId":                b.ChainId,
+		"auctionContractAddress": [20]byte(b.AuctionContractAddress),
 	}
 
 	typedData := apitypes.TypedData{


### PR DESCRIPTION
This PR adds more types to timeboost bids for stronger replay protection across chains. Although the only timeboost-enabled chain right now is Arbitrum One, this future-proofs the bid system