### PR TITLE
fix(das): fix deadlock when context is canceled in Aggregator.Store

### DIFF
--- a/daprovider/das/aggregator.go
+++ b/daprovider/das/aggregator.go
@@ -191,13 +191,13 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64) 
 
 			if cert.DataHash != expectedHash {
 				incFailureMetric()
-				log.Warn("DAS Aggregator got a store response with a data hash not matching the expected hash", "backend", d.metricName, "dataHash", cert.DataHash, "expectedHash", expectedHash, "err", err)
+				log.Warn("DAS Aggregator got a store response with a data hash not matching the expected hash", "backend", d.metricName, "dataHash", cert.DataHash, "expectedHash", expectedHash)
 				responses <- storeResponse{d, nil, errors.New("hash verification failed")}
 				return
 			}
 			if cert.Timeout != timeout {
 				incFailureMetric()
-				log.Warn("DAS Aggregator got a store response with any expiry time not matching the expected expiry time", "backend", d.metricName, "dataHash", cert.DataHash, "expectedHash", expectedHash, "err", err)
+				log.Warn("DAS Aggregator got a store response with any expiry time not matching the expected expiry time", "backend", d.metricName, "timeout", cert.Timeout, "expectedTimeout", timeout)
 				responses <- storeResponse{d, nil, fmt.Errorf("timeout was %d, expected %d", cert.Timeout, timeout)}
 				return
 			}
@@ -228,14 +228,6 @@ func (a *Aggregator) Store(ctx context.Context, message []byte, timeout uint64) 
 		var returned int // 0-no status, 1-succeeded, 2-failed
 		for i := 0; i < len(a.services); i++ {
 			select {
-			case <-ctx.Done():
-				if returned == 0 {
-					cd := certDetails{}
-					cd.err = ctx.Err()
-					certDetailsChan <- cd
-					returned = 2
-				}
-				return
 			case r := <-responses:
 				if r.err != nil {
 					_ = storeFailures.Add(1)


### PR DESCRIPTION
There was a bug where if the context got canceled before we got enough responses, the Store function would hang forever. The collector goroutine would exit on ctx.Done() but never send anything to certDetailsChan, so the main goroutine would block waiting for a value that never comes.

The docs say it should return an error on context cancel, but it was just deadlocking instead.

Fixed it by having the collector send ctx.Err() when canceled, and using select in the main function to handle cancellation properly.