### PR TITLE
Do not `defer` in a loop

### DIFF
--- a/changelog/pmikolajczyk-defer-in-loop.md
+++ b/changelog/pmikolajczyk-defer-in-loop.md
@@ -1,0 +1,2 @@
+### Ignored
+ - Do not defer releasing resources in a loop in a system test

--- a/cmd/nitro/init_test.go
+++ b/cmd/nitro/init_test.go
@@ -297,37 +297,39 @@ func TestSetLatestSnapshotUrl(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		t.Log("running test case", testCase.name)
+		func() {
+			t.Log("running test case", testCase.name)
 
-		// Create latest file
-		serverDir := t.TempDir()
+			// Create latest file
+			serverDir := t.TempDir()
 
-		err := os.Mkdir(filepath.Join(serverDir, chain), dirPerm)
-		Require(t, err)
-		err = os.WriteFile(filepath.Join(serverDir, chain, latestFile), []byte(testCase.latestContents), filePerm)
-		Require(t, err)
+			err := os.Mkdir(filepath.Join(serverDir, chain), dirPerm)
+			Require(t, err)
+			err = os.WriteFile(filepath.Join(serverDir, chain, latestFile), []byte(testCase.latestContents), filePerm)
+			Require(t, err)
 
-		// Start HTTP server
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		addr := "http://" + startFileServer(t, ctx, serverDir)
+			// Start HTTP server
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			addr := "http://" + startFileServer(t, ctx, serverDir)
 
-		// Set latest snapshot URL
-		initConfig := conf.InitConfigDefault
-		initConfig.Latest = snapshotKind
-		initConfig.LatestBase = addr
-		configChain := testCase.chain
-		if configChain == "" {
-			configChain = chain
-		}
-		err = setLatestSnapshotUrl(ctx, &initConfig, configChain)
-		Require(t, err)
+			// Set latest snapshot URL
+			initConfig := conf.InitConfigDefault
+			initConfig.Latest = snapshotKind
+			initConfig.LatestBase = addr
+			configChain := testCase.chain
+			if configChain == "" {
+				configChain = chain
+			}
+			err = setLatestSnapshotUrl(ctx, &initConfig, configChain)
+			Require(t, err)
 
-		// Check url
-		want := testCase.wantUrl(addr)
-		if initConfig.Url != want {
-			t.Fatalf("initConfig.Url = %s; want: %s", initConfig.Url, want)
-		}
+			// Check url
+			want := testCase.wantUrl(addr)
+			if initConfig.Url != want {
+				t.Fatalf("initConfig.Url = %s; want: %s", initConfig.Url, want)
+			}
+		}()
 	}
 }
 


### PR DESCRIPTION
Generally it's not always safe to `defer` releasing resources in a loop. One of our system tests did so, and this was a probable reason for some random CI failures, like: https://github.com/OffchainLabs/nitro/actions/runs/21587866160/job/62200382110#step:10:1580

As a follow-up we can add another linter that ensures no `defer` directly in a loop.