### PR TITLE
Allow wasm directory in database dir validation

### DIFF
--- a/cmd/nitro/init/init.go
+++ b/cmd/nitro/init/init.go
@@ -406,7 +406,7 @@ func checkEmptyDatabaseDir(dir string, force bool) error {
 	}
 	unexpectedFiles := []string{}
 	allowedFiles := map[string]bool{
-		"LOCK": true, "classic-msg": true, "l2chaindata": true,
+		"LOCK": true, "classic-msg": true, "l2chaindata": true, "wasm": true,
 	}
 	for _, entry := range entries {
 		if !allowedFiles[entry.Name()] {

--- a/cmd/nitro/init/init_test.go
+++ b/cmd/nitro/init/init_test.go
@@ -378,7 +378,7 @@ func TestEmptyDatabaseDir(t *testing.T) {
 		},
 		{
 			name:  "succeed with expected files",
-			files: []string{"LOCK", "classic-msg", "l2chaindata"},
+			files: []string{"LOCK", "classic-msg", "l2chaindata", "wasm"},
 		},
 		{
 			name:    "fail with unexpected files",


### PR DESCRIPTION
Fixes NIT-4608

The checkEmptyDatabaseDir function was missing "wasm" in its allowlist,
causing existing nodes with a wasm database directory to fail on startup
after the geth v1.17.0 merge.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
