### PR TITLE
Remove legacy Version0 blob proof support now that Fusaka has launched

### DIFF
--- a/arbnode/parent/parent.go
+++ b/arbnode/parent/parent.go
@@ -110,27 +110,3 @@ func (p *ParentChain) BlobFeePerByte(ctx context.Context, h *types.Header) (*big
 	}
 	return eip4844.CalcBlobFee(pCfg, header), nil
 }
-
-// SupportsCellProofs returns whether the parent chain has activated the Osaka fork
-// (Fusaka), which introduced cell proofs for blobs.
-// Passing in a nil header will use the time from the latest header.
-func (p *ParentChain) SupportsCellProofs(ctx context.Context, h *types.Header) (bool, error) {
-	header := h
-	if h == nil {
-		lh, err := p.L1Reader.LastHeader(ctx)
-		if err != nil {
-			return false, err
-		}
-		header = lh
-	}
-	pCfg, err := p.chainConfig()
-	if err != nil {
-		return false, err
-	}
-	if pCfg.IsArbitrum() {
-		// Arbitrum does not support blob transactions, so this should not have been called.
-		return false, nil
-	}
-	// arbosVersion 0 because we're checking L1 (not L2 Arbitrum)
-	return pCfg.IsOsaka(pCfg.LondonBlock, header.Time, 0), nil
-}

--- a/util/blobs/blobs.go
+++ b/util/blobs/blobs.go
@@ -128,36 +128,21 @@ func ComputeCommitmentsAndHashes(blobs []kzg4844.Blob) ([]kzg4844.Commitment, []
 	return commitments, versionedHashes, nil
 }
 
-// ComputeProofs computes either legacy blob proofs (Version0) or cell proofs (Version1)
-// based on the enableCellProofs flag. Returns proofs, version byte, and error.
-func ComputeProofs(blobs []kzg4844.Blob, commitments []kzg4844.Commitment, enableCellProofs bool) ([]kzg4844.Proof, byte, error) {
+// ComputeProofs computes cell proofs for the given blobs.
+// Each blob generates CellProofsPerBlob (128) proofs.
+// Returns proofs, version byte (always 1), and error.
+func ComputeProofs(blobs []kzg4844.Blob, commitments []kzg4844.Commitment) ([]kzg4844.Proof, byte, error) {
 	if len(blobs) != len(commitments) {
 		return nil, 0, fmt.Errorf("ComputeProofs got %v blobs but %v commitments", len(blobs), len(commitments))
 	}
 
-	if enableCellProofs {
-		// Version1: Use cell proofs for Fusaka compatibility
-		// Each blob generates CellProofsPerBlob (128) proofs
-		proofs := make([]kzg4844.Proof, 0, len(blobs)*kzg4844.CellProofsPerBlob)
-		for i := range blobs {
-			cellProofs, err := kzg4844.ComputeCellProofs(&blobs[i])
-			if err != nil {
-				return nil, 0, fmt.Errorf("failed to compute cell proofs for blob %d: %w", i, err)
-			}
-			proofs = append(proofs, cellProofs...)
-		}
-		return proofs, 1, nil // BlobSidecarVersion1
-	}
-
-	// Version0: Use legacy blob proofs (pre-Fusaka)
-	// Each blob generates 1 proof
-	proofs := make([]kzg4844.Proof, len(blobs))
+	proofs := make([]kzg4844.Proof, 0, len(blobs)*kzg4844.CellProofsPerBlob)
 	for i := range blobs {
-		var err error
-		proofs[i], err = kzg4844.ComputeBlobProof(&blobs[i], commitments[i])
+		cellProofs, err := kzg4844.ComputeCellProofs(&blobs[i])
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to compute blob proof for blob %d: %w", i, err)
+			return nil, 0, fmt.Errorf("failed to compute cell proofs for blob %d: %w", i, err)
 		}
+		proofs = append(proofs, cellProofs...)
 	}
-	return proofs, 0, nil // BlobSidecarVersion0
+	return proofs, 1, nil
 }

--- a/util/blobs/blobs_test.go
+++ b/util/blobs/blobs_test.go
@@ -52,45 +52,6 @@ outer:
 	}
 }
 
-func TestComputeProofsVersion0(t *testing.T) {
-	testData := []byte("test data for blob proof version 0")
-	blobs, err := EncodeBlobs(testData)
-	if err != nil {
-		t.Fatalf("failed to encode blobs: %v", err)
-	}
-	if len(blobs) == 0 {
-		t.Fatal("expected at least one blob")
-	}
-	commitments, _, err := ComputeCommitmentsAndHashes(blobs)
-	if err != nil {
-		t.Fatalf("failed to compute commitments: %v", err)
-	}
-
-	proofs, version, err := ComputeProofs(blobs, commitments, false)
-	if err != nil {
-		t.Fatalf("failed to compute version 0 proofs: %v", err)
-	}
-
-	// Check version
-	if version != 0 {
-		t.Errorf("expected version 0, got %d", version)
-	}
-
-	// Check proof count: should be 1 proof per blob
-	expectedProofCount := len(blobs)
-	if len(proofs) != expectedProofCount {
-		t.Errorf("expected %d proofs, got %d", expectedProofCount, len(proofs))
-	}
-
-	// Verify the proofs are valid
-	for i := range blobs {
-		err = kzg4844.VerifyBlobProof(&blobs[i], commitments[i], proofs[i])
-		if err != nil {
-			t.Errorf("blob proof verification failed for blob %d: %v", i, err)
-		}
-	}
-}
-
 func TestComputeProofsVersion1(t *testing.T) {
 	testData := []byte("test data for blob proof version 1 with cell proofs")
 	blobs, err := EncodeBlobs(testData)
@@ -105,7 +66,7 @@ func TestComputeProofsVersion1(t *testing.T) {
 		t.Fatalf("failed to compute commitments: %v", err)
 	}
 
-	proofs, version, err := ComputeProofs(blobs, commitments, true)
+	proofs, version, err := ComputeProofs(blobs, commitments)
 	if err != nil {
 		t.Fatalf("failed to compute version 1 proofs: %v", err)
 	}
@@ -135,51 +96,9 @@ func TestComputeProofsMismatchedInputs(t *testing.T) {
 		t.Fatalf("failed to encode blobs: %v", err)
 	}
 
-	_, _, err = ComputeProofs(blobs, []kzg4844.Commitment{}, false)
+	_, _, err = ComputeProofs(blobs, []kzg4844.Commitment{})
 	if err == nil {
 		t.Error("expected error for mismatched blobs and commitments, got nil")
-	}
-}
-
-func TestComputeProofsMultipleBlobsVersion0(t *testing.T) {
-	// Create test data large enough to span multiple blobs
-	testData := make([]byte, bytesEncodedPerBlob*2)
-	for i := range testData {
-		testData[i] = byte(i % 256)
-	}
-	multiBlobs, err := EncodeBlobs(testData)
-	if err != nil {
-		t.Fatalf("failed to encode blobs: %v", err)
-	}
-	if len(multiBlobs) < 2 {
-		t.Fatalf("expected at least 2 blobs, got %d", len(multiBlobs))
-	}
-
-	multiCommitments, _, err := ComputeCommitmentsAndHashes(multiBlobs)
-	if err != nil {
-		t.Fatalf("failed to compute commitments: %v", err)
-	}
-
-	proofs, version, err := ComputeProofs(multiBlobs, multiCommitments, false)
-	if err != nil {
-		t.Fatalf("failed to compute proofs: %v", err)
-	}
-
-	if version != 0 {
-		t.Errorf("expected version 0, got %d", version)
-	}
-
-	// Should be 1 proof per blob
-	if len(proofs) != len(multiBlobs) {
-		t.Errorf("expected %d proofs, got %d", len(multiBlobs), len(proofs))
-	}
-
-	// Verify all proofs
-	for i := range multiBlobs {
-		err = kzg4844.VerifyBlobProof(&multiBlobs[i], multiCommitments[i], proofs[i])
-		if err != nil {
-			t.Errorf("blob proof verification failed for blob %d: %v", i, err)
-		}
 	}
 }
 
@@ -202,7 +121,7 @@ func TestComputeProofsMultipleBlobsVersion1(t *testing.T) {
 		t.Fatalf("failed to compute commitments: %v", err)
 	}
 
-	proofs, version, err := ComputeProofs(multiBlobs, multiCommitments, true)
+	proofs, version, err := ComputeProofs(multiBlobs, multiCommitments)
 	if err != nil {
 		t.Fatalf("failed to compute proofs: %v", err)
 	}


### PR DESCRIPTION
related to NIT-4182

The Fusaka hard fork made cell proofs (Version1) universally required, so the legacy single-proof-per-blob (Version0) code path is no longer needed.

- Remove enableCellProofs parameter from ComputeProofs(), always use cell proofs
- Remove EnableCellProofs config field and --enable-cell-proofs flag
- Remove shouldEnableCellProofs() function from data_poster.go
- Remove SupportsCellProofs() function from parent.go
- Remove Version0 tests