### PR TITLE
Set postedData to nil on certificate validation failure

### DIFF
--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -337,6 +337,7 @@ func (v *StatelessBlockValidator) readFullBatch(ctx context.Context, batchNum ui
 					log.Error(err.Error())
 				} else if daprovider.IsDACertificateMessageHeaderByte(headerByte) && daprovider.IsCertificateValidationError(err) {
 					log.Warn("Certificate validation of sequencer batch failed, treating it as an empty batch", "batch", batchNum, "error", err)
+					postedData = nil
 				} else {
 					return false, nil, err
 				}


### PR DESCRIPTION
Sets postedData to nil when certificate validation fails, matching the existing behavior.