### PR TITLE
ci: bump actions/cache to v5

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -43,13 +43,13 @@ runs:
       shell: bash
 
     - name: Cache Go build
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/go-build
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
     - name: Cache Rust build
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/
@@ -62,7 +62,7 @@ runs:
 
     - name: Cache cbrotli
       id: cache-cbrotli
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           target/include/brotli/
@@ -81,3 +81,4 @@ runs:
       if: steps.cache-cbrotli.outputs.cache-hit != 'true'
       run: ./scripts/build-brotli.sh -w -d
       shell: bash
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
           driver-opts: network=host
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
@@ -106,3 +106,4 @@ jobs:
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               "${{ github.api_url }}/repos/${{ github.repository }}/actions/caches?key=$key"
           done
+

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -21,7 +21,7 @@ jobs:
           driver-opts: network=host
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
@@ -29,3 +29,4 @@ jobs:
 
       - name: Startup Nitro testnode
         run: ./scripts/startup-testnode.bash
+


### PR DESCRIPTION
Upgrade actions/cache from v4 to v5 across CI setup and workflows.
Ref: https://github.com/actions/cache/releases/tag/v5.0.1