### PR TITLE
Fix additional flaky tests: SeqInboxReader, TransactionFilterers, RedisBatchPoster

### DIFF
--- a/changelog/jco-fix-more-flaky-tests.md
+++ b/changelog/jco-fix-more-flaky-tests.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fix additional flaky test failures: increase TestSequencerInboxReader batch count wait timeout, add time buffer in TestManageTransactionFilterers to prevent race with block time advancement, increase L1 funding in TestRedisBatchPosterHandoff to prevent balance exhaustion

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -258,7 +258,7 @@ func TestRedisBatchPosterHandoff(t *testing.T) {
 	addNewBatchPoster(ctx, t, builder, srv.Address)
 
 	builder.L1.SendWaitTestTransactions(t, []*types.Transaction{
-		builder.L1Info.PrepareTxTo("Faucet", &srv.Address, 30000, big.NewInt(1e18), nil)})
+		builder.L1Info.PrepareTxTo("Faucet", &srv.Address, 30000, new(big.Int).Mul(big.NewInt(1e18), big.NewInt(10)), nil)})
 
 	var txs []*types.Transaction
 

--- a/system_tests/filtered_transactions_test.go
+++ b/system_tests/filtered_transactions_test.go
@@ -73,8 +73,9 @@ func TestManageTransactionFilterers(t *testing.T) {
 	_, err = arbOwner.SetTransactionFilteringFrom(&ownerTxOpts, tryEnableAt)
 	require.Error(t, err)
 
-	// Enable transaction filtering feature 7 days in the future and warp time forward
-	enableAt := hdr.Time + precompiles.FeatureEnableDelay
+	// Enable transaction filtering feature 7 days in the future and warp time forward.
+	// Add a buffer to account for block time advancing between header fetch and tx execution.
+	enableAt := hdr.Time + precompiles.FeatureEnableDelay + 120
 	tx, err := arbOwner.SetTransactionFilteringFrom(&ownerTxOpts, enableAt)
 	require.NoError(t, err)
 	_, err = builder.L2.EnsureTxSucceeded(tx)

--- a/system_tests/seqinbox_test.go
+++ b/system_tests/seqinbox_test.go
@@ -402,10 +402,10 @@ func testSequencerInboxReaderImpl(t *testing.T, validator bool) {
 			}
 			if batchCount.Cmp(big.NewInt(int64(len(blockStates)))) == 0 {
 				break
-			} else if i >= 140 {
+			} else if i >= 500 {
 				Fatal(t, "timed out waiting for l1 batch count update; have", batchCount, "want", len(blockStates)-1)
 			}
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 		}
 
 		expectedBlockNumber := blockStates[len(blockStates)-1].l2BlockNumber


### PR DESCRIPTION
## Summary
Fixes three additional flaky system tests not covered by #4523:

- **TestSequencerInboxReader**: Increase batch count wait timeout from 1.4s to 10s. After large chain reorgs (every 10th iteration), the inbox reader needs more time to reprocess batches and update counts.
- **TestManageTransactionFilterers**: Add 120s buffer to the `enableAt` timestamp. The precompile validates `timestamp >= blockTime + FeatureEnableDelay`, but block time can advance between the header fetch and tx execution, causing a spurious revert.
- **TestRedisBatchPosterHandoff**: Increase external signer L1 funding from 1 ETH to 10 ETH. The DataPoster divides available balance by `maxMempoolWeight` for per-tx allocation; with many pending batches and high simulated gas costs, 1 ETH was insufficient.

All three tests passed on CI re-run, confirming they are timing/resource-sensitive rather than logic bugs.

## Test plan
- [ ] CI passes with the updated test parameters
- [ ] No regressions in other system tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)