### PR TITLE
fix: handle missing execution result when fetching finality data

### DIFF
--- a/arbnode/consensus_execution_syncer.go
+++ b/arbnode/consensus_execution_syncer.go
@@ -103,7 +103,12 @@ func (c *ConsensusExecutionSyncer) getFinalityData(
 		log.Error("Error getting message result", "msgIdx", msgIdx, "err", err)
 		return nil, err
 	}
-
+	if msgResult == nil {
+		return nil, fmt.Errorf(
+			"execution result missing for message index %d", msgIdx,
+		)
+	}
+	
 	finalityData := &arbutil.FinalityData{
 		MsgIdx:    msgIdx,
 		BlockHash: msgResult.BlockHash,


### PR DESCRIPTION
Adds a defensive check for a missing execution result.
