### PR TITLE
Fix address filter S3 syncer hex decoding for 0x-prefixed values

### DIFF
--- a/changelog/mnasr-fix-address-filter-s3-hex-prefix.md
+++ b/changelog/mnasr-fix-address-filter-s3-hex-prefix.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fix address filter S3 syncer failing to parse hash list JSON when salt or hash values use `0x`/`0X` hex prefix. Go's `encoding/hex.DecodeString` does not handle the prefix, so it is now stripped before decoding.

--- a/execution/gethexec/addressfilter/s3_sync.go
+++ b/execution/gethexec/addressfilter/s3_sync.go
@@ -8,12 +8,20 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/offchainlabs/nitro/util/s3syncer"
 )
+
+// trimHexPrefix strips a leading "0x" or "0X" prefix from a hex string.
+func trimHexPrefix(s string) string {
+	s = strings.TrimPrefix(s, "0x")
+	s = strings.TrimPrefix(s, "0X")
+	return s
+}
 
 // hashListPayload represents the JSON structure of the hash list file used for unmarshalling.
 type hashListPayload struct {
@@ -73,7 +81,7 @@ func parseHashListJSON(data []byte) ([]byte, []common.Hash, error) {
 			"scheme", payload.HashingScheme)
 	}
 
-	salt, err := hex.DecodeString(payload.Salt)
+	salt, err := hex.DecodeString(trimHexPrefix(payload.Salt))
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid salt hex: %w", err)
 	}
@@ -83,7 +91,7 @@ func parseHashListJSON(data []byte) ([]byte, []common.Hash, error) {
 
 	hashes := make([]common.Hash, len(payload.AddressHashes))
 	for i, h := range payload.AddressHashes {
-		hashBytes, err := hex.DecodeString(h.Hash)
+		hashBytes, err := hex.DecodeString(trimHexPrefix(h.Hash))
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid hash hex at index %d: %w", i, err)
 		}

--- a/execution/gethexec/addressfilter/service_test.go
+++ b/execution/gethexec/addressfilter/service_test.go
@@ -273,6 +273,28 @@ func TestParseHashListJSON(t *testing.T) {
 		t.Errorf("expected 1 hash, got %d", len(hashes))
 	}
 
+	// Test with 0x-prefixed salt and hashes (lowercase)
+	prefixedPayload := map[string]interface{}{
+		"salt": "0x" + hex.EncodeToString([]byte("test-salt")),
+		"address_hashes": []map[string]interface{}{
+			{"hash": "0x" + hex.EncodeToString(hashed_addr1[:])},
+			{"hash": "0X" + hex.EncodeToString(hashed_addr2[:])},
+		},
+	}
+	prefixedJSON, _ := json.Marshal(prefixedPayload)
+	salt, hashes, err = parseHashListJSON(prefixedJSON)
+	if err != nil {
+		t.Fatalf("failed to parse 0x-prefixed JSON: %v", err)
+	}
+	if string(salt) != "test-salt" {
+		t.Errorf("expected salt 'test-salt', got '%s'", string(salt))
+	}
+	if len(hashes) != 2 {
+		t.Errorf("expected 2 hashes, got %d", len(hashes))
+	}
+	if hashes[0] != hashed_addr1 {
+		t.Errorf("hash[0] mismatch: got %x, want %x", hashes[0], hashed_addr1)
+	}
 	// Test without hashing_scheme field (backward compatible)
 	noSchemePayload := map[string]interface{}{
 		"salt": hex.EncodeToString([]byte("test-salt")),


### PR DESCRIPTION
## Summary
- Go's `encoding/hex.DecodeString` fails on values prefixed with `0x`/`0X` because it doesn't strip the prefix
- Real S3 blobs use `0x`-prefixed hex strings for salt and hash values, causing parse failures like: `"failed to parse hash list: invalid salt hex: encoding/hex: invalid byte: U+0078 'x'"`
- Add `trimHexPrefix` helper and apply it before decoding salt and hashes in `parseHashListJSON`


## Test plan
* Created new test scenario. 
* Ran the nitro node with real aws blob and it was able to load successfully! 