### PR TITLE
Add FullValueCheckpoint config for pathdb trienode history

### DIFF
--- a/changelog/jco-full-value-checkpoint.md
+++ b/changelog/jco-full-value-checkpoint.md
@@ -1,0 +1,2 @@
+### Added
+- Add `--execution.caching.node-full-value-checkpoint` caching config for pathdb trienode history, defaulting to 8 to match geth

--- a/execution/gethexec/blockchain.go
+++ b/execution/gethexec/blockchain.go
@@ -57,6 +57,7 @@ type CachingConfig struct {
 	EnablePreimages                     bool          `koanf:"enable-preimages"`
 	PathdbMaxDiffLayers                 int           `koanf:"pathdb-max-diff-layers"`
 	StateSizeTracking                   bool          `koanf:"state-size-tracking"`
+	NodeFullValueCheckpoint             uint32        `koanf:"node-full-value-checkpoint"`
 }
 
 func CachingConfigAddOptions(prefix string, f *pflag.FlagSet) {
@@ -85,6 +86,7 @@ func CachingConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable-preimages", DefaultCachingConfig.EnablePreimages, "enable recording of preimages")
 	f.Int(prefix+".pathdb-max-diff-layers", DefaultCachingConfig.PathdbMaxDiffLayers, "maximum number of diff layers to keep in pathdb (path state-scheme only)")
 	f.Bool(prefix+".state-size-tracking", DefaultCachingConfig.StateSizeTracking, "enable tracking of state size over time")
+	f.Uint32(prefix+".node-full-value-checkpoint", DefaultCachingConfig.NodeFullValueCheckpoint, "rate at which trie nodes are encoded in full-value format in trienode history (path state-scheme only)")
 }
 
 func GetStateHistory(maxBlockSpeed time.Duration) uint64 {
@@ -117,6 +119,7 @@ var DefaultCachingConfig = CachingConfig{
 	EnablePreimages:                     false,
 	PathdbMaxDiffLayers:                 128,
 	StateSizeTracking:                   false,
+	NodeFullValueCheckpoint:             8,
 }
 
 func DefaultCacheConfigFor(cachingConfig *CachingConfig) *core.BlockChainConfig {
@@ -152,6 +155,7 @@ func DefaultCacheConfigTrieNoFlushFor(cachingConfig *CachingConfig, trieNoAsyncF
 		MaxDiffLayers:                      cachingConfig.PathdbMaxDiffLayers,
 		TrieNoAsyncFlush:                   trieNoAsyncFlush,
 		StateSizeTracking:                  cachingConfig.StateSizeTracking,
+		NodeFullValueCheckpoint:            cachingConfig.NodeFullValueCheckpoint,
 	}
 }
 


### PR DESCRIPTION
Expose geth's NodeFullValueCheckpoint setting through CachingConfig,
defaulting to 8 to match geth's default. Without this, the field
was left at zero which disables the storage optimization.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
