### PR TITLE
fix: build RawStepHeights CSV from step heights slice

### DIFF
--- a/bold/layer2-state-provider/history_commitment_provider.go
+++ b/bold/layer2-state-provider/history_commitment_provider.go
@@ -297,7 +297,7 @@ func (p *HistoryCommitmentProvider) historyCommitmentImpl(
 				return nil, err
 			}
 			rawStepHeights += strconv.Itoa(hInt)
-			if i != len(rawStepHeights)-1 {
+			if i != len(cfg.StepHeights)-1 {
 				rawStepHeights += ","
 			}
 		}


### PR DESCRIPTION
Previously RawStepHeights was constructed by inserting commas based on the current string length instead of the number of step heights. For some inputs this merged multiple heights into a single integer (e.g. [1,2,3] -> "123"), which broke the CSV format expected by the API backend and its parser.
This change inserts commas based on the index within cfg.StepHeights, so RawStepHeights is always a proper comma-separated list of step heights that round-trips correctly through the database and backend parsing.