### PR TITLE
Run nitro with rust validator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ COPY --from=wasm-libs-builder /workspace/ /
 FROM wasm-base AS wasm-bin-builder
 RUN apt update && apt install -y wabt
 # pinned go version
-RUN curl -L https://golang.org/dl/go1.25.1.linux-`dpkg --print-architecture`.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://golang.org/dl/go1.25.8.linux-`dpkg --print-architecture`.tar.gz | tar -C /usr/local -xzf -
 COPY ./Makefile ./go.mod ./go.sum ./
 COPY ./arbcompress ./arbcompress
 COPY ./arbos ./arbos

--- a/Dockerfile
+++ b/Dockerfile
@@ -140,6 +140,7 @@ RUN touch -a -m crates/prover/src/lib.rs
 RUN NITRO_BUILD_IGNORE_TIMESTAMPS=1 make build-prover-lib
 RUN NITRO_BUILD_IGNORE_TIMESTAMPS=1 make build-prover-bin
 RUN NITRO_BUILD_IGNORE_TIMESTAMPS=1 make build-jit
+RUN NITRO_BUILD_IGNORE_TIMESTAMPS=1 make build-validation-server
 
 FROM scratch AS prover-export
 COPY --from=prover-builder /workspace/target/ /
@@ -344,6 +345,13 @@ COPY --from=module-root-calc /workspace/target/machines/latest/machine.wavm.br /
 COPY --from=module-root-calc /workspace/target/machines/latest/until-host-io-state.bin /home/user/target/machines/latest/
 COPY --from=module-root-calc /workspace/target/machines/latest/module-root.txt /home/user/target/machines/latest/
 COPY --from=module-root-calc /workspace/target/machines/latest/replay.wasm /home/user/target/machines/latest/
+COPY --from=prover-export /bin/validator /usr/local/bin/
+# Symlink legacy machine dirs into /home/user/target/machines so the Rust
+# validator can serve all module roots from a single --root-path.
+RUN for dir in /home/user/nitro-legacy/machines/*/; do \
+      name=$(basename "$dir"); \
+      [ "$name" != "latest" ] && ln -sf "$dir" /home/user/target/machines/"$name" || true; \
+    done
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y \

--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -203,8 +203,8 @@ func (c *BlockValidatorConfig) Validate() error {
 			if err != nil {
 				return fmt.Errorf("failed parsing validation server's url:%s err: %w", serverUrl, err)
 			}
-			if u.Scheme != "ws" && u.Scheme != "wss" {
-				return fmt.Errorf("validation server's url scheme is unsupported, it should either be ws or wss, url:%s", serverUrl)
+			if u.Scheme != "ws" && u.Scheme != "wss" && u.Scheme != "http" && u.Scheme != "https" {
+				return fmt.Errorf("validation server's url scheme is unsupported, it should be ws, wss, http, or https, url:%s", serverUrl)
 			}
 		}
 	}

--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -928,7 +928,7 @@ func (v *BlockValidator) advanceValidations(ctx context.Context) (*arbutil.Messa
 		}
 		v.testingProgressMadeMutex.Unlock()
 
-		log.Trace("result validated", "count", v.validated(), "blockHash", v.lastValidGS.BlockHash)
+		log.Info("block validated", "count", v.validated(), "blockHash", v.lastValidGS.BlockHash, "batch", v.lastValidGS.Batch, "posInBatch", v.lastValidGS.PosInBatch)
 	}
 }
 


### PR DESCRIPTION
Replace the Go validation node (`nitro-val`) with the Rust validation server (`crates/validator`) in the nitro-testnode setup. The Rust server is fully compatible with the Go validation client and exposes JIT validation over HTTP JSON-RPC.

# Changes

**Dockerfile**
  - Build the Rust validator binary in the `prover-builder` stage (alongside jit, prover-lib, prover-bin)
  - Copy validator binary into the `nitro-node-dev` image at `/usr/local/bin/`
  - Symlink legacy machine directories from `/home/user/nitro-legacy/machines/` into `/home/user/target/machines/` so the Rust validator can serve all module roots (latest + legacy) from a single `--root-path`
  - Bump Go version from 1.25.1 to 1.25.8 (I had some problems with fetching the old version)

**`staker/block_validator.go`**
  - Allow `http://` and `https://` URL schemes for validation server configs (previously only `ws://`/`wss://` were accepted)
  - Upgrade `"result validated"` log from `Trace` to `Info` level with additional fields (`batch`, `posInBatch`) for easier debugging

**nitro-testnode (submodule)**
  - `docker-compose.yaml`: Replace `nitro-val` with validator as entrypoint for the `validation_node` service, configure it with CLI args (`--address`, `--root-path`), add `RUST_LOG=tower_http=debug,info` for HTTP-level request tracing, and add a healthcheck so dependent services wait for the server to be ready
  - `scripts/config.ts`: Remove jwtsecret from block-validator config (Rust server doesn't use JWT auth)
  - `scripts/index.ts`: Change default validation node URL from `ws://validation_node:8549` to `http://validation_node:4141`

# Reproduction

```
cd nitro-testnode
./test-node.bash --dev --init-force --validate
```

**Expected output**

```
# validation_node (Rust server) — HTTP request/response traces from tower_http:
DEBUG tower_http: started processing request method=POST uri=/
DEBUG tower_http: finished processing request latency=42ms status=200

# validator (Go node) — Block validation confirmations:
INFO block validated count=42 blockHash=0x... batch=1 posInBatch=0
```

companion PR: https://github.com/OffchainLabs/nitro-testnode/pull/181