### PR TITLE
Fix TestRetryableFilteringStylusSandwichRollback flakiness - NIT-4762

### DIFF
--- a/changelog/mnasr-nit-4762.md
+++ b/changelog/mnasr-nit-4762.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed flakiness in `TestRetryableFilteringStylusSandwichRollback`.

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -1885,6 +1885,31 @@ func (s *Sequencer) StopAndWait() {
 	}
 }
 
+// SequenceTransactionsForTest sequences the given transactions in a single block,
+// using the sequencer's real preTxFilter and postTxFilter. This bypasses the
+// txQueue, guaranteeing all transactions land in the same block.
+func (s *Sequencer) SequenceTransactionsForTest(t *testing.T, txes types.Transactions) (*types.Block, []error) {
+	t.Helper()
+	hooks := MakeZeroTxSizeSequencingHooksForTesting(txes, s.preTxFilter, s.postTxFilter, nil)
+
+	s.L1BlockAndTimeMutex.Lock()
+	l1Block := s.l1BlockNumber.Load()
+	s.L1BlockAndTimeMutex.Unlock()
+
+	header := &arbostypes.L1IncomingMessageHeader{
+		Kind:        arbostypes.L1MessageType_L2Message,
+		Poster:      l1pricing.BatchPosterAddress,
+		BlockNumber: l1Block,
+		Timestamp:   arbmath.SaturatingUCast[uint64](time.Now().Unix()),
+	}
+
+	block, err := s.execEngine.SequenceTransactions(header, hooks, nil)
+	if err != nil {
+		t.Fatalf("SequenceTransactionsForTest: %v", err)
+	}
+	return block, hooks.GetTxErrors()
+}
+
 func (s *Sequencer) StoreFilterRulesForTest(t *testing.T, salt []byte, hashes []common.Hash, digest string) {
 	t.Helper()
 	if s.addressFilterService == nil {

--- a/system_tests/retryable_tickets_filtering_stylus_test.go
+++ b/system_tests/retryable_tickets_filtering_stylus_test.go
@@ -3,7 +3,6 @@ package arbtest
 import (
 	"context"
 	"math/big"
-	"sync"
 	"testing"
 	"time"
 
@@ -28,8 +27,8 @@ func deployStylusStorageContract(
 
 // TestRetryableFilteringStylusSandwichRollback verifies that a group rollback
 // of a Stylus redeem chain does not affect neighboring transactions in the same
-// block. Three L2 transactions are forced into one block via sequencer
-// Pause/Activate:
+// block. Three L2 transactions are forced into one block via
+// SequenceTransactionsForTest (bypasses the sequencer queue):
 //   - TX1: writes keyBefore to multicall's storage
 //   - TX2: manual redeem that triggers a Stylus chain (multicall writes
 //     keyRedeem + CALLs filtered Stylus contract) → group rollback
@@ -103,43 +102,28 @@ func TestRetryableFilteringStylusSandwichRollback(t *testing.T) {
 	tx3Args = multicallAppendStore(tx3Args, keyAfter, valueAfter, false, false)
 	tx3 := builder.L2Info.PrepareTxTo("Sender2", &multicallAddr, 1e9, nil, tx3Args)
 
-	// --- Pause sequencer, queue all 3, resume → same block ---
+	// --- Sequence all 3 txs in a single block (bypasses queue for determinism) ---
 	sequencer.Pause()
+	defer sequencer.Activate()
 
-	var wg sync.WaitGroup
-	var tx1Err, tx2Err, tx3Err error
-	wg.Add(3)
+	block, txErrors := sequencer.SequenceTransactionsForTest(
+		t, types.Transactions{tx1, tx2, tx3},
+	)
+	require.NotNil(t, block, "block should have been created")
+	require.Len(t, txErrors, 3, "should have 3 tx results")
 
-	go func() {
-		defer wg.Done()
-		tx1Err = sequencer.PublishTransaction(ctx, tx1, nil)
-	}()
-	go func() {
-		defer wg.Done()
-		tx2Err = sequencer.PublishTransaction(ctx, tx2, nil)
-	}()
-	go func() {
-		defer wg.Done()
-		tx3Err = sequencer.PublishTransaction(ctx, tx3, nil)
-	}()
-
-	sequencer.Activate()
-	wg.Wait()
-
-	require.NoError(t, tx1Err, "TX1 should have been published successfully")
-	require.NoError(t, tx3Err, "TX3 should have been published successfully")
+	require.NoError(t, txErrors[0], "TX1 should have succeeded")
+	require.NoError(t, txErrors[2], "TX3 should have succeeded")
 
 	// TX2 should have failed (cascading redeem filtered)
-	require.Error(t, tx2Err, "redeem should have been rejected by filter")
-	require.ErrorContains(t, tx2Err, "cascading redeem filtered")
+	require.Error(t, txErrors[1], "redeem should have been rejected by filter")
+	require.ErrorContains(t, txErrors[1], "cascading redeem filtered")
 
-	// Wait for TX1 and TX3 receipts
+	// TX1 and TX3 are in the same block by construction (single SequenceTransactions call)
 	tx1Receipt, err := builder.L2.EnsureTxSucceeded(tx1)
 	require.NoError(t, err)
 	tx3Receipt, err := builder.L2.EnsureTxSucceeded(tx3)
 	require.NoError(t, err)
-
-	// Verify same block
 	require.Equal(t, tx1Receipt.BlockNumber.Uint64(), tx3Receipt.BlockNumber.Uint64(),
 		"TX1 and TX3 should be in the same block")
 


### PR DESCRIPTION
## Fix TestRetryableFilteringStylusSandwichRollback flakiness
### Summary                                                                                                                                                                       
  - Add `SequenceTransactionsForTest` to sequence transactions directly in a single block, bypassing the sequencer queue                                                           
  - Replace the racy `Pause`/`Activate` goroutine pattern in `TestRetryableFilteringStylusSandwichRollback` with the new helper                                                    
                                                                                                                                                                                   
  Fixes NIT-4762  