### PR TITLE
Add note on `node.feed.output.signed` that batch poster wallet is used

### DIFF
--- a/changelog/pmikolajczyk-nit-3561.md
+++ b/changelog/pmikolajczyk-nit-3561.md
@@ -1,0 +1,2 @@
+### Added
+- Added a note to the `--node.feed.output.signed` flag that this will use batch poster's wallet for signing.

--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -82,7 +82,7 @@ type BroadcasterConfigFetcher func() *BroadcasterConfig
 
 func BroadcasterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultBroadcasterConfig.Enable, "enable broadcaster")
-	f.Bool(prefix+".signed", DefaultBroadcasterConfig.Signed, "sign broadcast messages")
+	f.Bool(prefix+".signed", DefaultBroadcasterConfig.Signed, "sign broadcast messages with the batch poster wallet")
 	f.String(prefix+".addr", DefaultBroadcasterConfig.Addr, "address to bind the relay feed output to")
 	f.Duration(prefix+".read-timeout", DefaultBroadcasterConfig.ReadTimeout, "duration to wait before timing out reading data (i.e. pings) from clients")
 	f.Duration(prefix+".write-timeout", DefaultBroadcasterConfig.WriteTimeout, "duration to wait before timing out writing data to clients")


### PR DESCRIPTION
closes NIT-3561