### PR TITLE
Filtered retryable submission redirect and event filter in delayed path

### DIFF
--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -215,10 +215,34 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, multiGasUsed multigas.MultiG
 		defer (startTracer())()
 		statedb := evm.StateDB
 		ticketId := underlyingTx.Hash()
+
 		escrow := retryables.RetryableEscrowAddress(ticketId)
 		networkFeeAccount, _ := p.state.NetworkFeeAccount()
 		from := tx.From
 		scenario := util.TracingDuringEVM
+
+		// Check if this transaction is in the onchain filter. If so, redirect FeeRefundAddr
+		// and Beneficiary to the filteredFundsRecipient (or networkFeeAccount as fallback).
+		// filteredErr is set as result.Err so that PostTxFilter can detect the tx was
+		// already handled by the onchain filter and skip halting.
+		var filteredErr error
+		isFiltered := false
+		if p.state.FilteredTransactions().IsFilteredFree(ticketId) {
+			recipient, err := p.state.FilteredFundsRecipientOrDefault()
+			if err != nil {
+				return true, multigas.ZeroGas(), err, nil
+			}
+			// For symmetry with other filtered tx paths, deletion from the onchain filter
+			// is handled by the external tx authority service rather than here.
+			// Note: deletion here *would* be committed despite the ErrFilteredTx in
+			// result.Err, because endTxNow=true means the outer error is nil and state
+			// is not reverted. May move to direct deletion here in future.
+			// p.state.FilteredTransactions().DeleteFree(ticketId)
+			tx.FeeRefundAddr = recipient
+			tx.Beneficiary = recipient
+			isFiltered = true
+			filteredErr = &core.ErrFilteredTx{TxHash: ticketId}
+		}
 
 		// mint funds with the deposit, then charge fees later
 		availableRefund := new(big.Int).Set(tx.DepositValue)
@@ -319,7 +343,7 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, multiGasUsed multigas.MultiG
 				// should never happen as from's balance should be at least availableRefund at this point
 				log.Error("failed to transfer gasCostRefund", "err", err)
 			}
-			return true, multigas.ZeroGas(), nil, ticketId.Bytes()
+			return true, multigas.ZeroGas(), filteredErr, ticketId.Bytes()
 		}
 
 		// pay for the retryable's gas and update the pools
@@ -336,7 +360,7 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, multiGasUsed multigas.MultiG
 				infraCost = takeFunds(networkCost, infraCost)
 				if err := transfer(&tx.From, &infraFeeAccount, infraCost, tracing.BalanceIncreaseInfraFee); err != nil {
 					log.Error("failed to transfer gas cost to infrastructure fee account", "err", err)
-					return true, multigas.ZeroGas(), nil, ticketId.Bytes()
+					return true, multigas.ZeroGas(), filteredErr, ticketId.Bytes()
 				}
 			}
 		}
@@ -344,7 +368,7 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, multiGasUsed multigas.MultiG
 			if err := transfer(&tx.From, &networkFeeAccount, networkCost, tracing.BalanceIncreaseNetworkFee); err != nil {
 				// should be impossible because we just checked the tx.From balance
 				log.Error("failed to transfer gas cost to network fee account", "err", err)
-				return true, multigas.ZeroGas(), nil, ticketId.Bytes()
+				return true, multigas.ZeroGas(), filteredErr, ticketId.Bytes()
 			}
 		}
 
@@ -360,6 +384,14 @@ func (p *TxProcessor) StartTxHook() (endTxNow bool, multiGasUsed multigas.MultiG
 		}
 		availableRefund.Add(availableRefund, withheldGasFunds)
 		availableRefund.Add(availableRefund, withheldSubmissionFee)
+
+		// For filtered retryables, skip auto-redeem scheduling. The retryable
+		// is created with a redirected beneficiary who can redeem manually.
+		// This prevents the auto-redeem from executing calls against
+		// potentially filtered addresses.
+		if isFiltered {
+			return true, multigas.L2CalldataGas(usergas), filteredErr, ticketId.Bytes()
+		}
 
 		// emit RedeemScheduled event
 		retryTxInner, err := retryable.MakeTx(

--- a/changelog/Tristan-Wilson-filtered-retryable-redirect-NIT-4545.md
+++ b/changelog/Tristan-Wilson-filtered-retryable-redirect-NIT-4545.md
@@ -1,0 +1,2 @@
+### Added
+- Filtered retryable submission redirect: when an ArbitrumSubmitRetryableTx is in the onchain filter, redirect beneficiary/feeRefundAddr and skip auto-redeem.

--- a/contracts-local/src/mocks/AddressFilterTest.sol
+++ b/contracts-local/src/mocks/AddressFilterTest.sol
@@ -72,7 +72,7 @@ contract AddressFilterTest {
     /// @notice Selfdestructs this contract and sends balance to beneficiary
     function selfDestructTo(
         address payable beneficiary
-    ) external {
+    ) external payable {
         selfdestruct(beneficiary);
     }
 

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -50,6 +50,7 @@ import (
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/consensus"
 	"github.com/offchainlabs/nitro/execution"
+	"github.com/offchainlabs/nitro/execution/gethexec/eventfilter"
 	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/containers"
 	"github.com/offchainlabs/nitro/util/sharedmetrics"
@@ -99,10 +100,14 @@ var ErrDelayedTxFiltered = errors.New("delayed transaction filtered")
 type DelayedFilteringSequencingHooks struct {
 	arbos.NoopSequencingHooks
 	FilteredTxHashes []common.Hash
+	eventFilter      *eventfilter.EventFilter
 }
 
-func NewDelayedFilteringSequencingHooks(txes types.Transactions) *DelayedFilteringSequencingHooks {
-	return &DelayedFilteringSequencingHooks{NoopSequencingHooks: *arbos.NewNoopSequencingHooks(txes)}
+func NewDelayedFilteringSequencingHooks(txes types.Transactions, ef *eventfilter.EventFilter) *DelayedFilteringSequencingHooks {
+	return &DelayedFilteringSequencingHooks{
+		NoopSequencingHooks: *arbos.NewNoopSequencingHooks(txes),
+		eventFilter:         ef,
+	}
 }
 
 // PostTxFilter touches To/From addresses and checks IsAddressFiltered.
@@ -121,6 +126,8 @@ func (f *DelayedFilteringSequencingHooks) PostTxFilter(header *types.Header, db 
 	if arbosutil.DoesTxTypeAlias(&txType) {
 		db.TouchAddress(arbosutil.InverseRemapL1Address(sender))
 	}
+	touchRetryableAddresses(db, tx)
+	applyEventFilter(f.eventFilter, db)
 
 	if db.IsAddressFiltered() {
 		// If the STF already handled this tx via the onchain filter mechanism,
@@ -134,6 +141,34 @@ func (f *DelayedFilteringSequencingHooks) PostTxFilter(header *types.Header, db 
 		f.FilteredTxHashes = append(f.FilteredTxHashes, tx.Hash())
 	}
 	return nil
+}
+
+func applyEventFilter(ef *eventfilter.EventFilter, db *state.StateDB) {
+	if ef == nil {
+		return
+	}
+	logs := db.GetCurrentTxLogs()
+	for _, l := range logs {
+		for _, addr := range ef.AddressesForFiltering(l.Topics, l.Data, l.Address, common.Address{}) {
+			db.TouchAddress(addr)
+		}
+	}
+}
+
+// touchRetryableAddresses touches addresses from retryable inner fields
+// (Beneficiary, FeeRefundAddr, RetryTo) so the address filter can detect them.
+// Also touches de-aliased versions to catch L1 contract addresses that were
+// aliased by the Inbox contract.
+func touchRetryableAddresses(db *state.StateDB, tx *types.Transaction) {
+	if inner, ok := tx.GetInner().(*types.ArbitrumSubmitRetryableTx); ok {
+		db.TouchAddress(inner.Beneficiary)
+		db.TouchAddress(inner.FeeRefundAddr)
+		if inner.RetryTo != nil {
+			db.TouchAddress(*inner.RetryTo)
+		}
+		db.TouchAddress(arbosutil.InverseRemapL1Address(inner.Beneficiary))
+		db.TouchAddress(arbosutil.InverseRemapL1Address(inner.FeeRefundAddr))
+	}
 }
 
 type L1PriceDataOfMsg struct {
@@ -182,6 +217,7 @@ type ExecutionEngine struct {
 	runningMaintenance atomic.Bool
 
 	addressChecker               state.AddressChecker
+	eventFilter                  *eventfilter.EventFilter
 	transactionFiltererRPCClient *TransactionFiltererRPCClient
 }
 
@@ -841,7 +877,7 @@ func (s *ExecutionEngine) createBlockFromNextMessage(msg *arbostypes.MessageWith
 			log.Warn("error parsing incoming message for filtering", "err", err)
 			txes = types.Transactions{}
 		}
-		filteringHooks := NewDelayedFilteringSequencingHooks(txes)
+		filteringHooks := NewDelayedFilteringSequencingHooks(txes, s.eventFilter)
 
 		block, receipts, err := arbos.ProduceBlockAdvanced(
 			msg.Message.Header,
@@ -1284,6 +1320,10 @@ func (s *ExecutionEngine) MaintenanceStatus() *execution.MaintenanceStatus {
 
 func (s *ExecutionEngine) SetAddressChecker(checker state.AddressChecker) {
 	s.addressChecker = checker
+}
+
+func (s *ExecutionEngine) SetEventFilter(ef *eventfilter.EventFilter) {
+	s.eventFilter = ef
 }
 
 func (s *ExecutionEngine) SetTransactionFiltererRPCClient(client *TransactionFiltererRPCClient) {

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -576,6 +576,7 @@ func NewSequencer(ctx context.Context, execEngine *ExecutionEngine, l1Reader *he
 	}
 	s.Pause()
 	execEngine.EnableReorgSequencing()
+	execEngine.SetEventFilter(eventFilter)
 	return s, nil
 }
 

--- a/system_tests/delayed_message_filter_test.go
+++ b/system_tests/delayed_message_filter_test.go
@@ -18,9 +18,15 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 
+	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbos"
+	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/arbos/l2pricing"
+	"github.com/offchainlabs/nitro/arbos/retryables"
 	arbosutil "github.com/offchainlabs/nitro/arbos/util"
+	"github.com/offchainlabs/nitro/cmd/chaininfo"
 	"github.com/offchainlabs/nitro/cmd/transaction-filterer/api"
+	"github.com/offchainlabs/nitro/execution/gethexec/eventfilter"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/solgen/go/localgen"
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
@@ -63,11 +69,12 @@ func sendDelayedBatch(t *testing.T, ctx context.Context, builder *NodeBuilder, t
 	Require(t, err)
 }
 
-// advanceAndWaitForDelayed advances L1 blocks and waits for delayed message processing.
-func advanceAndWaitForDelayed(t *testing.T, ctx context.Context, builder *NodeBuilder) {
+// advanceL1ForDelayed advances L1 blocks so the delayed sequencer picks up pending messages.
+// Callers should use their own wait mechanism (WaitForTx, waitForDelayedSequencerHaltOnHashes, etc.)
+// rather than relying on a sleep.
+func advanceL1ForDelayed(t *testing.T, ctx context.Context, builder *NodeBuilder) {
 	t.Helper()
 	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 30)
-	<-time.After(time.Second * 2)
 }
 
 // waitForDelayedSequencerHaltOnHashes waits until the delayed sequencer is halted on exactly the given hashes.
@@ -210,7 +217,7 @@ func TestDelayedMessageFilterHalting(t *testing.T) {
 	txHash := sendDelayedTx(t, ctx, builder, delayedTx)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify sequencer is halted on this tx
 	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{txHash}, 10*time.Second)
@@ -266,7 +273,7 @@ func TestDelayedMessageFilterBypass(t *testing.T) {
 	txHash := sendDelayedTx(t, ctx, builder, delayedTx)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify sequencer is halted
 	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{txHash}, 10*time.Second)
@@ -291,7 +298,7 @@ func TestDelayedMessageFilterBypass(t *testing.T) {
 	waitForDelayedSequencerResume(t, ctx, builder, 10*time.Second)
 
 	// Advance L1 again to ensure delayed message is processed
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify filtered address balance did NOT change (tx executed as no-op)
 	finalBalance, err := builder.L2.Client.BalanceAt(ctx, filteredAddr, nil)
@@ -379,7 +386,7 @@ func TestDelayedMessageFilterBlocksSubsequent(t *testing.T) {
 	sendDelayedTx(t, ctx, builder, delayedTx3)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify sequencer is halted on first tx
 	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{txHash1}, 10*time.Second)
@@ -405,7 +412,7 @@ func TestDelayedMessageFilterBlocksSubsequent(t *testing.T) {
 	waitForDelayedSequencerResume(t, ctx, builder, 10*time.Second)
 
 	// Advance L1 again to ensure all delayed messages are processed
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify filtered tx executed as no-op (balance unchanged)
 	filteredFinal, err := builder.L2.Client.BalanceAt(ctx, filteredAddr, nil)
@@ -495,7 +502,7 @@ func TestDelayedMessageFilterBatch(t *testing.T) {
 	sendDelayedBatch(t, ctx, builder, txBatch)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify sequencer is halted on tx2 (the filtered one, which is NOT the first in the batch)
 	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{tx2.Hash()}, 10*time.Second)
@@ -521,7 +528,7 @@ func TestDelayedMessageFilterBatch(t *testing.T) {
 	waitForDelayedSequencerResume(t, ctx, builder, 10*time.Second)
 
 	// Advance L1 again to ensure all delayed messages are processed
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify final balances:
 	// tx1: User1 should receive transferAmount
@@ -580,7 +587,7 @@ func TestDelayedMessageFilterNonFilteredPasses(t *testing.T) {
 	sendDelayedTx(t, ctx, builder, delayedTx)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Give some time for processing
 	<-time.After(time.Second)
@@ -679,7 +686,7 @@ func TestDelayedMessageFilterCall(t *testing.T) {
 	txHash := sendDelayedTx(t, ctx, builder, delayedTx)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify sequencer is halted on this tx
 	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{txHash}, 10*time.Second)
@@ -749,7 +756,7 @@ func TestDelayedMessageFilterStaticCall(t *testing.T) {
 	txHash := sendDelayedTx(t, ctx, builder, delayedTx)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify sequencer is halted on this tx
 	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{txHash}, 10*time.Second)
@@ -820,7 +827,7 @@ func TestDelayedMessageFilterCreate(t *testing.T) {
 	txHash := sendDelayedTx(t, ctx, builder, delayedTx)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify sequencer is halted on this tx
 	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{txHash}, 10*time.Second)
@@ -889,7 +896,7 @@ func TestDelayedMessageFilterCreate2(t *testing.T) {
 	txHash := sendDelayedTx(t, ctx, builder, delayedTx)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify sequencer is halted on this tx
 	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{txHash}, 10*time.Second)
@@ -956,7 +963,7 @@ func TestDelayedMessageFilterSelfdestruct(t *testing.T) {
 	txHash := sendDelayedTx(t, ctx, builder, delayedTx)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify sequencer is halted on this tx
 	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{txHash}, 10*time.Second)
@@ -1023,7 +1030,7 @@ func TestDelayedMessageFilterTxHashesUpdateOnchainFilter(t *testing.T) {
 	sendDelayedBatch(t, ctx, builder, txBatch)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify sequencer is halted on both tx1 and tx2
 	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{tx1.Hash(), tx2.Hash()}, 10*time.Second)
@@ -1041,7 +1048,7 @@ func TestDelayedMessageFilterTxHashesUpdateOnchainFilter(t *testing.T) {
 	waitForDelayedSequencerResume(t, ctx, builder, 10*time.Second)
 
 	// Advance L1 again to ensure delayed message is processed
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify both receipts exist and have failed status (executed as no-ops)
 	receipt1, err := builder.L2.Client.TransactionReceipt(ctx, tx1.Hash())
@@ -1097,7 +1104,7 @@ func TestDelayedMessageFilterTxHashesUpdateAddressSetChange(t *testing.T) {
 	sendDelayedBatch(t, ctx, builder, txBatch)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify sequencer is halted on both tx1 and tx2
 	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{tx1.Hash(), tx2.Hash()}, 10*time.Second)
@@ -1117,7 +1124,7 @@ func TestDelayedMessageFilterTxHashesUpdateAddressSetChange(t *testing.T) {
 	waitForDelayedSequencerResume(t, ctx, builder, 10*time.Second)
 
 	// Advance L1 again to ensure delayed message is processed
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify tx1 succeeded (User1 received funds - no longer filtered)
 	user1Final, err := builder.L2.Client.BalanceAt(ctx, user1Addr, nil)
@@ -1141,7 +1148,552 @@ func TestDelayedMessageFilterTxHashesUpdateAddressSetChange(t *testing.T) {
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt2.Status, "tx2 should have success status")
 }
 
-// TestFilteredArbitrumDepositTx verifies that an L1→L2 ETH deposit (ArbitrumDepositTx)
+// retryableFilterTestParams holds common params for retryable filter tests.
+type retryableFilterTestParams struct {
+	builder            *NodeBuilder
+	ctx                context.Context
+	delayedInbox       *bridgegen.Inbox
+	lookupL2Tx         func(*types.Receipt) *types.Transaction
+	filtererName       string
+	fundsRecipientAddr common.Address
+}
+
+// setupRetryableFilterTest sets up a node for retryable filtering tests.
+// It creates a Filterer account with the transaction-filterer role.
+// When setFundsRecipient is true, it also sets the filteredFundsRecipient.
+func setupRetryableFilterTest(t *testing.T, ctx context.Context, setFundsRecipient bool, eventFilterRules []eventfilter.EventRule) (*retryableFilterTestParams, func()) {
+	t.Helper()
+	builder := setupFilteredTxTestBuilder(t, ctx)
+	if eventFilterRules != nil {
+		builder.WithEventFilterRules(eventFilterRules)
+	}
+	cleanup := builder.Build(t)
+
+	delayedInbox, err := bridgegen.NewInbox(builder.L1Info.GetAddress("Inbox"), builder.L1.Client)
+	require.NoError(t, err)
+
+	delayedBridge, err := arbnode.NewDelayedBridge(builder.L1.Client, builder.L1Info.GetAddress("Bridge"), 0)
+	require.NoError(t, err)
+
+	lookupL2Tx := func(l1Receipt *types.Receipt) *types.Transaction {
+		messages, err := delayedBridge.LookupMessagesInRange(ctx, l1Receipt.BlockNumber, l1Receipt.BlockNumber, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, messages, "no delayed messages found")
+		var submissionTxs []*types.Transaction
+		for _, message := range messages {
+			if message.Message.Header.Kind != arbostypes.L1MessageType_SubmitRetryable {
+				continue
+			}
+			txs, err := arbos.ParseL2Transactions(message.Message, chaininfo.ArbitrumDevTestChainConfig().ChainID, params.MaxDebugArbosVersionSupported)
+			require.NoError(t, err)
+			for _, tx := range txs {
+				if tx.Type() == types.ArbitrumSubmitRetryableTxType {
+					submissionTxs = append(submissionTxs, tx)
+				}
+			}
+		}
+		require.Len(t, submissionTxs, 1, "expected exactly 1 retryable submission tx")
+		return submissionTxs[0]
+	}
+
+	builder.L2Info.GenerateAccount("Filterer")
+	builder.L2Info.GenerateAccount("FundsRecipient")
+	builder.L2.TransferBalance(t, "Owner", "Filterer", big.NewInt(1e18), builder.L2Info)
+
+	ownerTxOpts := builder.L2Info.GetDefaultTransactOpts("Owner", ctx)
+	arbOwner, err := precompilesgen.NewArbOwner(types.ArbOwnerAddress, builder.L2.Client)
+	require.NoError(t, err)
+
+	tx, err := arbOwner.AddTransactionFilterer(&ownerTxOpts, builder.L2Info.GetAddress("Filterer"))
+	require.NoError(t, err)
+	_, err = builder.L2.EnsureTxSucceeded(tx)
+	require.NoError(t, err)
+
+	fundsRecipientAddr := builder.L2Info.GetAddress("FundsRecipient")
+	if setFundsRecipient {
+		tx, err = arbOwner.SetFilteredFundsRecipient(&ownerTxOpts, fundsRecipientAddr)
+		require.NoError(t, err)
+		_, err = builder.L2.EnsureTxSucceeded(tx)
+		require.NoError(t, err)
+	}
+
+	return &retryableFilterTestParams{
+		builder:            builder,
+		ctx:                ctx,
+		delayedInbox:       delayedInbox,
+		lookupL2Tx:         lookupL2Tx,
+		filtererName:       "Filterer",
+		fundsRecipientAddr: fundsRecipientAddr,
+	}, cleanup
+}
+
+// submitRetryableViaL1 submits a retryable ticket via the L1 delayed inbox.
+// Returns the L1 receipt and the L2 submission tx hash (ticketId).
+func submitRetryableViaL1(
+	t *testing.T,
+	p *retryableFilterTestParams,
+	l1Sender string,
+	destAddr common.Address,
+	callValue *big.Int,
+	beneficiary common.Address,
+	feeRefundAddr common.Address,
+	data []byte,
+) (*types.Receipt, common.Hash) {
+	t.Helper()
+
+	deposit := arbmath.BigMul(big.NewInt(1e12), big.NewInt(1e12))
+	maxSubmissionCost := big.NewInt(1e16)
+	gasLimit := big.NewInt(100000)
+	maxFeePerGas := big.NewInt(l2pricing.InitialBaseFeeWei * 2)
+
+	l1opts := p.builder.L1Info.GetDefaultTransactOpts(l1Sender, p.ctx)
+	l1opts.Value = deposit
+	l1tx, err := p.delayedInbox.CreateRetryableTicket(
+		&l1opts,
+		destAddr,
+		callValue,
+		maxSubmissionCost,
+		feeRefundAddr,
+		beneficiary,
+		gasLimit,
+		maxFeePerGas,
+		data,
+	)
+	require.NoError(t, err)
+
+	l1Receipt, err := p.builder.L1.EnsureTxSucceeded(l1tx)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, l1Receipt.Status)
+
+	l2Tx := p.lookupL2Tx(l1Receipt)
+	return l1Receipt, l2Tx.Hash()
+}
+
+func TestFilteredRetryableRedirectWithExplicitRecipient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p, cleanup := setupRetryableFilterTest(t, ctx, true, nil)
+	defer cleanup()
+
+	builder := p.builder
+
+	builder.L2Info.GenerateAccount("FilteredUser")
+	builder.L2Info.GenerateAccount("Destination")
+
+	filteredAddr := builder.L2Info.GetAddress("FilteredUser")
+	destAddr := builder.L2Info.GetAddress("Destination")
+
+	// Set up address filter to block FilteredUser
+	filter := newHashedChecker([]common.Address{filteredAddr})
+	builder.L2.ExecNode.ExecEngine.SetAddressChecker(filter)
+
+	// Record initial balance of filtered address
+	filteredInitialBalance, err := builder.L2.Client.BalanceAt(ctx, filteredAddr, nil)
+	require.NoError(t, err)
+
+	// Submit retryable with filtered beneficiary and feeRefundAddr
+	_, ticketId := submitRetryableViaL1(t, p, "Faucet", destAddr, common.Big0, filteredAddr, filteredAddr, nil)
+
+	// Advance L1 to trigger delayed message processing
+	advanceL1ForDelayed(t, ctx, builder)
+
+	// Sequencer should halt because PostTxFilter touches beneficiary/feeRefundAddr
+	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{ticketId}, 10*time.Second)
+
+	// Verify filtered address balance did not change while halted
+	filteredMidBalance, err := builder.L2.Client.BalanceAt(ctx, filteredAddr, nil)
+	require.NoError(t, err)
+	require.Equal(t, filteredInitialBalance, filteredMidBalance, "balance should not change while halted")
+
+	// Add tx hash to onchain filter to authorize processing
+	addTxHashToOnChainFilter(t, ctx, builder, ticketId, "Filterer")
+
+	// Wait for delayed sequencer to resume
+	waitForDelayedSequencerResume(t, ctx, builder, 10*time.Second)
+
+	// Advance L1 again to ensure delayed message is processed
+	advanceL1ForDelayed(t, ctx, builder)
+
+	// Wait for the L2 receipt
+	receipt, err := WaitForTx(ctx, builder.L2.Client, ticketId, time.Second*10)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusFailed, receipt.Status, "filtered retryable should have failed receipt status")
+
+	// Verify retryable was created with redirected beneficiary
+	arbRetryable, err := precompilesgen.NewArbRetryableTx(common.HexToAddress("6e"), builder.L2.Client)
+	require.NoError(t, err)
+	beneficiary, err := arbRetryable.GetBeneficiary(&bind.CallOpts{}, ticketId)
+	require.NoError(t, err)
+	require.Equal(t, p.fundsRecipientAddr, beneficiary, "retryable beneficiary should be redirected to FundsRecipient")
+
+	// Verify filtered address balance did not increase
+	filteredFinalBalance, err := builder.L2.Client.BalanceAt(ctx, filteredAddr, nil)
+	require.NoError(t, err)
+	require.Equal(t, filteredInitialBalance, filteredFinalBalance, "filtered address should not receive any funds")
+
+	// Verify redirect address received fee refunds
+	redirectBalance, err := builder.L2.Client.BalanceAt(ctx, p.fundsRecipientAddr, nil)
+	require.NoError(t, err)
+	require.True(t, redirectBalance.Sign() > 0, "redirect address should have received fee refunds")
+
+	// Verify sequencer is not re-halted
+	_, waiting := builder.L2.ConsensusNode.DelayedSequencer.WaitingForFilteredTx(t)
+	require.False(t, waiting, "sequencer should not be re-halted after processing filtered retryable")
+}
+
+func TestFilteredRetryableRedirectFallbackToNetworkFee(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p, cleanup := setupRetryableFilterTest(t, ctx, false, nil)
+	defer cleanup()
+
+	builder := p.builder
+
+	builder.L2Info.GenerateAccount("FilteredUser")
+	builder.L2Info.GenerateAccount("Destination")
+
+	filteredAddr := builder.L2Info.GetAddress("FilteredUser")
+	destAddr := builder.L2Info.GetAddress("Destination")
+
+	// Get the networkFeeAccount for comparison
+	arbOwnerPublic, err := precompilesgen.NewArbOwnerPublic(types.ArbOwnerPublicAddress, builder.L2.Client)
+	require.NoError(t, err)
+	networkFeeAccount, err := arbOwnerPublic.GetNetworkFeeAccount(&bind.CallOpts{})
+	require.NoError(t, err)
+
+	// Verify filteredFundsRecipient is zero
+	configuredRecipient, err := arbOwnerPublic.GetFilteredFundsRecipient(&bind.CallOpts{})
+	require.NoError(t, err)
+	require.Equal(t, common.Address{}, configuredRecipient, "filteredFundsRecipient should be zero")
+
+	// Set up address filter
+	filter := newHashedChecker([]common.Address{filteredAddr})
+	builder.L2.ExecNode.ExecEngine.SetAddressChecker(filter)
+
+	filteredInitialBalance, err := builder.L2.Client.BalanceAt(ctx, filteredAddr, nil)
+	require.NoError(t, err)
+
+	// Snapshot networkFeeAccount balance before retryable processing
+	nfaBefore, err := builder.L2.Client.BalanceAt(ctx, networkFeeAccount, nil)
+	require.NoError(t, err)
+
+	// Submit retryable with filtered beneficiary
+	_, ticketId := submitRetryableViaL1(t, p, "Faucet", destAddr, common.Big0, filteredAddr, filteredAddr, nil)
+
+	// Advance L1 to trigger delayed message processing
+	advanceL1ForDelayed(t, ctx, builder)
+
+	// Sequencer should halt on filtered beneficiary/feeRefundAddr
+	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{ticketId}, 10*time.Second)
+
+	// Add tx hash to onchain filter to authorize processing
+	addTxHashToOnChainFilter(t, ctx, builder, ticketId, "Filterer")
+
+	// Wait for delayed sequencer to resume
+	waitForDelayedSequencerResume(t, ctx, builder, 10*time.Second)
+
+	// Advance L1 again to ensure delayed message is processed
+	advanceL1ForDelayed(t, ctx, builder)
+
+	// Wait for receipt
+	receipt, err := WaitForTx(ctx, builder.L2.Client, ticketId, time.Second*10)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusFailed, receipt.Status)
+
+	// Verify beneficiary fell back to networkFeeAccount
+	arbRetryable, err := precompilesgen.NewArbRetryableTx(common.HexToAddress("6e"), builder.L2.Client)
+	require.NoError(t, err)
+	beneficiary, err := arbRetryable.GetBeneficiary(&bind.CallOpts{}, ticketId)
+	require.NoError(t, err)
+	require.Equal(t, networkFeeAccount, beneficiary, "retryable beneficiary should fallback to networkFeeAccount")
+
+	// Verify filtered address untouched
+	filteredFinalBalance, err := builder.L2.Client.BalanceAt(ctx, filteredAddr, nil)
+	require.NoError(t, err)
+	require.Equal(t, filteredInitialBalance, filteredFinalBalance, "filtered address should not receive any funds")
+
+	// Verify networkFeeAccount balance increased from fee refunds
+	nfaAfter, err := builder.L2.Client.BalanceAt(ctx, networkFeeAccount, nil)
+	require.NoError(t, err)
+	require.True(t, nfaAfter.Cmp(nfaBefore) > 0, "network fee account should have received fee refunds")
+}
+
+func TestFilteredRetryableNoRedirectWhenNotFiltered(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p, cleanup := setupRetryableFilterTest(t, ctx, true, nil)
+	defer cleanup()
+
+	builder := p.builder
+
+	builder.L2Info.GenerateAccount("FilteredUser")
+	builder.L2Info.GenerateAccount("NormalBeneficiary")
+	builder.L2Info.GenerateAccount("Destination")
+
+	filteredAddr := builder.L2Info.GetAddress("FilteredUser")
+	normalBeneficiary := builder.L2Info.GetAddress("NormalBeneficiary")
+	destAddr := builder.L2Info.GetAddress("Destination")
+
+	// Set up address filter to block FilteredUser only (NOT NormalBeneficiary)
+	filter := newHashedChecker([]common.Address{filteredAddr})
+	builder.L2.ExecNode.ExecEngine.SetAddressChecker(filter)
+
+	// Submit retryable with non-filtered beneficiary
+	_, ticketId := submitRetryableViaL1(t, p, "Faucet", destAddr, common.Big0, normalBeneficiary, normalBeneficiary, nil)
+
+	advanceL1ForDelayed(t, ctx, builder)
+
+	// Wait for the L2 receipt — this should succeed normally.
+	// A successful receipt proves no filtering happened (filtered retryables get ReceiptStatusFailed).
+	// We can't check GetBeneficiary because the auto-redeem runs immediately
+	// and deletes the retryable ticket on success.
+	receipt, err := WaitForTx(ctx, builder.L2.Client, ticketId, time.Second*10)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "non-filtered retryable should succeed")
+
+	// Verify sequencer is NOT halted
+	_, waiting := builder.L2.ConsensusNode.DelayedSequencer.WaitingForFilteredTx(t)
+	require.False(t, waiting, "sequencer should not be halted for non-filtered retryable")
+}
+
+func TestFilteredRetryableWithCallValue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p, cleanup := setupRetryableFilterTest(t, ctx, true, nil)
+	defer cleanup()
+
+	builder := p.builder
+
+	builder.L2Info.GenerateAccount("FilteredUser")
+	builder.L2Info.GenerateAccount("Destination")
+
+	filteredAddr := builder.L2Info.GetAddress("FilteredUser")
+	destAddr := builder.L2Info.GetAddress("Destination")
+
+	// Set up address filter
+	filter := newHashedChecker([]common.Address{filteredAddr})
+	builder.L2.ExecNode.ExecEngine.SetAddressChecker(filter)
+
+	callValue := big.NewInt(1e6)
+
+	// Submit retryable with call value and filtered beneficiary
+	_, ticketId := submitRetryableViaL1(t, p, "Faucet", destAddr, callValue, filteredAddr, filteredAddr, nil)
+
+	// Advance L1 to trigger delayed message processing
+	advanceL1ForDelayed(t, ctx, builder)
+
+	// Sequencer should halt on filtered beneficiary/feeRefundAddr
+	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{ticketId}, 10*time.Second)
+
+	// Add tx hash to onchain filter to authorize processing
+	addTxHashToOnChainFilter(t, ctx, builder, ticketId, "Filterer")
+
+	// Wait for delayed sequencer to resume
+	waitForDelayedSequencerResume(t, ctx, builder, 10*time.Second)
+
+	// Advance L1 again to ensure delayed message is processed
+	advanceL1ForDelayed(t, ctx, builder)
+
+	// Wait for receipt
+	receipt, err := WaitForTx(ctx, builder.L2.Client, ticketId, time.Second*10)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusFailed, receipt.Status)
+
+	// Verify retryable beneficiary is redirected
+	arbRetryable, err := precompilesgen.NewArbRetryableTx(common.HexToAddress("6e"), builder.L2.Client)
+	require.NoError(t, err)
+	beneficiary, err := arbRetryable.GetBeneficiary(&bind.CallOpts{}, ticketId)
+	require.NoError(t, err)
+	require.Equal(t, p.fundsRecipientAddr, beneficiary, "retryable beneficiary should be redirected")
+
+	// Verify escrow holds the call value
+	escrowAddr := retryables.RetryableEscrowAddress(ticketId)
+	state, err := builder.L2.ExecNode.ArbInterface.BlockChain().State()
+	require.NoError(t, err)
+	escrowBalance := state.GetBalance(escrowAddr)
+	require.Equal(t, callValue, escrowBalance.ToBig(), "escrow should hold the call value")
+
+	// Verify filtered address did not receive anything
+	filteredBalance, err := builder.L2.Client.BalanceAt(ctx, filteredAddr, nil)
+	require.NoError(t, err)
+	require.True(t, filteredBalance.Sign() == 0, "filtered address should have zero balance")
+
+	// Verify redirect address received fee refunds
+	redirectBalance, err := builder.L2.Client.BalanceAt(ctx, p.fundsRecipientAddr, nil)
+	require.NoError(t, err)
+	require.True(t, redirectBalance.Sign() > 0, "redirect address should have received fee refunds")
+}
+
+func TestFilteredRetryableSequencerDoesNotReHalt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p, cleanup := setupRetryableFilterTest(t, ctx, true, nil)
+	defer cleanup()
+
+	builder := p.builder
+
+	builder.L2Info.GenerateAccount("FilteredUser")
+	builder.L2Info.GenerateAccount("Destination")
+	builder.L2Info.GenerateAccount("NormalRecipient")
+	builder.L2Info.GenerateAccount("Sender")
+	builder.L2.TransferBalance(t, "Owner", "Sender", big.NewInt(1e18), builder.L2Info)
+
+	filteredAddr := builder.L2Info.GetAddress("FilteredUser")
+	destAddr := builder.L2Info.GetAddress("Destination")
+	normalRecipientAddr := builder.L2Info.GetAddress("NormalRecipient")
+
+	// Set up address filter
+	filter := newHashedChecker([]common.Address{filteredAddr})
+	builder.L2.ExecNode.ExecEngine.SetAddressChecker(filter)
+
+	// Record initial balance of normal recipient
+	normalInitialBalance, err := builder.L2.Client.BalanceAt(ctx, normalRecipientAddr, nil)
+	require.NoError(t, err)
+
+	// Submit filtered retryable via L1
+	_, ticketId := submitRetryableViaL1(t, p, "Faucet", destAddr, common.Big0, filteredAddr, filteredAddr, nil)
+
+	// Submit a normal delayed transfer behind it
+	transferAmount := big.NewInt(1e12)
+	delayedTx := builder.L2Info.PrepareTx("Sender", "NormalRecipient", builder.L2Info.TransferGas, transferAmount, nil)
+	delayedTxHash := sendDelayedTx(t, ctx, builder, delayedTx)
+
+	// Advance L1 to trigger delayed message processing
+	advanceL1ForDelayed(t, ctx, builder)
+
+	// Sequencer should halt on the filtered retryable
+	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{ticketId}, 10*time.Second)
+
+	// Add tx hash to onchain filter to authorize processing
+	addTxHashToOnChainFilter(t, ctx, builder, ticketId, "Filterer")
+
+	// Wait for delayed sequencer to resume
+	waitForDelayedSequencerResume(t, ctx, builder, 10*time.Second)
+
+	// Advance L1 again to ensure all delayed messages are processed
+	advanceL1ForDelayed(t, ctx, builder)
+
+	// Verify filtered retryable processed with redirect
+	receipt, err := WaitForTx(ctx, builder.L2.Client, ticketId, time.Second*10)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusFailed, receipt.Status, "filtered retryable should have failed receipt")
+
+	// Wait for the normal delayed transfer to also be processed. The delayed sequencer
+	// may not have sequenced it in the same iteration as the retryable if the inbox
+	// reader hadn't indexed it yet when the sequencer resumed.
+	_, err = WaitForTx(ctx, builder.L2.Client, delayedTxHash, time.Second*10)
+	require.NoError(t, err)
+
+	arbRetryable, err := precompilesgen.NewArbRetryableTx(common.HexToAddress("6e"), builder.L2.Client)
+	require.NoError(t, err)
+	beneficiary, err := arbRetryable.GetBeneficiary(&bind.CallOpts{}, ticketId)
+	require.NoError(t, err)
+	require.Equal(t, p.fundsRecipientAddr, beneficiary, "retryable beneficiary should be redirected")
+
+	// Verify the normal delayed transfer behind it also processed (no re-halt)
+	normalFinalBalance, err := builder.L2.Client.BalanceAt(ctx, normalRecipientAddr, nil)
+	require.NoError(t, err)
+	expectedBalance := new(big.Int).Add(normalInitialBalance, transferAmount)
+	require.Equal(t, expectedBalance, normalFinalBalance, "normal transfer should be processed after filtered retryable")
+
+	// Verify redirect address received fee refunds
+	redirectBalance, err := builder.L2.Client.BalanceAt(ctx, p.fundsRecipientAddr, nil)
+	require.NoError(t, err)
+	require.True(t, redirectBalance.Sign() > 0, "redirect address should have received fee refunds")
+
+	// Verify sequencer is NOT halted
+	_, waiting := builder.L2.ConsensusNode.DelayedSequencer.WaitingForFilteredTx(t)
+	require.False(t, waiting, "sequencer should not be re-halted after processing")
+}
+
+// TestDelayedMessageFilterCatchesEventFilter verifies that the delayed
+// message PostTxFilter runs the event filter. A normal delayed tx that
+// emits a Transfer event naming a filtered address causes the sequencer
+// to halt. After adding the tx hash to the onchain filter, the sequencer
+// resumes and the tx is processed.
+func TestDelayedMessageFilterCatchesEventFilter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	selector, _, err := eventfilter.CanonicalSelectorFromEvent("Transfer(address,address,uint256)")
+	require.NoError(t, err)
+	rules := []eventfilter.EventRule{{
+		Event:          "Transfer(address,address,uint256)",
+		Selector:       selector,
+		TopicAddresses: []int{1, 2},
+	}}
+
+	arbOSInit := &params.ArbOSInit{
+		TransactionFilteringEnabled: true,
+	}
+	builder := NewNodeBuilder(ctx).
+		DefaultConfig(t, true).
+		WithArbOSVersion(params.ArbosVersion_60).
+		WithArbOSInit(arbOSInit).
+		WithEventFilterRules(rules)
+	builder.isSequencer = true
+	builder.nodeConfig.DelayedSequencer.Enable = true
+	builder.nodeConfig.DelayedSequencer.FinalizeDistance = 1
+	cleanup := builder.Build(t)
+	defer cleanup()
+
+	builder.L2Info.GenerateAccount("Sender")
+	builder.L2Info.GenerateAccount("Filterer")
+	builder.L2Info.GenerateAccount("FilteredTarget")
+	builder.L2.TransferBalance(t, "Owner", "Sender", big.NewInt(1e18), builder.L2Info)
+	builder.L2.TransferBalance(t, "Owner", "Filterer", big.NewInt(1e18), builder.L2Info)
+
+	// Grant Filterer the transaction filterer role
+	ownerTxOpts := builder.L2Info.GetDefaultTransactOpts("Owner", ctx)
+	arbOwner, err := precompilesgen.NewArbOwner(types.ArbOwnerAddress, builder.L2.Client)
+	require.NoError(t, err)
+	tx, err := arbOwner.AddTransactionFilterer(&ownerTxOpts, builder.L2Info.GetAddress("Filterer"))
+	require.NoError(t, err)
+	_, err = builder.L2.EnsureTxSucceeded(tx)
+	require.NoError(t, err)
+
+	senderAddr := builder.L2Info.GetAddress("Sender")
+	filteredAddr := builder.L2Info.GetAddress("FilteredTarget")
+
+	contractAddr, _ := deployAddressFilterTestContractForDelayed(t, ctx, builder)
+
+	addrFilter := newHashedChecker([]common.Address{filteredAddr})
+	builder.L2.ExecNode.ExecEngine.SetAddressChecker(addrFilter)
+
+	contractABI, err := localgen.AddressFilterTestMetaData.GetAbi()
+	require.NoError(t, err)
+	callData, err := contractABI.Pack("emitTransfer", senderAddr, filteredAddr)
+	require.NoError(t, err)
+
+	delayedTx := prepareDelayedContractCall(t, builder, "Sender", contractAddr, callData)
+	txHash := sendDelayedTx(t, ctx, builder, delayedTx)
+
+	advanceL1ForDelayed(t, ctx, builder)
+
+	// Sequencer should halt because event filter detects the Transfer event
+	// with the filtered address in a topic
+	waitForDelayedSequencerHaltOnHashes(t, ctx, builder, []common.Hash{txHash}, 10*time.Second)
+
+	// Add tx hash to onchain filter to allow it through
+	addTxHashToOnChainFilter(t, ctx, builder, txHash, "Filterer")
+
+	waitForDelayedSequencerResume(t, ctx, builder, 10*time.Second)
+
+	advanceL1ForDelayed(t, ctx, builder)
+
+	// Tx should now be processed (as a filtered no-op with failed receipt)
+	receipt, err := WaitForTx(ctx, builder.L2.Client, txHash, time.Second*10)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusFailed, receipt.Status,
+		"filtered tx should have failed receipt status")
+}
+
+// TestFilteredArbitrumDepositTx verifies that an L1->L2 ETH deposit (ArbitrumDepositTx)
 // to a filtered address is handled correctly when the tx hash is in the onchain filter.
 // The deposit funds should be redirected to FilteredFundsRecipient (or networkFeeAccount
 // as default fallback) instead of the filtered address.
@@ -1198,7 +1750,7 @@ func TestFilteredArbitrumDepositTx(t *testing.T) {
 	require.NoError(t, err)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Wait for delayed sequencer to halt on the filtered deposit
 	var depositTxHash common.Hash
@@ -1221,7 +1773,7 @@ func TestFilteredArbitrumDepositTx(t *testing.T) {
 	waitForDelayedSequencerResume(t, ctx, builder, 30*time.Second)
 
 	// Advance L1 again to ensure the deposit block is processed
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Wait for the deposit tx receipt on L2
 	receipt, err := WaitForTx(ctx, builder.L2.Client, depositTxHash, 30*time.Second)
@@ -1316,7 +1868,7 @@ func TestDelayedMessageFilterAliasedSender(t *testing.T) {
 	require.NoError(t, err)
 
 	// Advance L1 to trigger delayed message processing
-	advanceAndWaitForDelayed(t, ctx, builder)
+	advanceL1ForDelayed(t, ctx, builder)
 
 	// Verify sequencer is halted on this tx.
 	// The filter catches the original L1 address via de-aliasing in PostTxFilter.


### PR DESCRIPTION
PostTxFilter touches sender and tx.To() but not retryable-specific fields (Beneficiary, FeeRefundAddr, RetryTo). When the onchain filter contains the tx hash, StartTxHook had no handling for the retryable case, so funds would flow to filtered addresses unchecked. Additionally, the event filter (log-based address detection for Transfer events) was only wired into the sequencer's postTxFilter, not into the delayed message path.

Retryable submissions are L1 delayed messages that are force-included from L1 and must be processed; the user's ETH is already locked in the L1 bridge and will be minted on L2. Rejecting the submission would leave funds stuck in escrow with an unreachable beneficiary, so we redirect instead.

- In StartTxHook for ArbitrumSubmitRetryableTx, check IsFilteredFree(ticketId). When the tx hash is in the onchain filter, redirect Beneficiary and FeeRefundAddr to filteredFundsRecipient (falls back to networkFeeAccount), still create the ticket, and skip auto-redeem scheduling. Set ErrFilteredTx so PostTxFilter knows the tx was already handled and skips re-halting the delayed sequencer.
- Add touchRetryableAddresses() in PostTxFilter to touch Beneficiary, FeeRefundAddr, RetryTo, plus de-aliased Beneficiary and FeeRefundAddr (InverseRemapL1Address). This ensures the address filter detects retryable-specific fields during the initial tentative pass before the tx hash is in the onchain filter.
- Wire event filter through DelayedFilteringSequencingHooks via applyEventFilter() in PostTxFilter and SetEventFilter on ExecutionEngine.
- Add 6 system tests covering explicit redirect, networkFeeAccount fallback, non-filtered passthrough, call value handling, no re-halt after processing, and event filter detection in the delayed path.

fixes NIT-4545