### PR TITLE
refactor: remove unnecessary copy in emit_log

### DIFF
--- a/arbitrator/arbutil/src/evm/req.rs
+++ b/arbitrator/arbutil/src/evm/req.rs
@@ -255,13 +255,11 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         self.last_return_data.clone().expect("missing return data")
     }
 
-    fn emit_log(&mut self, data: Vec<u8>, topics: u32) -> Result<()> {
-        // TODO: remove copy
-        let mut request = Vec::with_capacity(4 + data.len());
-        request.extend(topics.to_be_bytes());
-        request.extend(data);
+    fn emit_log(&mut self, mut data: Vec<u8>, topics: u32) -> Result<()> {
+        let topics_bytes = topics.to_be_bytes();
+        data.splice(0..0, topics_bytes);
 
-        let (res, _, _) = self.request(EvmApiMethod::EmitLog, request);
+        let (res, _, _) = self.request(EvmApiMethod::EmitLog, data);
         if !res.is_empty() {
             bail!(String::from_utf8(res).unwrap_or("malformed emit-log response".into()))
         }


### PR DESCRIPTION
## Description

Remove unnecessary data copy in `emit_log` method by reusing the input vector instead of creating a new one.

## Changes

- Reuse `data` vector directly instead of creating a new `request` vector
- Prepend topics bytes to `data` using `splice` method
- Remove TODO comment