### PR TITLE
Return nil from dumpKeyset after successful keyset dump

### DIFF
--- a/cmd/datool/datool.go
+++ b/cmd/datool/datool.go
@@ -372,5 +372,5 @@ func dumpKeyset(args []string) error {
 	fmt.Printf("Keyset: %s\n", hexutil.Encode(keysetBytes))
 	fmt.Printf("KeysetHash: %s\n", hexutil.Encode(keysetHash[:]))
 
-	return err
+	return nil
 }


### PR DESCRIPTION
replace the redundant return err at the end of dumpKeyset with an explicit return nil for the success path