### PR TITLE
Do not require BatchMetadata for reading DelayedInbox

### DIFF
--- a/arbnode/delayed.go
+++ b/arbnode/delayed.go
@@ -155,7 +155,7 @@ func (m *DelayedInboxMessage) AfterInboxAcc() common.Hash {
 	return crypto.Keccak256Hash(m.BeforeInboxAcc[:], hash)
 }
 
-func (b *DelayedBridge) LookupMessagesInRange(ctx context.Context, from, to *big.Int, batchFetcher arbostypes.FallibleBatchFetcher) ([]*DelayedInboxMessage, error) {
+func (b *DelayedBridge) LookupMessagesInRange(ctx context.Context, from, to *big.Int, batchFetcher arbostypes.FallibleBatchFetcherWithParentBlock) ([]*DelayedInboxMessage, error) {
 	query := ethereum.FilterQuery{
 		BlockHash: nil,
 		FromBlock: from,
@@ -184,7 +184,7 @@ func (l sortableMessageList) Less(i, j int) bool {
 	return bytes.Compare(l[i].Message.Header.RequestId.Bytes(), l[j].Message.Header.RequestId.Bytes()) < 0
 }
 
-func (b *DelayedBridge) logsToDeliveredMessages(ctx context.Context, logs []types.Log, batchFetcher arbostypes.FallibleBatchFetcher) ([]*DelayedInboxMessage, error) {
+func (b *DelayedBridge) logsToDeliveredMessages(ctx context.Context, logs []types.Log, batchFetcher arbostypes.FallibleBatchFetcherWithParentBlock) ([]*DelayedInboxMessage, error) {
 	if len(logs) == 0 {
 		return nil, nil
 	}

--- a/arbnode/delayed_sequencer.go
+++ b/arbnode/delayed_sequencer.go
@@ -174,7 +174,7 @@ func (d *DelayedSequencer) sequenceWithoutLockout(ctx context.Context, lastBlock
 			}
 		}
 		lastDelayedAcc = acc
-		err = msg.FillInBatchGasFields(func(batchNum uint64, _parentChainBlockNumber uint64) ([]byte, error) {
+		err = msg.FillInBatchGasFields(func(batchNum uint64) ([]byte, error) {
 			data, _, err := d.reader.GetSequencerMessageBytesForParentBlock(ctx, batchNum, parentChainBlockNumber)
 			return data, err
 		})

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -350,7 +350,7 @@ func (t *InboxTracker) legacyGetDelayedMessageAndAccumulator(ctx context.Context
 		return nil, common.Hash{}, err
 	}
 
-	err = msg.FillInBatchGasFields(func(batchNum uint64, parentChainBlockNumber uint64) ([]byte, error) {
+	err = msg.FillInBatchGasFields(func(batchNum uint64) ([]byte, error) {
 		data, _, err := t.txStreamer.inboxReader.GetSequencerMessageBytes(ctx, batchNum)
 		return data, err
 	})
@@ -363,7 +363,7 @@ func (t *InboxTracker) GetDelayedMessageAccumulatorAndParentChainBlockNumber(ctx
 	if err != nil {
 		return msg, acc, parentChainBlockNumber, err
 	}
-	err = msg.FillInBatchGasFields(func(batchNum uint64, _parentChainBlockNumber uint64) ([]byte, error) {
+	err = msg.FillInBatchGasFields(func(batchNum uint64) ([]byte, error) {
 		data, _, err := t.txStreamer.inboxReader.GetSequencerMessageBytesForParentBlock(ctx, batchNum, parentChainBlockNumber)
 		return data, err
 	})

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -507,7 +507,7 @@ func (s *TransactionStreamer) GetMessage(msgIdx arbutil.MessageIndex) (*arbostyp
 		}
 	}
 
-	err = message.Message.FillInBatchGasFields(func(batchNum uint64, _parentChainBlockNumber uint64) ([]byte, error) {
+	err = message.Message.FillInBatchGasFields(func(batchNum uint64) ([]byte, error) {
 		ctx, err := s.GetContextSafe()
 		if err != nil {
 			return nil, err

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -127,7 +127,7 @@ func (i WavmInbox) SetPositionWithinMessage(pos uint64) {
 func (i WavmInbox) ReadDelayedInbox(seqNum uint64) (*arbostypes.L1IncomingMessage, error) {
 	log.Info("ReadDelayedMsg", "seqNum", seqNum)
 	data := wavmio.ReadDelayedInboxMessage(seqNum)
-	return arbostypes.ParseIncomingL1Message(bytes.NewReader(data), func(batchNum uint64, parentChainBlockNumber uint64) ([]byte, error) {
+	return arbostypes.ParseIncomingL1Message(bytes.NewReader(data), func(batchNum uint64) ([]byte, error) {
 		return wavmio.ReadInboxMessage(batchNum), nil
 	})
 }
@@ -236,7 +236,7 @@ func main() {
 		panic(fmt.Sprintf("Error opening state db: %v", err.Error()))
 	}
 
-	batchFetcher := func(batchNum uint64, parentChainBlockNumber uint64) ([]byte, error) {
+	batchFetcher := func(batchNum uint64) ([]byte, error) {
 		currentBatch := wavmio.GetInboxPosition()
 		if batchNum > currentBatch {
 			return nil, fmt.Errorf("invalid batch fetch request %d, max %d", batchNum, currentBatch)

--- a/system_tests/state_fuzz_test.go
+++ b/system_tests/state_fuzz_test.go
@@ -55,7 +55,7 @@ func BuildBlock(
 	delayedMessagesRead = inboxMultiplexer.DelayedMessagesRead()
 	l1Message := message.Message
 
-	batchFetcher := func(uint64, uint64) ([]byte, error) {
+	batchFetcher := func(uint64) ([]byte, error) {
 		return seqBatch, nil
 	}
 	err = l1Message.FillInBatchGasFields(batchFetcher)


### PR DESCRIPTION
Fixes NIT-4150

`BatchMetadata` might not be available when called on a `DelayedInbox` message, so we fetch parent block hash from `GetDelayedMessageAccumulatorAndParentChainBlockNumber` instead to avoid missing BatchMetadata. We do so by avoiding to read `BatchMetadata` on most callsites of `FillInBatchGasFields` which are 8:

[1] - `arbnode/delayed_sequencer.go:sequenceWithoutLockout()`

A little bit above the call to `FillInBatchGasFields` we have a call to the following where we can get parentChainBlockNumber from it.
```go
msg, acc, parentChainBlockNumber, err := d.inbox.GetDelayedMessageAccumulatorAndParentChainBlockNumber(ctx, pos)
...
err = msg.FillInBatchGasFields(func(batchNum uint64, _parentChainBlockNumber uint64) ([]byte, error) {
			data, _, err := d.reader.GetSequencerMessageBytesForParentBlock(ctx, batchNum, parentChainBlockNumber)
```
[2] - `arbnode/delayed.go:logsToDeliveredMessages()`
```go
err := msg.Message.FillInBatchGasFields(batchFetcher)
```
such batchFetcher implementation is coming from https://github.com/OffchainLabs/nitro/blob/aa985884340fb200a70ad727354b62ca397deeb8/arbnode/inbox_reader.go#L476-L486

here it gets a bit tricky as at the level of `LookupMessagesInRange` call we don't have access to `parentChainBlockNumber`, so we introduce another anonymous function `arbostypes.FallibleBatchFetcherWithParentBlock` to also take in `parentChainBlockNumber`. That way inside `LookupMessagesInRange` we have:
```
r.delayedBridge.LookupMessagesInRange(.., batchFetcher)
|
└─> b.logsToDeliveredMessages(ctx, logs, batchFetcher)
    |
    └─> parsedLog, err := b.con.ParseMessageDelivered(ethLog)
    |
    └─> err := msg.Message.FillInBatchGasFields(batchFetcher, parsedLog.Raw.BlockNumber)
```
Then inside `FillInBatchGasFields` we pass `parsedLog.Raw.BlockNumber` to `batchFetcher`, then that way we can call `GetSequencerMessageBytesForParentBlock` instead of `GetSequencerMessageBytesFor`.

[3] - `arbnode/inbox_tracker.go:legacyGetDelayedMessageAndAccumulator`

`legacyGetDelayedMessageAndAccumulator` is only used for legacy messages so it's okay to rely on `BatchMetadata`

[4] - `arbnode/inbox_tracker.go:GetDelayedMessageAccumulatorAndParentChainBlockNumber`

Similar to case [1] we get `parentChainBlockNumber` from a call just above `FillInBatchGasFields`, then it becomes:
```go
msg, acc, parentChainBlockNumber, err := t.getRawDelayedMessageAccumulatorAndParentChainBlockNumber(ctx, seqNum)
	err = msg.FillInBatchGasFields(func(batchNum uint64, _parentChainBlockNumber uint64) ([]byte, error) {
		data, _, err := t.txStreamer.inboxReader.GetSequencerMessageBytesForParentBlock(ctx, batchNum, parentChainBlockNumber)
```
[5] - `arbnode/transaction_streamer.go:GetMessage()`

This is a tricky case and the logic now became:
1. If this is a delayed message, we extract `ParentChainBlockNumber` using `getRawDelayedMessageAccumulatorAndParentChainBlockNumber`
2. If 1 fails (it's possible we got this message from feed before we read it from delayed-inbox), then we try reading the batch with `GetBatchMetadata`
3. If 2 fails (possibly due to blob-read failure), we check if `LegacyBatchGasCost` is non-nil, and if so we use the message as is.
4. If all fails then we return an error.

[6] - `arbos/arbostypes/incomingmessage.go:ParseIncomingL1Message`

This callsite is okay and no modifications are needed as most calls to `ParseIncomingL1Message` don't require an anonymous function `FallibleBatchFetcher`. The only one that does is from `cmd/replay/main.go` which does not make use of `GetSequencerMessageBytesFor`: https://github.com/OffchainLabs/nitro/blob/179bd980a4ae87e649393b7858f3978ea16d43b6/cmd/replay/main.go#L130-L132

[7] - `cmd/replay/main.go:main()`

similar to case [6] the anonymous function batchFetcher does not make a call into `GetSequencerMessageBytesFor` so no modifications required.

[8] - `system_tests/state_fuzz_test.go:BuildBlock()`

this is a test and similar to cases [6] and [7] the anonymous function `batchFetcher` does not make a call into `GetSequencerMessageBytesFor` so no modifications required.

In short:

- No modifications needed for callsites in cases [3], [6], [7] and [8]
- To support cases [1] and [4] we get `parentChainBlockNumber` from a call outside of `FillInBatchGasFields` then we use `GetSequencerMessageBytesForParentBlock`.
- Case [2] we pass `parentChainBlockNumber` to new function `FillInBatchGasFieldsWithParentBlock`
- And for case [5] we try to fetch `parentChainBlockNumber` if it's a `DelayedMessage` if not we fallback to using `BatchMetadata`