### PR TITLE
perf(tests): use testing.B.Loop() for benchmarks

### DIFF
--- a/bold/commitment/history/history_test.go
+++ b/bold/commitment/history/history_test.go
@@ -40,16 +40,16 @@ func FuzzHistoryCommitter(f *testing.F) {
 }
 
 func BenchmarkPrefixProofGeneration_Legacy(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		prefixIndex := 13384
-		simpleHash := crypto.Keccak256Hash([]byte("foo"))
-		hashes := make([]common.Hash, 1<<14)
-		for i := 0; i < len(hashes); i++ {
-			hashes[i] = simpleHash
-		}
+	prefixIndex := 13384
+	simpleHash := crypto.Keccak256Hash([]byte("foo"))
+	hashes := make([]common.Hash, 1<<14)
+	for i := 0; i < len(hashes); i++ {
+		hashes[i] = simpleHash
+	}
 
-		lowCommitmentNumLeaves := prefixIndex + 1
-		hiCommitmentNumLeaves := (1 << 14)
+	lowCommitmentNumLeaves := prefixIndex + 1
+	hiCommitmentNumLeaves := (1 << 14)
+	for b.Loop() {
 		prefixExpansion, err := prefix.ExpansionFromLeaves(hashes[:lowCommitmentNumLeaves])
 		require.NoError(b, err)
 		_, err = prefix.GeneratePrefixProof(
@@ -63,14 +63,12 @@ func BenchmarkPrefixProofGeneration_Legacy(b *testing.B) {
 }
 
 func BenchmarkPrefixProofGeneration_Optimized(b *testing.B) {
-	b.StopTimer()
 	simpleHash := crypto.Keccak256Hash([]byte("foo"))
 	hashes := []common.Hash{crypto.Keccak256Hash(simpleHash[:])}
 	prefixIndex := uint64(13384)
 	virtual := uint64(1 << 14)
 	committer := newCommitter()
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _, err := committer.generatePrefixProof(prefixIndex, hashes, virtual)
 		require.NoError(b, err)
 	}
@@ -307,13 +305,11 @@ func TestMaximumDepthHistoryCommitment(t *testing.T) {
 }
 
 func BenchmarkMaximumDepthHistoryCommitment(b *testing.B) {
-	b.StopTimer()
 	simpleHash := crypto.Keccak256Hash([]byte("foo"))
 	hashedLeaves := []common.Hash{
 		simpleHash,
 	}
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := ComputeRoot(hashedLeaves, 1<<26)
 		_ = err
 	}

--- a/execution/gethexec/express_lane_service_test.go
+++ b/execution/gethexec/express_lane_service_test.go
@@ -904,14 +904,12 @@ func Test_expressLaneService_dontCareWithQueuedTransactions(t *testing.T) {
 }
 
 func Benchmark_expressLaneService_validateExpressLaneTx(b *testing.B) {
-	b.StopTimer()
 	addr := crypto.PubkeyToAddress(testPriv.PublicKey)
 	tr := defaultTestTrackerWithConfig(common.HexToAddress("0x2Aef36410182881a4b13664a1E079762D7F716e6"), defaultTestRoundTimingInfo(time.Now()))
 	tr.roundControl.Store(0, addr)
 
 	sub := buildValidSubmission(b, common.HexToAddress("0x2Aef36410182881a4b13664a1E079762D7F716e6"), testPriv, 0)
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		err := tr.ValidateExpressLaneTx(sub)
 		require.NoError(b, err)
 	}

--- a/staker/challenge-cache/cache_test.go
+++ b/staker/challenge-cache/cache_test.go
@@ -406,7 +406,6 @@ func Test_determineFilePath(t *testing.T) {
 }
 
 func BenchmarkCache_Read_32Mb(b *testing.B) {
-	b.StopTimer()
 	basePath := os.TempDir()
 	if err := os.MkdirAll(basePath, os.ModePerm); err != nil {
 		b.Fatal(err)
@@ -428,8 +427,7 @@ func BenchmarkCache_Read_32Mb(b *testing.B) {
 	if err := cache.Put(key, hashes); err != nil {
 		b.Fatal(err)
 	}
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		readUpTo := uint64(1 << 20)
 		hashes, err := cache.Get(key, readUpTo)
 		if err != nil {

--- a/timeboost/bid_cache_test.go
+++ b/timeboost/bid_cache_test.go
@@ -144,7 +144,6 @@ func TestTopTwoBids(t *testing.T) {
 }
 
 func BenchmarkBidValidation(b *testing.B) {
-	b.StopTimer()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	redisURL := redisutil.CreateTestRedis(ctx, b)
@@ -157,8 +156,7 @@ func BenchmarkBidValidation(b *testing.B) {
 	newBid, err := bc.Bid(ctx, big.NewInt(5), testSetup.accounts[0].txOpts.From)
 	require.NoError(b, err)
 
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err = bv.validateBid(newBid, bv.auctionContract.BalanceOf)
 		require.NoError(b, err)
 	}


### PR DESCRIPTION
Replace for i := 0; i < b.N; i++ with b.Loop() to exclude setup from timing and prevent compiler optimizations.