### PR TITLE
chore(tests): remove deprecated rand.Seed calls

### DIFF
--- a/arbos/activate_test.go
+++ b/arbos/activate_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestActivationDataFee(t *testing.T) {
-	rand.Seed(time.Now().UTC().UnixNano())
 	state, _ := arbosState.NewArbosMemoryBackedArbOSState()
 	pricer := state.Programs().DataPricer()
 	// #nosec G115

--- a/arbos/retryable_test.go
+++ b/arbos/retryable_test.go
@@ -33,7 +33,6 @@ func TestOpenNonexistentRetryable(t *testing.T) {
 }
 
 func TestRetryableLifecycle(t *testing.T) {
-	rand.Seed(time.Now().UTC().UnixNano())
 	state, statedb := arbosState.NewArbosMemoryBackedArbOSState()
 	retryableState := state.RetryableState()
 
@@ -156,7 +155,6 @@ func TestRetryableLifecycle(t *testing.T) {
 }
 
 func TestRetryableCleanup(t *testing.T) {
-	rand.Seed(time.Now().UTC().UnixNano())
 	state, statedb := arbosState.NewArbosMemoryBackedArbOSState()
 	retryableState := state.RetryableState()
 

--- a/arbos/util/retryable_encoding_test.go
+++ b/arbos/util/retryable_encoding_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestRetryableEncoding(t *testing.T) {
-	rand.Seed(time.Now().UnixMilli())
 	fakeAddr := testhelpers.RandomAddress()
 	key, err := crypto.GenerateKey()
 	testhelpers.RequireImpl(t, err)

--- a/blsSignatures/blsSignatures_test.go
+++ b/blsSignatures/blsSignatures_test.go
@@ -99,7 +99,6 @@ func TestSignatureAggregationAnyOrder(t *testing.T) {
 		sigs = append(sigs, sig)
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(NumSignaturesToAggregate, func(i, j int) { sigs[i], sigs[j] = sigs[j], sigs[i] })
 	rand.Shuffle(NumSignaturesToAggregate, func(i, j int) { pubKeys[i], pubKeys[j] = pubKeys[j], pubKeys[i] })
 

--- a/daprovider/anytrust/aggregator_test.go
+++ b/daprovider/anytrust/aggregator_test.go
@@ -246,7 +246,7 @@ func initTest(t *testing.T) int {
 		Require(t, err, "Failed to parse string")
 		seed = int64(intSeed)
 	}
-	rand.Seed(seed)
+	rand.Seed(seed) //nolint:staticcheck // used for test reproducibility via -seed flag
 
 	runs := 2 ^ 32
 	if len(*testflag.RunsFlag) > 0 {

--- a/zeroheavy/zeroheavy_test.go
+++ b/zeroheavy/zeroheavy_test.go
@@ -63,8 +63,6 @@ func l1Cost(data []byte) int {
 }
 
 func TestZeroHeavyRandomDataRandom(t *testing.T) {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	trials := 1024
 	avg := 0.0
 	best := 0.0
@@ -103,8 +101,6 @@ func TestZeroHeavyRandomDataRandom(t *testing.T) {
 }
 
 func TestZeroHeavyRandomDataBrotli(t *testing.T) {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	trials := 256
 	avg := 0.0
 	best := 0.0


### PR DESCRIPTION
Remove rand.Seed calls as global RNG is auto-seeded.