### PR TITLE
precompiles: remove incorrect unused lint suppression from Context.Burned

### DIFF
--- a/precompiles/context.go
+++ b/precompiles/context.go
@@ -44,7 +44,6 @@ func (c *Context) Burn(kind multigas.ResourceKind, amount uint64) error {
 	return nil
 }
 
-//nolint:unused
 func (c *Context) Burned() uint64 {
 	return c.gasUsed.SingleGas()
 }


### PR DESCRIPTION
Removes the `//nolint:unused` directive from the `Context.Burned()` method.