### PR TITLE
[WIP] Optimize RebuildDelayedMsgPreimages by tracking delayed msg outbox accumulator's size natively

### DIFF
--- a/arbnode/mel/runner/initialize.go
+++ b/arbnode/mel/runner/initialize.go
@@ -22,6 +22,11 @@ func (m *MessageExtractor) initialize(ctx context.Context, current *fsm.CurrentS
 	if err := melState.RebuildDelayedMsgPreimages(m.melDB.FetchDelayedMessage); err != nil {
 		return m.config.RetryInterval, fmt.Errorf("error rebuilding delayed msg preimages: %w", err)
 	}
+	m.outboxTracker = NewOutboxSizeTracker(
+		melState.ParentChainBlockNumber,
+		melState.OutboxSize(),
+		m.GetFinalizedBlockNum,
+	)
 	// Start mel state is now ready. Check if the state's parent chain block hash exists in the parent chain
 	startBlock, err := m.parentChainReader.HeaderByNumber(ctx, new(big.Int).SetUint64(melState.ParentChainBlockNumber))
 	if err != nil {

--- a/arbnode/mel/runner/mel.go
+++ b/arbnode/mel/runner/mel.go
@@ -117,6 +117,7 @@ type MessageExtractor struct {
 	reorgEventsNotifier      chan uint64
 	seqBatchCounter          SequencerBatchCountFetcher
 	l1Reader                 *headerreader.HeaderReader
+	outboxTracker            *OutboxSizeTracker
 }
 
 // Creates a message extractor instance with the specified parameters,
@@ -285,17 +286,17 @@ func (m *MessageExtractor) GetL1Reader() *headerreader.HeaderReader {
 	return m.l1Reader
 }
 
-// GetFinalizedDelayedMessagesRead uses MessageExtractor's context for calls to parentChainReader
-func (m *MessageExtractor) GetFinalizedDelayedMessagesRead() (uint64, error) {
+// GetFinalizedBlockNum returns the current finalized parent chain block number.
+func (m *MessageExtractor) GetFinalizedBlockNum() (uint64, error) {
 	ctx, err := m.GetContextSafe()
 	if err != nil {
 		return 0, fmt.Errorf("message extractor not running: %w", err)
 	}
-	state, err := m.getStateByRPCBlockNum(ctx, rpc.FinalizedBlockNumber)
+	blk, err := m.parentChainReader.HeaderByNumber(ctx, big.NewInt(rpc.FinalizedBlockNumber.Int64()))
 	if err != nil {
 		return 0, err
 	}
-	return state.DelayedMessagesRead, nil
+	return blk.Number.Uint64(), nil
 }
 
 func (m *MessageExtractor) GetHeadState() (*mel.State, error) {

--- a/arbnode/mel/runner/outbox_size_tracker.go
+++ b/arbnode/mel/runner/outbox_size_tracker.go
@@ -1,0 +1,98 @@
+// Copyright 2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+package melrunner
+
+import "github.com/ethereum/go-ethereum/log"
+
+// OutboxSizeTracker maintains a sliding window of outbox sizes indexed by
+// parent chain block number. This enables O(1) pivot lookup during
+// RebuildDelayedMsgPreimages instead of the O(N²) findPivot search.
+//
+// The window is trimmed from the left when parent chain blocks finalize
+// (those entries are no longer needed for reorg recovery) and trimmed
+// from the right on reorgs (discarding entries for reorged blocks).
+type OutboxSizeTracker struct {
+	startBlock        uint64
+	sizes             []int
+	getFinalizedBlock func() (uint64, error)
+}
+
+func NewOutboxSizeTracker(startBlock uint64, initialOutboxSize int, getFinalizedBlock func() (uint64, error)) *OutboxSizeTracker {
+	return &OutboxSizeTracker{
+		startBlock:        startBlock,
+		sizes:             []int{initialOutboxSize},
+		getFinalizedBlock: getFinalizedBlock,
+	}
+}
+
+// Record appends the outbox size for the given block number.
+// Block numbers must be recorded sequentially.
+func (t *OutboxSizeTracker) Record(blockNum uint64, outboxSize int) {
+	expected := t.startBlock + uint64(len(t.sizes))
+	if blockNum != expected {
+		log.Warn("OutboxSizeTracker: non-sequential block recorded, resetting",
+			"expected", expected, "got", blockNum)
+		t.startBlock = blockNum
+		t.sizes = []int{outboxSize}
+		return
+	}
+	t.sizes = append(t.sizes, outboxSize)
+}
+
+// Lookup returns the outbox size at the given block number if available.
+func (t *OutboxSizeTracker) Lookup(blockNum uint64) (int, bool) {
+	if blockNum < t.startBlock {
+		return 0, false
+	}
+	idx := blockNum - t.startBlock
+	if idx >= uint64(len(t.sizes)) {
+		return 0, false
+	}
+	return t.sizes[idx], true
+}
+
+// TrimLeft discards entries for blocks <= upToBlock, advancing startBlock.
+func (t *OutboxSizeTracker) TrimLeft(upToBlock uint64) {
+	if upToBlock < t.startBlock {
+		return
+	}
+	trimCount := min(uint64(len(t.sizes)), upToBlock-t.startBlock+1)
+	t.sizes = t.sizes[trimCount:]
+	t.startBlock = upToBlock + 1
+}
+
+// TrimRight discards entries for blocks >= fromBlock.
+func (t *OutboxSizeTracker) TrimRight(fromBlock uint64) {
+	if fromBlock <= t.startBlock {
+		t.startBlock = fromBlock
+		t.sizes = nil
+		return
+	}
+	keepCount := fromBlock - t.startBlock
+	if keepCount < uint64(len(t.sizes)) {
+		t.sizes = t.sizes[:keepCount]
+	}
+}
+
+// Reset discards all tracked state and reinitializes from the given block.
+// Called when corruption is detected (e.g., negative outbox size).
+func (t *OutboxSizeTracker) Reset(startBlock uint64, outboxSize int) {
+	t.startBlock = startBlock
+	t.sizes = []int{outboxSize}
+}
+
+// TrimToFinalized calls the stored finalization callback to get the current
+// finalized block number, then trims entries for finalized blocks.
+func (t *OutboxSizeTracker) TrimToFinalized() {
+	if t.getFinalizedBlock == nil {
+		return
+	}
+	finalizedBlock, err := t.getFinalizedBlock()
+	if err != nil {
+		log.Debug("OutboxSizeTracker: failed to get finalized block", "err", err)
+		return
+	}
+	if finalizedBlock > 0 {
+		t.TrimLeft(finalizedBlock)
+	}
+}

--- a/arbnode/mel/runner/outbox_size_tracker_test.go
+++ b/arbnode/mel/runner/outbox_size_tracker_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+package melrunner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutboxSizeTracker_RecordAndLookup(t *testing.T) {
+	t.Parallel()
+	tracker := NewOutboxSizeTracker(100, 5, nil)
+
+	// Initial entry
+	val, ok := tracker.Lookup(100)
+	require.True(t, ok)
+	require.Equal(t, 5, val)
+
+	// Record sequential blocks
+	tracker.Record(101, 5)
+	tracker.Record(102, 8) // pour happened
+	tracker.Record(103, 7) // pop happened
+
+	val, ok = tracker.Lookup(101)
+	require.True(t, ok)
+	require.Equal(t, 5, val)
+
+	val, ok = tracker.Lookup(102)
+	require.True(t, ok)
+	require.Equal(t, 8, val)
+
+	val, ok = tracker.Lookup(103)
+	require.True(t, ok)
+	require.Equal(t, 7, val)
+
+	// Out of range lookups
+	_, ok = tracker.Lookup(99)
+	require.False(t, ok)
+	_, ok = tracker.Lookup(104)
+	require.False(t, ok)
+}
+
+func TestOutboxSizeTracker_NonSequentialRecord(t *testing.T) {
+	t.Parallel()
+	tracker := NewOutboxSizeTracker(100, 5, nil)
+	tracker.Record(101, 6)
+
+	// Non-sequential record resets
+	tracker.Record(200, 10)
+
+	_, ok := tracker.Lookup(100)
+	require.False(t, ok)
+	_, ok = tracker.Lookup(101)
+	require.False(t, ok)
+
+	val, ok := tracker.Lookup(200)
+	require.True(t, ok)
+	require.Equal(t, 10, val)
+}
+
+func TestOutboxSizeTracker_TrimLeft(t *testing.T) {
+	t.Parallel()
+	tracker := NewOutboxSizeTracker(100, 0, nil)
+	for i := uint64(101); i <= 110; i++ {
+		// #nosec G115
+		tracker.Record(i, int(i-100))
+	}
+
+	// Trim up to block 105
+	tracker.TrimLeft(105)
+
+	_, ok := tracker.Lookup(105)
+	require.False(t, ok)
+
+	val, ok := tracker.Lookup(106)
+	require.True(t, ok)
+	require.Equal(t, 6, val)
+
+	val, ok = tracker.Lookup(110)
+	require.True(t, ok)
+	require.Equal(t, 10, val)
+}
+
+func TestOutboxSizeTracker_TrimLeft_BeyondAll(t *testing.T) {
+	t.Parallel()
+	tracker := NewOutboxSizeTracker(100, 5, nil)
+	tracker.Record(101, 6)
+
+	// Trim beyond all entries — sizes becomes empty
+	tracker.TrimLeft(200)
+
+	_, ok := tracker.Lookup(100)
+	require.False(t, ok)
+	_, ok = tracker.Lookup(101)
+	require.False(t, ok)
+}
+
+func TestOutboxSizeTracker_TrimRight(t *testing.T) {
+	t.Parallel()
+	tracker := NewOutboxSizeTracker(100, 0, nil)
+	for i := uint64(101); i <= 110; i++ {
+		// #nosec G115
+		tracker.Record(i, int(i-100))
+	}
+
+	// Trim from block 108 onwards
+	tracker.TrimRight(108)
+
+	val, ok := tracker.Lookup(107)
+	require.True(t, ok)
+	require.Equal(t, 7, val)
+
+	_, ok = tracker.Lookup(108)
+	require.False(t, ok)
+	_, ok = tracker.Lookup(110)
+	require.False(t, ok)
+}
+
+func TestOutboxSizeTracker_TrimRight_AtStart(t *testing.T) {
+	t.Parallel()
+	tracker := NewOutboxSizeTracker(100, 5, nil)
+	tracker.Record(101, 6)
+	tracker.Record(102, 7)
+
+	// Trim at startBlock empties the array
+	tracker.TrimRight(100)
+
+	_, ok := tracker.Lookup(100)
+	require.False(t, ok)
+	_, ok = tracker.Lookup(101)
+	require.False(t, ok)
+}
+
+func TestOutboxSizeTracker_Reset(t *testing.T) {
+	t.Parallel()
+	tracker := NewOutboxSizeTracker(100, 5, nil)
+	tracker.Record(101, 6)
+	tracker.Record(102, 7)
+
+	tracker.Reset(200, 42)
+
+	_, ok := tracker.Lookup(100)
+	require.False(t, ok)
+
+	val, ok := tracker.Lookup(200)
+	require.True(t, ok)
+	require.Equal(t, 42, val)
+}
+
+func TestOutboxSizeTracker_TrimToFinalized(t *testing.T) {
+	t.Parallel()
+	finalizedBlock := uint64(100)
+	tracker := NewOutboxSizeTracker(95, 0, func() (uint64, error) {
+		return finalizedBlock, nil
+	})
+	for i := uint64(96); i <= 110; i++ {
+		// #nosec G115
+		tracker.Record(i, int(i-95))
+	}
+
+	tracker.TrimToFinalized()
+
+	_, ok := tracker.Lookup(100)
+	require.False(t, ok)
+
+	val, ok := tracker.Lookup(101)
+	require.True(t, ok)
+	require.Equal(t, 6, val)
+}
+
+func TestOutboxSizeTracker_NegativeValues(t *testing.T) {
+	t.Parallel()
+	tracker := NewOutboxSizeTracker(100, -1, nil)
+
+	val, ok := tracker.Lookup(100)
+	require.True(t, ok)
+	require.Equal(t, -1, val)
+}

--- a/arbnode/mel/runner/process_next_block.go
+++ b/arbnode/mel/runner/process_next_block.go
@@ -71,7 +71,7 @@ func (m *MessageExtractor) processNextBlock(ctx context.Context, current *fsm.Cu
 	}
 	// Reorging of MEL states successfully completed, we can now rewind MEL validator and rebuild delayedMsgPreimages based on inbox and outbox accumulators
 	if processAction.prevStepWasReorg {
-		if err := preState.RebuildDelayedMsgPreimages(m.melDB.FetchDelayedMessage); err != nil {
+		if err := m.rebuildDelayedMsgPreimagesWithTracker(preState); err != nil {
 			return m.config.RetryInterval, fmt.Errorf("error rebuilding delayed msg preimages after reorg: %w", err)
 		}
 		if m.reorgEventsNotifier != nil {
@@ -94,8 +94,8 @@ func (m *MessageExtractor) processNextBlock(ctx context.Context, current *fsm.Cu
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), mel.ErrDelayedMessagePreimageNotFound.Error()) {
-			if err := preState.RebuildDelayedMsgPreimages(m.melDB.FetchDelayedMessage); err != nil {
-				return m.config.RetryInterval, fmt.Errorf("error rebuilding delayed msg preimages when missing some preimages: %w", err)
+			if rebuildErr := m.rebuildDelayedMsgPreimagesWithTracker(preState); rebuildErr != nil {
+				return m.config.RetryInterval, fmt.Errorf("error rebuilding delayed msg preimages when missing some preimages: %w", rebuildErr)
 			}
 		}
 		return m.config.RetryInterval, err
@@ -108,4 +108,29 @@ func (m *MessageExtractor) processNextBlock(ctx context.Context, current *fsm.Cu
 		delayedMessages:  delayedMsgs,
 		batchMetas:       batchMetas,
 	})
+}
+
+// rebuildDelayedMsgPreimagesWithTracker attempts to use the outbox size tracker
+// for an O(1) pivot lookup. Falls back to O(N²) findPivot if the tracker doesn't
+// have the entry or if corruption is detected, and resets the tracker accordingly.
+func (m *MessageExtractor) rebuildDelayedMsgPreimagesWithTracker(state *mel.State) error {
+	if m.outboxTracker == nil {
+		return state.RebuildDelayedMsgPreimages(m.melDB.FetchDelayedMessage)
+	}
+	fullRebuildAndTrackerReset := func() error {
+		if err := state.RebuildDelayedMsgPreimages(m.melDB.FetchDelayedMessage); err != nil {
+			return err
+		}
+		m.outboxTracker.Reset(state.ParentChainBlockNumber, state.OutboxSize())
+		return nil
+	}
+	outboxSize, ok := m.outboxTracker.Lookup(state.ParentChainBlockNumber)
+	// Corruption or Tracker miss: reset tracker with fresh O(N²) rebuild
+	if outboxSize < 0 || !ok {
+		return fullRebuildAndTrackerReset()
+	}
+	if err := state.RebuildDelayedMsgPreimages(m.melDB.FetchDelayedMessage, outboxSize); err != nil {
+		return fullRebuildAndTrackerReset()
+	}
+	return nil
 }

--- a/arbnode/mel/runner/reorg.go
+++ b/arbnode/mel/runner/reorg.go
@@ -24,6 +24,9 @@ func (m *MessageExtractor) reorg(ctx context.Context, current *fsm.CurrentState[
 	if err != nil {
 		return m.config.RetryInterval, err
 	}
+	if m.outboxTracker != nil {
+		m.outboxTracker.TrimRight(currentDirtyState.ParentChainBlockNumber)
+	}
 	m.logsAndHeadersPreFetcher.reset()
 	return 0, m.fsm.Do(processNextBlock{
 		prevStepWasReorg: true,

--- a/arbnode/mel/runner/save_messages.go
+++ b/arbnode/mel/runner/save_messages.go
@@ -31,6 +31,20 @@ func (m *MessageExtractor) saveMessages(ctx context.Context, current *fsm.Curren
 		log.Error("Error saving latest state as head state to db", "err", err)
 		return m.config.RetryInterval, err
 	}
+	if m.outboxTracker != nil {
+		outboxSize := saveAction.postState.OutboxSize()
+		if outboxSize < 0 {
+			log.Warn("Negative outbox size detected, resetting tracker",
+				"block", saveAction.postState.ParentChainBlockNumber, "outboxSize", outboxSize)
+			if err := saveAction.postState.RebuildDelayedMsgPreimages(m.melDB.FetchDelayedMessage); err != nil {
+				log.Error("Error rebuilding delayed msg preimages after negative outbox size", "err", err)
+			}
+			m.outboxTracker.Reset(saveAction.postState.ParentChainBlockNumber, saveAction.postState.OutboxSize())
+		} else {
+			m.outboxTracker.Record(saveAction.postState.ParentChainBlockNumber, outboxSize)
+		}
+		m.outboxTracker.TrimToFinalized()
+	}
 	return 0, m.fsm.Do(processNextBlock{
 		melState: saveAction.postState,
 	})

--- a/arbnode/mel/state.go
+++ b/arbnode/mel/state.go
@@ -57,6 +57,11 @@ type State struct {
 	// accumulated and read in the same block, so it may not be in the DB yet
 	// when ReadDelayedMessage is called in native mode.
 	initMsg *DelayedInboxMessage
+
+	// outboxSize tracks the number of unread messages currently in the outbox.
+	// This is transient (not RLP-serialized) and maintained during pour/pop.
+	// A negative value signals corruption in the tracker.
+	outboxSize int
 }
 
 // MessageConsumer is an interface to be implemented by readers of MEL such as transaction streamer of the nitro node
@@ -69,6 +74,7 @@ type MessageConsumer interface {
 }
 
 func (s *State) InitMsg() *DelayedInboxMessage { return s.initMsg }
+func (s *State) OutboxSize() int               { return s.outboxSize }
 
 func (s *State) Hash() common.Hash {
 	encoded, err := rlp.EncodeToBytes(s)
@@ -115,6 +121,7 @@ func (s *State) Clone() *State {
 		delayedMsgPreimagesDest: s.delayedMsgPreimagesDest,
 		delayedMsgPreimages:     s.delayedMsgPreimages,
 		initMsg:                 s.initMsg,
+		outboxSize:              s.outboxSize,
 	}
 }
 
@@ -231,6 +238,8 @@ func (s *State) PourDelayedInboxToOutbox() error {
 	}
 	// Inbox is now empty
 	s.DelayedMessageInboxAcc = common.Hash{}
+	// #nosec G115
+	s.outboxSize += int(inboxSize)
 	return nil
 }
 
@@ -254,6 +263,7 @@ func (s *State) PopDelayedOutbox() (common.Hash, error) {
 		return common.Hash{}, fmt.Errorf("outbox preimage: %w", err)
 	}
 	s.DelayedMessageOutboxAcc = prevOutbox
+	s.outboxSize--
 	return msgHash, nil
 }
 
@@ -368,9 +378,9 @@ func (s *State) buildHashChain(start, end, step int, msgHashes []common.Hash, ms
 //   - Outbox [0..pivot): messages already poured, chain built in reverse order
 //   - Inbox  [pivot..N): messages not yet poured, chain built in forward order
 //
-// The pivot is found via an O(N²) search that tries each candidate partition
-// until the recomputed inbox accumulator matches.
-func (s *State) RebuildDelayedMsgPreimages(fetchDelayedMsg func(index uint64) (*DelayedInboxMessage, error)) error {
+// If knownOutboxSize is provided and non-negative, it is used as the pivot
+// directly (O(1)). Otherwise, the pivot is found via an O(N²) search.
+func (s *State) RebuildDelayedMsgPreimages(fetchDelayedMsg func(index uint64) (*DelayedInboxMessage, error), knownOutboxSize ...int) error {
 	if s.DelayedMessagesRead == s.DelayedMessagesSeen {
 		return nil
 	}
@@ -381,10 +391,15 @@ func (s *State) RebuildDelayedMsgPreimages(fetchDelayedMsg func(index uint64) (*
 	if err != nil {
 		return err
 	}
-	pivot := s.findPivot(totalUnread, msgHashes)
-	if pivot < 0 {
-		return fmt.Errorf("failed to find pivot: neither outbox acc %s nor inbox acc %s matched any partition",
-			s.DelayedMessageOutboxAcc.Hex(), s.DelayedMessageInboxAcc.Hex())
+	var pivot int
+	if len(knownOutboxSize) > 0 && knownOutboxSize[0] >= 0 {
+		pivot = knownOutboxSize[0]
+	} else {
+		pivot = s.findPivot(totalUnread, msgHashes)
+		if pivot < 0 {
+			return fmt.Errorf("failed to find pivot: neither outbox acc %s nor inbox acc %s matched any partition",
+				s.DelayedMessageOutboxAcc.Hex(), s.DelayedMessageInboxAcc.Hex())
+		}
 	}
 	// Rebuild outbox chain: messages [0..pivot) in reverse order (pivot-1, pivot-2, ..., 0)
 	if pivot > 0 {
@@ -402,5 +417,6 @@ func (s *State) RebuildDelayedMsgPreimages(fetchDelayedMsg func(index uint64) (*
 			return fmt.Errorf("inbox accumulator mismatch after rebuild: got %s, want %s", acc.Hex(), s.DelayedMessageInboxAcc.Hex())
 		}
 	}
+	s.outboxSize = pivot
 	return nil
 }

--- a/arbnode/mel/state_test.go
+++ b/arbnode/mel/state_test.go
@@ -317,3 +317,96 @@ func TestRebuildThenPourAndPop_MatchesOriginal(t *testing.T) {
 
 	require.Equal(t, originalHashes[1:], rebuiltHashes)
 }
+
+func TestOutboxSizeTracking(t *testing.T) {
+	t.Parallel()
+	s := &State{}
+
+	// Accumulate 5 messages — outboxSize stays 0
+	msgs := createTestDelayedMessages(5)
+	accumulateN(t, s, msgs)
+	require.Equal(t, 0, s.OutboxSize())
+
+	// Pour — outboxSize becomes 5
+	require.NoError(t, s.PourDelayedInboxToOutbox())
+	require.Equal(t, 5, s.OutboxSize())
+
+	// Pop 2 — outboxSize becomes 3
+	for range 2 {
+		_, err := s.PopDelayedOutbox()
+		require.NoError(t, err)
+		s.DelayedMessagesRead++
+	}
+	require.Equal(t, 3, s.OutboxSize())
+
+	// Accumulate 2 more — outboxSize unchanged
+	extra := createTestDelayedMessages(2)
+	for i := range extra {
+		reqID := common.BigToHash(big.NewInt(int64(100 + i)))
+		extra[i].Message.Header.RequestId = &reqID
+		extra[i].Message.L2msg = []byte(fmt.Sprintf("extra-%d", i))
+	}
+	accumulateN(t, s, extra)
+	require.Equal(t, 3, s.OutboxSize())
+}
+
+func TestRebuildWithKnownOutboxSize(t *testing.T) {
+	t.Parallel()
+
+	// Build a mixed state: accumulate 3, pour, accumulate 2 more
+	s := &State{}
+	msgs := createTestDelayedMessages(3)
+	accumulateN(t, s, msgs)
+	require.NoError(t, s.PourDelayedInboxToOutbox())
+
+	extra := createTestDelayedMessages(2)
+	for i := range extra {
+		reqID := common.BigToHash(big.NewInt(int64(100 + i)))
+		extra[i].Message.Header.RequestId = &reqID
+		extra[i].Message.L2msg = []byte(fmt.Sprintf("extra-%d", i))
+	}
+	accumulateN(t, s, extra)
+
+	knownOutboxSize := s.OutboxSize()
+	require.Equal(t, 3, knownOutboxSize)
+
+	// Rebuild with known outbox size
+	var allMsgs []*DelayedInboxMessage
+	allMsgs = append(allMsgs, msgs...)
+	allMsgs = append(allMsgs, extra...)
+	rebuilt := &State{
+		DelayedMessagesRead:     s.DelayedMessagesRead,
+		DelayedMessagesSeen:     s.DelayedMessagesSeen,
+		DelayedMessageInboxAcc:  s.DelayedMessageInboxAcc,
+		DelayedMessageOutboxAcc: s.DelayedMessageOutboxAcc,
+	}
+	fetcher := makeFetcher(allMsgs[rebuilt.DelayedMessagesRead:], rebuilt.DelayedMessagesRead)
+	require.NoError(t, rebuilt.RebuildDelayedMsgPreimages(fetcher, knownOutboxSize))
+	require.Equal(t, knownOutboxSize, rebuilt.OutboxSize())
+
+	// Verify pops work correctly
+	for rebuilt.DelayedMessagesRead < rebuilt.DelayedMessagesSeen {
+		_, err := rebuilt.PopDelayedOutbox()
+		require.NoError(t, err)
+		rebuilt.DelayedMessagesRead++
+	}
+}
+
+func TestRebuildSetsOutboxSize(t *testing.T) {
+	t.Parallel()
+
+	// Build state with all messages in inbox (no pour)
+	s := &State{}
+	msgs := createTestDelayedMessages(4)
+	accumulateN(t, s, msgs)
+
+	rebuilt := &State{
+		DelayedMessagesRead:     s.DelayedMessagesRead,
+		DelayedMessagesSeen:     s.DelayedMessagesSeen,
+		DelayedMessageInboxAcc:  s.DelayedMessageInboxAcc,
+		DelayedMessageOutboxAcc: s.DelayedMessageOutboxAcc,
+	}
+	fetcher := makeFetcher(msgs, rebuilt.DelayedMessagesRead)
+	require.NoError(t, rebuilt.RebuildDelayedMsgPreimages(fetcher))
+	require.Equal(t, 0, rebuilt.OutboxSize()) // all in inbox, pivot = 0
+}


### PR DESCRIPTION
This PR optimizes the rebuilding of delayed msg preimages by tracking the outbox accumulator's size natively using `OutboxSizeTracker`, which tracks the outbox acc's size at each parentchain block number, meaning we don't have to recompute the pivot when `RebuildDelayedMsgPreimages` is called during Reorgs or cache misses- thus saving O(N^2) time- but this benefit is debatable as it may not be worth it as N is usually low and the added code complexity is high.

coauthored by claude