### PR TITLE
Remove unnecessary ctx in MEL DelayedMessageDatabase

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1426,7 +1426,7 @@ func (b *BatchPoster) MaybePostSequencerBatch(ctx context.Context) (bool, error)
 
 	var dbBatchCount uint64
 	if b.msgExtractor != nil {
-		dbBatchCount, err = b.msgExtractor.GetBatchCount(ctx)
+		dbBatchCount, err = b.msgExtractor.GetBatchCount()
 	} else {
 		dbBatchCount, err = b.inbox.GetBatchCount()
 	}

--- a/arbnode/delayed_sequencer.go
+++ b/arbnode/delayed_sequencer.go
@@ -212,7 +212,7 @@ func (d *DelayedSequencer) sequenceWithoutLockout(ctx context.Context, lastBlock
 	var dbDelayedCount uint64
 	var err error
 	if d.msgExtractor != nil {
-		dbDelayedCount, err = d.msgExtractor.GetDelayedCount(ctx, 0)
+		dbDelayedCount, err = d.msgExtractor.GetDelayedCount(0)
 		if err != nil {
 			return err
 		}
@@ -234,7 +234,7 @@ func (d *DelayedSequencer) sequenceWithoutLockout(ctx context.Context, lastBlock
 	var messages []*arbostypes.L1IncomingMessage
 	for pos < dbDelayedCount {
 		if d.msgExtractor != nil {
-			finalizedPos, err := d.msgExtractor.GetDelayedCount(ctx, finalized)
+			finalizedPos, err := d.msgExtractor.GetDelayedCount(finalized)
 			if err != nil {
 				if !strings.Contains(err.Error(), "not found") {
 					return err

--- a/arbnode/mel/extraction/message_extraction_function.go
+++ b/arbnode/mel/extraction/message_extraction_function.go
@@ -23,7 +23,6 @@ import (
 // Defines a method that can read a delayed message from an external database.
 type DelayedMessageDatabase interface {
 	ReadDelayedMessage(
-		ctx context.Context,
 		state *mel.State,
 		index uint64,
 	) (*mel.DelayedInboxMessage, error)

--- a/arbnode/mel/extraction/messages_in_batch.go
+++ b/arbnode/mel/extraction/messages_in_batch.go
@@ -199,7 +199,7 @@ func extractDelayedMessageFromSegment(
 			DelayedMessagesRead: seqMsg.AfterDelayedMessages,
 		}, nil
 	}
-	delayed, err := delayedMsgDB.ReadDelayedMessage(ctx, melState, melState.DelayedMessagesRead)
+	delayed, err := delayedMsgDB.ReadDelayedMessage(melState, melState.DelayedMessagesRead)
 	if err != nil {
 		return nil, err
 	}

--- a/arbnode/mel/extraction/messages_in_batch_test.go
+++ b/arbnode/mel/extraction/messages_in_batch_test.go
@@ -334,7 +334,6 @@ type mockDelayedMessageDB struct {
 }
 
 func (m *mockDelayedMessageDB) ReadDelayedMessage(
-	_ context.Context,
 	_ *mel.State,
 	delayedMsgsRead uint64,
 ) (*mel.DelayedInboxMessage, error) {

--- a/arbnode/mel/recording/delayed_msg_database.go
+++ b/arbnode/mel/recording/delayed_msg_database.go
@@ -3,7 +3,6 @@
 package melrecording
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -47,11 +46,7 @@ func NewDelayedMsgDatabase(db ethdb.KeyValueStore, preimages daprovider.Preimage
 // ReadDelayedMessage allows for retrieving a delayed message that has been observed by MEL but not yet consumed in a batch
 // at a specific index. Underneath the hood, delayed messages are stored in a binary Merkle tree representation to make
 // retrieval possible in WASM mode. In recording mode, reading a delayed message records its access in a preimages mapping
-func (r *DelayedMsgDatabase) ReadDelayedMessage(ctx context.Context, state *mel.State, index uint64) (*mel.DelayedInboxMessage, error) {
-	if index == 0 { // Init message
-		// This message cannot be found in the database as it is supposed to be seen and read in the same block, so we persist that in DelayedMessageBacklog
-		return state.GetDelayedMessageBacklog().GetInitMsg(), nil
-	}
+func (r *DelayedMsgDatabase) ReadDelayedMessage(state *mel.State, index uint64) (*mel.DelayedInboxMessage, error) {
 	if !r.initialized {
 		if err := r.initialize(state); err != nil {
 			return nil, fmt.Errorf("error initializing recording database for MEL validation: %w", err)

--- a/arbnode/mel/runner/backlog.go
+++ b/arbnode/mel/runner/backlog.go
@@ -65,7 +65,7 @@ func indexToParentChainBlockMap(ctx context.Context, targetDelayedMessagesRead u
 	delayedMsgIndexToParentChainBlockNum := make(map[uint64]uint64)
 	curr := state
 	for i := state.ParentChainBlockNumber - 1; i > 0; i-- {
-		prev, err = db.State(ctx, i)
+		prev, err = db.State(i)
 		if err != nil {
 			return nil, err
 		}

--- a/arbnode/mel/runner/backlog_test.go
+++ b/arbnode/mel/runner/backlog_test.go
@@ -34,7 +34,7 @@ func TestDelayedMessageBacklogInitialization(t *testing.T) {
 		DelayedMessagesSeen:    1,
 		DelayedMessagesRead:    1,
 	}
-	require.NoError(t, melDB.SaveState(ctx, genesis))
+	require.NoError(t, melDB.SaveState(genesis))
 
 	numMelStates := 5
 	var delayedMsgs []*mel.DelayedInboxMessage
@@ -66,11 +66,11 @@ func TestDelayedMessageBacklogInitialization(t *testing.T) {
 			DelayedMessagesSeen:    head.DelayedMessagesSeen + 5,
 			DelayedMessagesRead:    1,
 		}
-		require.NoError(t, melDB.SaveDelayedMessages(ctx, state, delayedMsgs[(i)*5:(i+1)*5]))
-		require.NoError(t, melDB.SaveState(ctx, state))
+		require.NoError(t, melDB.SaveDelayedMessages(state, delayedMsgs[(i)*5:(i+1)*5]))
+		require.NoError(t, melDB.SaveState(state))
 		head = state
 	}
-	state, err := melDB.GetHeadMelState(ctx)
+	state, err := melDB.GetHeadMelState()
 	require.NoError(t, err)
 
 	require.True(t, state.DelayedMessagesSeen == uint64(numMelStates)*5+1) // #nosec G115
@@ -84,7 +84,7 @@ func TestDelayedMessageBacklogInitialization(t *testing.T) {
 
 	// Lets read the delayed messages and verify that they match with what we stored
 	for i, wantDelayed := range delayedMsgs {
-		haveDelayed, err := melDB.ReadDelayedMessage(ctx, state, uint64(i+1)) // #nosec G115
+		haveDelayed, err := melDB.ReadDelayedMessage(state, uint64(i+1)) // #nosec G115
 		require.NoError(t, err)
 		require.True(t, reflect.DeepEqual(haveDelayed, wantDelayed))
 	}
@@ -96,7 +96,7 @@ func TestDelayedMessageBacklogInitialization(t *testing.T) {
 		DelayedMessagesSeen:    26,
 		DelayedMessagesRead:    7,
 	}
-	require.NoError(t, melDB.SaveState(ctx, state))
+	require.NoError(t, melDB.SaveState(state))
 
 	// Advance head state indicating that we have read 10 delayed messages
 	newHeadState := &mel.State{
@@ -105,10 +105,10 @@ func TestDelayedMessageBacklogInitialization(t *testing.T) {
 		DelayedMessagesSeen:    26,
 		DelayedMessagesRead:    13,
 	}
-	require.NoError(t, melDB.SaveState(ctx, newHeadState))
+	require.NoError(t, melDB.SaveState(newHeadState))
 	// We provide InitializeDelayedMessageBacklog the current finalized block as 7 and verify that the delayedMessageBacklog has
 	// delayedMessageBacklogEntry for indexes below the DelayedMessagesRead as those have not been finalized yet!
-	newState, err := melDB.GetHeadMelState(ctx)
+	newState, err := melDB.GetHeadMelState()
 	require.NoError(t, err)
 	newDelayedMessageBacklog, err := mel.NewDelayedMessageBacklog(100, func() (uint64, error) { return 0, nil })
 	require.NoError(t, err)

--- a/arbnode/mel/runner/initialize.go
+++ b/arbnode/mel/runner/initialize.go
@@ -14,7 +14,7 @@ import (
 
 func (m *MessageExtractor) initialize(ctx context.Context, current *fsm.CurrentState[action, FSMState]) (time.Duration, error) {
 	// Start from the latest MEL state we have in the database
-	melState, err := m.melDB.GetHeadMelState(ctx)
+	melState, err := m.melDB.GetHeadMelState()
 	if err != nil {
 		return m.config.RetryInterval, err
 	}

--- a/arbnode/mel/runner/mel_test.go
+++ b/arbnode/mel/runner/mel_test.go
@@ -99,7 +99,7 @@ func TestMessageExtractor(t *testing.T) {
 			ParentChainBlockNumber: 1,
 			ParentChainBlockHash:   emptyblk0.Hash(),
 		}
-		require.NoError(t, melDB.SaveState(ctx, melState))
+		require.NoError(t, melDB.SaveState(melState))
 
 		parentChainReader.returnErr = errors.New("oops")
 		_, err := extractor.Act(ctx)

--- a/arbnode/mel/runner/process_next_block.go
+++ b/arbnode/mel/runner/process_next_block.go
@@ -89,10 +89,6 @@ func (m *MessageExtractor) processNextBlock(ctx context.Context, current *fsm.Cu
 	if err != nil {
 		return m.config.RetryInterval, err
 	}
-	// After processing every 100 parent chain blocks, print a status log
-	if postState.ParentChainBlockNumber%100 == 0 {
-		log.Info("Message extraction successful", "parentChainBlockNumber", postState.ParentChainBlockNumber, "msgCount", postState.MsgCount)
-	}
 	// Begin the next FSM state immediately.
 	return 0, m.fsm.Do(saveMessages{
 		preStateMsgCount: preState.MsgCount,

--- a/arbnode/mel/runner/reorg.go
+++ b/arbnode/mel/runner/reorg.go
@@ -18,7 +18,7 @@ func (m *MessageExtractor) reorg(ctx context.Context, current *fsm.CurrentState[
 	if currentDirtyState.ParentChainBlockNumber == 0 {
 		return m.config.RetryInterval, errors.New("invalid reorging stage, ParentChainBlockNumber of current mel state has reached 0")
 	}
-	previousState, err := m.melDB.State(ctx, currentDirtyState.ParentChainBlockNumber-1)
+	previousState, err := m.melDB.State(currentDirtyState.ParentChainBlockNumber - 1)
 	if err != nil {
 		return m.config.RetryInterval, err
 	}

--- a/arbnode/mel/runner/save_messages.go
+++ b/arbnode/mel/runner/save_messages.go
@@ -17,16 +17,16 @@ func (m *MessageExtractor) saveMessages(ctx context.Context, current *fsm.Curren
 		return m.config.RetryInterval, fmt.Errorf("invalid action: %T", current.SourceEvent)
 	}
 	saveAction.postState.GetDelayedMessageBacklog().CommitDirties()
-	if err := m.melDB.SaveBatchMetas(ctx, saveAction.postState, saveAction.batchMetas); err != nil {
+	if err := m.melDB.SaveBatchMetas(saveAction.postState, saveAction.batchMetas); err != nil {
 		return m.config.RetryInterval, err
 	}
-	if err := m.melDB.SaveDelayedMessages(ctx, saveAction.postState, saveAction.delayedMessages); err != nil {
+	if err := m.melDB.SaveDelayedMessages(saveAction.postState, saveAction.delayedMessages); err != nil {
 		return m.config.RetryInterval, err
 	}
 	if err := m.msgConsumer.PushMessages(ctx, saveAction.preStateMsgCount, saveAction.messages); err != nil {
 		return m.config.RetryInterval, err
 	}
-	if err := m.melDB.SaveState(ctx, saveAction.postState); err != nil {
+	if err := m.melDB.SaveState(saveAction.postState); err != nil {
 		log.Error("Error saving messages from MessageExtractor to MessageConsumer", "err", err)
 		return m.config.RetryInterval, err
 	}

--- a/arbnode/mel/state.go
+++ b/arbnode/mel/state.go
@@ -52,34 +52,6 @@ type State struct {
 	msgPreimagesDest daprovider.PreimagesMap
 }
 
-// DelayedMessageDatabase can read delayed messages by their global index.
-type DelayedMessageDatabase interface {
-	ReadDelayedMessage(
-		ctx context.Context,
-		state *State,
-		index uint64,
-	) (*DelayedInboxMessage, error)
-}
-
-// Defines a basic interface for MEL, including saving states, messages,
-// and delayed messages to a database.
-type StateDatabase interface {
-	DelayedMessageDatabase
-	State(
-		ctx context.Context,
-		parentChainBlockNumber uint64,
-	) (*State, error)
-	SaveState(
-		ctx context.Context,
-		state *State,
-	) error
-	SaveDelayedMessages(
-		ctx context.Context,
-		state *State,
-		delayedMessages []*DelayedInboxMessage,
-	) error
-}
-
 // MessageConsumer is an interface to be implemented by readers of MEL such as transaction streamer of the nitro node
 type MessageConsumer interface {
 	PushMessages(

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -825,12 +825,12 @@ func getMessageExtractor(
 		return nil, nil
 	}
 	melDB := melrunner.NewDatabase(arbDb)
-	if _, err := melDB.GetHeadMelState(ctx); err != nil {
+	if _, err := melDB.GetHeadMelState(); err != nil {
 		initialState, err := createInitialMELState(ctx, deployInfo, l1client)
 		if err != nil {
 			return nil, err
 		}
-		if err = melDB.SaveState(ctx, initialState); err != nil {
+		if err = melDB.SaveState(initialState); err != nil {
 			return nil, fmt.Errorf("failed to save initial mel state: %w", err)
 		}
 	}
@@ -1803,7 +1803,7 @@ func (n *Node) GetL1Confirmations(msgIdx arbutil.MessageIndex) containers.Promis
 	var found bool
 	var err error
 	if n.MessageExtractor != nil {
-		batchNum, found, err = n.MessageExtractor.FindInboxBatchContainingMessage(n.ctx, msgIdx)
+		batchNum, found, err = n.MessageExtractor.FindInboxBatchContainingMessage(msgIdx)
 	} else {
 		batchNum, found, err = n.InboxTracker.FindInboxBatchContainingMessage(msgIdx)
 	}
@@ -1875,7 +1875,7 @@ func (n *Node) FindBatchContainingMessage(msgIdx arbutil.MessageIndex) container
 	var found bool
 	var err error
 	if n.MessageExtractor != nil {
-		batchNum, found, err = n.MessageExtractor.FindInboxBatchContainingMessage(n.ctx, msgIdx)
+		batchNum, found, err = n.MessageExtractor.FindInboxBatchContainingMessage(msgIdx)
 	} else {
 		batchNum, found, err = n.InboxTracker.FindInboxBatchContainingMessage(msgIdx)
 	}

--- a/arbnode/sync_monitor.go
+++ b/arbnode/sync_monitor.go
@@ -116,7 +116,7 @@ func (s *SyncMonitor) maxMessageCount() (arbutil.MessageIndex, error) {
 	}
 
 	if s.msgExtractor != nil {
-		melMsgCount, err := s.msgExtractor.GetMsgCount(s.GetContext())
+		melMsgCount, err := s.msgExtractor.GetMsgCount()
 		if err != nil {
 			return msgCount, err
 		}
@@ -181,7 +181,7 @@ func (s *SyncMonitor) FullSyncProgressMap() map[string]interface{} {
 	res["feedPendingMessageCount"] = s.txStreamer.FeedPendingMessageCount()
 
 	if s.msgExtractor != nil {
-		headMelState, err := s.msgExtractor.GetHeadState(s.GetContext())
+		headMelState, err := s.msgExtractor.GetHeadState()
 		if err != nil {
 			log.Error("Error getting head state from mel", "err", err)
 			res["batchMetadataError"] = err.Error()
@@ -285,7 +285,7 @@ func (s *SyncMonitor) Synced() bool {
 	}
 
 	if s.msgExtractor != nil {
-		headMelState, err := s.msgExtractor.GetHeadState(s.GetContext())
+		headMelState, err := s.msgExtractor.GetHeadState()
 		if err != nil {
 			log.Error("Error getting head state from mel", "err", err)
 			return false

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -1190,7 +1190,7 @@ func (s *TransactionStreamer) PopulateFeedBacklog(ctx context.Context) error {
 	if s.msgExtractor == nil {
 		return nil
 	}
-	batchCount, err := s.msgExtractor.GetBatchCount(ctx)
+	batchCount, err := s.msgExtractor.GetBatchCount()
 	if err != nil {
 		return fmt.Errorf("error getting batch count: %w", err)
 	}

--- a/mel-replay/delayed_message_db.go
+++ b/mel-replay/delayed_message_db.go
@@ -3,23 +3,22 @@
 package melreplay
 
 import (
-	"context"
 	"fmt"
 	"math/bits"
 
 	"github.com/offchainlabs/nitro/arbnode/mel"
+	"github.com/offchainlabs/nitro/arbnode/mel/extraction"
 )
 
 type delayedMessageDatabase struct {
 	preimageResolver PreimageResolver
 }
 
-func NewDelayedMessageDatabase(preimageResolver PreimageResolver) mel.DelayedMessageDatabase {
+func NewDelayedMessageDatabase(preimageResolver PreimageResolver) melextraction.DelayedMessageDatabase {
 	return &delayedMessageDatabase{preimageResolver}
 }
 
 func (d *delayedMessageDatabase) ReadDelayedMessage(
-	ctx context.Context,
 	state *mel.State,
 	msgIndex uint64,
 ) (*mel.DelayedInboxMessage, error) {

--- a/mel-replay/delayed_message_db_test.go
+++ b/mel-replay/delayed_message_db_test.go
@@ -3,7 +3,6 @@
 package melreplay_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -22,7 +21,6 @@ import (
 )
 
 func TestRecordingPreimagesForReadDelayedMessage(t *testing.T) {
-	ctx := context.Background()
 	var delayedMessages []*mel.DelayedInboxMessage
 	numMsgs := uint64(10)
 	for i := range numMsgs {
@@ -40,7 +38,7 @@ func TestRecordingPreimagesForReadDelayedMessage(t *testing.T) {
 	}
 	db := rawdb.NewMemoryDatabase()
 	melDB := melrunner.NewDatabase(db)
-	err := melDB.SaveDelayedMessages(ctx, &mel.State{DelayedMessagesSeen: uint64(len(delayedMessages))}, delayedMessages)
+	err := melDB.SaveDelayedMessages(&mel.State{DelayedMessagesSeen: uint64(len(delayedMessages))}, delayedMessages)
 	require.NoError(t, err)
 
 	startBlockNum := uint64(3)
@@ -53,7 +51,7 @@ func TestRecordingPreimagesForReadDelayedMessage(t *testing.T) {
 		require.NoError(t, state.AccumulateDelayedMessage(delayedMessages[i]))
 	}
 	require.NoError(t, state.GenerateDelayedMessagesSeenMerklePartialsAndRoot())
-	require.NoError(t, melDB.SaveState(ctx, state))
+	require.NoError(t, melDB.SaveState(state))
 
 	preimages := make(daprovider.PreimagesMap)
 	recordingDB, err := melrecording.NewDelayedMsgDatabase(db, preimages)
@@ -67,7 +65,7 @@ func TestRecordingPreimagesForReadDelayedMessage(t *testing.T) {
 	// Simulate reading of delayed Messages in native mode to record preimages
 	numMsgsToRead := uint64(7)
 	for i := startBlockNum; i < numMsgsToRead; i++ {
-		delayed, err := recordingDB.ReadDelayedMessage(ctx, state, i)
+		delayed, err := recordingDB.ReadDelayedMessage(state, i)
 		require.NoError(t, err)
 		require.Equal(t, delayed.Hash(), delayedMessages[i].Hash())
 	}
@@ -80,7 +78,7 @@ func TestRecordingPreimagesForReadDelayedMessage(t *testing.T) {
 		),
 	)
 	for i := startBlockNum; i < numMsgsToRead; i++ {
-		msg, err := delayedDB.ReadDelayedMessage(ctx, state, i)
+		msg, err := delayedDB.ReadDelayedMessage(state, i)
 		require.NoError(t, err)
 		require.Equal(t, msg.Hash(), delayedMessages[i].Hash())
 	}

--- a/mel-replay/merkle_tree_fetcher_test.go
+++ b/mel-replay/merkle_tree_fetcher_test.go
@@ -1,7 +1,6 @@
 package melreplay_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -32,13 +31,12 @@ func (m *mockPreimageResolver) ResolveTypedPreimage(preimageType arbutil.Preimag
 
 func TestFetchObjectFromMerkleTree(t *testing.T) {
 	// Tests implementation of fetchObjectFromMerkleTree method
-	ctx := context.Background()
 	t.Run("message index out of range", func(t *testing.T) {
 		db := melreplay.NewDelayedMessageDatabase(nil)
 		state := &mel.State{
 			DelayedMessagesSeen: 5,
 		}
-		_, err := db.ReadDelayedMessage(ctx, state, 5)
+		_, err := db.ReadDelayedMessage(state, 5)
 		require.ErrorContains(t, err, "index 5 out of range, total delayed messages seen: 5")
 	})
 	t.Run("single message in Merkle tree", func(t *testing.T) {
@@ -58,7 +56,7 @@ func TestFetchObjectFromMerkleTree(t *testing.T) {
 			DelayedMessagesSeenRoot: root,
 		}
 
-		msg, err := db.ReadDelayedMessage(ctx, state, uint64(0)) // #nosec G115
+		msg, err := db.ReadDelayedMessage(state, uint64(0)) // #nosec G115
 		require.NoError(t, err)
 		require.Equal(t, []byte("foobar"), msg.Message.L2msg)
 	})
@@ -90,7 +88,7 @@ func TestFetchObjectFromMerkleTree(t *testing.T) {
 		// Test each message
 		expectedData := [][]byte{[]byte("a"), []byte("b")}
 		for i, expected := range expectedData {
-			msg, err := db.ReadDelayedMessage(ctx, state, uint64(i)) // #nosec G115
+			msg, err := db.ReadDelayedMessage(state, uint64(i)) // #nosec G115
 			require.NoError(t, err)
 			require.Equal(t, expected, msg.Message.L2msg)
 		}
@@ -123,7 +121,7 @@ func TestFetchObjectFromMerkleTree(t *testing.T) {
 		// Test each message
 		expectedData := [][]byte{[]byte("a"), []byte("b"), []byte("c")}
 		for i, expected := range expectedData {
-			msg, err := db.ReadDelayedMessage(ctx, state, uint64(i)) // #nosec G115
+			msg, err := db.ReadDelayedMessage(state, uint64(i)) // #nosec G115
 			require.NoError(t, err)
 			require.Equal(t, expected, msg.Message.L2msg)
 		}

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -897,7 +897,7 @@ func TestBatchPosterActuallyPostsBlobsToL1(t *testing.T) {
 	Require(t, err)
 	var melBatchCount uint64
 	for range 10 {
-		melBatchCount, err = builder.L2.ConsensusNode.MessageExtractor.GetBatchCount(ctx)
+		melBatchCount, err = builder.L2.ConsensusNode.MessageExtractor.GetBatchCount()
 		Require(t, err)
 		if melBatchCount == batchCount {
 			break

--- a/system_tests/inbox_blob_failure_test.go
+++ b/system_tests/inbox_blob_failure_test.go
@@ -89,7 +89,7 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	var batchNum uint64
 	for i := 0; i < 30; i++ {
 		var found bool
-		batchNum, found, err = builder.L2.ConsensusNode.MessageExtractor.FindInboxBatchContainingMessage(ctx, arbutil.MessageIndex(l2Block.NumberU64()))
+		batchNum, found, err = builder.L2.ConsensusNode.MessageExtractor.FindInboxBatchContainingMessage(arbutil.MessageIndex(l2Block.NumberU64()))
 		Require(t, err)
 		if found {
 			break
@@ -102,9 +102,9 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Record sequencer state before starting follower
-	seqDelayed, err := builder.L2.ConsensusNode.MessageExtractor.GetDelayedCount(ctx, 0)
+	seqDelayed, err := builder.L2.ConsensusNode.MessageExtractor.GetDelayedCount(0)
 	Require(t, err)
-	seqBatch, err := builder.L2.ConsensusNode.MessageExtractor.GetBatchCount(ctx)
+	seqBatch, err := builder.L2.ConsensusNode.MessageExtractor.GetBatchCount()
 	Require(t, err)
 
 	// Build follower with failing blob reader
@@ -124,9 +124,9 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Check if follower is out of sync
-	follDelayed, err := testClientB.ConsensusNode.MessageExtractor.GetDelayedCount(ctx, 0)
+	follDelayed, err := testClientB.ConsensusNode.MessageExtractor.GetDelayedCount(0)
 	Require(t, err)
-	follBatch, err := testClientB.ConsensusNode.MessageExtractor.GetBatchCount(ctx)
+	follBatch, err := testClientB.ConsensusNode.MessageExtractor.GetBatchCount()
 	Require(t, err)
 
 	if follDelayed == seqDelayed && follBatch < seqBatch {
@@ -190,7 +190,7 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 		verifyReceipt, _ := builder.L2.Client.TransactionReceipt(ctx, verifyTx.Hash())
 		if verifyReceipt != nil {
 			verifyBlock, _ := builder.L2.Client.BlockByHash(ctx, verifyReceipt.BlockHash)
-			_, found, err := builder.L2.ConsensusNode.MessageExtractor.FindInboxBatchContainingMessage(ctx, arbutil.MessageIndex(verifyBlock.NumberU64()))
+			_, found, err := builder.L2.ConsensusNode.MessageExtractor.FindInboxBatchContainingMessage(arbutil.MessageIndex(verifyBlock.NumberU64()))
 			if err == nil && found {
 				break
 			}

--- a/system_tests/message_extraction_layer_test.go
+++ b/system_tests/message_extraction_layer_test.go
@@ -67,7 +67,7 @@ func TestMessageExtractionLayer_SequencerBatchMessageEquivalence(t *testing.T) {
 	}
 
 	melDB := melrunner.NewDatabase(builder.L2.ConsensusNode.ConsensusDB)
-	Require(t, melDB.SaveState(ctx, melState)) // save head mel state
+	Require(t, melDB.SaveState(melState)) // save head mel state
 	mockMsgConsumer := &mockMELDB{savedMsgs: make([]*arbostypes.MessageWithMetadata, 0)}
 	reorgEventChan := make(chan uint64, 1)
 	extractor, err := melrunner.NewMessageExtractor(
@@ -128,7 +128,7 @@ func TestMessageExtractionLayer_SequencerBatchMessageEquivalence(t *testing.T) {
 			numMessages,
 		)
 	}
-	lastState, err := melDB.GetHeadMelState(ctx)
+	lastState, err := melDB.GetHeadMelState()
 	Require(t, err)
 	extractedNumMessages := lastState.MsgCount
 	if extractedNumMessages != uint64(inboxTrackerMessageCount) {
@@ -198,7 +198,7 @@ func TestMessageExtractionLayer_SequencerBatchMessageEquivalence_Blobs(t *testin
 	defer l1Reader.StopAndWait()
 
 	melDB := melrunner.NewDatabase(builder.L2.ConsensusNode.ConsensusDB)
-	Require(t, melDB.SaveState(ctx, melState)) // save head mel state
+	Require(t, melDB.SaveState(melState)) // save head mel state
 	mockMsgConsumer := &mockMELDB{savedMsgs: make([]*arbostypes.MessageWithMetadata, 0)}
 	blobReaderRegistry := daprovider.NewDAProviderRegistry()
 	Require(t, blobReaderRegistry.SetupBlobReader(daprovider.NewReaderForBlobReader(builder.L1.L1BlobReader)))
@@ -248,7 +248,7 @@ func TestMessageExtractionLayer_SequencerBatchMessageEquivalence_Blobs(t *testin
 
 	numDelayedMessages, err := builder.L2.ConsensusNode.InboxTracker.GetDelayedCount()
 	Require(t, err)
-	lastState, err := melDB.GetHeadMelState(ctx)
+	lastState, err := melDB.GetHeadMelState()
 	Require(t, err)
 	inboxStreamer := builder.L2.ConsensusNode.TxStreamer
 	trackerMsgCount, err := inboxStreamer.GetMessageCount()
@@ -337,7 +337,7 @@ func TestMessageExtractionLayer_DelayedMessageEquivalence_Simple(t *testing.T) {
 	defer l1Reader.StopAndWait()
 
 	melDB := melrunner.NewDatabase(builder.L2.ConsensusNode.ConsensusDB)
-	Require(t, melDB.SaveState(ctx, melState)) // save head mel state
+	Require(t, melDB.SaveState(melState)) // save head mel state
 	mockMsgConsumer := &mockMELDB{savedMsgs: make([]*arbostypes.MessageWithMetadata, 0)}
 	reorgEventChan := make(chan uint64, 1)
 	extractor, err := melrunner.NewMessageExtractor(
@@ -369,7 +369,7 @@ func TestMessageExtractionLayer_DelayedMessageEquivalence_Simple(t *testing.T) {
 	numDelayedMessages, err := builder.L2.ConsensusNode.InboxTracker.GetDelayedCount()
 	Require(t, err)
 
-	lastState, err := melDB.GetHeadMelState(ctx)
+	lastState, err := melDB.GetHeadMelState()
 	Require(t, err)
 
 	// Check that MEL extracted the same number of delayed messages the inbox tracker has seen.
@@ -395,7 +395,7 @@ func TestMessageExtractionLayer_DelayedMessageEquivalence_Simple(t *testing.T) {
 
 	// Small reorg of 4 mel states
 	reorgToBlockNum := lastState.ParentChainBlockNumber - 4
-	reorgToState, err := melDB.State(ctx, reorgToBlockNum)
+	reorgToState, err := melDB.State(reorgToBlockNum)
 	Require(t, err)
 	reorgToBlockHash := reorgToState.ParentChainBlockHash
 	reorgToBlock, err := builder.L1.Client.BlockByHash(ctx, reorgToBlockHash)
@@ -445,7 +445,7 @@ func TestMessageExtractionLayer_DelayedMessageEquivalence_Simple(t *testing.T) {
 		}
 	}
 
-	lastState, err = melDB.GetHeadMelState(ctx)
+	lastState, err = melDB.GetHeadMelState()
 	Require(t, err)
 	if lastState.ParentChainBlockNumber != reorgToBlockNum+1 {
 		t.Fatalf("Unexpected number of MEL states after a parent chain reorg. Want: %d, Have: %d", reorgToBlockNum+1, lastState.ParentChainBlockNumber)
@@ -659,7 +659,7 @@ func TestMessageExtractionLayer_UseArbDBForStoringDelayedMessages(t *testing.T) 
 	defer l1Reader.StopAndWait()
 
 	melDB := melrunner.NewDatabase(builder.L2.ConsensusNode.ConsensusDB)
-	Require(t, melDB.SaveState(ctx, melState)) // save head mel state
+	Require(t, melDB.SaveState(melState)) // save head mel state
 	// TODO: tx streamer to be used here when ready to run the node using mel thus replacing inbox reader-tracker code
 	mockMsgConsumer := &mockMELDB{savedMsgs: make([]*arbostypes.MessageWithMetadata, 0)}
 	reorgEventsChan := make(chan uint64, 1)
@@ -698,7 +698,7 @@ func TestMessageExtractionLayer_UseArbDBForStoringDelayedMessages(t *testing.T) 
 	numDelayedMessages, err := builder.L2.ConsensusNode.InboxTracker.GetDelayedCount()
 	Require(t, err)
 
-	lastState, err := melDB.State(ctx, headMelStateBlockNum)
+	lastState, err := melDB.State(headMelStateBlockNum)
 	Require(t, err)
 
 	// Check that MEL extracted the same number of delayed messages the inbox tracker has seen.
@@ -710,7 +710,7 @@ func TestMessageExtractionLayer_UseArbDBForStoringDelayedMessages(t *testing.T) 
 		)
 	}
 
-	newInitialState, err := melDB.GetHeadMelState(ctx)
+	newInitialState, err := melDB.GetHeadMelState()
 	Require(t, err)
 	if newInitialState.ParentChainBlockHash != lastState.ParentChainBlockHash {
 		t.Fatalf("head mel state ParentChainBlockHash mismatch. Want: %s, Have: %s", lastState.ParentChainBlockHash, newInitialState.ParentChainBlockHash)
@@ -723,7 +723,7 @@ func TestMessageExtractionLayer_UseArbDBForStoringDelayedMessages(t *testing.T) 
 	newInitialState.SetReadCountFromBacklog(newInitialState.DelayedMessagesSeen) // skip checking against accumulator- not the purpose of this test
 	for i := newInitialState.DelayedMessagesRead; i < newInitialState.DelayedMessagesSeen; i++ {
 		// Validates the pending unread delayed messages via accumulator
-		delayedMsgSavedByMel, err := melDB.ReadDelayedMessage(ctx, newInitialState, newInitialState.DelayedMessagesRead)
+		delayedMsgSavedByMel, err := melDB.ReadDelayedMessage(newInitialState, newInitialState.DelayedMessagesRead)
 		Require(t, err)
 		fetchedDelayedMsg, err := builder.L2.ConsensusNode.InboxTracker.GetDelayedMessage(ctx, i)
 		Require(t, err)


### PR DESCRIPTION
This PR removes unused ctx variable in MEL's `DelayedMessageDatabase` interface and its corresponding database impl.