### PR TITLE
fix(gethexec,nodeinterface): correct off-by-one bounds for outbox indices

### DIFF
--- a/execution/gethexec/classicMessage.go
+++ b/execution/gethexec/classicMessage.go
@@ -47,7 +47,7 @@ func (m *ClassicOutboxRetriever) GetMsg(batchNum *big.Int, index uint64) (*Class
 	lowest := uint64(0)
 	var root common.Hash
 	copy(root[:], batchHeader[8:40])
-	if merkleSize < index {
+	if index >= merkleSize {
 		return nil, fmt.Errorf("batch %d only has %d indexes", batchNum, merkleSize)
 	}
 	proofNodes := [][32]byte{}

--- a/execution/nodeInterface/NodeInterface.go
+++ b/execution/nodeInterface/NodeInterface.go
@@ -232,7 +232,7 @@ func (n NodeInterface) ConstructOutboxProof(c ctx, evm mech, size, leaf uint64) 
 
 	currentBlock := n.backend.CurrentBlock()
 	currentBlockInfo := types.DeserializeHeaderExtraInformation(currentBlock)
-	if leaf > currentBlockInfo.SendCount {
+	if leaf >= currentBlockInfo.SendCount {
 		return hash0, hash0, nil, errors.New("leaf does not exist")
 	}
 


### PR DESCRIPTION
The classic outbox message retrieval and proof construction treated the size as a count but allowed index/leaf == size to pass initial checks. This is out of range for 0-based indices and led to later confusing errors. Updated classicMessage.go:GetMsg() to use index >= merkleSize and NodeInterface.go:ConstructOutboxProof() to use leaf >= SendCount, aligning with Merkle and test conventions where valid indices are [0, size-1].