### PR TITLE
Add test-go-deps step in _bold-legacy.yml

### DIFF
--- a/.github/workflows/_bold-legacy.yml
+++ b/.github/workflows/_bold-legacy.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Setup CI
         uses: ./.github/actions/ci-setup
 
+      - name: Build
+        run: make -j8 build test-go-deps
+
       - name: run challenge tests
         run: >-
           ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags legacychallengetest


### PR DESCRIPTION
Close NIT-4161

This PR fixes [this](https://github.com/OffchainLabs/nitro/actions/runs/19817013744/job/56770628407#step:4:937) error by adding `make -j8 build test-go-deps` step for Bold legacy tests