### PR TITLE
Fix invalid DA cert branch in inbox

### DIFF
--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -123,6 +123,7 @@ func ParseSequencerMessage(ctx context.Context, batchNum uint64, batchBlockHash 
 					}
 				} else if daprovider.IsDACertificateMessageHeaderByte(payload[0]) && daprovider.IsCertificateValidationError(err) {
 					log.Warn("Certificate validation of sequencer batch failed, treating it as an empty batch", "batch", batchNum, "error", err)
+					payload = nil
 				} else {
 					return nil, err
 				}


### PR DESCRIPTION
When certificate validation fails for a DAC cert message, the code logged "treating it as an empty batch" but didn't actually set payload to nil.  The original payload (with the DAC header byte) would continue through the processing pipeline and fail later with a different error when parsed as batch data.

Setting `payload = nil` ensures we enter the `if payload == nil` branch and return an empty batch as the log message indicates, providing clearer and more predictable behavior.