### PR TITLE
chore: add dependabot config for Arbitrum/OffchainLabs npm deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directories:
+      - '**/*'
+    schedule:
+      interval: daily
+    versioning-strategy: increase
+    open-pull-requests-limit: 5
+    target-branch: master
+    allow:
+      - dependency-name: '@arbitrum/*'
+      - dependency-name: '@offchainlabs/*'


### PR DESCRIPTION
## Summary
- Adds dependabot configuration to automatically create PRs when `@arbitrum/*` or `@offchainlabs/*` npm dependencies have updates available
- Scans all directories (including submodules like `contracts/` and `nitro-testnode/scripts/`) for package.json files
- Limited to 5 open PRs at a time, checked daily

## Test plan
- [ ] Verify `.github/dependabot.yml` is correct
- [ ] After merge, GitHub should start creating dependabot PRs within 24 hours