### PR TITLE
port: fix dumpkeyset (#4176)

### DIFF
--- a/cmd/datool/datool.go
+++ b/cmd/datool/datool.go
@@ -358,6 +358,11 @@ func dumpKeyset(args []string) error {
 		return err
 	}
 
+	// Disable chunked store since dumpKeyset doesn't need to store data,
+	// it only needs to read public keys to compute the keyset hash.
+	// Chunked store requires a signer which is not available here.
+	config.Keyset.DASRPCClient.EnableChunkedStore = false
+
 	services, err := das.ParseServices(config.Keyset, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
Disable chunked-store in datool dumpkeyset so it no longer requires a signer and can compute keyset hashes directly from configured backends. 
If we don't disable it, this command will throw error `panic: chunked store requires a valid signer for replay protection; cannot use nil signer`