### PR TITLE
Handle sequencer blob data errors as empty batches

### DIFF
--- a/daprovider/util.go
+++ b/daprovider/util.go
@@ -44,9 +44,8 @@ func RecordPreimagesTo(preimages PreimagesMap) PreimageRecorder {
 }
 
 var (
-	ErrNoBlobReader          = errors.New("blob batch payload was encountered but no BlobReader was configured")
-	ErrInvalidBlobDataFormat = errors.New("blob batch data is not a list of hashes as expected")
-	ErrSeqMsgValidation      = errors.New("error validating recovered payload from batch")
+	ErrNoBlobReader     = errors.New("blob batch payload was encountered but no BlobReader was configured")
+	ErrSeqMsgValidation = errors.New("error validating recovered payload from batch")
 )
 
 // KeysetValidationMode controls validation of AnyTrust keysets.


### PR DESCRIPTION
When the sequencer posts malformed blob data, the chain should continue processing rather than halting. This change makes error handling consistent for blob-related failures:

- Invalid blob data format (hash list not multiple of 32 bytes) now logs a warning and returns nil payload instead of returning an error
- Added comments explaining why these errors result in empty batches rather than propagating: to avoid halting the chain on malformed data
- Removed unused ErrInvalidBlobDataFormat since it's no longer returned