### PR TITLE
Add test for addressfilter for self-destruct post eip-6780 specification #NIT-4262

### DIFF
--- a/changelog/mnasr-nit-4262-tests.md
+++ b/changelog/mnasr-nit-4262-tests.md
@@ -1,0 +1,2 @@
+### Ignored
+- Added addressfilter tests for EIP-6780 selfdestruct. 


### PR DESCRIPTION
## EIP-6780 selfdestruct introduced two execution paths:
### 1- When it is called for already existed contract (contracts that are created in previous txns). 
For this case it is just act as fancy term/opcode for transfering remaining  `ETH` to the given beneficiary.

This case we already have a test for it  [here](https://github.com/OffchainLabs/nitro/blob/a65884cc0774539c8f96227134e4eb035317fe59/system_tests/tx_address_filter_test.go#L286)  and since the basic self-destruct already replaced by the EIP-6780 one as shown [here](https://github.com/OffchainLabs/go-ethereum/blob/ea6d0f5d80c7146869f8378039f4294fd5460a7f/core/vm/jump_table.go#L110). then we don't need to do any more test for this case.


### 2- When we can self-destruct on the contract creation (on the contract constructor). 
For this case it actually delete the contract code/storage in addition to transfer remaining `ETH` to the given beneficiary. 
This PR add the test for this case. To ensure we are covered. 

