### PR TITLE
perf: preallocate slice in DecodeBlobs

### DIFF
--- a/util/blobs/blobs.go
+++ b/util/blobs/blobs.go
@@ -78,7 +78,11 @@ func EncodeBlobs(data []byte) ([]kzg4844.Blob, error) {
 
 // DecodeBlobs decodes blobs into the batch data encoded in them.
 func DecodeBlobs(blobs []kzg4844.Blob) ([]byte, error) {
-	var rlpData []byte
+	if len(blobs) == 0 {
+		return nil, nil
+	}
+	bytesPerBlob := params.BlobTxFieldElementsPerBlob*31 + params.BlobTxFieldElementsPerBlob*spareBlobBits/8
+	rlpData := make([]byte, 0, len(blobs)*bytesPerBlob)
 	for _, blob := range blobs {
 		for fieldIndex := 0; fieldIndex < params.BlobTxFieldElementsPerBlob; fieldIndex++ {
 			rlpData = append(rlpData, blob[fieldIndex*32+1:(fieldIndex+1)*32]...)


### PR DESCRIPTION
Preallocate rlpData slice capacity in DecodeBlobs to avoid repeated reallocations. Each blob contributes ~130KB, so without preallocation the slice grows through multiple reallocs during decode. This is called on every batch sync from L1.