### PR TITLE
Include all test profiles in Codecov reports

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -41,6 +41,8 @@ jobs:
     if: always()
     uses: ./.github/workflows/_codecov.yml
     secrets: inherit
+    permissions:
+      pull-requests: write
     with:
       post_comment: false
       upload_report: true


### PR DESCRIPTION
closes NIT-3919

1. Gather Codecov reports from all Go tests profiles.
1. Simplify workflow specification regarding failures: previously we combined `continue-on-error` with `always()` and then inspecting `outcome == 'failure'`. In our case `always()` is enough.
1. Don't pass unneeded permissions in `merge.yml`