### PR TITLE
refactor(arbnode): simplify length check in deleteFromRange

### DIFF
--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -263,7 +263,7 @@ func deleteFromRange(ctx context.Context, db ethdb.Database, prefix []byte, star
 		if currentKey >= endMinKey {
 			break
 		}
-		if len(prunedKeysRange) == 0 || len(prunedKeysRange) == 1 {
+		if len(prunedKeysRange) < 2 {
 			prunedKeysRange = append(prunedKeysRange, currentKey)
 		} else {
 			prunedKeysRange[1] = currentKey


### PR DESCRIPTION
Simplifies the conditional logic in `deleteFromRange` function by replacing a redundant boolean expression with a more concise equivalent.
