### PR TITLE
Fix typos in precompile comments

### DIFF
--- a/precompiles/ArbFunctionTable.go
+++ b/precompiles/ArbFunctionTable.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 )
 
-// ArbFunctionTable  precompile provided aggregator's the ability to manage function tables.
+// ArbFunctionTable precompile provides aggregators the ability to manage function tables.
 // Aggregation works differently in Nitro, so these methods have been stubbed and their effects disabled.
 // They are kept for backwards compatibility.
 type ArbFunctionTable struct {

--- a/precompiles/ArbGasInfo.go
+++ b/precompiles/ArbGasInfo.go
@@ -24,7 +24,7 @@ var storageArbGas = big.NewInt(int64(storage.StorageWriteCost))
 
 const AssumedSimpleTxSize = 140
 
-// GetPricesInWeiWithAggregator gets  prices in wei when using the provided aggregator
+// GetPricesInWeiWithAggregator gets prices in wei when using the provided aggregator
 func (con ArbGasInfo) GetPricesInWeiWithAggregator(
 	c ctx,
 	evm mech,

--- a/precompiles/ArbInfo.go
+++ b/precompiles/ArbInfo.go
@@ -10,7 +10,7 @@ import (
 	"github.com/offchainlabs/nitro/util/arbmath"
 )
 
-// ArbInfo povides the ability to lookup basic info about accounts and contracts.
+// ArbInfo provides the ability to lookup basic info about accounts and contracts.
 type ArbInfo struct {
 	Address addr // 0x65
 }

--- a/precompiles/ArbOwnerPublic.go
+++ b/precompiles/ArbOwnerPublic.go
@@ -46,7 +46,7 @@ func (con ArbOwnerPublic) GetAllNativeTokenOwners(c ctx, evm mech) ([]common.Add
 	return c.State.NativeTokenOwners().AllMembers(65536)
 }
 
-// GetNativeTokenMangementFrom returns the time in epoch seconds when the
+// GetNativeTokenManagementFrom returns the time in epoch seconds when the
 // native token management becomes enabled
 func (con ArbOwnerPublic) GetNativeTokenManagementFrom(c ctx, evm mech) (uint64, error) {
 	return c.State.NativeTokenManagementFromTime()

--- a/precompiles/ArbSys.go
+++ b/precompiles/ArbSys.go
@@ -51,7 +51,7 @@ func (con *ArbSys) ArbBlockHash(c ctx, evm mech, arbBlockNumber *big.Int) (bytes
 		if c.State.ArbOSVersion() >= params.ArbosVersion_11 {
 			return common.Hash{}, con.InvalidBlockNumberError(arbBlockNumber, evm.Context.BlockNumber)
 		}
-		return common.Hash{}, errors.New("invalid block number for ArbBlockHAsh")
+		return common.Hash{}, errors.New("invalid block number for ArbBlockHash")
 	}
 
 	return evm.Context.GetHash(requestedBlockNum), nil

--- a/precompiles/ArbWasm.go
+++ b/precompiles/ArbWasm.go
@@ -213,7 +213,7 @@ func (con ArbWasm) ProgramMemoryFootprint(c ctx, evm mech, program addr) (uint16
 	return c.State.Programs().ProgramMemoryFootprint(codehash, evm.Context.Time, params)
 }
 
-// Gets returns the amount of time remaining until the program expires
+// ProgramTimeLeft returns the amount of time remaining until the program expires
 func (con ArbWasm) ProgramTimeLeft(c ctx, evm mech, program addr) (uint64, error) {
 	codehash, params, err := con.getCodeHash(c, program)
 	if err != nil {

--- a/precompiles/ArbWasmCache.go
+++ b/precompiles/ArbWasmCache.go
@@ -12,12 +12,12 @@ type ArbWasmCache struct {
 	UpdateProgramCacheGasCost func(addr, bytes32, bool) (uint64, error)
 }
 
-// See if the user is a cache manager owner.
+// IsCacheManager checks if the user is a cache manager owner.
 func (con ArbWasmCache) IsCacheManager(c ctx, _ mech, addr addr) (bool, error) {
 	return c.State.Programs().CacheManagers().IsMember(addr)
 }
 
-// Retrieve all authorized address managers.
+// AllCacheManagers retrieves all authorized address managers.
 func (con ArbWasmCache) AllCacheManagers(c ctx, _ mech) ([]addr, error) {
 	return c.State.Programs().CacheManagers().AllMembers(65536)
 }


### PR DESCRIPTION
Corrects spelling errors and improves clarity in precompile documentation.