### PR TITLE
fix: cross typos.

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,43 @@
+[codespell]
+# Repository-specific configuration for codespell.
+# Keep this in sync with project conventions (generated files, vendored deps, and binary artifacts should be skipped).
+
+# Do not scan generated / third-party / large artifacts
+skip =
+    ./.git,
+    ./Cargo.lock,
+    ./**/Cargo.lock,
+    ./go.sum,
+    ./**/go.sum,
+    ./**/target,
+    ./go-ethereum,
+    ./third_party,
+    ./**/node_modules,
+    ./**/testdata,
+    ./linters/testdata,
+    ./system_tests/testdata,
+    ./arbos/testdata,
+    ./**/test-data,
+    ./system_tests/test-data,
+    ./system_tests,
+    ./validator/server_api/json_test.go,
+    ./**/*.pdf
+
+# Project-specific identifiers that codespell flags but are intentionally named
+ignore-words-list =
+    retryIn,
+    callE,
+    flate,
+    clientA,
+    userA,
+    allEdges,
+    CreateRespone,
+    Succes,
+    oFrom,
+    cummulative,
+    cummulativeCallDataUnits,
+    nd,
+    datas,
+    wast,
+    tipe,
+    tRival

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Centralize validator worker throttling in BlockValidator #NIT-3339: [[PR]](https://github.com/OffchainLabs/nitro/pull/4032)
 - Do not require BatchMetadata for reading DelayedInbox: [[PR]](https://github.com/OffchainLabs/nitro/pull/4106)
 - redis pubsub: add retries limit and option to disable retries: [[PR]](https://github.com/OffchainLabs/nitro/pull/2803)
-- Extract saturating arithmetics: [[PR]](https://github.com/OffchainLabs/nitro/pull/4126)
+- Extract saturating arithmetic: [[PR]](https://github.com/OffchainLabs/nitro/pull/4126)
 - Add MaxTxSize check to ValidateExpressLaneTx(): [[PR]](https://github.com/OffchainLabs/nitro/pull/4105)
 - Adjust pricing formula with weight normalisation by max weight: [[PR]](https://github.com/OffchainLabs/nitro/pull/4125)
 - Make bids receiver buffer size configurable: [[PR]](https://github.com/OffchainLabs/nitro/pull/4117)
@@ -133,4 +133,3 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - [MEL] - Implement preimage recorder for `DelayedMessageDatabase` interface: [[PR]](https://github.com/OffchainLabs/nitro/pull/4119)
 - [MEL] - Implement recording of preimages related to sequencer batches (DA providers): [[PR]](https://github.com/OffchainLabs/nitro/pull/4133)
 - Add new boolean option to `BlocksReExecutor` called `CommitStateToDisk` that will allow `BlocksReExecutor.Blocks` range to not only re-executes blocks but it will also commit their state to triedb on disk. [[PR]](https://github.com/OffchainLabs/nitro/pull/4132)
-

--- a/arbnode/mel/delayed_message_backlog_test.go
+++ b/arbnode/mel/delayed_message_backlog_test.go
@@ -37,7 +37,7 @@ func TestDelayedMessageBacklog(t *testing.T) {
 	// Test that clone works
 	cloned := backlog.clone()
 	if !reflect.DeepEqual(backlog, cloned) {
-		t.Fatal("cloned doesnt match original")
+		t.Fatal("cloned doesn't match original")
 	}
 
 	// Test failures with Get
@@ -51,7 +51,7 @@ func TestDelayedMessageBacklog(t *testing.T) {
 	}
 	// Index mismatch
 	failIndex := uint64(3)
-	backlog.entries[failIndex].Index = failIndex + 1 // shouldnt match
+	backlog.entries[failIndex].Index = failIndex + 1 // shouldn't match
 	_, err = backlog.Get(failIndex)
 	if err == nil {
 		t.Fatal("backlog Get function should've errored for an invalid entry in the backlog")
@@ -70,7 +70,7 @@ func TestDelayedMessageBacklog(t *testing.T) {
 	// Verify that Reorg handling works as expected, reorg of 5 indexes
 	newSeen := numEntries - 5
 	require.NoError(t, backlog.reorg(newSeen))
-	// as newDelayedMessageBacklog hasnt updated with new finalized info, its starting elements remain unchanged, just that the right parts are trimmed till (newSeen-1) delayed index
+	// as newDelayedMessageBacklog hasn't updated with new finalized info, its starting elements remain unchanged, just that the right parts are trimmed till (newSeen-1) delayed index
 	require.True(t, len(backlog.entries) == int(newSeen-finalizedAndRead)) // #nosec G115
 	require.True(t, backlog.entries[len(backlog.entries)-1].Index == newSeen-1)
 }

--- a/arbnode/mel/recording/dap_reader_source.go
+++ b/arbnode/mel/recording/dap_reader_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/offchainlabs/nitro/validator"
 )
 
-// DAPReader implements recording of data avaialability preimages when melextraction.ExtractMessages function is called by
+// DAPReader implements recording of data availability preimages when melextraction.ExtractMessages function is called by
 // MEL validator for creation of validation entry. Since ExtractMessages function would use daprovider.Reader interface to
 // fetch the sequencer batch via RecoverPayload we implement collecting of preimages as well in the same method and record it
 type DAPReader struct {

--- a/arbnode/mel/recording/delayed_msg_database.go
+++ b/arbnode/mel/recording/delayed_msg_database.go
@@ -121,7 +121,7 @@ func (r *DelayedMsgDatabase) initialize(state *mel.State) error {
 		}
 	}
 	if acc == nil {
-		return errors.New("couldnt initialize the accumulator")
+		return errors.New("couldn't initialize the accumulator")
 	}
 	acc.RecordPreimagesTo(r.preimages)
 	for i := state.DelayedMessagesRead; i < state.DelayedMessagesSeen; i++ {

--- a/arbnode/mel/runner/backlog.go
+++ b/arbnode/mel/runner/backlog.go
@@ -33,7 +33,7 @@ func InitializeDelayedMessageBacklog(ctx context.Context, d *mel.DelayedMessageB
 		return err
 	}
 	if uint64(len(delayedMsgIndexToParentChainBlockNum)) < state.DelayedMessagesSeen-targetDelayedMessagesRead {
-		return fmt.Errorf("number of mappings from index to ParentChainBlockNum: %d are insufficient, needed atleast: %d", len(delayedMsgIndexToParentChainBlockNum), state.DelayedMessagesSeen-targetDelayedMessagesRead)
+		return fmt.Errorf("number of mappings from index to ParentChainBlockNum: %d are insufficient, needed at least: %d", len(delayedMsgIndexToParentChainBlockNum), state.DelayedMessagesSeen-targetDelayedMessagesRead)
 	}
 
 	// Create DelayedMessageBacklogEntry for all the delayed messages that are seen but not read

--- a/arbnode/mel/runner/database_test.go
+++ b/arbnode/mel/runner/database_test.go
@@ -153,7 +153,7 @@ func TestMelDelayedMessagesAccumulation(t *testing.T) {
 		state.DelayedMessagesSeen++
 	}
 	require.NoError(t, melDB.SaveDelayedMessages(ctx, state, delayedMsgs[:numDelayed]))
-	// We can read all of these and prove that they are correct, by checking that ReadDelayedMessage doesnt error
+	// We can read all of these and prove that they are correct, by checking that ReadDelayedMessage doesn't error
 	// #nosec G115
 	for i := uint64(0); i < uint64(numDelayed); i++ {
 		have, err := melDB.ReadDelayedMessage(ctx, state, i)

--- a/arbnode/mel/state.go
+++ b/arbnode/mel/state.go
@@ -259,7 +259,7 @@ func (s *State) ReorgTo(newState *State) error {
 		return err
 	}
 	newState.delayedMessageBacklog = delayedMessageBacklog
-	// Reset the pre-read delayed messages count since they havent been verified against latest state's merkle root
+	// Reset the pre-read delayed messages count since they haven't been verified against latest state's merkle root
 	newState.readCountFromBacklog = 0
 	return nil
 }

--- a/arbos/arbosState/initialize.go
+++ b/arbos/arbosState/initialize.go
@@ -140,7 +140,7 @@ func InitializeArbosInDatabase(db ethdb.Database, cacheConfig *core.BlockChainCo
 		return common.Hash{}, err
 	}
 
-	log.Info("addresss table import complete")
+	log.Info("address table import complete")
 
 	retryableReader, err := initData.GetRetryableDataReader()
 	if err != nil {

--- a/blsSignatures/blsSignatures.go
+++ b/blsSignatures/blsSignatures.go
@@ -62,7 +62,7 @@ func PublicKeyFromPrivateKey(privateKey PrivateKey) (PublicKey, error) {
 // KeyValidityProof is the key validity proof mechanism is sufficient to prevent rogue key attacks, if applied to all keys
 // that come from untrusted sources. We use the private key to sign the public key, but in the
 // signature algorithm we use a tweaked version of the hash-to-curve function so that the result cannot be
-// re-used as an ordinary signature.
+// reused as an ordinary signature.
 //
 // For a proof that this is sufficient, see Theorem 1 in
 // Ristenpart & Yilek, "The Power of Proofs-of-Possession: ..." from EUROCRYPT 2007.

--- a/bold/assertions/manager.go
+++ b/bold/assertions/manager.go
@@ -164,14 +164,14 @@ func WithPostingInterval(t time.Duration) Opt {
 // WithPollingInterval overrides the default polling interval.
 //
 // This interval is the amount of time the assertion manager will wait between
-// atteampts to read new asseartions from the parent chain.
+// attempts to read new assertions from the parent chain.
 func WithPollingInterval(t time.Duration) Opt {
 	return func(m *Manager) {
 		m.times.pollInterval = t
 	}
 }
 
-// WithConfirmationInterval overrides the default a confiramtion interval.
+// WithConfirmationInterval overrides the default a confirmation interval.
 //
 // This is the interval the assertion manager will wait between attempts to
 // persist information about which assertions can be confirmed to the parent
@@ -185,7 +185,7 @@ func WithConfirmationInterval(t time.Duration) Opt {
 // WithAverageBlockCreationTime overrides the default average block creation
 // time.
 //
-// The average block cretion time is used by the assertion manager to emit
+// The average block creation time is used by the assertion manager to emit
 // warnings if the parent chain hasn't had any new blocks for considerably
 // longer than this expected delay.
 func WithAverageBlockCreationTime(t time.Duration) Opt {

--- a/bold/assertions/sync.go
+++ b/bold/assertions/sync.go
@@ -447,7 +447,7 @@ func (m *Manager) maybePostRivalAssertionAndChallenge(
 // Attempt to post a rival assertion based on the last agreed with ancestor
 // of a given assertion.
 //
-// If this parent assertion already has a rival we agree with that arleady exists
+// If this parent assertion already has a rival we agree with that already exists
 // then this function will return that assertion.
 func (m *Manager) maybePostRivalAssertion(
 	ctx context.Context,

--- a/bold/challenge/manager.go
+++ b/bold/challenge/manager.go
@@ -39,7 +39,7 @@ var (
 
 type Opt = func(val *Manager)
 
-// AssertionManager works with the challenge manager suppplying information
+// AssertionManager works with the challenge manager supplying information
 // about assertions.
 type AssertionManager interface {
 	Start(context.Context)
@@ -144,7 +144,7 @@ func New(
 	m.assertionManager.SetRivalHandler(m)
 	log.Info("Setting up challenge manager",
 		"name", m.name,
-		"addreess", m.chain.StakerAddress(),
+		"address", m.chain.StakerAddress(),
 		"rollup", m.chain.RollupAddress())
 	return m, nil
 }

--- a/bold/commitment/proof/prefix/prefix.go
+++ b/bold/commitment/proof/prefix/prefix.go
@@ -215,7 +215,7 @@ func TreeSize(me []common.Hash) uint64 {
 func AppendCompleteSubTree(
 	me []common.Hash, level uint64, subtreeRoot common.Hash,
 ) ([]common.Hash, error) {
-	// we use number representations of the levels elsewhere, so we need to ensure we're appending a leve
+	// we use number representations of the levels elsewhere, so we need to ensure we're appending a level
 	// that's too high to use in uint
 	if level >= MAX_LEVEL {
 		return nil, ErrLevelTooHigh

--- a/bold/containers/events/producer.go
+++ b/bold/containers/events/producer.go
@@ -54,7 +54,7 @@ func NewProducer[T any](opts ...ProducerOpt[T]) *Producer[T] {
 	return producer
 }
 
-// Start begins listening for subscription cancelation requests or context cancelation.
+// Start begins listening for subscription cancellation requests or context cancellation.
 func (ep *Producer[T]) Start(ctx context.Context) {
 	for {
 		select {
@@ -123,7 +123,7 @@ type Subscription[T any] struct {
 	done   chan subId
 }
 
-// Next waits for the next event or context cancelation, returning the event or an error.
+// Next waits for the next event or context cancellation, returning the event or an error.
 func (es *Subscription[T]) Next(ctx context.Context) (T, bool) {
 	var zeroVal T
 	for {

--- a/bold/protocol/sol/transact.go
+++ b/bold/protocol/sol/transact.go
@@ -96,8 +96,8 @@ func (a *AssertionChain) transact(
 		return nil, err
 	}
 
-	if commiter, ok := backend.(ChainCommitter); ok {
-		commiter.Commit()
+	if committer, ok := backend.(ChainCommitter); ok {
+		committer.Commit()
 	}
 	ctxWaitMined, cancelWaitMined := context.WithTimeout(ctx, time.Minute)
 	defer cancelWaitMined()

--- a/bold/state/history_commitment_provider.go
+++ b/bold/state/history_commitment_provider.go
@@ -49,7 +49,7 @@ type ProofCollector interface {
 //
 // The goal of CollectMachineHashes is to gather Arbitrator machine hashes for
 // a specific arbitrum block in the context of a BoLD challenge which has been
-// created to deterimine which assertion is correct.
+// created to determine which assertion is correct.
 //
 // Depending on the challenge level, the set of machine hashes the collector
 // needs to collect can vary. But, it will always be some set of machine hashes
@@ -60,8 +60,8 @@ type ProofCollector interface {
 //
 // To determine the exact block from which to collect the machine hashes, the
 // collector needs to know the `FromState` which contains the batch and position
-// within that batch of the first messsage to which the rival assertions are
-// committing. In addiiton, the collector needs to know the
+// within that batch of the first message to which the rival assertions are
+// committing. In addition, the collector needs to know the
 // `BlockChallengeHeight` (which is a relative index within the range of blocks
 // to which the rival assertions are committing where they first diverge.)
 //

--- a/bold/state/provider.go
+++ b/bold/state/provider.go
@@ -62,7 +62,7 @@ type ExecutionProvider interface {
 	// Produces the L2 execution state to assert to after the previous assertion
 	// state.
 	// Returns either the state at the batch count maxInboxCount (PosInBatch=0) or
-	// the state LayerZeroHeights.BlockChallengeHeight blokcs after
+	// the state LayerZeroHeights.BlockChallengeHeight blocks after
 	// previousGlobalState, whichever is an earlier state.
 	ExecutionStateAfterPreviousState(ctx context.Context, maxInboxCount uint64, previousGlobalState protocol.GoGlobalState) (*protocol.ExecutionState, error)
 }
@@ -83,14 +83,14 @@ type AssociatedAssertionMetadata struct {
 // challenged in the block level challenge, and the heights at which the
 // challenges at higher challenge levels originated.
 //
-// HistoryCommitment requestors can also specify an optional height at which to
+// HistoryCommitment requesters can also specify an optional height at which to
 // end the history commitment. If none, the request will commit to all the
 // leaves at the current challenge level.
 //
 // NOTE: It is NOT possible to request a history commitment which starts at
 // some height other than 0 for the current challenge level. This is because
 // the edge tracker only needs to be able to provide history commitments for
-// all machine state hases at the current challenge level, or sets of leaves
+// all machine state hashes at the current challenge level, or sets of leaves
 // which are prefixes to that full set of leaves. In all cases, the first leaf
 // is the one in relative position 0 for the challenge level.
 type HistoryCommitmentRequest struct {

--- a/broadcaster/backlog/backlog_test.go
+++ b/broadcaster/backlog/backlog_test.go
@@ -218,7 +218,7 @@ func TestDelete(t *testing.T) {
 		{
 			name:               "EmptyBacklog",
 			backlogIndexes:     []arbutil.MessageIndex{},
-			confirmed:          0, // no segements in backlog so nothing to delete
+			confirmed:          0, // no segments in backlog so nothing to delete
 			expectedCount:      0,
 			expectedStart:      0,
 			expectedEnd:        0,

--- a/changelog/bragaigor-nit-4407.md
+++ b/changelog/bragaigor-nit-4407.md
@@ -1,3 +1,3 @@
 ### Changed
 - update ProgramPrepare to accept wasm and wasm_size
-- remove unecessary statedb, addressForLogging, codePtr, codeSize, time, program, runCtxPtr params from ProgramPrepare
+- remove unnecessary statedb, addressForLogging, codePtr, codeSize, time, program, runCtxPtr params from ProgramPrepare

--- a/cmd/genericconf/server.go
+++ b/cmd/genericconf/server.go
@@ -75,7 +75,7 @@ func HTTPServerTimeoutConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Duration(prefix+".read-timeout", HTTPServerTimeoutConfigDefault.ReadTimeout, "the maximum duration for reading the entire request (http.Server.ReadTimeout)")
 	f.Duration(prefix+".read-header-timeout", HTTPServerTimeoutConfigDefault.ReadHeaderTimeout, "the amount of time allowed to read the request headers (http.Server.ReadHeaderTimeout)")
 	f.Duration(prefix+".write-timeout", HTTPServerTimeoutConfigDefault.WriteTimeout, "the maximum duration before timing out writes of the response (http.Server.WriteTimeout)")
-	f.Duration(prefix+".idle-timeout", HTTPServerTimeoutConfigDefault.IdleTimeout, "the maximum amount of time to wait for the next request when keep-alives are enabled (http.Server.IdleTimeout)")
+	f.Duration(prefix+".idle-timeout", HTTPServerTimeoutConfigDefault.IdleTimeout, "the maximum amount of time to wait for the next request when keep-alive is enabled (http.Server.IdleTimeout)")
 }
 
 type WSConfig struct {

--- a/crates/arbutil/src/evm/req.rs
+++ b/crates/arbutil/src/evm/req.rs
@@ -155,7 +155,7 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
             EvmApiStatus::Success => UserOutcomeKind::Success,
             EvmApiStatus::WriteProtection => UserOutcomeKind::Revert,
             EvmApiStatus::OutOfGas => UserOutcomeKind::OutOfInk,
-            _ => bail!("unexpect outcome"),
+            _ => bail!("unexpected outcome"),
         };
         Ok((cost, outcome))
     }
@@ -174,7 +174,7 @@ impl<D: DataReader, H: RequestHandler<D>> EvmApi<D> for EvmApiRequestor<D, H> {
         let outcome = match status.try_into()? {
             EvmApiStatus::Success => UserOutcomeKind::Success,
             EvmApiStatus::WriteProtection => UserOutcomeKind::Revert,
-            _ => bail!("unexpect outcome"),
+            _ => bail!("unexpected outcome"),
         };
 
         Ok(outcome)

--- a/crates/brotli/src/dicts/mod.rs
+++ b/crates/brotli/src/dicts/mod.rs
@@ -33,7 +33,7 @@ struct ForceSync<T>(T);
 unsafe impl<T> Sync for ForceSync<T> {}
 
 lazy_static! {
-    /// Memoizes dictionary preperation.
+    /// Memoizes dictionary preparation.
     static ref STYLUS_PROGRAM_DICT: ForceSync<*const EncoderPreparedDictionary> =
         ForceSync(unsafe {
             let data = Dictionary::StylusProgram.slice().unwrap();

--- a/crates/brotli/src/lib.rs
+++ b/crates/brotli/src/lib.rs
@@ -215,13 +215,13 @@ pub fn decompress(input: &[u8], dictionary: Dictionary) -> Result<Vec<u8>, Brotl
         // TODO: consider window and quality check?
         // TODO: fuzz
         if let Some(dict) = dictionary.slice() {
-            let attatched = BrotliDecoderAttachDictionary(
+            let attached = BrotliDecoderAttachDictionary(
                 state,
                 BrotliSharedDictionaryType::Raw,
                 dict.len(),
                 dict.as_ptr(),
             );
-            check!(attatched);
+            check!(attached);
         }
 
         let mut in_len = input.len();
@@ -276,13 +276,13 @@ pub fn decompress_fixed<'a>(
         }
 
         if let Some(dict) = dictionary.slice() {
-            let attatched = BrotliDecoderAttachDictionary(
+            let attached = BrotliDecoderAttachDictionary(
                 state,
                 BrotliSharedDictionaryType::Raw,
                 dict.len(),
                 dict.as_ptr(),
             );
-            check!(attatched == BrotliBool::True);
+            check!(attached == BrotliBool::True);
         }
 
         let mut in_len = input.len();

--- a/crates/jit/src/program.rs
+++ b/crates/jit/src/program.rs
@@ -232,7 +232,7 @@ pub fn get_last_msg(exec: &mut WasmEnv, id: u32) -> Result<MessageFromCothread, 
 }
 
 // gets data associated with last request.
-// request_id MUST be last request receieved
+// request_id MUST be last request received
 // data_ptr MUST point to a buffer of at least the length returned by get_request
 pub fn get_request_data(mut env: WasmEnvMut, id: u32, data_ptr: GuestPtr) -> MaybeEscape {
     let (mut mem, exec) = env.jit_env();

--- a/crates/prover/src/machine.rs
+++ b/crates/prover/src/machine.rs
@@ -507,7 +507,7 @@ impl Module {
             };
             ensure!(
                 memory_index == 0,
-                "Attempted to write to nonexistant memory"
+                "Attempted to write to nonexistent memory"
             );
 
             let offset = match (init.read()?, init.read()?, init.eof()) {
@@ -556,7 +556,7 @@ impl Module {
                 x => bail!("Non-constant element segment offset expression {x:?}"),
             };
             let Some(table) = tables.get_mut(t) else {
-                bail!("Element segment for non-exsistent table {}", t.red())
+                bail!("Element segment for non-existent table {}", t.red())
             };
 
             let mut contents = vec![];
@@ -2549,7 +2549,7 @@ impl Machine {
                     let ptr = value_stack.pop().unwrap().assume_u32();
                     let msg_num = value_stack.pop().unwrap().assume_u64();
                     let inbox_identifier =
-                        argument_data_to_inbox(inst.argument_data).expect("Bad inbox indentifier");
+                        argument_data_to_inbox(inst.argument_data).expect("Bad inbox identifier");
                     if let Some(message) = self.inbox_contents.get(&(inbox_identifier, msg_num)) {
                         if ptr as u64 + 32 > module.memory.size() {
                             error!();
@@ -3148,7 +3148,7 @@ impl Machine {
                     } else if next_inst.opcode == Opcode::ReadInboxMessage {
                         let msg_idx = value_stack.get(value_stack.len() - 3).unwrap().assume_u64();
                         let inbox_identifier =
-                            argument_data_to_inbox(arg).expect("Bad inbox indentifier");
+                            argument_data_to_inbox(arg).expect("Bad inbox identifier");
                         if let Some(msg_data) =
                             self.inbox_contents.get(&(inbox_identifier, msg_idx))
                         {

--- a/crates/prover/src/main.rs
+++ b/crates/prover/src/main.rs
@@ -43,7 +43,7 @@ struct Opts {
     #[structopt(long)]
     /// print wasm module root to the console
     print_wasmmoduleroot: bool,
-    /// profile output instead of generting proofs
+    /// profile output instead of generating proofs
     #[structopt(short = "p", long)]
     profile_run: bool,
     /// simple summary of hot opcodes
@@ -87,7 +87,7 @@ struct Opts {
     skip_until_host_io: bool,
     #[structopt(long)]
     max_steps: Option<u64>,
-    // JSON inputs supercede any of the command-line inputs which could
+    // JSON inputs supersede any of the command-line inputs which could
     // be specified in the JSON file.
     #[structopt(long)]
     json_inputs: Option<PathBuf>,

--- a/crates/tools/stylus_benchmark/src/scenarios/br_table.rs
+++ b/crates/tools/stylus_benchmark/src/scenarios/br_table.rs
@@ -3,7 +3,7 @@
 
 use std::io::Write;
 
-fn rm_identation(s: &mut String) {
+fn rm_indentation(s: &mut String) {
     for _ in 0..4 {
         s.pop();
     }
@@ -15,26 +15,26 @@ pub fn write_wat_ops(
     table_size: usize,
 ) {
     for _ in 0..number_of_ops_per_loop_iteration {
-        let mut identation = String::from("            ");
+        let mut indentation = String::from("            ");
         for _ in 0..table_size {
-            wat.write_all(format!("{}(block\n", identation).as_bytes())
+            wat.write_all(format!("{}(block\n", indentation).as_bytes())
                 .unwrap();
-            identation.push_str("    ");
+            indentation.push_str("    ");
         }
         // it will jump to the end of the first block
-        wat.write_all(format!("{}i32.const {}\n", identation, table_size - 1).as_bytes())
+        wat.write_all(format!("{}i32.const {}\n", indentation, table_size - 1).as_bytes())
             .unwrap();
 
         let mut br_table = String::from("br_table");
         for i in 0..table_size {
             br_table.push_str(&format!(" {}", i));
         }
-        wat.write_all(format!("{}{}\n", identation, br_table).as_bytes())
+        wat.write_all(format!("{}{}\n", indentation, br_table).as_bytes())
             .unwrap();
 
         for _ in 0..table_size {
-            rm_identation(&mut identation);
-            wat.write_all(format!("{})\n", identation).as_bytes())
+            rm_indentation(&mut indentation);
+            wat.write_all(format!("{})\n", indentation).as_bytes())
                 .unwrap();
         }
     }

--- a/crates/wasm-libraries/user-host-trait/lib.rs
+++ b/crates/wasm-libraries/user-host-trait/lib.rs
@@ -650,7 +650,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
     /// Gets a subset of the code from the account at the given address. The semantics are identical to that
     /// of the EVM's [`EXT_CODE_COPY`] opcode, aside from one small detail: the write to the buffer `dest` will
     /// stop after the last byte is written. This is unlike the EVM, which right pads with zeros in this scenario.
-    /// The return value is the number of bytes written, which allows the caller to detect if this has occured.
+    /// The return value is the number of bytes written, which allows the caller to detect if this has occurred.
     ///
     /// [`EXT_CODE_COPY`]: https://www.evm.codes/#3C
     fn account_code(

--- a/crates/wasm-libraries/user-host/src/link.rs
+++ b/crates/wasm-libraries/user-host/src/link.rs
@@ -176,7 +176,7 @@ pub unsafe extern "C" fn programs__get_request(id: u32, len_ptr: GuestPtr) -> u3
 ///
 /// # Safety
 ///
-/// `request_id` MUST be last request receieved
+/// `request_id` MUST be last request received
 /// `data_ptr` MUST point to a buffer of at least the length returned by `get_request`
 #[no_mangle]
 pub unsafe extern "C" fn programs__get_request_data(id: u32, data_ptr: GuestPtr) {

--- a/crates/wasm-testsuite/src/main.rs
+++ b/crates/wasm-testsuite/src/main.rs
@@ -279,7 +279,7 @@ fn main() -> eyre::Result<()> {
     }
 
     'next: for (index, command) in case.commands.into_iter().enumerate() {
-        // each iteration represets a test case
+        // each iteration represents a test case
 
         macro_rules! test_success {
             ($func:expr, $args:expr, $expected:expr) => {

--- a/daprovider/anytrust/local_file_storage_service.go
+++ b/daprovider/anytrust/local_file_storage_service.go
@@ -605,8 +605,8 @@ type trieLayout struct {
 
 	// Anything changing the layout (pruning, adding files) must go through
 	// this mutex.
-	// Pruning the entire history at statup of Arb Nova as of 2024-06-12 takes
-	// 5s on my laptop, so the overhead of pruning after startup should be neglibile.
+	// Pruning the entire history at startup of Arb Nova as of 2024-06-12 takes
+	// 5s on my laptop, so the overhead of pruning after startup should be negligible.
 	writeMutex sync.Mutex
 }
 

--- a/daprovider/util.go
+++ b/daprovider/util.go
@@ -26,7 +26,7 @@ type BlobReader interface {
 type PreimagesMap map[arbutil.PreimageType]map[common.Hash][]byte
 
 // PreimageRecorder is used to add (key,value) pair to the map accessed by key = ty of a bigger map, preimages.
-// If ty doesn't exist as a key in the preimages map, then it is intialized to map[common.Hash][]byte and then (key,value) pair is added
+// If ty doesn't exist as a key in the preimages map, then it is initialized to map[common.Hash][]byte and then (key,value) pair is added
 type PreimageRecorder func(key common.Hash, value []byte, ty arbutil.PreimageType)
 
 // RecordPreimagesTo takes in preimages map and returns a function that can be used

--- a/docs/decisions/0001-avoid-primitive-constraint-types.md
+++ b/docs/decisions/0001-avoid-primitive-constraint-types.md
@@ -10,7 +10,7 @@ decision-makers: eljobe@ plasmapower@
 
 When working on the go code for BoLD, we became slightly annoyed that several
 places in the history package were checking the constraint that the `virtual`
-argumet to a function was positive. One possible workaround would have been
+argument to a function was positive. One possible workaround would have been
 to create a constrained wrapper type around `uint64` which would only allow
 positive values. For example:
 
@@ -72,7 +72,7 @@ is too prone to bugs introduced by refactoring.
 
 ## Pros and Cons of the Options
 
-### New Pacakge: `util/chk` for checking type constraint
+### New Package: `util/chk` for checking type constraint
 
 * Good, because it is expressive
 * Good, because the constraint only needs to be checked during construction
@@ -81,7 +81,7 @@ is too prone to bugs introduced by refactoring.
 ### Status Quo: check the constraint in multiple places
 
 * Good, because it is what the code is already doing
-* Good, because when a funciton becomes public, the constraint holds
+* Good, because when a function becomes public, the constraint holds
 * Good, because when a function moves to another file or package, the constraint holds
 * Bad, because it means the check may need to be repeated. DRY
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -3,8 +3,8 @@
 For new Architectural Decision Records (ADRs), please use one of the following templates as a starting point:
 
 * [adr-template.md](adr-template.md) has all sections, with explanations about them.
-* [adr-template-minmal.md](adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
-* [adr-template-bare.md](adr-template-bare.md) has all sections, wich are empty (no explanations).
+* [adr-template-minimal.md](adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
+* [adr-template-bare.md](adr-template-bare.md) has all sections, which are empty (no explanations).
 * [adr-template-bare-minimal.md](adr-template-bare-minimal.md) has the mandatory sections, without explanations. <!-- ### Consequences also contained, though marked as "optional" -->
 
 The MADR documentation is available at <https://adr.github.io/madr/> while general information about ADRs is available at <https://adr.github.io/>.

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -1036,7 +1036,7 @@ func (s *ExecutionEngine) cacheL1PriceDataOfMsg(msgIdx arbutil.MessageIndex, blo
 	var callDataUnits uint64
 	if !blockBuiltUsingDelayedMessage {
 		// s.cachedL1PriceData tracks L1 price data for messages posted by Nitro,
-		// so delayed messages should not update cummulative values kept on it.
+		// so delayed messages should not update cumulative values kept on it.
 
 		for _, tx := range block.Transactions() {
 			_, cachedUnits := tx.GetRawCachedCalldataUnits()

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -227,7 +227,7 @@ func ValidateMaxTxDataSize(maxTxDataSize uint64) error {
 	// tighter limit https://github.com/OffchainLabs/nitro/commit/ed015e752d7d24e59ec9e6f894fe1a26ffa19036
 	// The default block gas limit can fit 1523 txs
 	// Each Tx adds an 8-byte of length prefix.
-	// 50K is enoguh to add 1523 times 8 bytes and still stay in an L2 message
+	// 50K is enough to add 1523 times 8 bytes and still stay in an L2 message
 	const maxConfigurableTxDataSize = arbostypes.MaxL2MessageSize - 50000
 	if maxTxDataSize > maxConfigurableTxDataSize {
 		return fmt.Errorf("max-tx-data-size %d exceeds maximum allowed value of %d", maxTxDataSize, maxConfigurableTxDataSize)

--- a/execution/nodeinterface/node_interface.go
+++ b/execution/nodeinterface/node_interface.go
@@ -568,7 +568,7 @@ func (n NodeInterface) LegacyLookupMessageBatchProof(c ctx, evm mech, batchNum h
 		return
 	}
 	if node.ClassicOutbox == nil {
-		err = errors.New("this node doesnt support classicLookupMessageBatchProof")
+		err = errors.New("this node doesn't support classicLookupMessageBatchProof")
 		return
 	}
 	msg, err := node.ClassicOutbox.GetMsg(batchNum, index)

--- a/mel-replay/trie_fetcher.go
+++ b/mel-replay/trie_fetcher.go
@@ -140,7 +140,7 @@ func decodeBinary[T any](data []byte) (*T, error) {
 	v := new(T)
 	u, ok := any(v).(interface{ UnmarshalBinary([]byte) error })
 	if !ok {
-		return empty, errors.New("decodeBinary is called on a type that doesnt implement UnmarshalBinary")
+		return empty, errors.New("decodeBinary is called on a type that doesn't implement UnmarshalBinary")
 	}
 	if err := u.UnmarshalBinary(data); err != nil {
 		return empty, err

--- a/precompiles/context_test.go
+++ b/precompiles/context_test.go
@@ -48,7 +48,7 @@ func TestContextBurn(t *testing.T) {
 
 	// Burn 200 more storage growth, which should error with out of gas
 	if err := ctx.Burn(multigas.ResourceKindStorageGrowth, 200); !errors.Is(err, vm.ErrOutOfGas) {
-		t.Errorf("wrong erro from burn: got %v, want %v", err, vm.ErrOutOfGas)
+		t.Errorf("wrong error from burn: got %v, want %v", err, vm.ErrOutOfGas)
 	}
 	if got, want := ctx.GasLeft(), uint64(0); got != want {
 		t.Errorf("wrong gas left: got %v, want %v", got, want)
@@ -96,7 +96,7 @@ func TestContextBurnMultiGas(t *testing.T) {
 	}
 
 	if err := ctx.BurnMultiGas(gasToBurn); !errors.Is(err, vm.ErrOutOfGas) {
-		t.Errorf("wrong erro from burn: got %v, want %v", err, vm.ErrOutOfGas)
+		t.Errorf("wrong error from burn: got %v, want %v", err, vm.ErrOutOfGas)
 	}
 	if got, want := ctx.GasLeft(), uint64(0); got != want {
 		t.Errorf("wrong gas left: got %v, want %v", got, want)

--- a/relay/relay_stress_test.go
+++ b/relay/relay_stress_test.go
@@ -152,7 +152,7 @@ func largeBacklogRelayTestImpl(t *testing.T, numClients, backlogSize, l2MsgSize 
 		defer client.StopOnly()
 	}
 
-	// wait for all clients to atleast connect once
+	// wait for all clients to at least connect once
 	connectDeadlineTimer := time.NewTicker(connectDeadline)
 	defer connectDeadlineTimer.Stop()
 	select {

--- a/scripts/convert-databases.bash
+++ b/scripts/convert-databases.bash
@@ -40,7 +40,7 @@ echo Usage: "$0" \[OPTIONS..\]
     echo "--src             directory containing source databases (default: \"$DEFAULT_SRC\")"
     echo "--dst             destination directory"
     echo "--force           remove destination directory if it exists"
-    echo "--skip-existing   skip convertion of databases which directories already exist in the destination directory"
+    echo "--skip-existing   skip conversion of databases which directories already exist in the destination directory"
     echo "--clean           sets what should be removed in case of error, possible values:"
     echo "                      \"failed\" - remove database which conversion failed (default)"
     echo "                      \"none\"   - remove nothing, leave unfinished and potentially corrupted databases"

--- a/staker/bold/bold_state_provider.go
+++ b/staker/bold/bold_state_provider.go
@@ -484,7 +484,7 @@ func (s *BOLDStateProvider) messageNum(md *state.AssociatedAssertionMetadata, ch
 // current batch. In that case, the chalHeight will be a block in the virtual
 // padding of the history commitment of this validator.
 //
-// If there is an Option.Some() retrun value, it means that callers don't need
+// If there is an Option.Some() return value, it means that callers don't need
 // to actually step through a machine to produce a series of hashes, because all
 // of the hashes can just be "virtual" copies of a single machine in the
 // FINISHED state's hash.

--- a/staker/legacy/staker.go
+++ b/staker/legacy/staker.go
@@ -1134,7 +1134,7 @@ func (s *Staker) advanceStake(ctx context.Context, info *OurStakerInfo, effectiv
 			return s.tryFastConfirmationNodeNumber(ctx, action.number, action.hash)
 		}
 		log.Info("staking on existing node", "node", action.number)
-		// We'll return early if we already havea stake
+		// We'll return early if we already have a stake
 		if info.StakeExists {
 			_, err = s.rollup.StakeOnExistingNode(s.builder.Auth(ctx), action.number, action.hash)
 			if err != nil {

--- a/util/headerreader/blob_client.go
+++ b/util/headerreader/blob_client.go
@@ -201,7 +201,7 @@ func (b *BlobClient) GetBlobsBySlot(ctx context.Context, slot uint64, versionedH
 	if err != nil {
 		// Create a new HTTP client with a dedicated transport that disables connection reuse.
 		// With the default client (nil Transport), Go reuses the global DefaultTransport and its connection pool,
-		// which may keep using the same problematic backend connection. Disabling keep-alives forces a fresh TCP
+		// which may keep using the same problematic backend connection. Disabling keep-alive forces a fresh TCP
 		// connection on the next request, increasing the chance of hitting a healthy backend behind a load balancer.
 		b.httpClient.Store(&http.Client{Transport: &http.Transport{DisableKeepAlives: true}})
 		return nil, fmt.Errorf("error fetching blobs for slot %d: %w", slot, err)

--- a/util/redisutil/test_redis.go
+++ b/util/redisutil/test_redis.go
@@ -21,7 +21,7 @@ func CreateTestRedis(ctx context.Context, t testing.TB) string {
 	return url
 }
 
-// IsSharedTestRedisInstance checks if the redis instance is shared between multiple tests - that's the case when --test_redis flag is sepecified
+// IsSharedTestRedisInstance checks if the redis instance is shared between multiple tests - that's the case when --test_redis flag is specified
 func IsSharedTestRedisInstance() bool {
 	return *testflag.RedisFlag != ""
 }

--- a/validator/server_arb/validator_spawner.go
+++ b/validator/server_arb/validator_spawner.go
@@ -173,7 +173,7 @@ func (v *ArbitratorSpawner) execute(
 ) (validator.GoGlobalState, error) {
 	basemachine, err := v.machineLoader.GetHostIoMachine(ctx, moduleRoot)
 	if err != nil {
-		return validator.GoGlobalState{}, fmt.Errorf("unabled to get WASM machine: %w", err)
+		return validator.GoGlobalState{}, fmt.Errorf("unable to get WASM machine: %w", err)
 	}
 
 	arbMach := basemachine.Clone()

--- a/wsbroadcastserver/connectionlimiter.go
+++ b/wsbroadcastserver/connectionlimiter.go
@@ -80,7 +80,7 @@ type ipStringAndLimit struct {
 func (l *ConnectionLimiter) getIpStringsAndLimits(ip net.IP) []ipStringAndLimit {
 	var result []ipStringAndLimit
 	if ip == nil || ip.IsPrivate() || ip.IsLoopback() {
-		log.Warn("Ignoring private, loopback, or unparseable IP. Please check relay and network configuration to ensure client IP addresses are detected correctly", "ip", ip)
+		log.Warn("Ignoring private, loopback, or unparsable IP. Please check relay and network configuration to ensure client IP addresses are detected correctly", "ip", ip)
 		return result
 	}
 


### PR DESCRIPTION
What I changed
Fixed safe typos across the repo in comments / doc text / log & error strings (e.g., havent -> haven't, atleast -> at least, represets -> represents, etc.). Fixed remaining error-string typos in crates/prover/src/machine.rs: nonexistant -> nonexistent
non-exsistent -> non-existent
indentifier -> identifier (multiple occurrences)
Fixed a comment in util/headerreader/blob_client.go: keep-alives -> keep-alive
Updated .codespellrc to ignore a few intentional identifiers/terms (including tRival) to keep future runs low-noise.