### PR TITLE
Add configurable cranelift fallback for Stylus compilation

### DIFF
--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -50,18 +50,18 @@ type bytes32 = C.Bytes32
 type rustBytes = C.RustBytes
 type rustSlice = C.RustSlice
 
-// craneliftFallback controls whether LLVM compilation failures fall back to Cranelift.
-// Set once at startup via SetCraneliftFallback; defaults to true (fallback enabled).
-var craneliftFallback atomic.Bool
+// allowFallback controls whether compilation failures fall back to an alternative compiler.
+// Set once at startup via SetAllowFallback; defaults to true (fallback enabled).
+var allowFallback atomic.Bool
 
 func init() {
-	craneliftFallback.Store(true)
+	allowFallback.Store(true)
 }
 
-// SetCraneliftFallback configures whether to fall back to Cranelift on LLVM failure.
-func SetCraneliftFallback(enabled bool) {
-	craneliftFallback.Store(enabled)
-	log.Info("Cranelift fallback for Stylus compilation configured", "enabled", enabled)
+// SetAllowFallback configures whether to fall back to an alternative compiler on failure.
+func SetAllowFallback(enabled bool) {
+	allowFallback.Store(enabled)
+	log.Info("Compiler fallback for Stylus compilation configured", "enabled", enabled)
 }
 
 var (
@@ -241,11 +241,11 @@ func activateProgramInternal(
 				timeout := time.Second * 15
 				asm, err := compileNative(wasm, stylusVersion, debug, target, cranelift, timeout)
 				if err != nil {
-					if craneliftFallback.Load() {
+					if allowFallback.Load() {
 						log.Warn("initial stylus compilation failed, falling back to cranelift", "address", addressForLogging, "cranelift", cranelift, "timeout", timeout, "err", err)
 						asm, err = compileNative(wasm, stylusVersion, debug, target, !cranelift, timeout)
 					} else {
-						log.Warn("stylus LLVM compilation failed and cranelift fallback is disabled", "address", addressForLogging, "target", target, "timeout", timeout, "err", err)
+						log.Warn("stylus compilation failed and fallback is disabled", "address", addressForLogging, "target", target, "timeout", timeout, "err", err)
 					}
 				}
 				results <- result{target, asm, err}
@@ -273,10 +273,10 @@ func activateProgramInternal(
 			"codehash", codehash,
 			"moduleHash", info.moduleHash,
 			"targets", targets,
-			"craneliftFallback", craneliftFallback.Load(),
+			"allowFallback", allowFallback.Load(),
 			"err", err,
 		)
-		panic(fmt.Sprintf("Compilation of %v failed for one or more targets despite activation succeeding (craneliftFallback=%v): %v", addressForLogging, craneliftFallback.Load(), err))
+		panic(fmt.Sprintf("Compilation of %v failed for one or more targets despite activation succeeding (allowFallback=%v): %v", addressForLogging, allowFallback.Load(), err))
 	}
 	return info, asmMap, err
 }

--- a/changelog/bragaigor-nit-4683.md
+++ b/changelog/bragaigor-nit-4683.md
@@ -1,2 +1,2 @@
 ### Configuration
-- Add `--execution.stylus-target.cranelift-fallback` flag: if true, fall back to Cranelift when LLVM compilation of a Stylus program fails (default: true).
+- Add `--execution.stylus-target.allow-fallback` flag: if true, fall back to an alternative compiler when compilation of a Stylus program fails (default: true).

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -343,7 +343,7 @@ func (s *ExecutionEngine) Initialize(rustCacheCapacityMB uint32, targetConfig *S
 		return fmt.Errorf("error populating stylus target cache: %w", err)
 	}
 	s.wasmTargets = targetConfig.WasmTargets()
-	programs.SetCraneliftFallback(targetConfig.CraneliftFallback)
+	programs.SetAllowFallback(targetConfig.AllowFallback)
 	return nil
 }
 

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -47,11 +47,11 @@ import (
 )
 
 type StylusTargetConfig struct {
-	Arm64             string   `koanf:"arm64"`
-	Amd64             string   `koanf:"amd64"`
-	Host              string   `koanf:"host"`
-	ExtraArchs        []string `koanf:"extra-archs"`
-	CraneliftFallback bool     `koanf:"cranelift-fallback"`
+	Arm64         string   `koanf:"arm64"`
+	Amd64         string   `koanf:"amd64"`
+	Host          string   `koanf:"host"`
+	ExtraArchs    []string `koanf:"extra-archs"`
+	AllowFallback bool     `koanf:"allow-fallback"`
 
 	wasmTargets []rawdb.WasmTarget
 }
@@ -84,11 +84,11 @@ func (c *StylusTargetConfig) Validate() error {
 }
 
 var DefaultStylusTargetConfig = StylusTargetConfig{
-	Arm64:             programs.DefaultTargetDescriptionArm,
-	Amd64:             programs.DefaultTargetDescriptionX86,
-	Host:              "",
-	ExtraArchs:        []string{string(rawdb.TargetWavm)},
-	CraneliftFallback: true,
+	Arm64:         programs.DefaultTargetDescriptionArm,
+	Amd64:         programs.DefaultTargetDescriptionX86,
+	Host:          "",
+	ExtraArchs:    []string{string(rawdb.TargetWavm)},
+	AllowFallback: true,
 }
 
 func StylusTargetConfigAddOptions(prefix string, f *pflag.FlagSet) {
@@ -96,7 +96,7 @@ func StylusTargetConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.String(prefix+".amd64", DefaultStylusTargetConfig.Amd64, "stylus programs compilation target for amd64 linux")
 	f.String(prefix+".host", DefaultStylusTargetConfig.Host, "stylus programs compilation target for system other than 64-bit ARM or 64-bit x86")
 	f.StringSlice(prefix+".extra-archs", DefaultStylusTargetConfig.ExtraArchs, fmt.Sprintf("Comma separated list of extra architectures to cross-compile stylus program to and cache in wasm store (additionally to local target). Currently must include at least %s. (supported targets: %s, %s, %s, %s)", rawdb.TargetWavm, rawdb.TargetWavm, rawdb.TargetArm64, rawdb.TargetAmd64, rawdb.TargetHost))
-	f.Bool(prefix+".cranelift-fallback", DefaultStylusTargetConfig.CraneliftFallback, "if true, fall back to Cranelift when LLVM compilation of a Stylus program fails")
+	f.Bool(prefix+".allow-fallback", DefaultStylusTargetConfig.AllowFallback, "if true, fall back to an alternative compiler when compilation of a Stylus program fails")
 }
 
 type TxIndexerConfig struct {

--- a/execution/gethexec/wasmstorerebuilder.go
+++ b/execution/gethexec/wasmstorerebuilder.go
@@ -70,7 +70,7 @@ func RebuildWasmStore(ctx context.Context, wasmStore ethdb.KeyValueStore, execut
 		return fmt.Errorf("error populating stylus target cache: %w", err)
 	}
 	targets := targetConfig.WasmTargets()
-	programs.SetCraneliftFallback(targetConfig.CraneliftFallback)
+	programs.SetAllowFallback(targetConfig.AllowFallback)
 
 	latestHeader := l2Blockchain.CurrentBlock()
 	arbosVersion := types.DeserializeHeaderExtraInformation(latestHeader).ArbOSFormatVersion


### PR DESCRIPTION
When LLVM compilation of a Stylus program fails, the node unconditionally retries with Cranelift. This PR makes that fallback behavior configurable via a new --node.stylus.target.cranelift-fallback flag (default: true to preserve existing behavior).

The cranelift fallback is a node-level setting, configured once at startup, that only affects a single code path: the compilation retry in `activateProgramInternal`. Rather than threading the flag through `MessageRunContext`, `BlockChain`, `HeaderChain`, `APIBackend`, and dozens of constructor callsites across both nitro and go-ethereum, this PR
  uses a package-level `atomic.Bool` in `arbos/programs` — set at initialization, read at compilation time.

This follows the existing pattern used by `SetWasmLruCacheCapacity`, which is also a node-level config set via a package-level function from `ExecutionEngine.Initialize()`.

  The global is set in two places to cover all paths to activateProgramInternal:
  - `ExecutionEngine.Initialize()` — covers runtime paths (on-chain activation, lazy recompilation)
  - `RebuildWasmStore()` — covers the wasm store rebuild path, which runs before engine initialization

closes NIT-4683