### PR TITLE
refactor(mel): remove redundant hash calculation in delayed message scaffolds

### DIFF
--- a/arbnode/mel/extraction/delayed_message_lookup.go
+++ b/arbnode/mel/extraction/delayed_message_lookup.go
@@ -156,8 +156,6 @@ func delayedMessageScaffoldsFromLogs(
 
 	// Next, we construct the messages themselves from the parsed logs.
 	for _, parsedLog := range parsedLogs {
-		msgKey := common.BigToHash(parsedLog.MessageIndex)
-		_ = msgKey
 		requestId := common.BigToHash(parsedLog.MessageIndex)
 		msg := &mel.DelayedInboxMessage{
 			BlockHash:      parsedLog.Raw.BlockHash,


### PR DESCRIPTION
Removes dead code and eliminates redundant hash computation in `delayedMessageScaffoldsFromLogs`.
