### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -10,7 +10,7 @@ Parameters
 Licensor:             Offchain Labs
 
 Licensed Work:        Arbitrum Nitro
-                      The Licensed Work is (c) 2021-2025 Offchain Labs
+                      The Licensed Work is (c) 2021-2026 Offchain Labs
 
 Additional Use Grant: You may use the Licensed Work in a production environment solely
                       to provide a point of interface to permit end users or applications


### PR DESCRIPTION
## Summary
Updated copyright year in LICENSE file(s).

**Before:** 2025
**After:** 2026

Routine maintenance to keep copyright notices up to date.