### PR TITLE
update ProgramPrepare to accept wasm instead of statedb and code

### DIFF
--- a/arbos/programs/wasm.go
+++ b/arbos/programs/wasm.go
@@ -133,7 +133,6 @@ func ProgramPrepare(
 	pagelimit uint32,
 	debugMode uint32,
 	stylusVersion uint32,
-	runCtxPtr unsafe.Pointer,
 )
 
 //go:wasmimport programs pop
@@ -178,7 +177,6 @@ func handleProgramPrepare(statedb vm.StateDB, moduleHash common.Hash, addressFor
 			uint32(params.PageLimit),
 			debugInt,
 			uint32(params.Version),
-			unsafe.Pointer(runCtx),
 		)
 	}
 

--- a/changelog/bragaigor-nit-4407.md
+++ b/changelog/bragaigor-nit-4407.md
@@ -1,3 +1,3 @@
 ### Changed
-- update ProgramPrepare to accept wasm and wasm_size instead of statedb and code
-- remove unecessary time, addressForLogging, program params from ProgramPrepare
+- update ProgramPrepare to accept wasm and wasm_size
+- remove unecessary statedb, addressForLogging, codePtr, codeSize, time, program, runCtxPtr params from ProgramPrepare

--- a/crates/jit/src/program.rs
+++ b/crates/jit/src/program.rs
@@ -196,7 +196,6 @@ pub fn program_prepare(
     _page_limit: u32,
     _debug_mode: u32,
     _stylus_version: u32,
-    _run_ctx_ptr: GuestPtr,
 ) -> MaybeEscape {
     Ok(())
 }

--- a/crates/wasm-libraries/user-host/src/link.rs
+++ b/crates/wasm-libraries/user-host/src/link.rs
@@ -155,7 +155,6 @@ pub unsafe extern "C" fn programs__program_prepare(
     _page_limit: u32,
     _debug_mode: u32,
     _stylus_version: u32,
-    _run_ctx_ptr: GuestPtr,
 ) {
 }
 


### PR DESCRIPTION
Updates `ProgramPrepare` to accept `wasm` instead of `statedb` and `code`.

Closes NIT-4407