### PR TITLE
refactor(mel): remove unused msgKey variable in delayed message parsing

### DIFF
--- a/arbnode/mel/extraction/delayed_message_lookup.go
+++ b/arbnode/mel/extraction/delayed_message_lookup.go
@@ -121,8 +121,6 @@ func delayedMessageScaffoldsFromLogs(
 
 	// Next, we construct the messages themselves from the parsed logs.
 	for _, parsedLog := range parsedLogs {
-		msgKey := common.BigToHash(parsedLog.MessageIndex)
-		_ = msgKey
 		requestId := common.BigToHash(parsedLog.MessageIndex)
 		msg := &mel.DelayedInboxMessage{
 			BlockHash:      parsedLog.Raw.BlockHash,


### PR DESCRIPTION
Removes dead code from `delayedMessageScaffoldsFromLogs` function by eliminating an unused `msgKey` local variable.