### PR TITLE
fix: skip execution DB init when using external EL

### DIFF
--- a/changelog/AnkushinDaniil-fix-external-el-init.md
+++ b/changelog/AnkushinDaniil-fix-external-el-init.md
@@ -1,0 +1,2 @@
+### Fixed
+ - Skip execution DB initialization when using external EL via `--node.execution-rpc-client.url`


### PR DESCRIPTION
When running Nitro CL with `--node.execution-rpc-client.url` pointing to an external EL, the node would fail with `no --init.* mode supplied and chain data not in expected directory` because `openInitializeExecutionDB()` was called unconditionally.

This change:
- Makes execution DB initialization conditional based on `ExecutionRPCClient.URL`
- Uses `chainInfo.ChainConfig` instead of `l2BlockChain.Config()` for places that need chain config when `l2BlockChain` may be nil
- Skips blockchain validation when using external EL