### PR TITLE
Fix expose-multi-gas when using a live tracer

### DIFF
--- a/arbnode/inbox_test.go
+++ b/arbnode/inbox_test.go
@@ -135,7 +135,7 @@ func NewTransactionStreamerForTest(t *testing.T, ctx context.Context, ownerAddre
 	initReader := statetransfer.NewMemoryInitDataReader(&initData)
 
 	options := core.DefaultConfig().WithStateScheme(env.GetTestStateScheme())
-	bc, err := gethexec.WriteOrTestBlockChain(executionDB, options, initReader, chainConfig, nil, nil, arbostypes.TestInitMessage, &gethexec.ConfigDefault.TxIndexer, 0)
+	bc, err := gethexec.WriteOrTestBlockChain(executionDB, options, initReader, chainConfig, nil, nil, arbostypes.TestInitMessage, &gethexec.ConfigDefault.TxIndexer, 0, false)
 
 	if err != nil {
 		Fail(t, err)

--- a/changelog/gligneul-nit-4339.md
+++ b/changelog/gligneul-nit-4339.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix expose-multigas feature when using a live tracer

--- a/cmd/nitro/init/init.go
+++ b/cmd/nitro/init/init.go
@@ -837,7 +837,7 @@ func getNewBlockchain(parsedInitMessage *arbostypes.ParsedInitMessage, config *c
 	txIndexWg := sync.WaitGroup{}
 
 	if initDataReader == nil {
-		l2BlockChain, err := gethexec.GetBlockChain(executionDB, cacheConfig, chainConfig, tracer, &config.Execution.TxIndexer)
+		l2BlockChain, err := gethexec.GetBlockChain(executionDB, cacheConfig, chainConfig, tracer, &config.Execution.TxIndexer, config.Execution.ExposeMultiGas)
 		if err != nil {
 			return nil, err
 		}
@@ -880,7 +880,7 @@ func getNewBlockchain(parsedInitMessage *arbostypes.ParsedInitMessage, config *c
 		if !emptyBlockChain && (cacheConfig.StateScheme == rawdb.PathScheme) && config.Init.Force {
 			return nil, errors.New("it is not possible to force init with non-empty blockchain when using path scheme")
 		}
-		l2BlockChain, err = gethexec.WriteOrTestBlockChain(executionDB, cacheConfig, initDataReader, chainConfig, genesisArbOSInit, tracer, parsedInitMessage, &config.Execution.TxIndexer, config.Init.AccountsPerSync)
+		l2BlockChain, err = gethexec.WriteOrTestBlockChain(executionDB, cacheConfig, initDataReader, chainConfig, genesisArbOSInit, tracer, parsedInitMessage, &config.Execution.TxIndexer, config.Init.AccountsPerSync, config.Execution.ExposeMultiGas)
 		if err != nil {
 			return nil, err
 		}
@@ -1014,7 +1014,7 @@ func OpenExistingExecutionDB(stack *node.Node, config *config.NodeConfig, chainI
 					return nil, nil, nil, chainConfig, err
 				}
 
-				l2BlockChain, err := gethexec.GetBlockChain(executionDB, cacheConfig, chainConfig, tracer, &config.Execution.TxIndexer)
+				l2BlockChain, err := gethexec.GetBlockChain(executionDB, cacheConfig, chainConfig, tracer, &config.Execution.TxIndexer, config.Execution.ExposeMultiGas)
 				if err != nil {
 					return nil, nil, nil, chainConfig, err
 				}

--- a/execution/gethexec/blockchain.go
+++ b/execution/gethexec/blockchain.go
@@ -255,6 +255,7 @@ func GetBlockChain(
 	chainConfig *params.ChainConfig,
 	tracer *tracing.Hooks,
 	txIndexerConfig *TxIndexerConfig,
+	exposeMultiGas bool,
 ) (*core.BlockChain, error) {
 	engine := arbos.Engine{
 		IsSequencer: true,
@@ -263,6 +264,7 @@ func GetBlockChain(
 	vmConfig := vm.Config{
 		EnablePreimageRecording: false,
 		Tracer:                  tracer,
+		ExposeMultiGas:          exposeMultiGas,
 	}
 	cacheConfig.VmConfig = vmConfig
 
@@ -288,13 +290,14 @@ func WriteOrTestBlockChain(
 	initMessage *arbostypes.ParsedInitMessage,
 	txIndexerConfig *TxIndexerConfig,
 	accountsPerSync uint,
+	exposeMultiGas bool,
 ) (*core.BlockChain, error) {
 	emptyBlockChain := rawdb.ReadHeadHeader(executionDB) == nil
 	if !emptyBlockChain && (cacheConfig.StateScheme == rawdb.PathScheme) {
 		// When using path scheme, and the stored state trie is not empty,
 		// WriteOrTestGenBlock is not able to recover EmptyRootHash state trie node.
 		// In that case Nitro doesn't test genblock, but just returns the BlockChain.
-		return GetBlockChain(executionDB, cacheConfig, chainConfig, tracer, txIndexerConfig)
+		return GetBlockChain(executionDB, cacheConfig, chainConfig, tracer, txIndexerConfig, exposeMultiGas)
 	}
 
 	err := WriteOrTestGenblock(executionDB, cacheConfig, initData, chainConfig, genesisArbOSInit, initMessage, accountsPerSync)
@@ -305,7 +308,7 @@ func WriteOrTestBlockChain(
 	if err != nil {
 		return nil, err
 	}
-	return GetBlockChain(executionDB, cacheConfig, chainConfig, tracer, txIndexerConfig)
+	return GetBlockChain(executionDB, cacheConfig, chainConfig, tracer, txIndexerConfig, exposeMultiGas)
 }
 
 func init() {

--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -600,7 +600,7 @@ func create2ndNodeWithConfigForBoldProtocol(
 	execConfig := ExecConfigDefaultNonSequencerTest(t, rawdb.HashScheme)
 	Require(t, execConfig.Validate())
 	coreCacheConfig := gethexec.DefaultCacheConfigFor(&execConfig.Caching)
-	l2blockchain, err := gethexec.WriteOrTestBlockChain(l2executionDB, coreCacheConfig, initReader, chainConfig, nil, nil, initMessage, &execConfig.TxIndexer, 0)
+	l2blockchain, err := gethexec.WriteOrTestBlockChain(l2executionDB, coreCacheConfig, initReader, chainConfig, nil, nil, initMessage, &execConfig.TxIndexer, 0, execConfig.ExposeMultiGas)
 	Require(t, err)
 
 	l1ChainId, err := l1client.ChainID(ctx)

--- a/system_tests/bold_customda_challenge_test.go
+++ b/system_tests/bold_customda_challenge_test.go
@@ -209,7 +209,7 @@ func createNodeBWithSharedContracts(
 	execConfig := ExecConfigDefaultNonSequencerTest(t, rawdb.HashScheme)
 	Require(t, execConfig.Validate())
 	coreCacheConfig := gethexec.DefaultCacheConfigFor(&execConfig.Caching)
-	l2blockchain, err := gethexec.WriteOrTestBlockChain(l2executionDB, coreCacheConfig, initReader, chainConfig, nil, nil, initMessage, &execConfig.TxIndexer, 0)
+	l2blockchain, err := gethexec.WriteOrTestBlockChain(l2executionDB, coreCacheConfig, initReader, chainConfig, nil, nil, initMessage, &execConfig.TxIndexer, 0, execConfig.ExposeMultiGas)
 	Require(t, err)
 
 	execNode, err := gethexec.CreateExecutionNode(ctx, l2stack, l2executionDB, l2blockchain, l1client, NewCommonConfigFetcher(execConfig), big.NewInt(1337), 0)

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -2039,7 +2039,7 @@ func createNonL1BlockChainWithStackConfig(
 		}
 	}
 	coreCacheConfig := gethexec.DefaultCacheConfigTrieNoFlushFor(&execConfig.Caching, trieNoAsyncFlush)
-	blockchain, err := gethexec.WriteOrTestBlockChain(executionDB, coreCacheConfig, initReader, chainConfig, arbOSInit, nil, initMessage, &gethexec.ConfigDefault.TxIndexer, 0)
+	blockchain, err := gethexec.WriteOrTestBlockChain(executionDB, coreCacheConfig, initReader, chainConfig, arbOSInit, nil, initMessage, &gethexec.ConfigDefault.TxIndexer, 0, execConfig.ExposeMultiGas)
 	Require(t, err)
 
 	return info, stack, executionDB, consensusDB, blockchain
@@ -2153,7 +2153,7 @@ func Create2ndNodeWithConfig(
 		tracer, err = tracers.LiveDirectory.New(execConfig.VmTrace.TracerName, json.RawMessage(execConfig.VmTrace.JSONConfig))
 		Require(t, err)
 	}
-	blockchain, err := gethexec.WriteOrTestBlockChain(executionDB, coreCacheConfig, initReader, chainConfig, nil, tracer, initMessage, &execConfig.TxIndexer, 0)
+	blockchain, err := gethexec.WriteOrTestBlockChain(executionDB, coreCacheConfig, initReader, chainConfig, nil, tracer, initMessage, &execConfig.TxIndexer, 0, execConfig.ExposeMultiGas)
 	Require(t, err)
 
 	AddValNodeIfNeeded(t, ctx, nodeConfig, true, "", valnodeConfig.Wasm.RootPath)

--- a/system_tests/staterecovery_test.go
+++ b/system_tests/staterecovery_test.go
@@ -62,7 +62,7 @@ func TestRecreateMissingStates(t *testing.T) {
 		// For now Archive node should use HashScheme
 		cachingConfig.StateScheme = rawdb.HashScheme
 		cacheConfig := gethexec.DefaultCacheConfigFor(&cachingConfig)
-		bc, err := gethexec.GetBlockChain(executionDB, cacheConfig, builder.chainConfig, nil, &builder.execConfig.TxIndexer)
+		bc, err := gethexec.GetBlockChain(executionDB, cacheConfig, builder.chainConfig, nil, &builder.execConfig.TxIndexer, builder.execConfig.ExposeMultiGas)
 		Require(t, err)
 		err = staterecovery.RecreateMissingStates(executionDB, bc, cacheConfig, 1)
 		Require(t, err)


### PR DESCRIPTION
When using --execution.expose-multi-gas and --execution.vmtrace, Nitro wouldn't generate the used multi-gas in the transaction receipts. This PR fixes this problem.

Since this is a small conflict between two experimental features, I don't think it is worth adding a system test.

I manually tested this using the dev node, by running the commands in the following section.

1. Start-up Nitro node with expose multi-gas and a live tracer.

    go run ./cmd/nitro --dev --http.addr 0.0.0.0 --http.api=net,web3,eth,debug \
        --execution.expose-multi-gas \
        --execution.vmtrace.tracer-name=supply \
        --execution.vmtrace.json-config='{"path": "/tmp/supply-traces", "maxSize": 50}'

2. Set variables and send a dummy transaction.

    export RPC=http://localhost:8547
    export KEY=0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659
    export ADDR=0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E
    export TX=$(cast send -r $RPC --private-key $KEY --value 1 $ADDR | grep transactionHash | cut -f2 -w)

3. Get the transaction receipt.

    curl $RPC -X POST -H "Content-Type: application/json" --data \
        '{"method":"eth_getTransactionReceipt","params":["'$TX'"],"id":1,"jsonrpc":"2.0"}' | jq

4. Check the receipt has the following field.

    "result": {
      ...
      "multiGasUsed": {
         "unknown": "0x0",
         "computation": "0x5208",
         "historyGrowth": "0x0",
         "storageAccess": "0x0",
         "storageGrowth": "0x0",
         "l1Calldata": "0xdcb40",
         "l2Calldata": "0x0",
         "wasmComputation": "0x0",
         "refund": "0x0",
         "total": "0xe1d48"
       },

Close NIT-4339