### PR TITLE
Fix concurrency issue in TestRedisForwarder

### DIFF
--- a/changelog/gligneul-nit-4419.md
+++ b/changelog/gligneul-nit-4419.md
@@ -1,0 +1,2 @@
+### Ignored
+- Fix concurrency issue in TestRedisForwarder

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -224,13 +224,8 @@ func TestRedisForwarder(t *testing.T) {
 	var seqNodes []*arbnode.Node
 	var seqClients []*ethclient.Client
 	for _, path := range nodePaths {
-		testClientSeq, _ := createSequencer(t, builder, path, redisUrl)
-		node := testClientSeq.ConsensusNode
-
-		t.Cleanup(func() {
-			node.StopAndWait()
-		})
-
+		testClientSeq, cleanupTestSeq := createSequencer(t, builder, path, redisUrl)
+		defer cleanupTestSeq()
 		seqNodes = append(seqNodes, testClientSeq.ConsensusNode)
 		seqClients = append(seqClients, testClientSeq.Client)
 	}


### PR DESCRIPTION
The test was explicitly stopping the consensus node instead of calling the cleanup function provided by NoneBuilder. By doing so, it didn't stop the execution node, so we got random panics on CI like the following.

```
panic: fatal: 000015.log:
	orig err: rename /home/runner/work/nitro/nitro/target/tmp/deadbeefbee/TestRedisForwarder2662827029/009/test-stack-name/l2chaindata/000005.log /home/runner/work/nitro/nitro/target/tmp/deadbeefbee/TestRedisForwarder2662827029/009/test-stack-name/l2chaindata/000015.log: no such file or directory
	list err: open /home/runner/work/nitro/nitro/target/tmp/deadbeefbee/TestRedisForwarder2662827029/009/test-stack-name/l2chaindata: no such file or directory
```

Close NIT-4419