### PR TITLE
Fix goroutine leak in bold events Producer causing flaky CI tests

### DIFF
--- a/bold/containers/events/producer.go
+++ b/bold/containers/events/producer.go
@@ -5,12 +5,11 @@ package events
 
 import (
 	"context"
+	"slices"
 	"sync"
-	"time"
 )
 
 const (
-	defaultBroadcastTimeout       = time.Millisecond * 500
 	defaultSubscriptionBufferSize = 10
 )
 
@@ -19,24 +18,19 @@ type Producer[T any] struct {
 	sync.RWMutex
 	subscriptionBufferSize int
 	subs                   []*Subscription[T]
-	doneListener           chan subId    // channel to listen for IDs of subscriptions to be remove.
-	broadcastTimeout       time.Duration // maximum duration to wait for an event to be sent.
-	nextId                 subId         // monotonically increasing id for stable subscription identification
+	doneListener           chan subId // channel to listen for IDs of subscriptions to be removed.
+	nextId                 subId      // monotonically increasing id for stable subscription identification
 }
 
 type ProducerOpt[T any] func(*Producer[T])
 
-// WithBroadcastTimeout enables the amount of time the broadcaster will wait to send
-// to each subscriber before dropping the send.
-func WithBroadcastTimeout[T any](timeout time.Duration) ProducerOpt[T] {
-	return func(ep *Producer[T]) {
-		ep.broadcastTimeout = timeout
-	}
-}
-
 // WithSubscriptionBuffer customizes the size of the subscription buffer channel.
+// If size is less than 1, the default buffer size is used.
 func WithSubscriptionBuffer[T any](size int) ProducerOpt[T] {
 	return func(ep *Producer[T]) {
+		if size < 1 {
+			size = defaultSubscriptionBufferSize
+		}
 		ep.subscriptionBufferSize = size
 	}
 }
@@ -46,7 +40,6 @@ func NewProducer[T any](opts ...ProducerOpt[T]) *Producer[T] {
 		subs:                   make([]*Subscription[T], 0),
 		subscriptionBufferSize: defaultSubscriptionBufferSize,
 		doneListener:           make(chan subId, 100),
-		broadcastTimeout:       defaultBroadcastTimeout,
 	}
 	for _, opt := range opts {
 		opt(producer)
@@ -54,27 +47,20 @@ func NewProducer[T any](opts ...ProducerOpt[T]) *Producer[T] {
 	return producer
 }
 
-// Start begins listening for subscription cancelation requests or context cancelation.
+// Start begins listening for subscription cancellation requests or context cancellation.
 func (ep *Producer[T]) Start(ctx context.Context) {
 	for {
 		select {
 		case id := <-ep.doneListener:
 			ep.Lock()
-			// Find the subscription by stable id and remove it if present.
-			idx := -1
-			for i, s := range ep.subs {
-				if s.id == id {
-					idx = i
-					break
-				}
-			}
-			if idx >= 0 {
-				ep.subs = append(ep.subs[:idx], ep.subs[idx+1:]...)
-			}
+			ep.subs = slices.DeleteFunc(ep.subs, func(s *Subscription[T]) bool {
+				return s.id == id
+			})
 			ep.Unlock()
 		case <-ctx.Done():
-			close(ep.doneListener)
+			ep.Lock()
 			ep.subs = nil
+			ep.Unlock()
 			return
 		}
 	}
@@ -86,8 +72,8 @@ func (ep *Producer[T]) Subscribe() *Subscription[T] {
 	ep.Lock()
 	defer ep.Unlock()
 	sub := &Subscription[T]{
-		id:     ep.nextId, // Assign a stable, monotonically increasing ID
-		events: make(chan T),
+		id:     ep.nextId,
+		events: make(chan T, ep.subscriptionBufferSize),
 		done:   ep.doneListener,
 	}
 	ep.nextId++
@@ -95,21 +81,19 @@ func (ep *Producer[T]) Subscribe() *Subscription[T] {
 	return sub
 }
 
-// Broadcast sends an event to all active subscriptions, respecting a configured timeout or context.
-// It spawns goroutines to send events to each subscription so as to not block the producer to submitting
-// to all consumers. Broadcast should be used if not all consumers are expected to consume the event,
-// within a reasonable time, or if the configured broadcast timeout is short enough.
-func (ep *Producer[T]) Broadcast(ctx context.Context, event T) {
+// Broadcast sends an event to all active subscriptions. If a subscription's
+// buffer is full the event is dropped, as the subscriber already has pending
+// events to process. This avoids spawning goroutines per broadcast and
+// eliminates goroutine leaks when subscribers are slow. The ctx parameter is
+// unused but retained for API compatibility.
+func (ep *Producer[T]) Broadcast(_ context.Context, event T) {
 	ep.RLock()
 	defer ep.RUnlock()
 	for _, sub := range ep.subs {
-		go func(listener *Subscription[T]) {
-			select {
-			case listener.events <- event:
-			case <-time.After(ep.broadcastTimeout):
-			case <-ctx.Done():
-			}
-		}(sub)
+		select {
+		case sub.events <- event:
+		default:
+		}
 	}
 }
 
@@ -123,17 +107,19 @@ type Subscription[T any] struct {
 	done   chan subId
 }
 
-// Next waits for the next event or context cancelation, returning the event or an error.
+// Next waits for the next event or context cancellation. It returns the event
+// and false on success, or a zero value and true if the context was cancelled.
 func (es *Subscription[T]) Next(ctx context.Context) (T, bool) {
 	var zeroVal T
-	for {
+	select {
+	case ev := <-es.events:
+		return ev, false
+	case <-ctx.Done():
+		// Non-blocking send: Start() may have already exited, leaving no receiver.
 		select {
-		case ev := <-es.events:
-			return ev, false
-		case <-ctx.Done():
-			es.done <- es.id
-			close(es.events)
-			return zeroVal, true
+		case es.done <- es.id:
+		default:
 		}
+		return zeroVal, true
 	}
 }

--- a/bold/containers/events/producer_test.go
+++ b/bold/containers/events/producer_test.go
@@ -5,6 +5,7 @@ package events
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -18,39 +19,93 @@ func TestSubscribe(t *testing.T) {
 	require.NotNil(t, sub)
 }
 
-func TestBroadcast(t *testing.T) {
+func TestBroadcastToMultipleSubscribers(t *testing.T) {
 	producer := NewProducer[int]()
-	sub := producer.Subscribe()
-	done := make(chan bool)
-	go func() {
-		event, shouldEnd := sub.Next(context.Background())
-		require.False(t, shouldEnd)
-		require.Equal(t, 42, event)
-		done <- true
-	}()
 	ctx := context.Background()
-	producer.Broadcast(ctx, 42)
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Test timed out waiting for event")
+
+	sub1 := producer.Subscribe()
+	sub2 := producer.Subscribe()
+	sub3 := producer.Subscribe()
+
+	producer.Broadcast(ctx, 99)
+
+	for i, sub := range []*Subscription[int]{sub1, sub2, sub3} {
+		event, shouldEnd := sub.Next(ctx)
+		require.False(t, shouldEnd, "subscriber %d should not end", i)
+		require.Equal(t, 99, event, "subscriber %d got wrong event", i)
 	}
 }
 
-func TestBroadcastTimeout(t *testing.T) {
-	timeout := 50 * time.Millisecond
-	producer := NewProducer(WithBroadcastTimeout[int](timeout))
+func TestBroadcastDropsWhenFull(t *testing.T) {
+	producer := NewProducer(WithSubscriptionBuffer[int](1))
 	sub := producer.Subscribe()
+	ctx := context.Background()
 
-	go func() {
-		// Delay sending to simulate timeout scenario
-		time.Sleep(100 * time.Millisecond)
-		sub.events <- 42
-	}()
+	// First broadcast fills the buffer
+	producer.Broadcast(ctx, 1)
+	// Second broadcast should be dropped (buffer full)
+	producer.Broadcast(ctx, 2)
 
-	event, shouldEnd := sub.Next(context.Background())
+	event, shouldEnd := sub.Next(ctx)
 	require.False(t, shouldEnd)
-	require.Equal(t, 42, event)
+	require.Equal(t, 1, event)
+
+	// After draining, subsequent broadcasts should work
+	producer.Broadcast(ctx, 3)
+	event, shouldEnd = sub.Next(ctx)
+	require.False(t, shouldEnd)
+	require.Equal(t, 3, event)
+}
+
+func TestSubscriptionBufferSize(t *testing.T) {
+	bufSize := 5
+	producer := NewProducer(WithSubscriptionBuffer[int](bufSize))
+	sub := producer.Subscribe()
+	ctx := context.Background()
+
+	// Fill the buffer completely
+	for i := 0; i < bufSize; i++ {
+		producer.Broadcast(ctx, i)
+	}
+	// One more should be dropped
+	producer.Broadcast(ctx, 999)
+
+	// Drain and verify we get exactly the buffered events
+	for i := 0; i < bufSize; i++ {
+		event, shouldEnd := sub.Next(ctx)
+		require.False(t, shouldEnd)
+		require.Equal(t, i, event)
+	}
+}
+
+func TestWithSubscriptionBufferValidation(t *testing.T) {
+	// Zero and negative sizes should fall back to the default buffer size.
+	for _, size := range []int{0, -1, -100} {
+		producer := NewProducer(WithSubscriptionBuffer[int](size))
+		require.Equal(t, defaultSubscriptionBufferSize, producer.subscriptionBufferSize,
+			"size %d should fall back to default", size)
+	}
+}
+
+func TestNoGoroutineLeakOnBroadcast(t *testing.T) {
+	// Verify that Broadcast does not leak goroutines when subscribers are slow.
+	producer := NewProducer(WithSubscriptionBuffer[int](1))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go producer.Start(ctx)
+
+	_ = producer.Subscribe()
+	_ = producer.Subscribe()
+	_ = producer.Subscribe()
+
+	before := runtime.NumGoroutine()
+	for i := 0; i < 1000; i++ {
+		producer.Broadcast(ctx, i)
+	}
+	after := runtime.NumGoroutine()
+	// A naive goroutine-per-send implementation would create 3000+ goroutines
+	// here. Non-blocking sends create none.
+	require.Less(t, after-before, 10, "broadcast should not spawn goroutines")
 }
 
 func TestEventProducer_Start(t *testing.T) {
@@ -60,19 +115,95 @@ func TestEventProducer_Start(t *testing.T) {
 
 	sub := producer.Subscribe()
 
-	// Simulate removing the subscription.
 	cancel()
 	_, shouldEnd := sub.Next(ctx)
-	if !shouldEnd {
-		t.Error("Expected to end after context cancellation")
+	require.True(t, shouldEnd, "Expected to end after context cancellation")
+}
+
+func TestNextExitsOnCancel(t *testing.T) {
+	producer := NewProducer[int]()
+	sub := producer.Subscribe()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan bool)
+	go func() {
+		_, shouldEnd := sub.Next(ctx)
+		done <- shouldEnd
+	}()
+
+	cancel()
+	select {
+	case shouldEnd := <-done:
+		require.True(t, shouldEnd)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Next did not return after context cancellation")
+	}
+}
+
+func TestNextExitsCleanlyWhenStartNotRunning(t *testing.T) {
+	// Verify Next returns without blocking even if Start() was never called
+	// (no receiver on doneListener).
+	producer := NewProducer[int]()
+	sub := producer.Subscribe()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan bool)
+	go func() {
+		_, shouldEnd := sub.Next(ctx)
+		done <- shouldEnd
+	}()
+
+	select {
+	case shouldEnd := <-done:
+		require.True(t, shouldEnd)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Next blocked when Start was not running")
+	}
+}
+
+func TestConcurrentBroadcastAndShutdown(t *testing.T) {
+	// Verify no panics when broadcasting and cancelling concurrently.
+	for i := 0; i < 100; i++ {
+		producer := NewProducer(WithSubscriptionBuffer[int](1))
+		ctx, cancel := context.WithCancel(context.Background())
+		go producer.Start(ctx)
+
+		subs := make([]*Subscription[int], 5)
+		for j := range subs {
+			subs[j] = producer.Subscribe()
+		}
+
+		// Broadcast and cancel concurrently
+		done := make(chan struct{})
+		go func() {
+			for k := 0; k < 100; k++ {
+				producer.Broadcast(ctx, k)
+			}
+			close(done)
+		}()
+		// Cancel mid-broadcast
+		cancel()
+		<-done
+
+		// All subscribers should eventually exit cleanly
+		for _, sub := range subs {
+			for {
+				_, shouldEnd := sub.Next(ctx)
+				if shouldEnd {
+					break
+				}
+				// Subscriber drained a buffered event; keep reading until ctx cancellation
+			}
+		}
 	}
 }
 
 func TestRemovalUsesStableId(t *testing.T) {
 	// This test ensures that removing subscriptions uses stable IDs rather than slice indices.
-	// Before the fix, deleting two subscriptions by their IDs 0 and 1 would incorrectly
-	// remove the first (index 0) and the third (now at index 1 after compaction), leaving
-	// the second subscription in place instead of the third.
+	// Using indices would cause incorrect removals when earlier subscriptions are deleted,
+	// shifting remaining subscriptions to lower indices.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -92,19 +223,9 @@ func TestRemovalUsesStableId(t *testing.T) {
 	}
 
 	// Wait until the producer processes removal and only one subscription remains.
-	deadline := time.Now().Add(2 * time.Second)
-	for {
+	require.Eventually(t, func() bool {
 		producer.RLock()
-		remaining := len(producer.subs)
-		producer.RUnlock()
-		if remaining == 1 || time.Now().After(deadline) {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-
-	producer.RLock()
-	require.Equal(t, 1, len(producer.subs))
-	require.Same(t, s2, producer.subs[0])
-	producer.RUnlock()
+		defer producer.RUnlock()
+		return len(producer.subs) == 1 && producer.subs[0] == s2
+	}, 2*time.Second, 5*time.Millisecond)
 }

--- a/changelog/jcolvin-fix-bold-events-goroutine-leak.md
+++ b/changelog/jcolvin-fix-bold-events-goroutine-leak.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fix goroutine leak in bold events Producer causing flaky CI tests


### PR DESCRIPTION
Broadcast spawned a goroutine per subscriber per call, each blocking on
an unbuffered channel with a 500ms timeout. With many subscribers and
frequent broadcasts, goroutines accumulated causing
TestEndToEnd_ManyEvilValidators to fail in CI with thousands of stuck
goroutines.

Changes:
- Replace goroutine-per-subscriber broadcast with non-blocking send into
  a buffered channel (uses existing subscriptionBufferSize, default 10)
- Remove unsafe channel closes in Next() and Start() that could panic
  from concurrent send-on-closed-channel during shutdown
- Replace manual subscription removal loop with slices.DeleteFunc
- Remove unused WithBroadcastTimeout and broadcastTimeout field
- Add input validation to WithSubscriptionBuffer for size < 1
- Add comprehensive tests: goroutine leak detection, concurrent
  broadcast/shutdown, buffer-full drop behavior, edge cases

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
