### PR TITLE
Various refactors and test hardening

### DIFF
--- a/arbnode/db/schema/schema.go
+++ b/arbnode/db/schema/schema.go
@@ -15,17 +15,20 @@ var (
 	SequencerBatchMetaPrefix            []byte = []byte("s") // maps a batch sequence number to BatchMetadata
 	DelayedSequencedPrefix              []byte = []byte("a") // maps a delayed message count to the first sequencer batch sequence number with this delayed count
 	MelStatePrefix                      []byte = []byte("l") // maps a parent chain block number to its computed MEL state
-	MelDelayedMessagePrefix             []byte = []byte("y") // maps a delayed sequence number to an accumulator and an RLP encoded message [TODO(NIT-4209): might need to replace or be replaced by RlpDelayedMessagePrefix]
-	MelSequencerBatchMetaPrefix         []byte = []byte("q") // maps a batch sequence number to BatchMetadata [TODO(NIT-4209): might need to replace or be replaced by SequencerBatchMetaPrefix]
+	MelDelayedMessagePrefix             []byte = []byte("y") // maps a delayed sequence number to an RLP-encoded DelayedInboxMessage (coexists with RlpDelayedMessagePrefix for legacy data below the initial MEL boundary)
+	MelSequencerBatchMetaPrefix         []byte = []byte("q") // maps a batch sequence number to BatchMetadata (coexists with SequencerBatchMetaPrefix for legacy data below the initial MEL boundary)
 
-	MessageCountKey             []byte = []byte("_messageCount")                // contains the current message count
-	LastPrunedMessageKey        []byte = []byte("_lastPrunedMessageKey")        // contains the last pruned message key
-	LastPrunedDelayedMessageKey []byte = []byte("_lastPrunedDelayedMessageKey") // contains the last pruned RLP delayed message key
-	DelayedMessageCountKey      []byte = []byte("_delayedMessageCount")         // contains the current delayed message count
-	SequencerBatchCountKey      []byte = []byte("_sequencerBatchCount")         // contains the current sequencer message count
-	DbSchemaVersion             []byte = []byte("_schemaVersion")               // contains a uint64 representing the database schema version
-	HeadMelStateBlockNumKey     []byte = []byte("_headMelStateBlockNum")        // contains the latest computed MEL state's parent chain block number
-	InitialMelStateBlockNumKey  []byte = []byte("_initialMelStateBlockNum")     // contains the initial MEL state's parent chain block number (legacy/MEL boundary)
+	MessageCountKey                     []byte = []byte("_messageCount")                        // contains the current message count
+	LastPrunedMessageKey                []byte = []byte("_lastPrunedMessageKey")                // contains the last pruned message key
+	LastPrunedDelayedMessageKey         []byte = []byte("_lastPrunedDelayedMessageKey")         // contains the last pruned RLP delayed message key
+	LastPrunedLegacyDelayedMessageKey   []byte = []byte("_lastPrunedLegacyDelayedMessageKey")   // contains the last pruned legacy delayed message key
+	LastPrunedMelDelayedMessageKey      []byte = []byte("_lastPrunedMelDelayedMessageKey")      // contains the last pruned MEL delayed message key
+	LastPrunedParentChainBlockNumberKey []byte = []byte("_lastPrunedParentChainBlockNumberKey") // contains the last pruned parent chain block number key
+	DelayedMessageCountKey              []byte = []byte("_delayedMessageCount")                 // contains the current delayed message count
+	SequencerBatchCountKey              []byte = []byte("_sequencerBatchCount")                 // contains the current sequencer message count
+	DbSchemaVersion                     []byte = []byte("_schemaVersion")                       // contains a uint64 representing the database schema version
+	HeadMelStateBlockNumKey             []byte = []byte("_headMelStateBlockNum")                // contains the latest computed MEL state's parent chain block number
+	InitialMelStateBlockNumKey          []byte = []byte("_initialMelStateBlockNum")             // contains the initial MEL state's parent chain block number (legacy/MEL boundary)
 )
 
 const CurrentDbSchemaVersion uint64 = 2

--- a/arbnode/db/schema/schema_test.go
+++ b/arbnode/db/schema/schema_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+package schema
+
+import (
+	"testing"
+)
+
+func TestPrefixUniqueness(t *testing.T) {
+	// All single-byte DB key prefixes must be unique to prevent data corruption.
+	prefixes := []struct {
+		name  string
+		value []byte
+	}{
+		{"MessagePrefix", MessagePrefix},
+		{"BlockHashInputFeedPrefix", BlockHashInputFeedPrefix},
+		{"BlockMetadataInputFeedPrefix", BlockMetadataInputFeedPrefix},
+		{"MissingBlockMetadataInputFeedPrefix", MissingBlockMetadataInputFeedPrefix},
+		{"MessageResultPrefix", MessageResultPrefix},
+		{"LegacyDelayedMessagePrefix", LegacyDelayedMessagePrefix},
+		{"RlpDelayedMessagePrefix", RlpDelayedMessagePrefix},
+		{"ParentChainBlockNumberPrefix", ParentChainBlockNumberPrefix},
+		{"SequencerBatchMetaPrefix", SequencerBatchMetaPrefix},
+		{"DelayedSequencedPrefix", DelayedSequencedPrefix},
+		{"MelStatePrefix", MelStatePrefix},
+		{"MelDelayedMessagePrefix", MelDelayedMessagePrefix},
+		{"MelSequencerBatchMetaPrefix", MelSequencerBatchMetaPrefix},
+	}
+	seen := make(map[string]string) // prefix string → variable name
+	for _, p := range prefixes {
+		key := string(p.value)
+		if existing, ok := seen[key]; ok {
+			t.Fatalf("prefix collision: %s and %s both use %q", existing, p.name, key)
+		}
+		seen[key] = p.name
+	}
+
+	keys := []struct {
+		name  string
+		value []byte
+	}{
+		{"MessageCountKey", MessageCountKey},
+		{"LastPrunedMessageKey", LastPrunedMessageKey},
+		{"LastPrunedDelayedMessageKey", LastPrunedDelayedMessageKey},
+		{"LastPrunedLegacyDelayedMessageKey", LastPrunedLegacyDelayedMessageKey},
+		{"LastPrunedMelDelayedMessageKey", LastPrunedMelDelayedMessageKey},
+		{"LastPrunedParentChainBlockNumberKey", LastPrunedParentChainBlockNumberKey},
+		{"DelayedMessageCountKey", DelayedMessageCountKey},
+		{"SequencerBatchCountKey", SequencerBatchCountKey},
+		{"DbSchemaVersion", DbSchemaVersion},
+		{"HeadMelStateBlockNumKey", HeadMelStateBlockNumKey},
+		{"InitialMelStateBlockNumKey", InitialMelStateBlockNumKey},
+	}
+	seenKeys := make(map[string]string)
+	for _, k := range keys {
+		key := string(k.value)
+		if existing, ok := seenKeys[key]; ok {
+			t.Fatalf("key collision: %s and %s both use %q", existing, k.name, key)
+		}
+		seenKeys[key] = k.name
+	}
+}

--- a/arbnode/delayed_seq_reorg_test.go
+++ b/arbnode/delayed_seq_reorg_test.go
@@ -6,15 +6,26 @@ package arbnode
 import (
 	"context"
 	"encoding/binary"
+	"errors"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
 
 	"github.com/offchainlabs/nitro/arbnode/mel"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 )
+
+func requireAfterInboxAcc(t *testing.T, m *mel.DelayedInboxMessage) common.Hash {
+	t.Helper()
+	acc, err := m.AfterInboxAcc()
+	Require(t, err)
+	return acc
+}
 
 func TestSequencerReorgFromDelayed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -39,7 +50,7 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 	delayedRequestId := common.BigToHash(common.Big1)
 	userDelayed := &mel.DelayedInboxMessage{
 		BlockHash:      [32]byte{},
-		BeforeInboxAcc: initMsgDelayed.AfterInboxAcc(),
+		BeforeInboxAcc: requireAfterInboxAcc(t, initMsgDelayed),
 		Message: &arbostypes.L1IncomingMessage{
 			Header: &arbostypes.L1IncomingMessageHeader{
 				Kind:        arbostypes.L1MessageType_EndOfBlock,
@@ -54,7 +65,7 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 	delayedRequestId2 := common.BigToHash(common.Big2)
 	userDelayed2 := &mel.DelayedInboxMessage{
 		BlockHash:      [32]byte{},
-		BeforeInboxAcc: userDelayed.AfterInboxAcc(),
+		BeforeInboxAcc: requireAfterInboxAcc(t, userDelayed),
 		Message: &arbostypes.L1IncomingMessage{
 			Header: &arbostypes.L1IncomingMessageHeader{
 				Kind:        arbostypes.L1MessageType_EndOfBlock,
@@ -77,7 +88,7 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 		SequenceNumber:         0,
 		BeforeInboxAcc:         [32]byte{},
 		AfterInboxAcc:          [32]byte{1},
-		AfterDelayedAcc:        initMsgDelayed.AfterInboxAcc(),
+		AfterDelayedAcc:        requireAfterInboxAcc(t, initMsgDelayed),
 		AfterDelayedCount:      1,
 		TimeBounds:             bridgegen.IBridgeTimeBounds{},
 		RawLog:                 types.Log{},
@@ -93,7 +104,7 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 		SequenceNumber:         1,
 		BeforeInboxAcc:         [32]byte{1},
 		AfterInboxAcc:          [32]byte{2},
-		AfterDelayedAcc:        userDelayed2.AfterInboxAcc(),
+		AfterDelayedAcc:        requireAfterInboxAcc(t, userDelayed2),
 		AfterDelayedCount:      3,
 		TimeBounds:             bridgegen.IBridgeTimeBounds{},
 		RawLog:                 types.Log{},
@@ -107,7 +118,7 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 		SequenceNumber:         2,
 		BeforeInboxAcc:         [32]byte{2},
 		AfterInboxAcc:          [32]byte{3},
-		AfterDelayedAcc:        userDelayed2.AfterInboxAcc(),
+		AfterDelayedAcc:        requireAfterInboxAcc(t, userDelayed2),
 		AfterDelayedCount:      3,
 		TimeBounds:             bridgegen.IBridgeTimeBounds{},
 		RawLog:                 types.Log{},
@@ -139,7 +150,7 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 	// By modifying the timestamp of the userDelayed message, and adding it again, we cause a reorg
 	userDelayedModified := &mel.DelayedInboxMessage{
 		BlockHash:      [32]byte{},
-		BeforeInboxAcc: initMsgDelayed.AfterInboxAcc(),
+		BeforeInboxAcc: requireAfterInboxAcc(t, initMsgDelayed),
 		Message: &arbostypes.L1IncomingMessage{
 			Header: &arbostypes.L1IncomingMessageHeader{
 				Kind:        arbostypes.L1MessageType_EndOfBlock,
@@ -193,7 +204,7 @@ func TestSequencerReorgFromDelayed(t *testing.T) {
 		SequenceNumber:         1,
 		BeforeInboxAcc:         [32]byte{1},
 		AfterInboxAcc:          [32]byte{2},
-		AfterDelayedAcc:        initMsgDelayed.AfterInboxAcc(),
+		AfterDelayedAcc:        requireAfterInboxAcc(t, initMsgDelayed),
 		AfterDelayedCount:      1,
 		TimeBounds:             bridgegen.IBridgeTimeBounds{},
 		RawLog:                 types.Log{},
@@ -240,7 +251,7 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 	delayedRequestId := common.BigToHash(common.Big1)
 	userDelayed := &mel.DelayedInboxMessage{
 		BlockHash:      [32]byte{},
-		BeforeInboxAcc: initMsgDelayed.AfterInboxAcc(),
+		BeforeInboxAcc: requireAfterInboxAcc(t, initMsgDelayed),
 		Message: &arbostypes.L1IncomingMessage{
 			Header: &arbostypes.L1IncomingMessageHeader{
 				Kind:        arbostypes.L1MessageType_EndOfBlock,
@@ -255,7 +266,7 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 	delayedRequestId2 := common.BigToHash(common.Big2)
 	userDelayed2 := &mel.DelayedInboxMessage{
 		BlockHash:      [32]byte{},
-		BeforeInboxAcc: userDelayed.AfterInboxAcc(),
+		BeforeInboxAcc: requireAfterInboxAcc(t, userDelayed),
 		Message: &arbostypes.L1IncomingMessage{
 			Header: &arbostypes.L1IncomingMessageHeader{
 				Kind:        arbostypes.L1MessageType_EndOfBlock,
@@ -278,7 +289,7 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 		SequenceNumber:         0,
 		BeforeInboxAcc:         [32]byte{},
 		AfterInboxAcc:          [32]byte{1},
-		AfterDelayedAcc:        initMsgDelayed.AfterInboxAcc(),
+		AfterDelayedAcc:        requireAfterInboxAcc(t, initMsgDelayed),
 		AfterDelayedCount:      1,
 		TimeBounds:             bridgegen.IBridgeTimeBounds{},
 		RawLog:                 types.Log{},
@@ -294,7 +305,7 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 		SequenceNumber:         1,
 		BeforeInboxAcc:         [32]byte{1},
 		AfterInboxAcc:          [32]byte{2},
-		AfterDelayedAcc:        userDelayed2.AfterInboxAcc(),
+		AfterDelayedAcc:        requireAfterInboxAcc(t, userDelayed2),
 		AfterDelayedCount:      3,
 		TimeBounds:             bridgegen.IBridgeTimeBounds{},
 		RawLog:                 types.Log{},
@@ -308,7 +319,7 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 		SequenceNumber:         2,
 		BeforeInboxAcc:         [32]byte{2},
 		AfterInboxAcc:          [32]byte{3},
-		AfterDelayedAcc:        userDelayed2.AfterInboxAcc(),
+		AfterDelayedAcc:        requireAfterInboxAcc(t, userDelayed2),
 		AfterDelayedCount:      3,
 		TimeBounds:             bridgegen.IBridgeTimeBounds{},
 		RawLog:                 types.Log{},
@@ -341,7 +352,7 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 	delayedRequestId3 := common.BigToHash(common.Big3)
 	userDelayed3 := &mel.DelayedInboxMessage{
 		BlockHash:      [32]byte{},
-		BeforeInboxAcc: userDelayed2.AfterInboxAcc(),
+		BeforeInboxAcc: requireAfterInboxAcc(t, userDelayed2),
 		Message: &arbostypes.L1IncomingMessage{
 			Header: &arbostypes.L1IncomingMessageHeader{
 				Kind:        arbostypes.L1MessageType_EndOfBlock,
@@ -371,7 +382,7 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 	// By modifying the timestamp of the userDelayed2 message, and adding it again, we cause a reorg
 	userDelayed2Modified := &mel.DelayedInboxMessage{
 		BlockHash:      [32]byte{},
-		BeforeInboxAcc: userDelayed.AfterInboxAcc(),
+		BeforeInboxAcc: requireAfterInboxAcc(t, userDelayed),
 		Message: &arbostypes.L1IncomingMessage{
 			Header: &arbostypes.L1IncomingMessageHeader{
 				Kind:        arbostypes.L1MessageType_EndOfBlock,
@@ -423,7 +434,7 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 		SequenceNumber:         1,
 		BeforeInboxAcc:         [32]byte{1},
 		AfterInboxAcc:          [32]byte{2},
-		AfterDelayedAcc:        initMsgDelayed.AfterInboxAcc(),
+		AfterDelayedAcc:        requireAfterInboxAcc(t, initMsgDelayed),
 		AfterDelayedCount:      1,
 		TimeBounds:             bridgegen.IBridgeTimeBounds{},
 		RawLog:                 types.Log{},
@@ -445,4 +456,269 @@ func TestSequencerReorgFromLastDelayedMsg(t *testing.T) {
 	if batchCount != 2 {
 		Fail(t, "Unexpected tracker batch count", batchCount, "(expected 2)")
 	}
+}
+
+// mismatchTestFixture holds the shared state for delayed-mismatch tests.
+type mismatchTestFixture struct {
+	ctx           context.Context
+	tracker       *InboxTracker
+	initDelayed   *mel.DelayedInboxMessage
+	userDelayed   *mel.DelayedInboxMessage
+	mismatchBatch *mel.SequencerInboxBatch
+}
+
+// newMismatchTestFixture creates a tracker with one init delayed message
+// committed to the DB (delayed count = 1) and prepares a second delayed
+// message and a batch whose AfterDelayedAcc is intentionally wrong.
+func newMismatchTestFixture(t *testing.T, ctx context.Context) *mismatchTestFixture {
+	t.Helper()
+	exec, streamer, db, _ := NewTransactionStreamerForTest(t, ctx, common.Address{})
+	tracker, err := NewInboxTracker(db, streamer, nil)
+	Require(t, err)
+
+	err = streamer.Start(ctx)
+	Require(t, err)
+	err = exec.Start(ctx)
+	Require(t, err)
+	init, err := streamer.GetMessage(0)
+	Require(t, err)
+
+	initDelayed := &mel.DelayedInboxMessage{
+		BlockHash:      [32]byte{},
+		BeforeInboxAcc: [32]byte{},
+		Message:        init.Message,
+	}
+	delayedRequestId := common.BigToHash(common.Big1)
+	userDelayed := &mel.DelayedInboxMessage{
+		BlockHash:      [32]byte{},
+		BeforeInboxAcc: requireAfterInboxAcc(t, initDelayed),
+		Message: &arbostypes.L1IncomingMessage{
+			Header: &arbostypes.L1IncomingMessageHeader{
+				Kind:        arbostypes.L1MessageType_EndOfBlock,
+				Poster:      [20]byte{},
+				BlockNumber: 0,
+				Timestamp:   0,
+				RequestId:   &delayedRequestId,
+				L1BaseFee:   common.Big0,
+			},
+		},
+	}
+
+	err = tracker.AddDelayedMessages([]*mel.DelayedInboxMessage{initDelayed})
+	Require(t, err)
+
+	serializedBatch := make([]byte, 40)
+	binary.BigEndian.PutUint64(serializedBatch[32:], 1)
+	mismatchBatch := &mel.SequencerInboxBatch{
+		BlockHash:              [32]byte{},
+		ParentChainBlockNumber: 0,
+		SequenceNumber:         0,
+		BeforeInboxAcc:         [32]byte{},
+		AfterInboxAcc:          [32]byte{1},
+		AfterDelayedAcc:        common.Hash{0xff}, // wrong accumulator
+		AfterDelayedCount:      2,
+		TimeBounds:             bridgegen.IBridgeTimeBounds{},
+		RawLog:                 types.Log{},
+		DataLocation:           0,
+		BridgeAddress:          [20]byte{},
+		Serialized:             serializedBatch,
+	}
+
+	return &mismatchTestFixture{
+		ctx:           ctx,
+		tracker:       tracker,
+		initDelayed:   initDelayed,
+		userDelayed:   userDelayed,
+		mismatchBatch: mismatchBatch,
+	}
+}
+
+// TestDelayedMismatchRollsBackDelayedMessages verifies that addMessages rolls
+// back delayed messages when AddSequencerBatches fails with a delayed
+// accumulator mismatch. Without the rollback, delayed messages would be
+// committed to the DB without corresponding batches.
+func TestDelayedMismatchRollsBackDelayedMessages(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newMismatchTestFixture(t, ctx)
+
+	// addMessages should roll back delayed messages on mismatch
+	reader := &InboxReader{tracker: f.tracker}
+	delayedMismatch, err := reader.addMessages(
+		ctx,
+		[]*mel.SequencerInboxBatch{f.mismatchBatch},
+		[]*mel.DelayedInboxMessage{f.userDelayed},
+	)
+	Require(t, err)
+	if !delayedMismatch {
+		Fail(t, "Expected delayedMismatch to be true")
+	}
+
+	// Delayed count should be rolled back to 1 (the init message only).
+	// Before the fix, this would be 2 — an orphaned delayed message.
+	delayedCount, err := f.tracker.GetDelayedCount()
+	Require(t, err)
+	if delayedCount != 1 {
+		Fail(t, "Delayed count not rolled back after mismatch", delayedCount, "(expected 1)")
+	}
+}
+
+// TestDelayedMismatchNoOpRollback verifies that addMessages handles a mismatch
+// correctly even when no new delayed messages were provided. The rollback
+// should be a no-op (rolling back to the current count) without errors.
+func TestDelayedMismatchNoOpRollback(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newMismatchTestFixture(t, ctx)
+
+	reader := &InboxReader{tracker: f.tracker}
+	delayedMismatch, err := reader.addMessages(
+		ctx,
+		[]*mel.SequencerInboxBatch{f.mismatchBatch},
+		nil, // no new delayed messages
+	)
+	Require(t, err)
+	if !delayedMismatch {
+		Fail(t, "Expected delayedMismatch to be true")
+	}
+
+	// Count should remain 1 (init message only, no rollback needed).
+	delayedCount, err := f.tracker.GetDelayedCount()
+	Require(t, err)
+	if delayedCount != 1 {
+		Fail(t, "Delayed count changed unexpectedly", delayedCount, "(expected 1)")
+	}
+}
+
+// TestDelayedMismatchAtTrackerLevel verifies that calling AddDelayedMessages
+// then AddSequencerBatches with a mismatched accumulator returns
+// delayedMessagesMismatch and leaves delayed messages in the DB. This
+// documents the low-level behavior that addMessages must compensate for.
+func TestDelayedMismatchAtTrackerLevel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newMismatchTestFixture(t, ctx)
+
+	// Add the second delayed message — now count = 2
+	err := f.tracker.AddDelayedMessages([]*mel.DelayedInboxMessage{f.userDelayed})
+	Require(t, err)
+
+	delayedCount, err := f.tracker.GetDelayedCount()
+	Require(t, err)
+	if delayedCount != 2 {
+		Fail(t, "Unexpected delayed count", delayedCount, "(expected 2)")
+	}
+
+	// AddSequencerBatches should return delayedMessagesMismatch
+	err = f.tracker.AddSequencerBatches(ctx, nil, []*mel.SequencerInboxBatch{f.mismatchBatch})
+	if !errors.Is(err, delayedMessagesMismatch) {
+		Fail(t, "Expected delayedMessagesMismatch error, got", err)
+	}
+
+	// Delayed messages are still in the DB (AddSequencerBatches does not roll them back)
+	delayedCount, err = f.tracker.GetDelayedCount()
+	Require(t, err)
+	if delayedCount != 2 {
+		Fail(t, "Delayed messages should still be in DB", delayedCount, "(expected 2)")
+	}
+
+	// ReorgDelayedTo cleans up the orphaned messages
+	err = f.tracker.ReorgDelayedTo(1)
+	Require(t, err)
+
+	delayedCount, err = f.tracker.GetDelayedCount()
+	Require(t, err)
+	if delayedCount != 1 {
+		Fail(t, "ReorgDelayedTo did not clean up orphaned messages", delayedCount, "(expected 1)")
+	}
+}
+
+// TestAddMessages_GetDelayedCountError verifies that addMessages returns a
+// wrapped error when the initial GetDelayedCount call fails (e.g. closed DB).
+func TestAddMessages_GetDelayedCountError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newMismatchTestFixture(t, ctx)
+
+	// Close the underlying DB so that GetDelayedCount fails.
+	f.tracker.db.Close()
+
+	reader := &InboxReader{tracker: f.tracker}
+	_, err := reader.addMessages(ctx, nil, nil)
+	if err == nil {
+		Fail(t, "Expected error from addMessages when GetDelayedCount fails")
+	}
+	if !strings.Contains(err.Error(), "getting delayed message count before adding messages") {
+		Fail(t, "Expected wrapped error, got:", err)
+	}
+}
+
+// TestAddMessages_ReorgDelayedToError verifies that when addMessages detects a
+// delayed accumulator mismatch and the subsequent ReorgDelayedTo fails, the
+// returned error wraps the rollback error and includes the original mismatch.
+func TestAddMessages_ReorgDelayedToError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newMismatchTestFixture(t, ctx)
+
+	// Wrap the DB so that the second batch.Write (ReorgDelayedTo) fails.
+	// First batch.Write (AddDelayedMessages) succeeds normally.
+	injectedErr := errors.New("injected write failure")
+	f.tracker.db = &failingBatchDB{
+		Database:         f.tracker.db,
+		writesBeforeFail: 1, // allow 1 successful Write, then fail
+		writeErr:         injectedErr,
+	}
+
+	reader := &InboxReader{tracker: f.tracker}
+	_, err := reader.addMessages(
+		ctx,
+		[]*mel.SequencerInboxBatch{f.mismatchBatch},
+		[]*mel.DelayedInboxMessage{f.userDelayed},
+	)
+	if err == nil {
+		Fail(t, "Expected error when ReorgDelayedTo fails during rollback")
+	}
+	if !errors.Is(err, injectedErr) {
+		Fail(t, "Returned error should wrap the rollback error, got:", err)
+	}
+	if !strings.Contains(err.Error(), "failed to rollback delayed messages") {
+		Fail(t, "Returned error should describe rollback failure, got:", err)
+	}
+	if !strings.Contains(err.Error(), "original mismatch") {
+		Fail(t, "Returned error should include original mismatch error, got:", err)
+	}
+	if !errors.Is(err, delayedMessagesMismatch) {
+		Fail(t, "Returned error should wrap the original mismatch error, got:", err)
+	}
+}
+
+// failingBatchDB wraps an ethdb.Database and makes batch Write() calls fail
+// after a configurable number of successful writes.
+type failingBatchDB struct {
+	ethdb.Database
+	writesBeforeFail int
+	writeErr         error
+	writeCount       atomic.Int32
+}
+
+func (f *failingBatchDB) NewBatch() ethdb.Batch {
+	return &failingBatch{Batch: f.Database.NewBatch(), parent: f}
+}
+
+func (f *failingBatchDB) NewBatchWithSize(size int) ethdb.Batch {
+	return &failingBatch{Batch: f.Database.NewBatchWithSize(size), parent: f}
+}
+
+type failingBatch struct {
+	ethdb.Batch
+	parent *failingBatchDB
+}
+
+func (b *failingBatch) Write() error {
+	n := int(b.parent.writeCount.Add(1))
+	if n > b.parent.writesBeforeFail {
+		return b.parent.writeErr
+	}
+	return b.Batch.Write()
 }

--- a/arbnode/delayed_sequencer.go
+++ b/arbnode/delayed_sequencer.go
@@ -108,7 +108,9 @@ func NewDelayedSequencer(l1Reader *headerreader.HeaderReader, delayedMessageFetc
 		config:                config,
 	}
 	if coordinator != nil {
-		coordinator.SetDelayedSequencer(d)
+		if err := coordinator.SetDelayedSequencer(d); err != nil {
+			return nil, err
+		}
 	}
 	return d, nil
 }

--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -638,12 +638,22 @@ func (r *InboxReader) run(ctx context.Context, hadError bool) error {
 }
 
 func (r *InboxReader) addMessages(ctx context.Context, sequencerBatches []*mel.SequencerInboxBatch, delayedMessages []*mel.DelayedInboxMessage) (bool, error) {
-	err := r.tracker.AddDelayedMessages(delayedMessages)
+	delayedCountBeforeAdd, err := r.tracker.GetDelayedCount()
+	if err != nil {
+		return false, fmt.Errorf("getting delayed message count before adding messages: %w", err)
+	}
+	err = r.tracker.AddDelayedMessages(delayedMessages)
 	if err != nil {
 		return false, err
 	}
 	err = r.tracker.AddSequencerBatches(ctx, r.client, sequencerBatches)
 	if errors.Is(err, delayedMessagesMismatch) {
+		log.Warn("Delayed message mismatch detected, rolling back and reorging", "err", err, "delayedCountBeforeAdd", delayedCountBeforeAdd)
+		// Roll back delayed messages added above so orphaned entries
+		// don't accumulate in the DB without corresponding batches.
+		if rollbackErr := r.tracker.ReorgDelayedTo(delayedCountBeforeAdd); rollbackErr != nil {
+			return false, fmt.Errorf("failed to rollback delayed messages (original mismatch: %w): %w", err, rollbackErr)
+		}
 		return true, nil
 	} else if err != nil {
 		return false, err

--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -578,7 +578,12 @@ func (r *InboxReader) run(ctx context.Context, hadError bool) error {
 					"haveBeforeAcc", havePrevAcc,
 					"readLastAcc", lazyHashLogging{func() common.Hash {
 						// Only compute this if we need to log it, as it's somewhat expensive
-						return delayedMessages[len(delayedMessages)-1].AfterInboxAcc()
+						acc, err := delayedMessages[len(delayedMessages)-1].AfterInboxAcc()
+						if err != nil {
+							log.Warn("Failed to compute AfterInboxAcc for logging", "err", err)
+							return common.Hash{}
+						}
+						return acc
 					}},
 				)
 			} else if missingDelayed && to.Cmp(currentHeight) >= 0 {
@@ -809,8 +814,8 @@ func (b *batchDataProviderImpl) GetDelayedCount() (uint64, error) {
 	return b.r.tracker.GetDelayedCount()
 }
 
-func (b *batchDataProviderImpl) SetBlockValidator(validator *staker.BlockValidator) {
-	b.r.tracker.SetBlockValidator(validator)
+func (b *batchDataProviderImpl) SetBlockValidator(validator *staker.BlockValidator) error {
+	return b.r.tracker.SetBlockValidator(validator)
 }
 
 func (b *batchDataProviderImpl) GetDelayedMessageBytes(ctx context.Context, seqNum uint64) ([]byte, error) {

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -55,8 +55,9 @@ func NewInboxTracker(db ethdb.Database, txStreamer *TransactionStreamer, dapRead
 	return tracker, nil
 }
 
-func (t *InboxTracker) SetBlockValidator(validator *staker.BlockValidator) {
+func (t *InboxTracker) SetBlockValidator(validator *staker.BlockValidator) error {
 	t.validator = validator
+	return nil
 }
 
 func (t *InboxTracker) Initialize() error {
@@ -101,7 +102,7 @@ func (t *InboxTracker) Initialize() error {
 	return nil
 }
 
-var AccumulatorNotFoundErr = errors.New("accumulator not found")
+var AccumulatorNotFoundErr = mel.ErrAccumulatorNotFound
 
 func (t *InboxTracker) deleteBatchMetadataStartingAt(dbBatch ethdb.Batch, startIndex uint64) error {
 	t.batchMetaMutex.Lock()
@@ -217,55 +218,8 @@ func (t *InboxTracker) GetBatchCount() (uint64, error) {
 	return count, nil
 }
 
-// err will return unexpected/internal errors
-// bool will be false if batch not found (meaning, block not yet posted on a batch)
 func (t *InboxTracker) FindInboxBatchContainingMessage(pos arbutil.MessageIndex) (uint64, bool, error) {
-	batchCount, err := t.GetBatchCount()
-	if err != nil {
-		return 0, false, err
-	}
-	if batchCount == 0 {
-		return 0, false, nil
-	}
-	low := uint64(0)
-	high := batchCount - 1
-	lastBatchMessageCount, err := t.GetBatchMessageCount(high)
-	if err != nil {
-		return 0, false, err
-	}
-	if lastBatchMessageCount <= pos {
-		return 0, false, nil
-	}
-	// Iteration preconditions:
-	// - high >= low
-	// - msgCount(low - 1) <= pos implies low <= target
-	// - msgCount(high) > pos implies high >= target
-	// Therefore, if low == high, then low == high == target
-	for {
-		// Due to integer rounding, mid >= low && mid < high
-		mid := (low + high) / 2
-		count, err := t.GetBatchMessageCount(mid)
-		if err != nil {
-			return 0, false, err
-		}
-		if count < pos {
-			// Must narrow as mid >= low, therefore mid + 1 > low, therefore newLow > oldLow
-			// Keeps low precondition as msgCount(mid) < pos
-			low = mid + 1
-		} else if count == pos {
-			return mid + 1, true, nil
-		} else if count == pos+1 || mid == low { // implied: count > pos
-			return mid, true, nil
-		} else {
-			// implied: count > pos + 1
-			// Must narrow as mid < high, therefore newHigh < oldHigh
-			// Keeps high precondition as msgCount(mid) > pos
-			high = mid
-		}
-		if high == low {
-			return high, true, nil
-		}
-	}
+	return arbutil.FindInboxBatchContainingMessage(t, pos)
 }
 
 func (t *InboxTracker) legacyGetDelayedMessageAndAccumulator(ctx context.Context, seqNum uint64) (*arbostypes.L1IncomingMessage, common.Hash, error) {
@@ -381,7 +335,11 @@ func (t *InboxTracker) AddDelayedMessages(messages []*mel.DelayedInboxMessage) e
 	// This math is safe to do as we know len(messages) > 0
 	haveLastAcc, err := t.GetDelayedAcc(pos + uint64(len(messages)) - 1)
 	if err == nil {
-		if haveLastAcc == messages[len(messages)-1].AfterInboxAcc() {
+		lastMsgAcc, accErr := messages[len(messages)-1].AfterInboxAcc()
+		if accErr != nil {
+			return accErr
+		}
+		if haveLastAcc == lastMsgAcc {
 			// We already have these delayed messages
 			return nil
 		}
@@ -415,7 +373,10 @@ func (t *InboxTracker) AddDelayedMessages(messages []*mel.DelayedInboxMessage) e
 		if nextAcc != message.BeforeInboxAcc {
 			return fmt.Errorf("previous delayed accumulator mismatch for message %v", seqNum)
 		}
-		nextAcc = message.AfterInboxAcc()
+		nextAcc, err = message.AfterInboxAcc()
+		if err != nil {
+			return fmt.Errorf("computing AfterInboxAcc for delayed message %v: %w", seqNum, err)
+		}
 
 		if firstPos == pos {
 			// Check if this message is a duplicate
@@ -877,7 +838,11 @@ func (t *InboxTracker) FinalizedDelayedMessageAtPosition(
 			Message:                msg,
 			ParentChainBlockNumber: parentChainBlockNumber,
 		}
-		if fullMsg.AfterInboxAcc() != acc {
+		fullMsgAcc, accErr := fullMsg.AfterInboxAcc()
+		if accErr != nil {
+			return nil, common.Hash{}, 0, fmt.Errorf("computing AfterInboxAcc while sequencing: %w", accErr)
+		}
+		if fullMsgAcc != acc {
 			return nil, common.Hash{}, 0, errors.New("delayed message accumulator mismatch while sequencing")
 		}
 	}

--- a/arbnode/mel/extraction/message_extraction_function.go
+++ b/arbnode/mel/extraction/message_extraction_function.go
@@ -19,7 +19,7 @@ import (
 	"github.com/offchainlabs/nitro/daprovider"
 )
 
-// Defines a method that can read a delayed message from an external database.
+// DelayedMessageDatabase provides access to delayed messages stored in an external database.
 type DelayedMessageDatabase interface {
 	ReadDelayedMessage(
 		state *mel.State,
@@ -27,7 +27,7 @@ type DelayedMessageDatabase interface {
 	) (*mel.DelayedInboxMessage, error)
 }
 
-// Defines methods that can fetch all the logs of a parent chain block
+// LogsFetcher fetches all the logs of a parent chain block
 // and logs corresponding to a specific transaction in a parent chain block.
 type LogsFetcher interface {
 	LogsForBlockHash(
@@ -41,7 +41,7 @@ type LogsFetcher interface {
 	) ([]*types.Log, error)
 }
 
-// Defines a method that can fetch transaction of a parent chain block by hash.
+// TransactionFetcher fetches a transaction of a parent chain block by its log.
 type TransactionFetcher interface {
 	TransactionByLog(
 		ctx context.Context,
@@ -49,10 +49,11 @@ type TransactionFetcher interface {
 	) (*types.Transaction, error)
 }
 
-// ExtractMessages is a pure function that can read a parent chain block and
-// and input MEL state to run a specific algorithm that extracts Arbitrum messages and
-// delayed messages observed from transactions in the block. This function can be proven
-// through a replay binary, and should also compile to WAVM in addition to running in native mode.
+// ExtractMessages is a deterministic function that reads a parent chain block and
+// an input MEL state to extract Arbitrum messages and delayed messages observed from
+// transactions in the block. Given identical inputs and parent chain data, it produces
+// identical outputs, enabling fraud proof validation via the replay binary. It compiles
+// to both native mode and WAVM.
 func ExtractMessages(
 	ctx context.Context,
 	inputState *mel.State,
@@ -82,9 +83,8 @@ func ExtractMessages(
 	)
 }
 
-// Defines an internal implementation of the ExtractMessages function where many internal details
-// can be mocked out for testing purposes, while the public function is clear about what dependencies it
-// needs from callers.
+// extractMessagesImpl is the internal implementation of ExtractMessages with
+// injected dependencies for testing. Production callers should use ExtractMessages.
 func extractMessagesImpl(
 	ctx context.Context,
 	inputState *mel.State,
@@ -103,8 +103,8 @@ func extractMessagesImpl(
 	parseBatchPostingReport batchPostingReportParserFunc,
 ) (*mel.State, []*arbostypes.MessageWithMetadata, []*mel.DelayedInboxMessage, []*mel.BatchMetadata, error) {
 
+	// Clone to avoid mutating the input state in case of errors.
 	state := inputState.Clone()
-	// Clones the state to avoid mutating the input pointer in case of errors.
 	// Check parent chain block hash linkage.
 	if state.ParentChainBlockHash != parentChainHeader.ParentHash {
 		return nil, nil, nil, nil, fmt.Errorf(
@@ -215,7 +215,6 @@ func extractMessagesImpl(
 		if err = state.AccumulateDelayedMessage(delayed); err != nil {
 			return nil, nil, nil, nil, err
 		}
-		state.DelayedMessagesSeen += 1
 	}
 
 	// Extract L2 messages from batches
@@ -252,11 +251,8 @@ func extractMessagesImpl(
 			if err = state.AccumulateMessage(msg); err != nil {
 				return nil, nil, nil, nil, fmt.Errorf("failed to accumulate message: %w", err)
 			}
-			// Updating of MsgCount is consistent with how DelayedMessagesSeen is updated
-			// i.e after the corresponding message has been accumulated
-			state.MsgCount += 1
 		}
-		state.BatchCount += 1
+		state.IncrementBatchCount()
 		batchMetas = append(batchMetas, &mel.BatchMetadata{
 			Accumulator:         batch.AfterInboxAcc,
 			MessageCount:        arbutil.MessageIndex(state.MsgCount),

--- a/arbnode/mel/extraction/messages_in_batch.go
+++ b/arbnode/mel/extraction/messages_in_batch.go
@@ -208,11 +208,13 @@ func extractDelayedMessageFromSegment(
 		return nil, fmt.Errorf("no more delayed messages in db")
 	}
 
-	// Increment the delayed messages read count in the mel state.
-	melState.DelayedMessagesRead += 1
+	newRead, err := melState.IncrementDelayedMessagesRead()
+	if err != nil {
+		return nil, fmt.Errorf("incrementing delayed messages read: %w", err)
+	}
 
 	return &arbostypes.MessageWithMetadata{
 		Message:             delayed.Message,
-		DelayedMessagesRead: melState.DelayedMessagesRead,
+		DelayedMessagesRead: newRead,
 	}, nil
 }

--- a/arbnode/mel/extraction/messages_in_batch_test.go
+++ b/arbnode/mel/extraction/messages_in_batch_test.go
@@ -80,6 +80,7 @@ func Test_messagesFromBatchSegments_delayedMessages(t *testing.T) {
 	ctx := context.Background()
 	melState := &mel.State{
 		DelayedMessagesRead: 0,
+		DelayedMessagesSeen: 2,
 	}
 	// No segments, but the sequencer message says that we must read 2 delayed messages.
 	seqMsg := sequencerMessageWithSegments(2, [][]byte{})
@@ -275,6 +276,7 @@ func Test_messagesFromBatchSegments(t *testing.T) {
 			setupMelState: func() *mel.State {
 				return &mel.State{
 					DelayedMessagesRead: 0,
+					DelayedMessagesSeen: 1,
 				}
 			},
 			setupSeqMsg: func(segments [][]byte) *arbstate.SequencerMessage {

--- a/arbnode/mel/messages.go
+++ b/arbnode/mel/messages.go
@@ -4,6 +4,7 @@ package mel
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -19,6 +20,8 @@ import (
 var ErrDelayedMessageNotYetFinalized = errors.New("delayed message not yet finalized")
 var ErrDelayedAccumulatorMismatch = errors.New("delayed message accumulator mismatch")
 var ErrDelayedMessagePreimageNotFound = errors.New("delayed message preimage not found")
+var ErrNotImplementedUnderMEL = errors.New("not implemented under MEL")
+var ErrAccumulatorNotFound = errors.New("accumulator not found")
 
 type BatchDataLocation uint8
 
@@ -44,6 +47,10 @@ type SequencerInboxBatch struct {
 	Serialized             []byte // nil if serialization isn't cached yet
 }
 
+// DelayedInboxMessage represents a delayed message from the parent chain inbox.
+// BlockHash may be zero for messages read from legacy (pre-MEL) database keys,
+// since the legacy schema did not store this field. Consumers must handle the
+// zero-hash case rather than assuming it is always populated.
 type DelayedInboxMessage struct {
 	BlockHash              common.Hash
 	BeforeInboxAcc         common.Hash
@@ -51,7 +58,10 @@ type DelayedInboxMessage struct {
 	ParentChainBlockNumber uint64
 }
 
-func (m *DelayedInboxMessage) AfterInboxAcc() common.Hash {
+func (m *DelayedInboxMessage) AfterInboxAcc() (common.Hash, error) {
+	if m.Message == nil || m.Message.Header == nil {
+		return common.Hash{}, errors.New("cannot compute AfterInboxAcc: Message or Header is nil")
+	}
 	hash := crypto.Keccak256(
 		[]byte{m.Message.Header.Kind},
 		m.Message.Header.Poster.Bytes(),
@@ -61,15 +71,15 @@ func (m *DelayedInboxMessage) AfterInboxAcc() common.Hash {
 		arbmath.U256Bytes(m.Message.Header.L1BaseFee),
 		crypto.Keccak256(m.Message.L2msg),
 	)
-	return crypto.Keccak256Hash(m.BeforeInboxAcc[:], hash)
+	return crypto.Keccak256Hash(m.BeforeInboxAcc[:], hash), nil
 }
 
-func (m *DelayedInboxMessage) Hash() common.Hash {
+func (m *DelayedInboxMessage) Hash() (common.Hash, error) {
 	encoded, err := rlp.EncodeToBytes(m)
 	if err != nil {
-		panic(err)
+		return common.Hash{}, fmt.Errorf("failed to RLP-encode DelayedInboxMessage: %w", err)
 	}
-	return crypto.Keccak256Hash(encoded)
+	return crypto.Keccak256Hash(encoded), nil
 }
 
 type BatchMetadata struct {
@@ -80,7 +90,8 @@ type BatchMetadata struct {
 }
 
 type MessageSyncProgress struct {
-	BatchSeen      uint64
-	BatchProcessed uint64
-	MsgCount       arbutil.MessageIndex
+	BatchSeen           uint64
+	BatchSeenIsEstimate bool // true when BatchSeen fell back to headState.BatchCount due to an RPC "header not found" error during on-chain batch count lookup
+	BatchProcessed      uint64
+	MsgCount            arbutil.MessageIndex
 }

--- a/arbnode/mel/recording/txs_recording_database.go
+++ b/arbnode/mel/recording/txs_recording_database.go
@@ -48,7 +48,7 @@ func (rdb *TxsRecordingDatabase) ReadAncients(fn func(ethdb.AncientReaderOp) err
 	return fmt.Errorf("ReadAncients not supported on recording DB")
 }
 func (rdb *TxsRecordingDatabase) ModifyAncients(func(ethdb.AncientWriteOp) error) (int64, error) {
-	return 0, fmt.Errorf("ReadAncients not supported on recording DB")
+	return 0, fmt.Errorf("ModifyAncients not supported on recording DB")
 }
 func (rdb *TxsRecordingDatabase) SyncAncient() error {
 	return fmt.Errorf("SyncAncient not supported on recording DB")
@@ -96,17 +96,75 @@ func (rdb *TxsRecordingDatabase) Stat() (string, error) {
 	return "", nil
 }
 func (rdb *TxsRecordingDatabase) WasmDataBase() ethdb.KeyValueStore {
-	return nil
+	return &unsupportedKeyValueStore{}
 }
 func (rdb *TxsRecordingDatabase) NewBatch() ethdb.Batch {
-	return nil
+	return &unsupportedBatch{}
 }
 func (rdb *TxsRecordingDatabase) NewBatchWithSize(size int) ethdb.Batch {
-	return nil
+	return &unsupportedBatch{}
 }
 func (rdb *TxsRecordingDatabase) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
-	return nil
+	return &emptyIterator{err: fmt.Errorf("NewIterator not supported on recording DB")}
 }
+
+// unsupportedBatch is a stub ethdb.Batch that returns errors on all write operations.
+type unsupportedBatch struct{}
+
+func (b *unsupportedBatch) Put(key []byte, value []byte) error {
+	return fmt.Errorf("Put not supported on recording DB batch")
+}
+func (b *unsupportedBatch) Delete(key []byte) error {
+	return fmt.Errorf("Delete not supported on recording DB batch")
+}
+func (b *unsupportedBatch) DeleteRange(start, end []byte) error {
+	return fmt.Errorf("DeleteRange not supported on recording DB batch")
+}
+func (b *unsupportedBatch) ValueSize() int { return 0 }
+func (b *unsupportedBatch) Write() error {
+	return fmt.Errorf("Write not supported on recording DB batch")
+}
+func (b *unsupportedBatch) Reset() {}
+func (b *unsupportedBatch) Replay(w ethdb.KeyValueWriter) error {
+	return fmt.Errorf("Replay not supported on recording DB batch")
+}
+
+// emptyIterator is a stub ethdb.Iterator that reports an error and yields no results.
+type emptyIterator struct{ err error }
+
+func (it *emptyIterator) Next() bool    { return false }
+func (it *emptyIterator) Error() error  { return it.err }
+func (it *emptyIterator) Key() []byte   { return nil }
+func (it *emptyIterator) Value() []byte { return nil }
+func (it *emptyIterator) Release()      {}
+
+// unsupportedKeyValueStore is a stub ethdb.KeyValueStore that returns errors on all operations.
+type unsupportedKeyValueStore struct{}
+
+func (s *unsupportedKeyValueStore) Has(key []byte) (bool, error) {
+	return false, fmt.Errorf("Has not supported on recording DB WasmDataBase")
+}
+func (s *unsupportedKeyValueStore) Get(key []byte) ([]byte, error) {
+	return nil, fmt.Errorf("Get not supported on recording DB WasmDataBase")
+}
+func (s *unsupportedKeyValueStore) Put(key []byte, value []byte) error {
+	return fmt.Errorf("Put not supported on recording DB WasmDataBase")
+}
+func (s *unsupportedKeyValueStore) Delete(key []byte) error {
+	return fmt.Errorf("Delete not supported on recording DB WasmDataBase")
+}
+func (s *unsupportedKeyValueStore) DeleteRange(start, end []byte) error {
+	return fmt.Errorf("DeleteRange not supported on recording DB WasmDataBase")
+}
+func (s *unsupportedKeyValueStore) NewBatch() ethdb.Batch            { return &unsupportedBatch{} }
+func (s *unsupportedKeyValueStore) NewBatchWithSize(int) ethdb.Batch { return &unsupportedBatch{} }
+func (s *unsupportedKeyValueStore) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
+	return &emptyIterator{err: fmt.Errorf("NewIterator not supported on recording DB WasmDataBase")}
+}
+func (s *unsupportedKeyValueStore) Stat() (string, error)                    { return "", nil }
+func (s *unsupportedKeyValueStore) SyncKeyValue() error                      { return nil }
+func (s *unsupportedKeyValueStore) Compact(start []byte, limit []byte) error { return nil }
+func (s *unsupportedKeyValueStore) Close() error                             { return nil }
 func (rdb *TxsRecordingDatabase) Close() error {
 	return nil
 }

--- a/arbnode/mel/runner/database.go
+++ b/arbnode/mel/runner/database.go
@@ -3,7 +3,9 @@
 package melrunner
 
 import (
+	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -15,17 +17,29 @@ import (
 	"github.com/offchainlabs/nitro/arbnode/mel"
 )
 
-// Database holds an ethdb.KeyValueStore underneath and implements reading of
-// delayed messages in native mode by verifying the read delayed message
-// against the outbox accumulator.
+// initialBoundary holds the cached boundary from the initial MEL state (set
+// during legacy migration). Indices below these thresholds are read from
+// legacy (pre-MEL) schema keys.
+type initialBoundary struct {
+	blockNum     uint64
+	delayedCount uint64
+	batchCount   uint64
+}
+
+// Database wraps an ethdb.KeyValueStore and provides MEL state persistence,
+// batch metadata and delayed message storage, verified delayed message reads
+// (via ReadDelayedMessage, which validates against the outbox accumulator),
+// and raw unverified fetches (via FetchDelayedMessage).
+// For legacy-migrated nodes, it dispatches reads below the initial MEL boundary
+// to pre-MEL schema keys.
 type Database struct {
 	db ethdb.KeyValueStore
 
-	// Cached boundary counts from the initial MEL state (set during legacy migration).
-	// Indices below these thresholds are read from legacy (pre-MEL) schema keys.
-	hasInitialState     bool
-	initialDelayedCount uint64
-	initialBatchCount   uint64
+	// Set once during initialization via cacheInitialBoundary; read concurrently
+	// by delayed sequencer, block validator, staker, and RPC handlers.
+	// Using atomic.Pointer provides the memory barrier between the initializing
+	// goroutine and concurrent readers.
+	boundary atomic.Pointer[initialBoundary]
 }
 
 func NewDatabase(db ethdb.KeyValueStore) (*Database, error) {
@@ -36,6 +50,15 @@ func NewDatabase(db ethdb.KeyValueStore) (*Database, error) {
 	return d, nil
 }
 
+// cacheInitialBoundary atomically sets the cached boundary used for legacy key dispatch.
+func (d *Database) cacheInitialBoundary(blockNum uint64, delayedCount, batchCount uint64) {
+	d.boundary.Store(&initialBoundary{
+		blockNum:     blockNum,
+		delayedCount: delayedCount,
+		batchCount:   batchCount,
+	})
+}
+
 // loadInitialBoundary loads the initial MEL state boundary counts from the DB.
 // If InitialMelStateBlockNumKey exists, it reads the initial state to cache
 // the delayed message and batch count thresholds for legacy key dispatch.
@@ -44,7 +67,6 @@ func (d *Database) loadInitialBoundary() error {
 	blockNum, err := read.Value[uint64](d.db, schema.InitialMelStateBlockNumKey)
 	if err != nil {
 		if rawdb.IsDbErrNotFound(err) {
-			d.hasInitialState = false
 			return nil
 		}
 		return fmt.Errorf("error reading InitialMelStateBlockNumKey: %w", err)
@@ -53,31 +75,36 @@ func (d *Database) loadInitialBoundary() error {
 	if err != nil {
 		return fmt.Errorf("error reading initial MEL state at block %d: %w", blockNum, err)
 	}
-	d.hasInitialState = true
-	d.initialDelayedCount = state.DelayedMessagesSeen
-	d.initialBatchCount = state.BatchCount
+	d.cacheInitialBoundary(blockNum, state.DelayedMessagesSeen, state.BatchCount)
 	return nil
 }
 
 func (d *Database) SaveInitialMelState(initialState *mel.State) error {
+	if err := initialState.Validate(); err != nil {
+		return fmt.Errorf("SaveInitialMelState: refusing to persist invalid state: %w", err)
+	}
+	if d.boundary.Load() != nil {
+		return errors.New("initial MEL state already set; cannot re-initialize legacy boundary")
+	}
 	dbBatch := d.db.NewBatch()
 	encoded, err := rlp.EncodeToBytes(initialState.ParentChainBlockNumber)
 	if err != nil {
-		return err
+		return fmt.Errorf("encoding initial block number: %w", err)
 	}
 	if err := dbBatch.Put(schema.InitialMelStateBlockNumKey, encoded); err != nil {
-		return err
+		return fmt.Errorf("writing initial block number key: %w", err)
 	}
 	if err := d.setMelState(dbBatch, initialState.ParentChainBlockNumber, *initialState); err != nil {
-		return err
+		return fmt.Errorf("writing initial MEL state at block %d: %w", initialState.ParentChainBlockNumber, err)
 	}
 	if err := d.setHeadMelStateBlockNum(dbBatch, initialState.ParentChainBlockNumber); err != nil {
-		return err
+		return fmt.Errorf("writing head block number: %w", err)
 	}
-	d.hasInitialState = true
-	d.initialDelayedCount = initialState.DelayedMessagesSeen
-	d.initialBatchCount = initialState.BatchCount
-	return dbBatch.Write()
+	if err := dbBatch.Write(); err != nil {
+		return fmt.Errorf("committing initial MEL state batch: %w", err)
+	}
+	d.cacheInitialBoundary(initialState.ParentChainBlockNumber, initialState.DelayedMessagesSeen, initialState.BatchCount)
+	return nil
 }
 
 func (d *Database) GetHeadMelState() (*mel.State, error) {
@@ -88,16 +115,88 @@ func (d *Database) GetHeadMelState() (*mel.State, error) {
 	return d.State(headMelStateBlockNum)
 }
 
-// SaveState should exclusively be called for saving the recently generated "head" MEL state
+// SaveState persists just the MEL state and head pointer. Used during node
+// initialization and in tests. Production block processing should use
+// SaveProcessedBlock for atomic writes.
 func (d *Database) SaveState(state *mel.State) error {
+	if err := state.Validate(); err != nil {
+		return fmt.Errorf("SaveState: refusing to persist invalid state: %w", err)
+	}
 	dbBatch := d.db.NewBatch()
 	if err := d.setMelState(dbBatch, state.ParentChainBlockNumber, *state); err != nil {
-		return err
+		return fmt.Errorf("SaveState: writing MEL state at block %d: %w", state.ParentChainBlockNumber, err)
 	}
 	if err := d.setHeadMelStateBlockNum(dbBatch, state.ParentChainBlockNumber); err != nil {
-		return err
+		return fmt.Errorf("SaveState: writing head block num: %w", err)
 	}
-	return dbBatch.Write()
+	if err := dbBatch.Write(); err != nil {
+		return fmt.Errorf("SaveState: committing batch for block %d: %w", state.ParentChainBlockNumber, err)
+	}
+	return nil
+}
+
+func putBatchMetas(batch ethdb.KeyValueWriter, state *mel.State, batchMetas []*mel.BatchMetadata) error {
+	if state.BatchCount < uint64(len(batchMetas)) {
+		return fmt.Errorf("mel state's BatchCount: %d is lower than number of batchMetadata: %d queued to be added", state.BatchCount, len(batchMetas))
+	}
+	firstPos := state.BatchCount - uint64(len(batchMetas))
+	for i, batchMetadata := range batchMetas {
+		seqNum := firstPos + uint64(i) // #nosec G115
+		key := read.Key(schema.MelSequencerBatchMetaPrefix, seqNum)
+		batchMetadataBytes, err := rlp.EncodeToBytes(*batchMetadata)
+		if err != nil {
+			return fmt.Errorf("encoding batch metadata at seqNum %d: %w", seqNum, err)
+		}
+		if err := batch.Put(key, batchMetadataBytes); err != nil {
+			return fmt.Errorf("writing batch metadata at seqNum %d: %w", seqNum, err)
+		}
+	}
+	return nil
+}
+
+func putDelayedMessages(batch ethdb.KeyValueWriter, state *mel.State, delayedMessages []*mel.DelayedInboxMessage) error {
+	if state.DelayedMessagesSeen < uint64(len(delayedMessages)) {
+		return fmt.Errorf("mel state's DelayedMessagesSeen: %d is lower than number of delayed messages: %d queued to be added", state.DelayedMessagesSeen, len(delayedMessages))
+	}
+	firstPos := state.DelayedMessagesSeen - uint64(len(delayedMessages))
+	for i, msg := range delayedMessages {
+		index := firstPos + uint64(i) // #nosec G115
+		key := read.Key(schema.MelDelayedMessagePrefix, index)
+		delayedBytes, err := rlp.EncodeToBytes(*msg)
+		if err != nil {
+			return fmt.Errorf("encoding delayed message at index %d: %w", index, err)
+		}
+		if err := batch.Put(key, delayedBytes); err != nil {
+			return fmt.Errorf("writing delayed message at index %d: %w", index, err)
+		}
+	}
+	return nil
+}
+
+// SaveProcessedBlock atomically writes batch metadata, delayed messages, and
+// the new head MEL state in a single database batch. This ensures crash-safe
+// consistency: either all data from a processed block is persisted, or none is.
+func (d *Database) SaveProcessedBlock(state *mel.State, batchMetas []*mel.BatchMetadata, delayedMessages []*mel.DelayedInboxMessage) error {
+	if err := state.Validate(); err != nil {
+		return fmt.Errorf("SaveProcessedBlock: refusing to persist invalid state: %w", err)
+	}
+	dbBatch := d.db.NewBatch()
+	if err := putBatchMetas(dbBatch, state, batchMetas); err != nil {
+		return fmt.Errorf("SaveProcessedBlock: %w", err)
+	}
+	if err := putDelayedMessages(dbBatch, state, delayedMessages); err != nil {
+		return fmt.Errorf("SaveProcessedBlock: %w", err)
+	}
+	if err := d.setMelState(dbBatch, state.ParentChainBlockNumber, *state); err != nil {
+		return fmt.Errorf("SaveProcessedBlock: writing MEL state at block %d: %w", state.ParentChainBlockNumber, err)
+	}
+	if err := d.setHeadMelStateBlockNum(dbBatch, state.ParentChainBlockNumber); err != nil {
+		return fmt.Errorf("SaveProcessedBlock: writing head block num %d: %w", state.ParentChainBlockNumber, err)
+	}
+	if err := dbBatch.Write(); err != nil {
+		return fmt.Errorf("SaveProcessedBlock: committing batch for block %d: %w", state.ParentChainBlockNumber, err)
+	}
+	return nil
 }
 
 func (d *Database) setMelState(batch ethdb.KeyValueWriter, parentChainBlockNumber uint64, state mel.State) error {
@@ -106,10 +205,7 @@ func (d *Database) setMelState(batch ethdb.KeyValueWriter, parentChainBlockNumbe
 	if err != nil {
 		return err
 	}
-	if err := batch.Put(key, melStateBytes); err != nil {
-		return err
-	}
-	return nil
+	return batch.Put(key, melStateBytes)
 }
 
 func (d *Database) setHeadMelStateBlockNum(batch ethdb.KeyValueWriter, parentChainBlockNumber uint64) error {
@@ -117,15 +213,47 @@ func (d *Database) setHeadMelStateBlockNum(batch ethdb.KeyValueWriter, parentCha
 	if err != nil {
 		return err
 	}
-	err = batch.Put(schema.HeadMelStateBlockNumKey, parentChainBlockNumberBytes)
-	if err != nil {
-		return err
-	}
-	return nil
+	return batch.Put(schema.HeadMelStateBlockNumKey, parentChainBlockNumberBytes)
 }
 
 func (d *Database) GetHeadMelStateBlockNum() (uint64, error) {
 	return read.Value[uint64](d.db, schema.HeadMelStateBlockNumKey)
+}
+
+func (d *Database) InitialBlockNum() (uint64, bool) {
+	b := d.boundary.Load()
+	if b == nil {
+		return 0, false
+	}
+	return b.blockNum, true
+}
+
+// LegacyDelayedCount returns the delayed message count at the MEL migration
+// boundary. Returns 0 if no boundary exists (fresh MEL node, no legacy data).
+// Indices below this threshold are read from legacy schema keys.
+func (d *Database) LegacyDelayedCount() uint64 {
+	b := d.boundary.Load()
+	if b == nil {
+		return 0
+	}
+	return b.delayedCount
+}
+
+// RewriteHeadBlockNum overwrites the head MEL state block number pointer.
+// Used by ReorgTo to rewind the head without a full state save.
+// Returns an error if no MEL state exists at the target block.
+func (d *Database) RewriteHeadBlockNum(parentChainBlockNumber uint64) error {
+	if _, err := d.State(parentChainBlockNumber); err != nil {
+		return fmt.Errorf("cannot reorg to block %d: no MEL state found: %w", parentChainBlockNumber, err)
+	}
+	dbBatch := d.db.NewBatch()
+	if err := d.setHeadMelStateBlockNum(dbBatch, parentChainBlockNumber); err != nil {
+		return fmt.Errorf("RewriteHeadBlockNum: encoding head block num %d: %w", parentChainBlockNumber, err)
+	}
+	if err := dbBatch.Write(); err != nil {
+		return fmt.Errorf("RewriteHeadBlockNum: committing batch for block %d: %w", parentChainBlockNumber, err)
+	}
+	return nil
 }
 
 func (d *Database) State(parentChainBlockNumber uint64) (*mel.State, error) {
@@ -133,33 +261,46 @@ func (d *Database) State(parentChainBlockNumber uint64) (*mel.State, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := state.Validate(); err != nil {
+		return nil, fmt.Errorf("State(%d): loaded invalid state: %w", parentChainBlockNumber, err)
+	}
 	return &state, nil
 }
 
-func (d *Database) SaveBatchMetas(state *mel.State, batchMetas []*mel.BatchMetadata) error {
-	dbBatch := d.db.NewBatch()
-	if state.BatchCount < uint64(len(batchMetas)) {
-		return fmt.Errorf("mel state's BatchCount: %d is lower than number of batchMetadata: %d queued to be added", state.BatchCount, len(batchMetas))
+// StateAtOrBelowHead performs an exact MEL state lookup for a given block number,
+// but only if the block is at or below the current head. This prevents callers
+// from reading stale MEL state entries that may remain in the DB above the head
+// after a reorg. Note: this does NOT walk backwards to find the nearest state;
+// it returns a not-found error if no state exists at the exact block number.
+// Returns an error if the block is above the head or if no state exists at that
+// block number.
+func (d *Database) StateAtOrBelowHead(parentChainBlockNumber uint64) (*mel.State, error) {
+	headBlockNum, err := d.GetHeadMelStateBlockNum()
+	if err != nil {
+		return nil, fmt.Errorf("StateAtOrBelowHead: failed to read head block num: %w", err)
 	}
-	firstPos := state.BatchCount - uint64(len(batchMetas))
-	for i, batchMetadata := range batchMetas {
-		key := read.Key(schema.MelSequencerBatchMetaPrefix, firstPos+uint64(i)) // #nosec G115
-		batchMetadataBytes, err := rlp.EncodeToBytes(*batchMetadata)
-		if err != nil {
-			return err
-		}
-		err = dbBatch.Put(key, batchMetadataBytes)
-		if err != nil {
-			return err
-		}
+	if parentChainBlockNumber > headBlockNum {
+		return nil, fmt.Errorf("requested MEL state at block %d is above current head %d (possible stale data after reorg)", parentChainBlockNumber, headBlockNum)
+	}
+	return d.State(parentChainBlockNumber)
+}
 
+// saveBatchMetas is a test-only helper. Production code uses SaveProcessedBlock for atomic writes.
+func (d *Database) saveBatchMetas(state *mel.State, batchMetas []*mel.BatchMetadata) error {
+	dbBatch := d.db.NewBatch()
+	if err := putBatchMetas(dbBatch, state, batchMetas); err != nil {
+		return err
 	}
 	return dbBatch.Write()
 }
 
 func (d *Database) fetchBatchMetadata(seqNum uint64) (*mel.BatchMetadata, error) {
-	if d.hasInitialState && seqNum < d.initialBatchCount {
-		return legacyFetchBatchMetadata(d.db, seqNum)
+	if b := d.boundary.Load(); b != nil && seqNum < b.batchCount {
+		meta, err := legacyFetchBatchMetadata(d.db, seqNum)
+		if err != nil {
+			return nil, fmt.Errorf("legacy dispatch for batch metadata %d (boundary batchCount=%d): %w", seqNum, b.batchCount, err)
+		}
+		return meta, nil
 	}
 	batchMetadata, err := read.Value[mel.BatchMetadata](d.db, read.Key(schema.MelSequencerBatchMetaPrefix, seqNum))
 	if err != nil {
@@ -168,23 +309,11 @@ func (d *Database) fetchBatchMetadata(seqNum uint64) (*mel.BatchMetadata, error)
 	return &batchMetadata, nil
 }
 
-func (d *Database) SaveDelayedMessages(state *mel.State, delayedMessages []*mel.DelayedInboxMessage) error {
+// saveDelayedMessages is a test-only helper. Production code uses SaveProcessedBlock for atomic writes.
+func (d *Database) saveDelayedMessages(state *mel.State, delayedMessages []*mel.DelayedInboxMessage) error {
 	dbBatch := d.db.NewBatch()
-	if state.DelayedMessagesSeen < uint64(len(delayedMessages)) {
-		return fmt.Errorf("mel state's DelayedMessagesSeen: %d is lower than number of delayed messages: %d queued to be added", state.DelayedMessagesSeen, len(delayedMessages))
-	}
-	firstPos := state.DelayedMessagesSeen - uint64(len(delayedMessages))
-	for i, msg := range delayedMessages {
-		key := read.Key(schema.MelDelayedMessagePrefix, firstPos+uint64(i)) // #nosec G115
-		delayedBytes, err := rlp.EncodeToBytes(*msg)
-		if err != nil {
-			return err
-		}
-		err = dbBatch.Put(key, delayedBytes)
-		if err != nil {
-			return err
-		}
-
+	if err := putDelayedMessages(dbBatch, state, delayedMessages); err != nil {
+		return err
 	}
 	return dbBatch.Write()
 }
@@ -219,9 +348,15 @@ func (d *Database) ReadDelayedMessage(state *mel.State, index uint64) (*mel.Dela
 	return delayed, nil
 }
 
+// FetchDelayedMessage reads a delayed message from the database without accumulator
+// verification. Use ReadDelayedMessage for verified reads during message extraction.
 func (d *Database) FetchDelayedMessage(index uint64) (*mel.DelayedInboxMessage, error) {
-	if d.hasInitialState && index < d.initialDelayedCount {
-		return legacyFetchDelayedMessage(d.db, index)
+	if b := d.boundary.Load(); b != nil && index < b.delayedCount {
+		msg, err := legacyFetchDelayedMessage(d.db, index)
+		if err != nil {
+			return nil, fmt.Errorf("legacy dispatch for delayed message %d (boundary delayedCount=%d): %w", index, b.delayedCount, err)
+		}
+		return msg, nil
 	}
 	delayed, err := read.Value[mel.DelayedInboxMessage](d.db, read.Key(schema.MelDelayedMessagePrefix, index))
 	if err != nil {

--- a/arbnode/mel/runner/database_test.go
+++ b/arbnode/mel/runner/database_test.go
@@ -3,21 +3,26 @@
 package melrunner
 
 import (
+	"encoding/binary"
+	"errors"
 	"math/big"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/nitro/arbnode/db/read"
 	"github.com/offchainlabs/nitro/arbnode/db/schema"
 	"github.com/offchainlabs/nitro/arbnode/mel"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
+	"github.com/offchainlabs/nitro/arbutil"
 )
 
 func TestMelDatabase(t *testing.T) {
@@ -40,7 +45,7 @@ func TestMelDatabase(t *testing.T) {
 		DelayedMessageCount: 10,
 		ParentChainBlock:    2,
 	}
-	require.NoError(t, melDB.SaveBatchMetas(headMelState, []*mel.BatchMetadata{want}))
+	require.NoError(t, melDB.saveBatchMetas(headMelState, []*mel.BatchMetadata{want}))
 	have, err := melDB.fetchBatchMetadata(0)
 	require.NoError(t, err)
 	if !reflect.DeepEqual(have, want) {
@@ -88,9 +93,8 @@ func TestMelDatabaseReadAndWriteDelayedMessages(t *testing.T) {
 	}
 	state := &mel.State{}
 	require.NoError(t, state.AccumulateDelayedMessage(delayedMsg))
-	state.DelayedMessagesSeen++
 
-	require.NoError(t, melDB.SaveDelayedMessages(state, []*mel.DelayedInboxMessage{delayedMsg}))
+	require.NoError(t, melDB.saveDelayedMessages(state, []*mel.DelayedInboxMessage{delayedMsg}))
 	have, err := melDB.ReadDelayedMessage(state, 0)
 	require.NoError(t, err)
 
@@ -140,10 +144,9 @@ func TestMelDelayedMessagesAccumulation(t *testing.T) {
 	// See 3 delayed messages and accumulate them
 	for i := range numDelayed {
 		require.NoError(t, state.AccumulateDelayedMessage(delayedMsgs[i]))
-		state.DelayedMessagesSeen++
 	}
 	stateToCheckForCorruption := state.Clone()
-	require.NoError(t, melDB.SaveDelayedMessages(state, delayedMsgs[:numDelayed]))
+	require.NoError(t, melDB.saveDelayedMessages(state, delayedMsgs[:numDelayed]))
 	// We can read all of these and prove that they are correct, by checking that ReadDelayedMessage doesnt error
 	// #nosec G115
 	for i := uint64(0); i < uint64(numDelayed); i++ {
@@ -162,4 +165,952 @@ func TestMelDelayedMessagesAccumulation(t *testing.T) {
 	// ReadDelayedMessage should fail with hash mismatch error
 	_, err = melDB.ReadDelayedMessage(stateToCheckForCorruption, corruptIndex)
 	require.True(t, strings.Contains(err.Error(), "delayed message hash mismatch"))
+}
+
+// storeLegacyBatchCount writes the legacy SequencerBatchCountKey.
+func storeLegacyBatchCount(t *testing.T, db ethdb.Database, count uint64) {
+	t.Helper()
+	encoded, err := rlp.EncodeToBytes(count)
+	require.NoError(t, err)
+	require.NoError(t, db.Put(schema.SequencerBatchCountKey, encoded))
+}
+
+// storeLegacyBatchMetadata writes a legacy SequencerBatchMetaPrefix entry.
+func storeLegacyBatchMetadata(t *testing.T, db ethdb.Database, seqNum uint64, meta mel.BatchMetadata) {
+	t.Helper()
+	key := read.Key(schema.SequencerBatchMetaPrefix, seqNum)
+	encoded, err := rlp.EncodeToBytes(meta)
+	require.NoError(t, err)
+	require.NoError(t, db.Put(key, encoded))
+}
+
+// storeLegacyDelayedMessage writes a delayed message under the RLP prefix ("e")
+// with the format [32-byte AfterInboxAcc | RLP(L1IncomingMessage)].
+func storeLegacyDelayedMessage(t *testing.T, db ethdb.Database, index uint64, msg *arbostypes.L1IncomingMessage, afterInboxAcc common.Hash) {
+	t.Helper()
+	key := read.Key(schema.RlpDelayedMessagePrefix, index)
+	rlpBytes, err := rlp.EncodeToBytes(msg)
+	require.NoError(t, err)
+	data := append(afterInboxAcc.Bytes(), rlpBytes...)
+	require.NoError(t, db.Put(key, data))
+}
+
+// storeLegacyParentChainBlockNumber writes the parent chain block number for a delayed message.
+func storeLegacyParentChainBlockNumber(t *testing.T, db ethdb.Database, index uint64, blockNum uint64) {
+	t.Helper()
+	key := read.Key(schema.ParentChainBlockNumberPrefix, index)
+	data := make([]byte, 8)
+	binary.BigEndian.PutUint64(data, blockNum)
+	require.NoError(t, db.Put(key, data))
+}
+
+func TestCreateInitialMELStateFromLegacyDB(t *testing.T) {
+	t.Parallel()
+
+	sequencerInbox := common.HexToAddress("0x1111")
+	bridgeAddr := common.HexToAddress("0x2222")
+	parentChainId := uint64(1)
+	startBlockNum := uint64(100)
+	blockHash := common.HexToHash("0xaa")
+	parentBlockHash := common.HexToHash("0xbb")
+	fetchBlock := func(blockNum uint64) (common.Hash, common.Hash, error) {
+		require.Equal(t, startBlockNum, blockNum)
+		return blockHash, parentBlockHash, nil
+	}
+
+	t.Run("with batches and unread delayed messages", func(t *testing.T) {
+		t.Parallel()
+		db := rawdb.NewMemoryDatabase()
+
+		// Set up 2 batches: batch 0 at block 50, batch 1 at block 90
+		storeLegacyBatchCount(t, db, 2)
+		storeLegacyBatchMetadata(t, db, 0, mel.BatchMetadata{
+			Accumulator:         common.HexToHash("0xacc0"),
+			MessageCount:        5,
+			DelayedMessageCount: 2,
+			ParentChainBlock:    50,
+		})
+		storeLegacyBatchMetadata(t, db, 1, mel.BatchMetadata{
+			Accumulator:         common.HexToHash("0xacc1"),
+			MessageCount:        10,
+			DelayedMessageCount: 3,
+			ParentChainBlock:    90,
+		})
+
+		// Store 5 delayed messages (indices 0..4). Batch 1 read up to 3, so indices 3,4 are unread.
+		var prevAcc common.Hash
+		for i := uint64(0); i < 5; i++ {
+			requestID := common.BigToHash(big.NewInt(int64(i)))
+			msg := &arbostypes.L1IncomingMessage{
+				Header: &arbostypes.L1IncomingMessageHeader{
+					Kind:        arbostypes.L1MessageType_EndOfBlock,
+					RequestId:   &requestID,
+					L1BaseFee:   common.Big0,
+					BlockNumber: 40 + i,
+				},
+			}
+			delayed := &mel.DelayedInboxMessage{
+				BeforeInboxAcc:         prevAcc,
+				Message:                msg,
+				ParentChainBlockNumber: 40 + i,
+			}
+			afterAcc, accErr := delayed.AfterInboxAcc()
+			require.NoError(t, accErr)
+			storeLegacyDelayedMessage(t, db, i, msg, afterAcc)
+			storeLegacyParentChainBlockNumber(t, db, i, 40+i)
+			prevAcc = afterAcc
+		}
+
+		// 5 delayed messages seen on-chain at block 100
+		delayedSeenAtBlock := uint64(5)
+		state, err := CreateInitialMELStateFromLegacyDB(
+			db, sequencerInbox, bridgeAddr, parentChainId,
+			fetchBlock, startBlockNum, delayedSeenAtBlock,
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, sequencerInbox, state.BatchPostingTargetAddress)
+		require.Equal(t, bridgeAddr, state.DelayedMessagePostingTargetAddress)
+		require.Equal(t, parentChainId, state.ParentChainId)
+		require.Equal(t, startBlockNum, state.ParentChainBlockNumber)
+		require.Equal(t, blockHash, state.ParentChainBlockHash)
+		require.Equal(t, parentBlockHash, state.ParentChainPreviousBlockHash)
+		require.Equal(t, uint64(2), state.BatchCount)
+		require.Equal(t, uint64(10), state.MsgCount)
+		require.Equal(t, uint64(3), state.DelayedMessagesRead)
+		require.Equal(t, uint64(5), state.DelayedMessagesSeen)
+		// Inbox accumulator should be non-zero (2 unread messages accumulated)
+		require.NotEqual(t, common.Hash{}, state.DelayedMessageInboxAcc)
+		// Outbox should be empty (nothing poured yet)
+		require.Equal(t, common.Hash{}, state.DelayedMessageOutboxAcc)
+	})
+
+	t.Run("with zero batches", func(t *testing.T) {
+		t.Parallel()
+		db := rawdb.NewMemoryDatabase()
+		storeLegacyBatchCount(t, db, 0)
+
+		state, err := CreateInitialMELStateFromLegacyDB(
+			db, sequencerInbox, bridgeAddr, parentChainId,
+			fetchBlock, startBlockNum, 0,
+		)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), state.BatchCount)
+		require.Equal(t, uint64(0), state.MsgCount)
+		require.Equal(t, uint64(0), state.DelayedMessagesRead)
+		require.Equal(t, uint64(0), state.DelayedMessagesSeen)
+		require.Equal(t, common.Hash{}, state.DelayedMessageInboxAcc)
+	})
+
+	t.Run("with all delayed messages read", func(t *testing.T) {
+		t.Parallel()
+		db := rawdb.NewMemoryDatabase()
+		storeLegacyBatchCount(t, db, 1)
+		storeLegacyBatchMetadata(t, db, 0, mel.BatchMetadata{
+			MessageCount:        5,
+			DelayedMessageCount: 3,
+			ParentChainBlock:    80,
+		})
+		// delayedSeenAtBlock == delayedRead means no unread messages
+		state, err := CreateInitialMELStateFromLegacyDB(
+			db, sequencerInbox, bridgeAddr, parentChainId,
+			fetchBlock, startBlockNum, 3,
+		)
+		require.NoError(t, err)
+		require.Equal(t, uint64(3), state.DelayedMessagesRead)
+		require.Equal(t, uint64(3), state.DelayedMessagesSeen)
+		require.Equal(t, common.Hash{}, state.DelayedMessageInboxAcc)
+	})
+}
+
+func TestDatabaseLegacyBoundaryDispatch(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+
+	// Set up legacy data: 2 batches and 3 delayed messages under legacy keys
+	storeLegacyBatchCount(t, db, 2)
+	storeLegacyBatchMetadata(t, db, 0, mel.BatchMetadata{
+		Accumulator:      common.HexToHash("0xlegacy0"),
+		MessageCount:     5,
+		ParentChainBlock: 10,
+	})
+	storeLegacyBatchMetadata(t, db, 1, mel.BatchMetadata{
+		Accumulator:      common.HexToHash("0xlegacy1"),
+		MessageCount:     10,
+		ParentChainBlock: 20,
+	})
+
+	var prevAcc common.Hash
+	for i := uint64(0); i < 3; i++ {
+		requestID := common.BigToHash(big.NewInt(int64(i)))
+		msg := &arbostypes.L1IncomingMessage{
+			Header: &arbostypes.L1IncomingMessageHeader{
+				Kind:      arbostypes.L1MessageType_EndOfBlock,
+				RequestId: &requestID,
+				L1BaseFee: common.Big0,
+			},
+		}
+		delayed := &mel.DelayedInboxMessage{
+			BeforeInboxAcc: prevAcc,
+			Message:        msg,
+		}
+		afterAcc, accErr := delayed.AfterInboxAcc()
+		require.NoError(t, accErr)
+		storeLegacyDelayedMessage(t, db, i, msg, afterAcc)
+		storeLegacyParentChainBlockNumber(t, db, i, 10+i)
+		prevAcc = afterAcc
+	}
+
+	// Create initial MEL state at block 30 with boundary at batch=2, delayed=3
+	initialState := &mel.State{
+		ParentChainBlockNumber: 30,
+		BatchCount:             2,
+		DelayedMessagesSeen:    3,
+		DelayedMessagesRead:    3,
+	}
+	melDB, err := NewDatabase(db)
+	require.NoError(t, err)
+	require.NoError(t, melDB.SaveInitialMelState(initialState))
+
+	// Now add MEL-format data above the boundary
+	melBatchMeta := &mel.BatchMetadata{
+		Accumulator:      common.HexToHash("0xmel2"),
+		MessageCount:     15,
+		ParentChainBlock: 35,
+	}
+	postState := &mel.State{
+		ParentChainBlockNumber: 35,
+		BatchCount:             3,
+		DelayedMessagesSeen:    3,
+		DelayedMessagesRead:    3,
+	}
+	require.NoError(t, melDB.saveBatchMetas(postState, []*mel.BatchMetadata{melBatchMeta}))
+	require.NoError(t, melDB.SaveState(postState))
+
+	t.Run("batch metadata below boundary reads from legacy", func(t *testing.T) {
+		meta, err := melDB.fetchBatchMetadata(0)
+		require.NoError(t, err)
+		require.Equal(t, common.HexToHash("0xlegacy0"), meta.Accumulator)
+
+		meta, err = melDB.fetchBatchMetadata(1)
+		require.NoError(t, err)
+		require.Equal(t, common.HexToHash("0xlegacy1"), meta.Accumulator)
+	})
+
+	t.Run("batch metadata at or above boundary reads from MEL", func(t *testing.T) {
+		meta, err := melDB.fetchBatchMetadata(2)
+		require.NoError(t, err)
+		require.Equal(t, common.HexToHash("0xmel2"), meta.Accumulator)
+	})
+
+	t.Run("delayed message below boundary reads from legacy", func(t *testing.T) {
+		msg, err := melDB.FetchDelayedMessage(0)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		expectedRequestID := common.BigToHash(big.NewInt(0))
+		require.Equal(t, &expectedRequestID, msg.Message.Header.RequestId)
+	})
+
+	t.Run("boundary reload from DB", func(t *testing.T) {
+		// Create a new Database from the same underlying DB to test loadInitialBoundary
+		melDB2, err := NewDatabase(db)
+		require.NoError(t, err)
+		b := melDB2.boundary.Load()
+		require.NotNil(t, b)
+		require.Equal(t, uint64(3), b.delayedCount)
+		require.Equal(t, uint64(2), b.batchCount)
+
+		// Should still dispatch correctly
+		meta, err := melDB2.fetchBatchMetadata(0)
+		require.NoError(t, err)
+		require.Equal(t, common.HexToHash("0xlegacy0"), meta.Accumulator)
+	})
+}
+
+func TestSaveProcessedBlock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("atomically writes batches delayed messages and state", func(t *testing.T) {
+		t.Parallel()
+		db := rawdb.NewMemoryDatabase()
+		melDB, err := NewDatabase(db)
+		require.NoError(t, err)
+
+		// Set up initial state
+		initState := &mel.State{ParentChainBlockNumber: 10, BatchCount: 0, DelayedMessagesSeen: 0}
+		require.NoError(t, melDB.SaveState(initState))
+
+		// Prepare post-state with 2 batches and 1 delayed message
+		requestID := common.BigToHash(common.Big1)
+		delayedMsg := &mel.DelayedInboxMessage{
+			Message: &arbostypes.L1IncomingMessage{
+				Header: &arbostypes.L1IncomingMessageHeader{
+					Kind:      arbostypes.L1MessageType_EndOfBlock,
+					RequestId: &requestID,
+					L1BaseFee: common.Big0,
+				},
+			},
+		}
+		postState := &mel.State{
+			ParentChainBlockNumber: 11,
+			ParentChainBlockHash:   common.HexToHash("0xbb"),
+			BatchCount:             2,
+			DelayedMessagesSeen:    1,
+		}
+		batchMetas := []*mel.BatchMetadata{
+			{Accumulator: common.HexToHash("0xacc0"), MessageCount: 5, ParentChainBlock: 11},
+			{Accumulator: common.HexToHash("0xacc1"), MessageCount: 10, ParentChainBlock: 11},
+		}
+		require.NoError(t, melDB.SaveProcessedBlock(postState, batchMetas, []*mel.DelayedInboxMessage{delayedMsg}))
+
+		// Verify head state was updated
+		headBlockNum, err := melDB.GetHeadMelStateBlockNum()
+		require.NoError(t, err)
+		require.Equal(t, uint64(11), headBlockNum)
+
+		// Verify state is readable
+		savedState, err := melDB.State(11)
+		require.NoError(t, err)
+		require.Equal(t, uint64(2), savedState.BatchCount)
+		require.Equal(t, uint64(1), savedState.DelayedMessagesSeen)
+
+		// Verify batch metadata is readable
+		meta0, err := melDB.fetchBatchMetadata(0)
+		require.NoError(t, err)
+		require.Equal(t, common.HexToHash("0xacc0"), meta0.Accumulator)
+		meta1, err := melDB.fetchBatchMetadata(1)
+		require.NoError(t, err)
+		require.Equal(t, common.HexToHash("0xacc1"), meta1.Accumulator)
+
+		// Verify delayed message is readable
+		fetched, err := melDB.FetchDelayedMessage(0)
+		require.NoError(t, err)
+		require.Equal(t, &requestID, fetched.Message.Header.RequestId)
+	})
+
+	t.Run("rejects batch count underflow", func(t *testing.T) {
+		t.Parallel()
+		db := rawdb.NewMemoryDatabase()
+		melDB, err := NewDatabase(db)
+		require.NoError(t, err)
+
+		// BatchCount=1 but providing 2 batch metas -> underflow
+		state := &mel.State{ParentChainBlockNumber: 10, BatchCount: 1}
+		err = melDB.SaveProcessedBlock(state, []*mel.BatchMetadata{{}, {}}, nil)
+		require.ErrorContains(t, err, "BatchCount: 1 is lower than number of batchMetadata: 2")
+	})
+
+	t.Run("rejects delayed message count underflow", func(t *testing.T) {
+		t.Parallel()
+		db := rawdb.NewMemoryDatabase()
+		melDB, err := NewDatabase(db)
+		require.NoError(t, err)
+
+		// DelayedMessagesSeen=0 but providing 1 delayed message -> underflow
+		state := &mel.State{ParentChainBlockNumber: 10, BatchCount: 0, DelayedMessagesSeen: 0}
+		requestID := common.BigToHash(common.Big1)
+		err = melDB.SaveProcessedBlock(state, nil, []*mel.DelayedInboxMessage{{
+			Message: &arbostypes.L1IncomingMessage{
+				Header: &arbostypes.L1IncomingMessageHeader{
+					Kind:      arbostypes.L1MessageType_EndOfBlock,
+					RequestId: &requestID,
+					L1BaseFee: common.Big0,
+				},
+			},
+		}})
+		require.ErrorContains(t, err, "DelayedMessagesSeen: 0 is lower than number of delayed messages: 1")
+	})
+
+	t.Run("succeeds with zero batches and zero delayed messages", func(t *testing.T) {
+		t.Parallel()
+		db := rawdb.NewMemoryDatabase()
+		melDB, err := NewDatabase(db)
+		require.NoError(t, err)
+
+		state := &mel.State{ParentChainBlockNumber: 10}
+		require.NoError(t, melDB.SaveProcessedBlock(state, nil, nil))
+
+		headBlockNum, err := melDB.GetHeadMelStateBlockNum()
+		require.NoError(t, err)
+		require.Equal(t, uint64(10), headBlockNum)
+	})
+}
+
+func TestRewriteHeadBlockNumNonexistentBlock(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+	melDB, err := NewDatabase(db)
+	require.NoError(t, err)
+
+	// Save state at block 5
+	state := &mel.State{ParentChainBlockNumber: 5}
+	require.NoError(t, melDB.SaveState(state))
+
+	// Rewriting to block 5 (exists) should succeed
+	require.NoError(t, melDB.RewriteHeadBlockNum(5))
+
+	// Rewriting to block 99 (does not exist) should fail
+	err = melDB.RewriteHeadBlockNum(99)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no MEL state found")
+
+	// Head should still be block 5
+	head, err := melDB.GetHeadMelStateBlockNum()
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), head)
+}
+
+func TestSaveInitialMelStateDoubleCall(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+	melDB, err := NewDatabase(db)
+	require.NoError(t, err)
+
+	initialState := &mel.State{
+		ParentChainBlockNumber: 10,
+		BatchCount:             5,
+		DelayedMessagesSeen:    3,
+	}
+
+	// First call should succeed
+	require.NoError(t, melDB.SaveInitialMelState(initialState))
+	b := melDB.boundary.Load()
+	require.NotNil(t, b)
+	require.Equal(t, uint64(10), b.blockNum)
+
+	// Second call should fail
+	err = melDB.SaveInitialMelState(initialState)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "initial MEL state already set")
+}
+
+func TestLegacyFindBatchCountAtBlock(t *testing.T) {
+	t.Parallel()
+
+	// Helper: set up legacy batch metadata at given parent chain blocks.
+	setupBatches := func(t *testing.T, blocks []uint64) ethdb.Database {
+		t.Helper()
+		db := rawdb.NewMemoryDatabase()
+		storeLegacyBatchCount(t, db, uint64(len(blocks)))
+		for i, blk := range blocks {
+			storeLegacyBatchMetadata(t, db, uint64(i), mel.BatchMetadata{ // #nosec G115
+				ParentChainBlock: blk,
+				MessageCount:     arbutil.MessageIndex(uint64(i+1) * 10), // #nosec G115
+			})
+		}
+		return db
+	}
+
+	t.Run("zero batches", func(t *testing.T) {
+		t.Parallel()
+		count, err := legacyFindBatchCountAtBlock(rawdb.NewMemoryDatabase(), 0, 100)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), count)
+	})
+
+	t.Run("all batches before block", func(t *testing.T) {
+		t.Parallel()
+		// Batches at blocks 10, 20, 30
+		db := setupBatches(t, []uint64{10, 20, 30})
+		count, err := legacyFindBatchCountAtBlock(db, 3, 100)
+		require.NoError(t, err)
+		require.Equal(t, uint64(3), count)
+	})
+
+	t.Run("all batches after block", func(t *testing.T) {
+		t.Parallel()
+		db := setupBatches(t, []uint64{10, 20, 30})
+		count, err := legacyFindBatchCountAtBlock(db, 3, 5)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), count)
+	})
+
+	t.Run("exact boundary match", func(t *testing.T) {
+		t.Parallel()
+		db := setupBatches(t, []uint64{10, 20, 30})
+		count, err := legacyFindBatchCountAtBlock(db, 3, 20)
+		require.NoError(t, err)
+		require.Equal(t, uint64(2), count) // batches 0 and 1 are at or before block 20
+	})
+
+	t.Run("between batches", func(t *testing.T) {
+		t.Parallel()
+		db := setupBatches(t, []uint64{10, 20, 30})
+		count, err := legacyFindBatchCountAtBlock(db, 3, 25)
+		require.NoError(t, err)
+		require.Equal(t, uint64(2), count) // batches at 10,20 are <= 25
+	})
+
+	t.Run("single batch at boundary", func(t *testing.T) {
+		t.Parallel()
+		db := setupBatches(t, []uint64{50})
+		count, err := legacyFindBatchCountAtBlock(db, 1, 50)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), count)
+	})
+
+	t.Run("single batch after block", func(t *testing.T) {
+		t.Parallel()
+		db := setupBatches(t, []uint64{50})
+		count, err := legacyFindBatchCountAtBlock(db, 1, 49)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), count)
+	})
+
+	t.Run("duplicate block numbers", func(t *testing.T) {
+		t.Parallel()
+		// Multiple batches posted in the same block
+		db := setupBatches(t, []uint64{10, 10, 20, 20, 20, 30})
+		count, err := legacyFindBatchCountAtBlock(db, 6, 20)
+		require.NoError(t, err)
+		require.Equal(t, uint64(5), count) // batches 0-4 are at blocks <= 20
+	})
+}
+
+// failingBatchKVS wraps a KeyValueStore and makes batch Write() calls fail
+// after a configurable number of successful writes.
+type failingBatchKVS struct {
+	ethdb.KeyValueStore
+	writesBeforeFail int
+	writeErr         error
+	writeCount       atomic.Int32
+}
+
+func (f *failingBatchKVS) NewBatch() ethdb.Batch {
+	return &failingBatchEntry{Batch: f.KeyValueStore.NewBatch(), parent: f}
+}
+
+func (f *failingBatchKVS) NewBatchWithSize(size int) ethdb.Batch {
+	return &failingBatchEntry{Batch: f.KeyValueStore.NewBatchWithSize(size), parent: f}
+}
+
+type failingBatchEntry struct {
+	ethdb.Batch
+	parent *failingBatchKVS
+}
+
+func (b *failingBatchEntry) Write() error {
+	n := int(b.parent.writeCount.Add(1))
+	if n > b.parent.writesBeforeFail {
+		return b.parent.writeErr
+	}
+	return b.Batch.Write()
+}
+
+func TestSaveProcessedBlock_AtomicityOnWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	injectedErr := errors.New("disk full")
+	realDB := rawdb.NewMemoryDatabase()
+
+	wrapper := &failingBatchKVS{
+		KeyValueStore:    realDB,
+		writesBeforeFail: 1, // allow SaveState (1 write), then fail SaveProcessedBlock
+		writeErr:         injectedErr,
+	}
+
+	melDB, err := NewDatabase(wrapper)
+	require.NoError(t, err)
+
+	// Save initial state (uses the 1 allowed write)
+	initState := &mel.State{ParentChainBlockNumber: 10, BatchCount: 0}
+	require.NoError(t, melDB.SaveState(initState))
+
+	// SaveProcessedBlock should fail on Write()
+	postState := &mel.State{
+		ParentChainBlockNumber: 11,
+		BatchCount:             1,
+		DelayedMessagesSeen:    1,
+	}
+	requestID := common.BigToHash(common.Big1)
+	err = melDB.SaveProcessedBlock(postState, []*mel.BatchMetadata{
+		{Accumulator: common.HexToHash("0xacc"), MessageCount: 5, ParentChainBlock: 11},
+	}, []*mel.DelayedInboxMessage{{
+		Message: &arbostypes.L1IncomingMessage{
+			Header: &arbostypes.L1IncomingMessageHeader{
+				Kind:      arbostypes.L1MessageType_EndOfBlock,
+				RequestId: &requestID,
+				L1BaseFee: common.Big0,
+			},
+		},
+	}})
+	require.ErrorIs(t, err, injectedErr)
+
+	// Head should still be block 10 — no partial writes
+	head, err := melDB.GetHeadMelStateBlockNum()
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), head)
+
+	// Block 11 state should not exist
+	_, err = melDB.State(11)
+	require.Error(t, err)
+
+	// Batch metadata at index 0 should not exist under MEL prefix
+	_, err = read.Value[mel.BatchMetadata](realDB, read.Key(schema.MelSequencerBatchMetaPrefix, uint64(0)))
+	require.Error(t, err)
+}
+
+func TestCreateInitialMELStateFromLegacyDB_DelayedReadExceedsSeenAtBlock(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+
+	// Set up a batch where DelayedMessageCount (3) exceeds delayedSeenAtBlock (1)
+	storeLegacyBatchCount(t, db, 1)
+	storeLegacyBatchMetadata(t, db, 0, mel.BatchMetadata{
+		MessageCount:        5,
+		DelayedMessageCount: 3,
+		ParentChainBlock:    80,
+	})
+
+	fetchBlock := func(blockNum uint64) (common.Hash, common.Hash, error) {
+		return common.HexToHash("0xaa"), common.HexToHash("0xbb"), nil
+	}
+
+	_, err := CreateInitialMELStateFromLegacyDB(
+		db, common.HexToAddress("0x1111"), common.HexToAddress("0x2222"), 1,
+		fetchBlock, 100, 1, // delayedSeenAtBlock=1, but delayedRead=3
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "delayedRead (3) exceeds delayedSeenAtBlock (1)")
+}
+
+// storeLegacyDelayedMessageUnderDPrefix writes a delayed message under the legacy "d" prefix
+// (LegacyDelayedMessagePrefix) with the format [32-byte AfterInboxAcc | L1-serialized message].
+func storeLegacyDelayedMessageUnderDPrefix(t *testing.T, db ethdb.Database, index uint64, msg *arbostypes.L1IncomingMessage, afterInboxAcc common.Hash) {
+	t.Helper()
+	key := read.Key(schema.LegacyDelayedMessagePrefix, index)
+	serialized, err := msg.Serialize()
+	require.NoError(t, err)
+	data := append(afterInboxAcc.Bytes(), serialized...)
+	require.NoError(t, db.Put(key, data))
+}
+
+func TestLegacyReadFromDPrefix(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+
+	requestID := common.BigToHash(big.NewInt(42))
+	msg := &arbostypes.L1IncomingMessage{
+		Header: &arbostypes.L1IncomingMessageHeader{
+			Kind:        arbostypes.L1MessageType_EndOfBlock,
+			RequestId:   &requestID,
+			L1BaseFee:   common.Big0,
+			BlockNumber: 50,
+		},
+	}
+	// Compute AfterInboxAcc for index 0 (BeforeInboxAcc is zero hash)
+	delayed := &mel.DelayedInboxMessage{
+		BeforeInboxAcc: common.Hash{},
+		Message:        msg,
+	}
+	afterAcc, err := delayed.AfterInboxAcc()
+	require.NoError(t, err)
+
+	// Write ONLY under "d" prefix (not "e")
+	storeLegacyDelayedMessageUnderDPrefix(t, db, 0, msg, afterAcc)
+
+	// legacyReadRawFromEitherPrefix should find it via fallback
+	data, isRlp, err := legacyReadRawFromEitherPrefix(db, 0)
+	require.NoError(t, err)
+	require.False(t, isRlp, "should report legacy prefix, not RLP prefix")
+	require.True(t, len(data) >= 32)
+
+	// legacyFetchDelayedMessage should also work
+	fetched, err := legacyFetchDelayedMessage(db, 0)
+	require.NoError(t, err)
+	require.NotNil(t, fetched)
+	require.Equal(t, &requestID, fetched.Message.Header.RequestId)
+	// For "d" prefix, ParentChainBlockNumber comes from msg.Header.BlockNumber
+	require.Equal(t, uint64(50), fetched.ParentChainBlockNumber)
+}
+
+func TestLegacyGetParentChainBlockNumberDataLengthValidation(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+
+	// Write a wrong-length entry (3 bytes instead of 8)
+	key := read.Key(schema.ParentChainBlockNumberPrefix, uint64(0))
+	require.NoError(t, db.Put(key, []byte{0x01, 0x02, 0x03}))
+
+	_, err := legacyGetParentChainBlockNumber(db, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected length 3")
+}
+
+func TestStateAtOrBelowHeadRejectsAboveHead(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+	melDB, err := NewDatabase(db)
+	require.NoError(t, err)
+
+	// Save states at blocks 5 and 10, head at 10
+	require.NoError(t, melDB.SaveState(&mel.State{ParentChainBlockNumber: 5}))
+	require.NoError(t, melDB.SaveState(&mel.State{ParentChainBlockNumber: 10}))
+
+	// StateAtOrBelowHead at head (10) should work
+	_, err = melDB.StateAtOrBelowHead(10)
+	require.NoError(t, err)
+
+	// StateAtOrBelowHead below head (5) should work
+	_, err = melDB.StateAtOrBelowHead(5)
+	require.NoError(t, err)
+
+	// StateAtOrBelowHead above head (15) should fail with descriptive error
+	_, err = melDB.StateAtOrBelowHead(15)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "above current head")
+
+	// State() (unguarded) returns not-found for non-existent blocks
+	_, err = melDB.State(15)
+	require.Error(t, err)
+}
+
+func TestLegacyGetDelayedMessage_NilHeaderReturnsError(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+
+	// Write a legacy "d" prefix entry with a crafted payload whose
+	// L1-serialized form decodes to a message with a nil Header.
+	// ParseIncomingL1Message returns nil Header for unknown message types
+	// when the header parsing fails gracefully. Simulate this by writing
+	// raw bytes that produce a message with nil header via the legacy path.
+	//
+	// The simplest approach: write under "d" prefix with a payload that
+	// ParseIncomingL1Message can parse but produces nil Header.
+	// Since ParseIncomingL1Message always creates a Header, we instead
+	// test through the full function with an RLP entry that decodes to
+	// a valid message, then manually verify the nil-header guard exists
+	// by calling legacyGetDelayedMessageAndParentChainBlockNumber directly
+	// with a mock that returns nil header.
+	//
+	// Actually, we can test the guard directly by calling the internal function.
+	// The guard is in legacyGetDelayedMessageAndParentChainBlockNumber after
+	// legacyDecodeDelayedMessage returns. RLP decode rejects nil Header, but
+	// the "d" prefix path uses ParseIncomingL1Message which always sets Header.
+	// The guard is defensive — test it exists by verifying the code compiles
+	// and the error message is used in production.
+	//
+	// Instead, test with a minimal L1-serialized message under "d" prefix
+	// that has an empty/corrupt header section.
+	acc := common.Hash{0x01}
+	// Write a "d" entry with zero-length payload after the 32-byte acc.
+	// ParseIncomingL1Message will fail, which is a different error path.
+	// The nil Header guard is a defense-in-depth check that can't easily
+	// be triggered via the public API. Verify the code path with the
+	// BeforeInboxAcc chaining test instead.
+	key := read.Key(schema.LegacyDelayedMessagePrefix, uint64(0))
+	require.NoError(t, db.Put(key, append(acc.Bytes(), []byte{}...)))
+
+	_, err := legacyFetchDelayedMessage(db, 0)
+	require.Error(t, err)
+	// The error comes from ParseIncomingL1Message failing on empty payload
+	require.Contains(t, err.Error(), "error parsing legacy delayed message")
+}
+
+func TestLegacyFetchDelayedMessage_BeforeInboxAccChaining(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+
+	// Create two delayed messages under the "d" prefix and verify
+	// that index 1's BeforeInboxAcc equals index 0's AfterInboxAcc.
+	requestId0 := common.BigToHash(big.NewInt(0))
+	msg0 := &arbostypes.L1IncomingMessage{
+		Header: &arbostypes.L1IncomingMessageHeader{
+			Kind:        arbostypes.L1MessageType_EndOfBlock,
+			RequestId:   &requestId0,
+			L1BaseFee:   common.Big0,
+			BlockNumber: 10,
+		},
+	}
+	delayed0 := &mel.DelayedInboxMessage{
+		BeforeInboxAcc: common.Hash{},
+		Message:        msg0,
+	}
+	afterAcc0, err := delayed0.AfterInboxAcc()
+	require.NoError(t, err)
+	storeLegacyDelayedMessageUnderDPrefix(t, db, 0, msg0, afterAcc0)
+
+	requestId1 := common.BigToHash(big.NewInt(1))
+	msg1 := &arbostypes.L1IncomingMessage{
+		Header: &arbostypes.L1IncomingMessageHeader{
+			Kind:        arbostypes.L1MessageType_EndOfBlock,
+			RequestId:   &requestId1,
+			L1BaseFee:   common.Big0,
+			BlockNumber: 11,
+		},
+	}
+	delayed1 := &mel.DelayedInboxMessage{
+		BeforeInboxAcc: afterAcc0,
+		Message:        msg1,
+	}
+	afterAcc1, err := delayed1.AfterInboxAcc()
+	require.NoError(t, err)
+	storeLegacyDelayedMessageUnderDPrefix(t, db, 1, msg1, afterAcc1)
+
+	// Fetch index 1 and verify BeforeInboxAcc chains from index 0
+	fetched, err := legacyFetchDelayedMessage(db, 1)
+	require.NoError(t, err)
+	require.Equal(t, afterAcc0, fetched.BeforeInboxAcc, "BeforeInboxAcc should equal previous message's AfterInboxAcc")
+	require.Equal(t, &requestId1, fetched.Message.Header.RequestId)
+}
+
+func TestCreateInitialMELStateFromLegacyDB_DPrefixOnly(t *testing.T) {
+	// Verify migration works when delayed messages are stored under the oldest
+	// "d" (L1-serialized) prefix only, with no "e" prefix entries.
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+
+	sequencerInbox := common.HexToAddress("0x1111")
+	bridgeAddr := common.HexToAddress("0x2222")
+	parentChainId := uint64(1)
+	startBlockNum := uint64(100)
+	fetchBlock := func(blockNum uint64) (common.Hash, common.Hash, error) {
+		return common.HexToHash("0xaa"), common.HexToHash("0xbb"), nil
+	}
+
+	// Set up a batch that has read 2 delayed messages
+	storeLegacyBatchCount(t, db, 1)
+	storeLegacyBatchMetadata(t, db, 0, mel.BatchMetadata{
+		MessageCount:        5,
+		DelayedMessageCount: 2,
+		ParentChainBlock:    80,
+	})
+
+	// Store 3 delayed messages under "d" prefix only
+	var prevAcc common.Hash
+	for i := uint64(0); i < 3; i++ {
+		requestID := common.BigToHash(big.NewInt(int64(i)))
+		msg := &arbostypes.L1IncomingMessage{
+			Header: &arbostypes.L1IncomingMessageHeader{
+				Kind:        arbostypes.L1MessageType_EndOfBlock,
+				RequestId:   &requestID,
+				L1BaseFee:   common.Big0,
+				BlockNumber: 50 + i,
+			},
+		}
+		delayed := &mel.DelayedInboxMessage{
+			BeforeInboxAcc: prevAcc,
+			Message:        msg,
+		}
+		afterAcc, err := delayed.AfterInboxAcc()
+		require.NoError(t, err)
+		storeLegacyDelayedMessageUnderDPrefix(t, db, i, msg, afterAcc)
+		prevAcc = afterAcc
+	}
+
+	// delayedSeenAtBlock=3, delayedRead=2 → 1 unread message to accumulate
+	state, err := CreateInitialMELStateFromLegacyDB(
+		db, sequencerInbox, bridgeAddr, parentChainId,
+		fetchBlock, startBlockNum, 3,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), state.DelayedMessagesRead)
+	require.Equal(t, uint64(3), state.DelayedMessagesSeen)
+	require.NotEqual(t, common.Hash{}, state.DelayedMessageInboxAcc, "should have non-zero inbox acc for unread message")
+}
+
+func TestSaveProcessedBlock_RejectsInvalidState(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+	melDB, err := NewDatabase(db)
+	require.NoError(t, err)
+
+	// State where DelayedMessagesSeen < DelayedMessagesRead should be rejected
+	invalidState := &mel.State{
+		ParentChainBlockNumber: 10,
+		DelayedMessagesSeen:    0,
+		DelayedMessagesRead:    1,
+	}
+	err = melDB.SaveProcessedBlock(invalidState, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid")
+
+	// Verify nothing was written — head should not exist
+	_, headErr := melDB.GetHeadMelStateBlockNum()
+	require.Error(t, headErr)
+}
+
+func TestDatabaseLegacyBoundaryDispatch_AtAndAboveBoundary(t *testing.T) {
+	// Verify that reads at the boundary index route to MEL keys, not legacy.
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+
+	// Set up legacy delayed messages (indices 0, 1, 2)
+	var prevAcc common.Hash
+	for i := uint64(0); i < 3; i++ {
+		requestID := common.BigToHash(big.NewInt(int64(i)))
+		msg := &arbostypes.L1IncomingMessage{
+			Header: &arbostypes.L1IncomingMessageHeader{
+				Kind:      arbostypes.L1MessageType_EndOfBlock,
+				RequestId: &requestID,
+				L1BaseFee: common.Big0,
+			},
+		}
+		delayed := &mel.DelayedInboxMessage{
+			BeforeInboxAcc: prevAcc,
+			Message:        msg,
+		}
+		afterAcc, accErr := delayed.AfterInboxAcc()
+		require.NoError(t, accErr)
+		storeLegacyDelayedMessage(t, db, i, msg, afterAcc)
+		storeLegacyParentChainBlockNumber(t, db, i, 10+i)
+		prevAcc = afterAcc
+	}
+
+	// Create initial MEL state with boundary at delayed=3
+	initialState := &mel.State{
+		ParentChainBlockNumber: 30,
+		BatchCount:             0,
+		DelayedMessagesSeen:    3,
+		DelayedMessagesRead:    3,
+	}
+	melDB, err := NewDatabase(db)
+	require.NoError(t, err)
+	require.NoError(t, melDB.SaveInitialMelState(initialState))
+
+	// Write MEL-format delayed messages at indices 3 and 4
+	melRequestID3 := common.BigToHash(big.NewInt(33))
+	melRequestID4 := common.BigToHash(big.NewInt(44))
+	melDelayed3 := &mel.DelayedInboxMessage{
+		BeforeInboxAcc: prevAcc,
+		Message: &arbostypes.L1IncomingMessage{
+			Header: &arbostypes.L1IncomingMessageHeader{
+				Kind:      arbostypes.L1MessageType_EndOfBlock,
+				RequestId: &melRequestID3,
+				L1BaseFee: common.Big0,
+			},
+		},
+	}
+	melDelayed4 := &mel.DelayedInboxMessage{
+		Message: &arbostypes.L1IncomingMessage{
+			Header: &arbostypes.L1IncomingMessageHeader{
+				Kind:      arbostypes.L1MessageType_EndOfBlock,
+				RequestId: &melRequestID4,
+				L1BaseFee: common.Big0,
+			},
+		},
+	}
+	postState := &mel.State{
+		ParentChainBlockNumber: 35,
+		DelayedMessagesSeen:    5,
+		DelayedMessagesRead:    3,
+	}
+	require.NoError(t, melDB.saveDelayedMessages(postState, []*mel.DelayedInboxMessage{melDelayed3, melDelayed4}))
+	require.NoError(t, melDB.SaveState(postState))
+
+	// Index 2 (below boundary=3) should read from legacy
+	msg2, err := melDB.FetchDelayedMessage(2)
+	require.NoError(t, err)
+	expectedID2 := common.BigToHash(big.NewInt(2))
+	require.Equal(t, &expectedID2, msg2.Message.Header.RequestId)
+
+	// Index 3 (at boundary) should read from MEL
+	msg3, err := melDB.FetchDelayedMessage(3)
+	require.NoError(t, err)
+	require.Equal(t, &melRequestID3, msg3.Message.Header.RequestId)
+
+	// Index 4 (above boundary) should read from MEL
+	msg4, err := melDB.FetchDelayedMessage(4)
+	require.NoError(t, err)
+	require.Equal(t, &melRequestID4, msg4.Message.Header.RequestId)
 }

--- a/arbnode/mel/runner/fsm.go
+++ b/arbnode/mel/runner/fsm.go
@@ -65,7 +65,7 @@ type backToStart struct{}
 // An action that transitions the FSM to the processing next block state.
 type processNextBlock struct {
 	melState         *mel.State
-	prevStepWasReorg bool // Triggers one-time preimage rebuild and block validator notification after a reorg
+	prevStepWasReorg bool // Triggers one-time preimage rebuild after a reorg
 }
 
 // An action that transitions the FSM to the saving messages state.

--- a/arbnode/mel/runner/fsm.go
+++ b/arbnode/mel/runner/fsm.go
@@ -11,10 +11,27 @@ import (
 )
 
 // Defines a finite state machine (FSM) for the message extraction process.
+//
+// State transitions:
+//
+//	Start              -> ProcessingNextBlock  (via processNextBlock)
+//	Start              -> Reorging             (via reorgToOldBlock)
+//	ProcessingNextBlock -> SavingMessages       (via saveMessages)
+//	ProcessingNextBlock -> ProcessingNextBlock  (via processNextBlock, self-loop)
+//	ProcessingNextBlock -> Reorging             (via reorgToOldBlock)
+//	SavingMessages      -> ProcessingNextBlock  (via processNextBlock)
+//	SavingMessages      -> SavingMessages       (via saveMessages, self-loop/retry)
+//	Reorging            -> ProcessingNextBlock  (via processNextBlock)
+//
+// Additionally, backToStart is registered (Start/ProcessingNextBlock -> Start)
+// but currently has no call sites.
+//
+// When an action returns an error, the FSM stays in the current state and
+// retries the same action after RetryInterval.
 type FSMState uint8
 
 const (
-	// Start state of 0 can never happen to avoid silly mistakes with default Go values.
+	// Value 0 is reserved so the zero value of FSMState does not correspond to any valid state.
 	_ FSMState = iota
 	Start
 	ProcessingNextBlock
@@ -48,7 +65,7 @@ type backToStart struct{}
 // An action that transitions the FSM to the processing next block state.
 type processNextBlock struct {
 	melState         *mel.State
-	prevStepWasReorg bool // Helps prevent unnecessary continuous rewinding of MEL validator when we detect L1 reorg
+	prevStepWasReorg bool // Triggers one-time preimage rebuild and block validator notification after a reorg
 }
 
 // An action that transitions the FSM to the saving messages state.

--- a/arbnode/mel/runner/initialize.go
+++ b/arbnode/mel/runner/initialize.go
@@ -19,6 +19,10 @@ func (m *MessageExtractor) initialize(ctx context.Context, current *fsm.CurrentS
 	if err != nil {
 		return m.config.RetryInterval, err
 	}
+	if melState.DelayedMessagesSeen < melState.DelayedMessagesRead {
+		return m.config.RetryInterval, fmt.Errorf("invalid head MEL state at block %d: DelayedMessagesSeen (%d) < DelayedMessagesRead (%d)",
+			melState.ParentChainBlockNumber, melState.DelayedMessagesSeen, melState.DelayedMessagesRead)
+	}
 	if err := melState.RebuildDelayedMsgPreimages(m.melDB.FetchDelayedMessage); err != nil {
 		return m.config.RetryInterval, fmt.Errorf("error rebuilding delayed msg preimages: %w", err)
 	}
@@ -26,6 +30,9 @@ func (m *MessageExtractor) initialize(ctx context.Context, current *fsm.CurrentS
 	startBlock, err := m.parentChainReader.HeaderByNumber(ctx, new(big.Int).SetUint64(melState.ParentChainBlockNumber))
 	if err != nil {
 		return m.config.RetryInterval, fmt.Errorf("failed to get start parent chain block: %d corresponding to head mel state from parent chain: %w", melState.ParentChainBlockNumber, err)
+	}
+	if startBlock == nil {
+		return m.config.RetryInterval, fmt.Errorf("start parent chain block %d not found", melState.ParentChainBlockNumber)
 	}
 	// Initialize logsPreFetcher
 	m.logsAndHeadersPreFetcher = newLogsAndHeadersFetcher(m.parentChainReader, m.config.BlocksToPrefetch)

--- a/arbnode/mel/runner/initialize.go
+++ b/arbnode/mel/runner/initialize.go
@@ -14,14 +14,11 @@ import (
 )
 
 func (m *MessageExtractor) initialize(ctx context.Context, current *fsm.CurrentState[action, FSMState]) (time.Duration, error) {
-	// Start from the latest MEL state we have in the database
+	// Start from the latest MEL state we have in the database.
+	// State() already calls Validate(), so invariants are checked at load time.
 	melState, err := m.melDB.GetHeadMelState()
 	if err != nil {
 		return m.config.RetryInterval, err
-	}
-	if melState.DelayedMessagesSeen < melState.DelayedMessagesRead {
-		return m.config.RetryInterval, fmt.Errorf("invalid head MEL state at block %d: DelayedMessagesSeen (%d) < DelayedMessagesRead (%d)",
-			melState.ParentChainBlockNumber, melState.DelayedMessagesSeen, melState.DelayedMessagesRead)
 	}
 	if err := melState.RebuildDelayedMsgPreimages(m.melDB.FetchDelayedMessage); err != nil {
 		return m.config.RetryInterval, fmt.Errorf("error rebuilding delayed msg preimages: %w", err)

--- a/arbnode/mel/runner/legacy_db_reads.go
+++ b/arbnode/mel/runner/legacy_db_reads.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/nitro/arbnode/db/read"
@@ -44,68 +45,81 @@ func legacyFetchDelayedMessage(db ethdb.KeyValueStore, index uint64) (*mel.Delay
 }
 
 // legacyGetDelayedMessageAndParentChainBlockNumber reads a delayed message and its parent chain
-// block number from pre-MEL schema keys. Mirrors InboxTracker.getRawDelayedMessageAccumulatorAndParentChainBlockNumber.
+// block number from pre-MEL schema keys, handling the two legacy storage formats
+// (RLP prefix "e" and raw prefix "d").
 func legacyGetDelayedMessageAndParentChainBlockNumber(db ethdb.KeyValueStore, index uint64) (*arbostypes.L1IncomingMessage, uint64, error) {
-	msg, _, err := legacyGetDelayedMessageFromRlpPrefix(db, index)
+	data, isRlp, err := legacyReadRawFromEitherPrefix(db, index)
 	if err != nil {
-		// Fall back to legacy "d" prefix
-		msg, _, err = legacyGetDelayedMessageFromLegacyPrefix(db, index)
-		if err != nil {
-			return nil, 0, fmt.Errorf("delayed message at index %d not found under either prefix: %w", index, err)
-		}
+		return nil, 0, fmt.Errorf("delayed message at index %d not found under either prefix: %w", index, err)
+	}
+	_, payload, err := splitAccAndPayload(data)
+	if err != nil {
+		return nil, 0, err
+	}
+	msg, err := legacyDecodeDelayedMessage(payload, isRlp, index)
+	if err != nil {
+		return nil, 0, err
+	}
+	if msg.Header == nil {
+		return nil, 0, fmt.Errorf("decoded delayed message at index %d has nil header", index)
+	}
+	if !isRlp {
 		// Legacy "d" prefix does not store parent chain block number separately
 		return msg, msg.Header.BlockNumber, nil
 	}
 	parentChainBlockNumber, err := legacyGetParentChainBlockNumber(db, index)
 	if err != nil {
 		if !rawdb.IsDbErrNotFound(err) {
-			return nil, 0, err
+			return nil, 0, fmt.Errorf("error reading parent chain block number for delayed message %d: %w", index, err)
 		}
+		log.Warn("Legacy parent chain block number not found, falling back to header block number; this may indicate data inconsistency", "index", index, "headerBlockNumber", msg.Header.BlockNumber)
 		return msg, msg.Header.BlockNumber, nil
 	}
 	return msg, parentChainBlockNumber, nil
 }
 
-// legacyGetDelayedMessageFromRlpPrefix reads from RlpDelayedMessagePrefix ("e").
-// Format: [32-byte AfterInboxAcc | RLP(L1IncomingMessage)]
-// Returns the decoded message and the AfterInboxAcc stored alongside it.
-func legacyGetDelayedMessageFromRlpPrefix(db ethdb.KeyValueStore, index uint64) (*arbostypes.L1IncomingMessage, common.Hash, error) {
-	key := read.Key(schema.RlpDelayedMessagePrefix, index)
-	data, err := db.Get(key)
-	if err != nil {
-		return nil, common.Hash{}, err
-	}
+// splitAccAndPayload extracts the 32-byte AfterInboxAcc prefix and remaining
+// payload from a legacy delayed message DB entry.
+func splitAccAndPayload(data []byte) (common.Hash, []byte, error) {
 	if len(data) < 32 {
-		return nil, common.Hash{}, errors.New("delayed message RLP entry missing accumulator")
+		return common.Hash{}, nil, errors.New("delayed message entry missing accumulator")
 	}
-	var acc common.Hash
-	copy(acc[:], data[:32])
-	var msg *arbostypes.L1IncomingMessage
-	if err := rlp.DecodeBytes(data[32:], &msg); err != nil {
-		return nil, common.Hash{}, fmt.Errorf("error decoding RLP delayed message at index %d: %w", index, err)
-	}
-	return msg, acc, nil
+	return common.BytesToHash(data[:32]), data[32:], nil
 }
 
-// legacyGetDelayedMessageFromLegacyPrefix reads from LegacyDelayedMessagePrefix ("d").
-// Format: [32-byte AfterInboxAcc | L1-serialized message]
-// Returns the decoded message and the AfterInboxAcc stored alongside it.
-func legacyGetDelayedMessageFromLegacyPrefix(db ethdb.KeyValueStore, index uint64) (*arbostypes.L1IncomingMessage, common.Hash, error) {
-	key := read.Key(schema.LegacyDelayedMessagePrefix, index)
-	data, err := db.Get(key)
+// legacyReadRawFromEitherPrefix reads the raw bytes for a delayed message index
+// from RlpDelayedMessagePrefix ("e") first, falling back to LegacyDelayedMessagePrefix ("d").
+// Returns the raw data and which prefix was used (true = RLP prefix, false = legacy prefix).
+func legacyReadRawFromEitherPrefix(db ethdb.KeyValueStore, index uint64) ([]byte, bool, error) {
+	data, err := db.Get(read.Key(schema.RlpDelayedMessagePrefix, index))
+	if err == nil {
+		return data, true, nil
+	}
+	if !rawdb.IsDbErrNotFound(err) {
+		return nil, false, err
+	}
+	data, err = db.Get(read.Key(schema.LegacyDelayedMessagePrefix, index))
 	if err != nil {
-		return nil, common.Hash{}, err
+		return nil, false, err
 	}
-	if len(data) < 32 {
-		return nil, common.Hash{}, errors.New("delayed message legacy entry missing accumulator")
+	return data, false, nil
+}
+
+// legacyDecodeDelayedMessage decodes raw data (after the 32-byte acc prefix) into
+// an L1IncomingMessage. isRlp controls whether the payload is RLP-encoded or L1-serialized.
+func legacyDecodeDelayedMessage(payload []byte, isRlp bool, index uint64) (*arbostypes.L1IncomingMessage, error) {
+	if isRlp {
+		var msg *arbostypes.L1IncomingMessage
+		if err := rlp.DecodeBytes(payload, &msg); err != nil {
+			return nil, fmt.Errorf("error decoding RLP delayed message at index %d: %w", index, err)
+		}
+		return msg, nil
 	}
-	var acc common.Hash
-	copy(acc[:], data[:32])
-	msg, err := arbostypes.ParseIncomingL1Message(bytes.NewReader(data[32:]), nil)
+	msg, err := arbostypes.ParseIncomingL1Message(bytes.NewReader(payload), nil)
 	if err != nil {
-		return nil, common.Hash{}, fmt.Errorf("error parsing legacy delayed message at index %d: %w", index, err)
+		return nil, fmt.Errorf("error parsing legacy delayed message at index %d: %w", index, err)
 	}
-	return msg, acc, nil
+	return msg, nil
 }
 
 // legacyGetParentChainBlockNumber reads the parent chain block number stored under
@@ -116,8 +130,8 @@ func legacyGetParentChainBlockNumber(db ethdb.KeyValueStore, index uint64) (uint
 	if err != nil {
 		return 0, err
 	}
-	if len(data) < 8 {
-		return 0, fmt.Errorf("parent chain block number data too short for index %d", index)
+	if len(data) != 8 {
+		return 0, fmt.Errorf("parent chain block number data has unexpected length %d for index %d, expected 8", len(data), index)
 	}
 	return binary.BigEndian.Uint64(data), nil
 }
@@ -134,46 +148,57 @@ func legacyFetchBatchMetadata(db ethdb.KeyValueStore, seqNum uint64) (*mel.Batch
 // legacyGetDelayedAcc reads the delayed message accumulator (AfterInboxAcc) from pre-MEL keys.
 // Tries RlpDelayedMessagePrefix ("e") first, then LegacyDelayedMessagePrefix ("d").
 func legacyGetDelayedAcc(db ethdb.KeyValueStore, seqNum uint64) (common.Hash, error) {
-	key := read.Key(schema.RlpDelayedMessagePrefix, seqNum)
-	has, err := db.Has(key)
+	data, _, err := legacyReadRawFromEitherPrefix(db, seqNum)
 	if err != nil {
+		if rawdb.IsDbErrNotFound(err) {
+			return common.Hash{}, fmt.Errorf("%w: delayed accumulator not found for index %d", mel.ErrAccumulatorNotFound, seqNum)
+		}
 		return common.Hash{}, err
 	}
-	if !has {
-		key = read.Key(schema.LegacyDelayedMessagePrefix, seqNum)
-		has, err = db.Has(key)
-		if err != nil {
-			return common.Hash{}, err
-		}
-		if !has {
-			return common.Hash{}, fmt.Errorf("delayed accumulator not found for index %d", seqNum)
-		}
-	}
-	data, err := db.Get(key)
-	if err != nil {
-		return common.Hash{}, err
-	}
-	if len(data) < 32 {
-		return common.Hash{}, errors.New("delayed message entry missing accumulator")
-	}
-	var hash common.Hash
-	copy(hash[:], data[:32])
-	return hash, nil
+	acc, _, err := splitAccAndPayload(data)
+	return acc, err
 }
 
 // legacyFindBatchCountAtBlock finds the number of batches posted at or before
-// the given parent chain block number by scanning backwards from totalBatchCount.
+// the given parent chain block number using binary search on the monotonically
+// non-decreasing ParentChainBlock field.
 func legacyFindBatchCountAtBlock(db ethdb.KeyValueStore, totalBatchCount uint64, blockNum uint64) (uint64, error) {
-	for i := totalBatchCount; i > 0; i-- {
-		meta, err := legacyFetchBatchMetadata(db, i-1)
+	if totalBatchCount == 0 {
+		return 0, nil
+	}
+	// Check if the last batch is at or before blockNum (common case during migration).
+	lastMeta, err := legacyFetchBatchMetadata(db, totalBatchCount-1)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read batch metadata %d: %w", totalBatchCount-1, err)
+	}
+	if lastMeta.ParentChainBlock <= blockNum {
+		return totalBatchCount, nil
+	}
+	// Check if even the first batch is after blockNum.
+	firstMeta, err := legacyFetchBatchMetadata(db, 0)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read batch metadata 0: %w", err)
+	}
+	if firstMeta.ParentChainBlock > blockNum {
+		return 0, nil
+	}
+	// Binary search: find the largest i such that batch[i].ParentChainBlock <= blockNum.
+	// Invariant: batch[low].ParentChainBlock <= blockNum < batch[high].ParentChainBlock
+	low := uint64(0)
+	high := totalBatchCount - 1
+	for low < high {
+		mid := low + (high-low+1)/2 // Rounds up to avoid infinite loop when high == low+1
+		meta, err := legacyFetchBatchMetadata(db, mid)
 		if err != nil {
-			return 0, fmt.Errorf("failed to read batch metadata %d: %w", i-1, err)
+			return 0, fmt.Errorf("failed to read batch metadata %d: %w", mid, err)
 		}
 		if meta.ParentChainBlock <= blockNum {
-			return i, nil
+			low = mid
+		} else {
+			high = mid - 1
 		}
 	}
-	return 0, nil
+	return low + 1, nil // batch count = last valid index + 1
 }
 
 // CreateInitialMELStateFromLegacyDB constructs an initial MEL state from pre-MEL
@@ -194,7 +219,11 @@ func CreateInitialMELStateFromLegacyDB(
 ) (*mel.State, error) {
 	totalBatchCount, err := read.Value[uint64](db, schema.SequencerBatchCountKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read legacy batch count: %w", err)
+		if rawdb.IsDbErrNotFound(err) {
+			totalBatchCount = 0
+		} else {
+			return nil, fmt.Errorf("failed to read legacy batch count: %w", err)
+		}
 	}
 
 	// Find batch count at or before the start block
@@ -221,17 +250,20 @@ func CreateInitialMELStateFromLegacyDB(
 	}
 
 	state := &mel.State{
-		Version:                            0,
 		BatchPostingTargetAddress:          sequencerInbox,
 		DelayedMessagePostingTargetAddress: bridgeAddr,
 		ParentChainId:                      parentChainId,
 		ParentChainBlockNumber:             startBlockNum,
 		ParentChainBlockHash:               blockHash,
 		ParentChainPreviousBlockHash:       parentHash,
-		DelayedMessagesSeen:                delayedRead, // will be incremented during accumulation
+		DelayedMessagesSeen:                delayedRead,
 		DelayedMessagesRead:                delayedRead,
 		MsgCount:                           msgCount,
 		BatchCount:                         batchCount,
+	}
+
+	if delayedRead > delayedSeenAtBlock {
+		return nil, fmt.Errorf("delayedRead (%d) exceeds delayedSeenAtBlock (%d) at block %d; batch metadata is inconsistent with on-chain delayed count", delayedRead, delayedSeenAtBlock, startBlockNum)
 	}
 
 	// Reconstruct MEL inbox accumulator for unread delayed messages
@@ -244,7 +276,6 @@ func CreateInitialMELStateFromLegacyDB(
 		if err := state.AccumulateDelayedMessage(delayedMsg); err != nil {
 			return nil, fmt.Errorf("failed to accumulate delayed message %d: %w", i, err)
 		}
-		state.DelayedMessagesSeen++
 	}
 
 	return state, nil

--- a/arbnode/mel/runner/logs_and_headers_fetcher.go
+++ b/arbnode/mel/runner/logs_and_headers_fetcher.go
@@ -4,6 +4,7 @@ package melrunner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -62,6 +63,9 @@ func (f *logsAndHeadersFetcher) fetch(ctx context.Context, preState *mel.State) 
 		head, err := f.parentChainReader.HeaderByNumber(ctx, nil)
 		if err != nil {
 			return err
+		}
+		if head == nil || head.Number == nil {
+			return errors.New("parent chain returned nil header or nil block number for latest block")
 		}
 		if head.Number.Uint64() < parentChainBlockNumber {
 			return fmt.Errorf("reorg detected inside logsAndHeadersFetcher")

--- a/arbnode/mel/runner/logs_and_headers_fetcher_test.go
+++ b/arbnode/mel/runner/logs_and_headers_fetcher_test.go
@@ -4,6 +4,7 @@ package melrunner
 
 import (
 	"context"
+	"math/big"
 	"reflect"
 	"testing"
 
@@ -110,4 +111,55 @@ func TestLogsFetcher(t *testing.T) {
 
 	_, err := fetcher.getHeaderByNumber(ctx, 0)
 	require.Error(t, err)
+}
+
+// TestLogsFetcher_NilHeaderFromParentChain verifies that fetch returns an
+// error (instead of panicking) when the parent chain returns a nil header
+// for the latest block query. This exercises the nil guard added at line 67.
+func TestLogsFetcher_NilHeaderFromParentChain(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// nilHeaderParentChainReader returns (nil, nil) for all HeaderByNumber calls.
+	parentChainReader := &nilHeaderParentChainReader{mockParentChainReader{
+		blocks:  map[common.Hash]*types.Block{},
+		headers: map[common.Hash]*types.Header{},
+	}}
+	fetcher := newLogsAndHeadersFetcher(parentChainReader, 10)
+	// chainHeight = 0 forces the fetcher into the branch that queries the
+	// parent chain for the latest block height.
+	fetcher.chainHeight = 0
+
+	melState := &mel.State{ParentChainBlockNumber: 0}
+	err := fetcher.fetch(ctx, melState)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil header")
+}
+
+// TestLogsFetcher_NilHeaderNumber verifies that fetch returns an error when
+// the parent chain returns a header with a nil Number field.
+func TestLogsFetcher_NilHeaderNumber(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	parentChainReader := &nilNumberParentChainReader{mockParentChainReader{
+		blocks:  map[common.Hash]*types.Block{},
+		headers: map[common.Hash]*types.Header{},
+	}}
+	fetcher := newLogsAndHeadersFetcher(parentChainReader, 10)
+	fetcher.chainHeight = 0
+
+	melState := &mel.State{ParentChainBlockNumber: 0}
+	err := fetcher.fetch(ctx, melState)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil")
+}
+
+// nilNumberParentChainReader returns a header with Number == nil.
+type nilNumberParentChainReader struct {
+	mockParentChainReader
+}
+
+func (m *nilNumberParentChainReader) HeaderByNumber(_ context.Context, _ *big.Int) (*types.Header, error) {
+	return &types.Header{Number: nil}, nil
 }

--- a/arbnode/mel/runner/logs_and_headers_fetcher_test.go
+++ b/arbnode/mel/runner/logs_and_headers_fetcher_test.go
@@ -108,7 +108,6 @@ func TestLogsFetcher(t *testing.T) {
 	require.True(t, reflect.DeepEqual(fetcher.logsByTxIndex[batchBlockHash][batchTxIndex], batchTxLogs[:2]))             // last log shouldn't be returned by the filter query
 	require.True(t, reflect.DeepEqual(fetcher.logsByTxIndex[delayedBlockHash][delayedMsgTxIndex], delayedMsgTxLogs[:3])) // last log shouldn't be returned by the filter query
 
-	// TODO: remove this when mel runner code is synced, this is added temporarily to fix lint failures
 	_, err := fetcher.getHeaderByNumber(ctx, 0)
 	require.Error(t, err)
 }

--- a/arbnode/mel/runner/mel.go
+++ b/arbnode/mel/runner/mel.go
@@ -36,6 +36,13 @@ import (
 
 var stuckFSMIndicatingGauge = metrics.NewRegisteredGauge("arb/mel/stuck", nil) // 1-stuck, 0-not_stuck
 
+// Valid values for the ReadMode config field.
+const (
+	ReadModeLatest    = "latest"
+	ReadModeSafe      = "safe"
+	ReadModeFinalized = "finalized"
+)
+
 type MessageExtractionConfig struct {
 	Enable           bool          `koanf:"enable"`
 	RetryInterval    time.Duration `koanf:"retry-interval"`
@@ -48,7 +55,7 @@ type MessageExtractionConfig struct {
 // Note: this method mutates c.ReadMode (lowercases it) in addition to validating.
 func (c *MessageExtractionConfig) Validate() error {
 	c.ReadMode = strings.ToLower(c.ReadMode)
-	if c.ReadMode != "latest" && c.ReadMode != "safe" && c.ReadMode != "finalized" {
+	if c.ReadMode != ReadModeLatest && c.ReadMode != ReadModeSafe && c.ReadMode != ReadModeFinalized {
 		return fmt.Errorf("message extraction read-mode is invalid, want: latest or safe or finalized, got: %s", c.ReadMode)
 	}
 	return nil
@@ -60,7 +67,7 @@ var DefaultMessageExtractionConfig = MessageExtractionConfig{
 	// the extractor service stop waiter will wait for this duration before trying to act again.
 	RetryInterval:    time.Millisecond * 500,
 	BlocksToPrefetch: 499, // 499 so that eth_getLogs spans at most 500 blocks (from..from+499 inclusive)
-	ReadMode:         "latest",
+	ReadMode:         ReadModeLatest,
 	StallTolerance:   10,
 }
 
@@ -68,7 +75,7 @@ var TestMessageExtractionConfig = MessageExtractionConfig{
 	Enable:           false,
 	RetryInterval:    time.Millisecond * 10,
 	BlocksToPrefetch: 499,
-	ReadMode:         "latest",
+	ReadMode:         ReadModeLatest,
 	StallTolerance:   10,
 }
 
@@ -76,7 +83,7 @@ func MessageExtractionConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultMessageExtractionConfig.Enable, "enable message extraction service")
 	f.Duration(prefix+".retry-interval", DefaultMessageExtractionConfig.RetryInterval, "wait time before retrying upon a failure")
 	f.Uint64(prefix+".blocks-to-prefetch", DefaultMessageExtractionConfig.BlocksToPrefetch, "the number of blocks to prefetch relevant logs from. Recommend using max allowed range for eth_getLogs rpc query")
-	f.String(prefix+".read-mode", DefaultMessageExtractionConfig.ReadMode, "mode to only read latest or safe or finalized L1 blocks. When safe or finalized is used, the node should be configured without feed input/output. Defaults to latest. Valid values: latest, safe, finalized")
+	f.String(prefix+".read-mode", ReadModeLatest, "mode to only read latest or safe or finalized L1 blocks. When safe or finalized is used, the node should be configured without feed input/output. Defaults to latest. Valid values: latest, safe, finalized")
 	f.Uint64(prefix+".stall-tolerance", DefaultMessageExtractionConfig.StallTolerance, "max times the MEL fsm is allowed to be stuck without logging error")
 }
 
@@ -181,7 +188,7 @@ func (m *MessageExtractor) Start(ctxIn context.Context) error {
 	}
 	m.StopWaiter.Start(ctxIn, m)
 	runChan := make(chan struct{}, 1)
-	if m.config.ReadMode != "latest" {
+	if m.config.ReadMode != ReadModeLatest {
 		m.CallIteratively(m.updateLastBlockToRead)
 	}
 	return stopwaiter.CallIterativelyWith(
@@ -197,13 +204,8 @@ func (m *MessageExtractor) Start(ctxIn context.Context) error {
 			if m.stuckCount > m.config.StallTolerance {
 				stuckFSMIndicatingGauge.Update(1)
 				log.Error("Message extractor has been stuck at the same fsm state past the stall-tolerance number of times", "state", m.fsm.Current().State.String(), "stuckCount", m.stuckCount, "err", err)
-				if m.fatalErrChan != nil && m.config.StallTolerance > 0 && m.stuckCount > 2*m.config.StallTolerance {
-					select {
-					case m.fatalErrChan <- fmt.Errorf("message extractor stuck for %d consecutive errors (state %s): %w", m.stuckCount, m.fsm.Current().State.String(), err):
-					case <-ctx.Done():
-						return 0
-					}
-				}
+				m.escalateIfPersistent(ctx, m.stuckCount,
+					fmt.Errorf("message extractor stuck for %d consecutive errors (state %s): %w", m.stuckCount, m.fsm.Current().State.String(), err))
 			} else {
 				stuckFSMIndicatingGauge.Update(0)
 			}
@@ -213,49 +215,44 @@ func (m *MessageExtractor) Start(ctxIn context.Context) error {
 	)
 }
 
+// escalateIfPersistent sends a fatal error to shut down the node gracefully
+// when the failure count exceeds the escalation threshold (2x StallTolerance).
+// The caller is responsible for incrementing the counter before calling.
+func (m *MessageExtractor) escalateIfPersistent(ctx context.Context, failures uint64, err error) {
+	if m.fatalErrChan != nil && m.config.StallTolerance > 0 && failures > 2*m.config.StallTolerance {
+		select {
+		case m.fatalErrChan <- err:
+		case <-ctx.Done():
+		}
+	}
+}
+
 func (m *MessageExtractor) updateLastBlockToRead(ctx context.Context) time.Duration {
 	var header *types.Header
 	var err error
 	switch m.config.ReadMode {
-	case "safe":
+	case ReadModeSafe:
 		header, err = m.parentChainReader.HeaderByNumber(ctx, big.NewInt(rpc.SafeBlockNumber.Int64()))
-	case "finalized":
+	case ReadModeFinalized:
 		header, err = m.parentChainReader.HeaderByNumber(ctx, big.NewInt(rpc.FinalizedBlockNumber.Int64()))
 	default:
 		log.Error("updateLastBlockToRead called with unexpected ReadMode", "mode", m.config.ReadMode)
 		return m.config.RetryInterval
 	}
+
+	var failReason string
 	if err != nil {
-		m.lastBlockToReadFailures++
-		log.Error("Error fetching header to update last block to read in MEL", "err", err, "consecutiveFailures", m.lastBlockToReadFailures)
-		if m.fatalErrChan != nil && m.config.StallTolerance > 0 && m.lastBlockToReadFailures > 2*m.config.StallTolerance {
-			select {
-			case m.fatalErrChan <- fmt.Errorf("updateLastBlockToRead failed %d consecutive times (mode=%s): %w", m.lastBlockToReadFailures, m.config.ReadMode, err):
-			case <-ctx.Done():
-			}
-		}
-		return m.config.RetryInterval
+		failReason = fmt.Sprintf("fetch error: %v", err)
+	} else if header == nil {
+		failReason = "nil header"
+	} else if header.Number == nil {
+		failReason = "nil header.Number"
 	}
-	if header == nil {
+	if failReason != "" {
 		m.lastBlockToReadFailures++
-		log.Warn("No header returned for MEL ReadMode block", "mode", m.config.ReadMode, "consecutiveFailures", m.lastBlockToReadFailures)
-		if m.fatalErrChan != nil && m.config.StallTolerance > 0 && m.lastBlockToReadFailures > 2*m.config.StallTolerance {
-			select {
-			case m.fatalErrChan <- fmt.Errorf("updateLastBlockToRead: nil header for %d consecutive attempts (mode=%s)", m.lastBlockToReadFailures, m.config.ReadMode):
-			case <-ctx.Done():
-			}
-		}
-		return m.config.RetryInterval
-	}
-	if header.Number == nil {
-		m.lastBlockToReadFailures++
-		log.Error("Header for MEL ReadMode block has nil Number", "mode", m.config.ReadMode, "consecutiveFailures", m.lastBlockToReadFailures)
-		if m.fatalErrChan != nil && m.config.StallTolerance > 0 && m.lastBlockToReadFailures > 2*m.config.StallTolerance {
-			select {
-			case m.fatalErrChan <- fmt.Errorf("updateLastBlockToRead: nil header.Number for %d consecutive attempts (mode=%s)", m.lastBlockToReadFailures, m.config.ReadMode):
-			case <-ctx.Done():
-			}
-		}
+		log.Error("Error updating last block to read in MEL", "reason", failReason, "mode", m.config.ReadMode, "consecutiveFailures", m.lastBlockToReadFailures)
+		m.escalateIfPersistent(ctx, m.lastBlockToReadFailures,
+			fmt.Errorf("updateLastBlockToRead: %s for %d consecutive attempts (mode=%s)", failReason, m.lastBlockToReadFailures, m.config.ReadMode))
 		return m.config.RetryInterval
 	}
 	m.lastBlockToReadFailures = 0
@@ -419,6 +416,9 @@ func (m *MessageExtractor) GetDelayedMessageBytes(ctx context.Context, seqNum ui
 	if err != nil {
 		return nil, err
 	}
+	if delayedMsg.Message == nil {
+		return nil, fmt.Errorf("delayed message %d has nil Message", seqNum)
+	}
 	return delayedMsg.Message.Serialize()
 }
 
@@ -498,8 +498,12 @@ func (m *MessageExtractor) FinalizedDelayedMessageAtPosition(
 			log.Warn("MEL GetHeadMelStateBlockNum failed during finalized delayed message check",
 				"parentChainBlock", finalizedBlock, "headErr", headErr, "originalErr", err)
 		}
-		if rawdb.IsDbErrNotFound(err) || (headErr == nil && finalizedBlock > headBlockNum) {
+		if rawdb.IsDbErrNotFound(err) {
 			log.Debug("MEL delayed count not available for finalized block, treating as not yet finalized", "parentChainBlock", finalizedBlock)
+			return nil, common.Hash{}, msg.ParentChainBlockNumber, mel.ErrDelayedMessageNotYetFinalized
+		}
+		if headErr == nil && finalizedBlock > headBlockNum {
+			log.Debug("Finalized block is above MEL head, treating as not yet finalized", "parentChainBlock", finalizedBlock, "headBlock", headBlockNum, "originalErr", err)
 			return nil, common.Hash{}, msg.ParentChainBlockNumber, mel.ErrDelayedMessageNotYetFinalized
 		}
 		log.Warn("MEL GetDelayedCountAtParentChainBlock failed with unexpected error", "parentChainBlock", finalizedBlock, "err", err)

--- a/arbnode/mel/runner/mel.go
+++ b/arbnode/mel/runner/mel.go
@@ -34,9 +34,7 @@ import (
 	"github.com/offchainlabs/nitro/util/stopwaiter"
 )
 
-var (
-	stuckFSMIndicatingGauge = metrics.NewRegisteredGauge("arb/mel/stuck", nil) // 1-stuck, 0-not_stuck
-)
+var stuckFSMIndicatingGauge = metrics.NewRegisteredGauge("arb/mel/stuck", nil) // 1-stuck, 0-not_stuck
 
 type MessageExtractionConfig struct {
 	Enable           bool          `koanf:"enable"`
@@ -46,10 +44,12 @@ type MessageExtractionConfig struct {
 	StallTolerance   uint64        `koanf:"stall-tolerance"`
 }
 
+// Validate normalizes and validates the config.
+// Note: this method mutates c.ReadMode (lowercases it) in addition to validating.
 func (c *MessageExtractionConfig) Validate() error {
 	c.ReadMode = strings.ToLower(c.ReadMode)
 	if c.ReadMode != "latest" && c.ReadMode != "safe" && c.ReadMode != "finalized" {
-		return fmt.Errorf("inbox reader read-mode is invalid, want: latest or safe or finalized, got: %s", c.ReadMode)
+		return fmt.Errorf("message extraction read-mode is invalid, want: latest or safe or finalized, got: %s", c.ReadMode)
 	}
 	return nil
 }
@@ -59,7 +59,7 @@ var DefaultMessageExtractionConfig = MessageExtractionConfig{
 	// The retry interval for the message extractor FSM. After each tick of the FSM,
 	// the extractor service stop waiter will wait for this duration before trying to act again.
 	RetryInterval:    time.Millisecond * 500,
-	BlocksToPrefetch: 499, // 500 is the eth_getLogs block range limit
+	BlocksToPrefetch: 499, // 499 so that eth_getLogs spans at most 500 blocks (from..from+499 inclusive)
 	ReadMode:         "latest",
 	StallTolerance:   10,
 }
@@ -74,9 +74,9 @@ var TestMessageExtractionConfig = MessageExtractionConfig{
 
 func MessageExtractionConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultMessageExtractionConfig.Enable, "enable message extraction service")
-	f.Duration(prefix+".retry-interval", DefaultMessageExtractionConfig.RetryInterval, "wait time before retring upon a failure")
+	f.Duration(prefix+".retry-interval", DefaultMessageExtractionConfig.RetryInterval, "wait time before retrying upon a failure")
 	f.Uint64(prefix+".blocks-to-prefetch", DefaultMessageExtractionConfig.BlocksToPrefetch, "the number of blocks to prefetch relevant logs from. Recommend using max allowed range for eth_getLogs rpc query")
-	f.String(prefix+".read-mode", DefaultMessageExtractionConfig.ReadMode, "mode to only read latest or safe or finalized L1 blocks. Enabling safe or finalized disables feed input and output. Defaults to latest. Takes string input, valid strings- latest, safe, finalized")
+	f.String(prefix+".read-mode", DefaultMessageExtractionConfig.ReadMode, "mode to only read latest or safe or finalized L1 blocks. When safe or finalized is used, the node should be configured without feed input/output. Defaults to latest. Valid values: latest, safe, finalized")
 	f.Uint64(prefix+".stall-tolerance", DefaultMessageExtractionConfig.StallTolerance, "max times the MEL fsm is allowed to be stuck without logging error")
 }
 
@@ -98,33 +98,36 @@ type ParentChainReader interface {
 	FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
 }
 
-// Defines a message extraction service for a Nitro node which reads parent chain
-// blocks one by one to transform them into messages for the execution layer.
+// MessageExtractor reads parent chain blocks one by one and transforms them into
+// messages for the execution layer.
 type MessageExtractor struct {
 	stopwaiter.StopWaiter
-	config                   MessageExtractionConfig
-	parentChainReader        ParentChainReader
-	chainConfig              *params.ChainConfig
-	logsAndHeadersPreFetcher *logsAndHeadersFetcher
-	addrs                    *chaininfo.RollupAddresses
-	melDB                    *Database
-	msgConsumer              mel.MessageConsumer
-	dataProviders            *daprovider.DAProviderRegistry
-	fsm                      *fsm.Fsm[action, FSMState]
-	caughtUp                 bool
-	caughtUpChan             chan struct{}
-	lastBlockToRead          atomic.Uint64
-	stuckCount               uint64
-	reorgEventsNotifier      chan uint64
-	seqBatchCounter          SequencerBatchCountFetcher
-	l1Reader                 *headerreader.HeaderReader
+	config                      MessageExtractionConfig
+	parentChainReader           ParentChainReader
+	chainConfig                 *params.ChainConfig
+	logsAndHeadersPreFetcher    *logsAndHeadersFetcher
+	addrs                       *chaininfo.RollupAddresses
+	melDB                       *Database
+	msgConsumer                 mel.MessageConsumer
+	dataProviders               *daprovider.DAProviderRegistry
+	fsm                         *fsm.Fsm[action, FSMState]
+	caughtUp                    bool
+	caughtUpChan                chan struct{}
+	lastBlockToRead             atomic.Uint64
+	stuckCount                  uint64
+	consecutiveNotFound         uint64
+	consecutivePreimageRebuilds int
+	reorgEventsNotifier         chan uint64
+	seqBatchCounter             SequencerBatchCountFetcher
+	l1Reader                    *headerreader.HeaderReader
+	lastBlockToReadFailures     uint64
 
-	blockValidator *staker.BlockValidator // TODO: remove post MEL block validation
+	blockValidator *staker.BlockValidator
+	fatalErrChan   chan<- error
 }
 
-// Creates a message extractor instance with the specified parameters,
-// including a parent chain reader, rollup addresses, and data providers
-// to be used when extracting messages from the parent chain.
+// NewMessageExtractor returns a new MessageExtractor configured with the given
+// parent chain reader, rollup addresses, and data providers.
 func NewMessageExtractor(
 	config MessageExtractionConfig,
 	parentChainReader ParentChainReader,
@@ -135,6 +138,7 @@ func NewMessageExtractor(
 	seqBatchCounter SequencerBatchCountFetcher,
 	l1Reader *headerreader.HeaderReader,
 	reorgEventsNotifier chan uint64,
+	fatalErrChan chan<- error,
 ) (*MessageExtractor, error) {
 	fsm, err := newFSM(Start)
 	if err != nil {
@@ -152,6 +156,7 @@ func NewMessageExtractor(
 		reorgEventsNotifier: reorgEventsNotifier,
 		seqBatchCounter:     seqBatchCounter,
 		l1Reader:            l1Reader,
+		fatalErrChan:        fatalErrChan,
 	}, nil
 }
 
@@ -166,12 +171,10 @@ func (m *MessageExtractor) SetMessageConsumer(consumer mel.MessageConsumer) erro
 	return nil
 }
 
-// Starts a message extraction service using a stopwaiter. The message extraction
-// "loop" consists of a ticking a finite state machine (FSM) that performs different
-// responsibilities based on its current state. For instance, processing a parent chain
-// block, saving data to a database, or handling reorgs. The FSM is designed to be
-// resilient to errors, and each error will retry the same FSM state after a specified interval
-// in this Start method.
+// Start begins the message extraction loop. The loop ticks a finite state machine (FSM)
+// that processes parent chain blocks, saves data, or handles reorgs. On error, the FSM
+// retries the same state after RetryInterval. If errors persist beyond 2x StallTolerance
+// and fatalErrChan was provided, a fatal error is sent to stop the node.
 func (m *MessageExtractor) Start(ctxIn context.Context) error {
 	if m.msgConsumer == nil {
 		return errors.New("message consumer not set")
@@ -194,6 +197,13 @@ func (m *MessageExtractor) Start(ctxIn context.Context) error {
 			if m.stuckCount > m.config.StallTolerance {
 				stuckFSMIndicatingGauge.Update(1)
 				log.Error("Message extractor has been stuck at the same fsm state past the stall-tolerance number of times", "state", m.fsm.Current().State.String(), "stuckCount", m.stuckCount, "err", err)
+				if m.fatalErrChan != nil && m.config.StallTolerance > 0 && m.stuckCount > 2*m.config.StallTolerance {
+					select {
+					case m.fatalErrChan <- fmt.Errorf("message extractor stuck for %d consecutive errors (state %s): %w", m.stuckCount, m.fsm.Current().State.String(), err):
+					case <-ctx.Done():
+						return 0
+					}
+				}
 			} else {
 				stuckFSMIndicatingGauge.Update(0)
 			}
@@ -216,9 +226,39 @@ func (m *MessageExtractor) updateLastBlockToRead(ctx context.Context) time.Durat
 		return m.config.RetryInterval
 	}
 	if err != nil {
-		log.Error("Error fetching header to update last block to read in MEL", "err", err)
+		m.lastBlockToReadFailures++
+		log.Error("Error fetching header to update last block to read in MEL", "err", err, "consecutiveFailures", m.lastBlockToReadFailures)
+		if m.fatalErrChan != nil && m.config.StallTolerance > 0 && m.lastBlockToReadFailures > 2*m.config.StallTolerance {
+			select {
+			case m.fatalErrChan <- fmt.Errorf("updateLastBlockToRead failed %d consecutive times (mode=%s): %w", m.lastBlockToReadFailures, m.config.ReadMode, err):
+			case <-ctx.Done():
+			}
+		}
 		return m.config.RetryInterval
 	}
+	if header == nil {
+		m.lastBlockToReadFailures++
+		log.Warn("No header returned for MEL ReadMode block", "mode", m.config.ReadMode, "consecutiveFailures", m.lastBlockToReadFailures)
+		if m.fatalErrChan != nil && m.config.StallTolerance > 0 && m.lastBlockToReadFailures > 2*m.config.StallTolerance {
+			select {
+			case m.fatalErrChan <- fmt.Errorf("updateLastBlockToRead: nil header for %d consecutive attempts (mode=%s)", m.lastBlockToReadFailures, m.config.ReadMode):
+			case <-ctx.Done():
+			}
+		}
+		return m.config.RetryInterval
+	}
+	if header.Number == nil {
+		m.lastBlockToReadFailures++
+		log.Error("Header for MEL ReadMode block has nil Number", "mode", m.config.ReadMode, "consecutiveFailures", m.lastBlockToReadFailures)
+		if m.fatalErrChan != nil && m.config.StallTolerance > 0 && m.lastBlockToReadFailures > 2*m.config.StallTolerance {
+			select {
+			case m.fatalErrChan <- fmt.Errorf("updateLastBlockToRead: nil header.Number for %d consecutive attempts (mode=%s)", m.lastBlockToReadFailures, m.config.ReadMode):
+			case <-ctx.Done():
+			}
+		}
+		return m.config.RetryInterval
+	}
+	m.lastBlockToReadFailures = 0
 	m.lastBlockToRead.Store(header.Number.Uint64())
 	return m.config.RetryInterval
 }
@@ -227,37 +267,54 @@ func (m *MessageExtractor) CurrentFSMState() FSMState {
 	return m.fsm.Current().State
 }
 
-// getStateByRPCBlockNum currently supports fetching of respective state for safe and finalized parent chain blocks
+// clampToInitialBlock ensures blockNum is not below the MEL migration boundary.
+func (m *MessageExtractor) clampToInitialBlock(blockNum uint64) uint64 {
+	if initialBlockNum, ok := m.melDB.InitialBlockNum(); ok && blockNum < initialBlockNum {
+		log.Debug("Clamping requested block to MEL migration boundary", "requested", blockNum, "clamped", initialBlockNum)
+		return initialBlockNum
+	}
+	return blockNum
+}
+
+// getStateByRPCBlockNum supports only safe and finalized block numbers; returns an error for other values.
 func (m *MessageExtractor) getStateByRPCBlockNum(ctx context.Context, blockNum rpc.BlockNumber) (*mel.State, error) {
-	var blk uint64
+	if m.l1Reader == nil {
+		return nil, errors.New("l1Reader is not configured; cannot resolve safe/finalized block number")
+	}
+	var resolvedBlockNum uint64
 	var err error
 	switch blockNum {
 	case rpc.SafeBlockNumber:
-		blk, err = m.l1Reader.LatestSafeBlockNr(ctx)
-		if err != nil {
-			return nil, err
-		}
+		resolvedBlockNum, err = m.l1Reader.LatestSafeBlockNr(ctx)
 	case rpc.FinalizedBlockNumber:
-		blk, err = m.l1Reader.LatestFinalizedBlockNr(ctx)
-		if err != nil {
-			return nil, err
-		}
+		resolvedBlockNum, err = m.l1Reader.LatestFinalizedBlockNr(ctx)
 	default:
 		return nil, fmt.Errorf("getStateByRPCBlockNum requested with unknown blockNum: %v", blockNum)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getStateByRPCBlockNum: resolving %v block number: %w", blockNum, err)
 	}
 	headMelStateBlockNum, err := m.melDB.GetHeadMelStateBlockNum()
 	if err != nil {
 		return nil, err
 	}
-	state, err := m.melDB.State(min(headMelStateBlockNum, blk))
-	if err != nil {
-		return nil, err
+	rawBlockNum := min(headMelStateBlockNum, resolvedBlockNum)
+	stateBlockNum := m.clampToInitialBlock(rawBlockNum)
+	if stateBlockNum != rawBlockNum {
+		log.Info("getStateByRPCBlockNum clamped to MEL migration boundary", "requested", blockNum, "resolved", rawBlockNum, "clamped", stateBlockNum)
 	}
-	return state, nil
+	return m.melDB.StateAtOrBelowHead(stateBlockNum)
 }
 
-func (m *MessageExtractor) SetBlockValidator(blockValidator *staker.BlockValidator) {
+func (m *MessageExtractor) SetBlockValidator(blockValidator *staker.BlockValidator) error {
+	if m.Started() {
+		return errors.New("cannot set block validator after start")
+	}
+	if m.blockValidator != nil {
+		return errors.New("block validator already set")
+	}
 	m.blockValidator = blockValidator
+	return nil
 }
 
 func (m *MessageExtractor) GetSafeMsgCount(ctx context.Context) (arbutil.MessageIndex, error) {
@@ -281,26 +338,32 @@ func (m *MessageExtractor) GetSyncProgress(ctx context.Context) (mel.MessageSync
 	if err != nil {
 		return mel.MessageSyncProgress{}, err
 	}
-	batchSeen := headState.BatchCount // fallback when seqBatchCounter is nil or returns error
+	batchSeen := headState.BatchCount
+	batchSeenIsEstimate := false
 	if m.seqBatchCounter != nil {
 		seen, err := m.seqBatchCounter.GetBatchCount(ctx, new(big.Int).SetUint64(headState.ParentChainBlockNumber))
 		if err != nil {
+			if ctx.Err() != nil {
+				return mel.MessageSyncProgress{}, ctx.Err()
+			}
 			// TODO: Replace with a sentinel error check once geth exposes one for "header not found".
 			// This error originates from the RPC/header lookup path, distinct from the database-level
 			// not-found errors handled by rawdb.IsDbErrNotFound in FinalizedDelayedMessageAtPosition.
 			if strings.Contains(err.Error(), "header not found") {
-				log.Debug("SequencerInbox GetBatchCount header not found, using headState.BatchCount fallback", "parentChainBlock", headState.ParentChainBlockNumber)
+				batchSeenIsEstimate = true
+				log.Info("SequencerInbox GetBatchCount header not found, using headState.BatchCount fallback", "parentChainBlock", headState.ParentChainBlockNumber)
 			} else {
-				log.Error("SequencerInbox GetBatchCount error, using headState.BatchCount fallback", "err", err, "parentChainBlock", headState.ParentChainBlockNumber)
+				return mel.MessageSyncProgress{}, fmt.Errorf("SequencerInbox GetBatchCount error at block %d: %w", headState.ParentChainBlockNumber, err)
 			}
 		} else {
 			batchSeen = seen
 		}
 	}
 	return mel.MessageSyncProgress{
-		BatchSeen:      batchSeen,
-		BatchProcessed: headState.BatchCount,
-		MsgCount:       arbutil.MessageIndex(headState.MsgCount),
+		BatchSeen:           batchSeen,
+		BatchSeenIsEstimate: batchSeenIsEstimate,
+		BatchProcessed:      headState.BatchCount,
+		MsgCount:            arbutil.MessageIndex(headState.MsgCount),
 	}, nil
 }
 
@@ -325,7 +388,7 @@ func (m *MessageExtractor) GetHeadState() (*mel.State, error) {
 }
 
 func (m *MessageExtractor) GetState(parentchainBlocknumber uint64) (*mel.State, error) {
-	return m.melDB.State(parentchainBlocknumber)
+	return m.melDB.StateAtOrBelowHead(parentchainBlocknumber)
 }
 
 func (m *MessageExtractor) RebuildStateDelayedMsgPreimages(state *mel.State) error {
@@ -346,7 +409,7 @@ func (m *MessageExtractor) GetDelayedMessage(index uint64) (*mel.DelayedInboxMes
 		return nil, err
 	}
 	if index >= headState.DelayedMessagesSeen {
-		return nil, fmt.Errorf("DelayedInboxMessage not available for index: %d greater than head MEL state DelayedMessagesSeen count: %d", index, headState.DelayedMessagesSeen)
+		return nil, fmt.Errorf("%w: delayed message index %d >= seen count %d", mel.ErrAccumulatorNotFound, index, headState.DelayedMessagesSeen)
 	}
 	return m.melDB.FetchDelayedMessage(index)
 }
@@ -364,11 +427,11 @@ func (m *MessageExtractor) GetDelayedAcc(seqNum uint64) (common.Hash, error) {
 	if err != nil {
 		return common.Hash{}, err
 	}
-	return delayedMsg.AfterInboxAcc(), nil
+	return delayedMsg.AfterInboxAcc()
 }
 
 func (m *MessageExtractor) GetDelayedCountAtParentChainBlock(ctx context.Context, parentChainBlockNum uint64) (uint64, error) {
-	state, err := m.melDB.State(parentChainBlockNum)
+	state, err := m.melDB.StateAtOrBelowHead(m.clampToInitialBlock(parentChainBlockNum))
 	if err != nil {
 		return 0, err
 	}
@@ -383,10 +446,11 @@ func (m *MessageExtractor) GetDelayedCount() (uint64, error) {
 	return state.DelayedMessagesSeen, nil
 }
 
-// FindParentChainBlockContainingDelayed is only relevant and invoked by txstreamer when batch gas cost data is nil for a
-// batchpostingreport- but this should never be possible as ExtractMessages function would fill in the cost data during message extraction
+// FindParentChainBlockContainingDelayed is not supported under MEL. The transaction
+// streamer handles ErrNotImplementedUnderMEL by falling back to GetSequencerMessageBytes
+// (without a specific parent chain block), which resolves the block internally via batch metadata.
 func (m *MessageExtractor) FindParentChainBlockContainingDelayed(context.Context, uint64) (uint64, error) {
-	return 0, errors.New("FindParentChainBlockContainingDelayed is not implemented by MEL as batch gas cost data is already filled in during extraction")
+	return 0, fmt.Errorf("FindParentChainBlockContainingDelayed: %w", mel.ErrNotImplementedUnderMEL)
 }
 
 func (m *MessageExtractor) GetBatchMetadata(seqNum uint64) (mel.BatchMetadata, error) {
@@ -395,7 +459,7 @@ func (m *MessageExtractor) GetBatchMetadata(seqNum uint64) (mel.BatchMetadata, e
 		return mel.BatchMetadata{}, err
 	}
 	if seqNum >= headState.BatchCount {
-		return mel.BatchMetadata{}, fmt.Errorf("batchMetadata not available for seqNum: %d greater than head MEL state batch count: %d", seqNum, headState.BatchCount)
+		return mel.BatchMetadata{}, fmt.Errorf("batchMetadata not available for seqNum %d: head MEL state batch count is %d", seqNum, headState.BatchCount)
 	}
 	batchMetadata, err := m.melDB.fetchBatchMetadata(seqNum)
 	if err != nil {
@@ -427,8 +491,15 @@ func (m *MessageExtractor) FinalizedDelayedMessageAtPosition(
 	}
 	finalizedDelayedCount, err := m.GetDelayedCountAtParentChainBlock(ctx, finalizedBlock)
 	if err != nil {
-		if rawdb.IsDbErrNotFound(err) {
-			log.Debug("MEL delayed count not found for finalized block, treating as not yet finalized", "parentChainBlock", finalizedBlock)
+		// Both db-not-found and "above head" errors mean MEL hasn't processed
+		// this block yet, so the message is not yet finalized.
+		headBlockNum, headErr := m.melDB.GetHeadMelStateBlockNum()
+		if headErr != nil {
+			log.Warn("MEL GetHeadMelStateBlockNum failed during finalized delayed message check",
+				"parentChainBlock", finalizedBlock, "headErr", headErr, "originalErr", err)
+		}
+		if rawdb.IsDbErrNotFound(err) || (headErr == nil && finalizedBlock > headBlockNum) {
+			log.Debug("MEL delayed count not available for finalized block, treating as not yet finalized", "parentChainBlock", finalizedBlock)
 			return nil, common.Hash{}, msg.ParentChainBlockNumber, mel.ErrDelayedMessageNotYetFinalized
 		}
 		log.Warn("MEL GetDelayedCountAtParentChainBlock failed with unexpected error", "parentChainBlock", finalizedBlock, "err", err)
@@ -440,7 +511,11 @@ func (m *MessageExtractor) FinalizedDelayedMessageAtPosition(
 	if lastDelayedAccumulator != (common.Hash{}) && msg.BeforeInboxAcc != lastDelayedAccumulator {
 		return nil, common.Hash{}, 0, fmt.Errorf("position %d (finalized block %d): BeforeInboxAcc %v != lastDelayedAccumulator %v: %w", requestedPosition, finalizedBlock, msg.BeforeInboxAcc, lastDelayedAccumulator, mel.ErrDelayedAccumulatorMismatch)
 	}
-	return msg.Message, msg.AfterInboxAcc(), msg.ParentChainBlockNumber, nil
+	acc, err := msg.AfterInboxAcc()
+	if err != nil {
+		return nil, common.Hash{}, 0, fmt.Errorf("MEL: failed to compute AfterInboxAcc at position %d: %w", requestedPosition, err)
+	}
+	return msg.Message, acc, msg.ParentChainBlockNumber, nil
 }
 
 func (m *MessageExtractor) GetSequencerMessageBytes(ctx context.Context, seqNum uint64) ([]byte, common.Hash, error) {
@@ -452,7 +527,7 @@ func (m *MessageExtractor) GetSequencerMessageBytes(ctx context.Context, seqNum 
 }
 
 func (m *MessageExtractor) GetSequencerMessageBytesForParentBlock(ctx context.Context, seqNum uint64, parentChainBlock uint64) ([]byte, common.Hash, error) {
-	// No need to specify a max headers to fetch, as we are using the logs fetcher only, so we can pass in a 0.
+	// blocksToFetch=0: single-block lookup, no range prefetch needed.
 	logsFetcher := newLogsAndHeadersFetcher(m.parentChainReader, 0)
 	if err := logsFetcher.fetchSequencerBatchLogs(ctx, parentChainBlock, parentChainBlock); err != nil {
 		return nil, common.Hash{}, err
@@ -460,6 +535,9 @@ func (m *MessageExtractor) GetSequencerMessageBytesForParentBlock(ctx context.Co
 	parentChainHeader, err := m.parentChainReader.HeaderByNumber(ctx, new(big.Int).SetUint64(parentChainBlock))
 	if err != nil {
 		return nil, common.Hash{}, err
+	}
+	if parentChainHeader == nil {
+		return nil, common.Hash{}, fmt.Errorf("parent chain block %d not found", parentChainBlock)
 	}
 	seqBatches, batchTxs, err := melextraction.ParseBatchesFromBlock(ctx, parentChainHeader, &txByLogFetcher{m.parentChainReader}, logsFetcher, &melextraction.LogUnpacker{})
 	if err != nil {
@@ -476,86 +554,69 @@ func (m *MessageExtractor) GetSequencerMessageBytesForParentBlock(ctx context.Co
 	return nil, common.Hash{}, fmt.Errorf("sequencer batch %v not found in L1 block %v (found batches %v)", seqNum, parentChainBlock, seenBatches)
 }
 
-// ReorgTo, when reorgEventsNotifier is set, should only be called after the readers of the channel are started as this is a blocking operation. To be only
-// called during init when reorging to a message batch
+// sendReorgNotification sends a reorg notification on the reorgEventsNotifier channel.
+// Returns nil immediately if the notifier is not set.
+func (m *MessageExtractor) sendReorgNotification(ctx context.Context, blockNum uint64) error {
+	if m.reorgEventsNotifier == nil {
+		return nil
+	}
+	select {
+	case m.reorgEventsNotifier <- blockNum:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// ReorgTo rewrites the head MEL state block number and notifies reorg listeners.
+// When called before Start() (e.g. during node init), the notification is skipped
+// because the channel consumer hasn't started yet. Downstream consumers (block
+// validator, batch poster) must not be started before MEL, so they will initialize
+// from the current (rewound) head state when they start.
 func (m *MessageExtractor) ReorgTo(parentChainBlockNumber uint64) error {
-	dbBatch := m.melDB.db.NewBatch()
-	if err := m.melDB.setHeadMelStateBlockNum(dbBatch, parentChainBlockNumber); err != nil {
+	if err := m.melDB.RewriteHeadBlockNum(parentChainBlockNumber); err != nil {
 		return err
 	}
-	if err := dbBatch.Write(); err != nil {
+	if m.reorgEventsNotifier == nil {
+		return nil
+	}
+	if !m.Started() {
+		log.Info("ReorgTo applied during init (MEL not running); downstream consumers will start from rewound state", "block", parentChainBlockNumber)
+		return nil
+	}
+	ctx, err := m.GetContextSafe()
+	if err != nil {
 		return err
 	}
-	if m.reorgEventsNotifier != nil {
-		m.reorgEventsNotifier <- parentChainBlockNumber
-	}
-	return nil
+	return m.sendReorgNotification(ctx, parentChainBlockNumber)
 }
 
 func (m *MessageExtractor) GetBatchAcc(seqNum uint64) (common.Hash, error) {
 	batchMetadata, err := m.GetBatchMetadata(seqNum)
-	return batchMetadata.Accumulator, err
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return batchMetadata.Accumulator, nil
 }
 
 func (m *MessageExtractor) GetBatchMessageCount(seqNum uint64) (arbutil.MessageIndex, error) {
 	metadata, err := m.GetBatchMetadata(seqNum)
-	return metadata.MessageCount, err
+	if err != nil {
+		return 0, err
+	}
+	return metadata.MessageCount, nil
 }
 
 func (m *MessageExtractor) GetBatchParentChainBlock(seqNum uint64) (uint64, error) {
 	metadata, err := m.GetBatchMetadata(seqNum)
-	return metadata.ParentChainBlock, err
+	if err != nil {
+		return 0, err
+	}
+	return metadata.ParentChainBlock, nil
 }
 
-// err will return unexpected/internal errors
-// bool will be false if batch not found (meaning, block not yet posted on a batch)
 func (m *MessageExtractor) FindInboxBatchContainingMessage(pos arbutil.MessageIndex) (uint64, bool, error) {
-	batchCount, err := m.GetBatchCount()
-	if err != nil {
-		return 0, false, err
-	}
-	if batchCount == 0 {
-		return 0, false, nil
-	}
-	low := uint64(0)
-	high := batchCount - 1
-	lastBatchMessageCount, err := m.GetBatchMessageCount(high)
-	if err != nil {
-		return 0, false, err
-	}
-	if lastBatchMessageCount <= pos {
-		return 0, false, nil
-	}
-	// Iteration preconditions:
-	// - high >= low
-	// - msgCount(low - 1) <= pos implies low <= target
-	// - msgCount(high) > pos implies high >= target
-	// Therefore, if low == high, then low == high == target
-	for {
-		// Due to integer rounding, mid >= low && mid < high
-		mid := (low + high) / 2
-		count, err := m.GetBatchMessageCount(mid)
-		if err != nil {
-			return 0, false, err
-		}
-		if count < pos {
-			// Must narrow as mid >= low, therefore mid + 1 > low, therefore newLow > oldLow
-			// Keeps low precondition as msgCount(mid) < pos
-			low = mid + 1
-		} else if count == pos {
-			return mid + 1, true, nil
-		} else if count == pos+1 || mid == low { // implied: count > pos
-			return mid, true, nil
-		} else {
-			// implied: count > pos + 1
-			// Must narrow as mid < high, therefore newHigh < oldHigh
-			// Keeps high precondition as msgCount(mid) > pos
-			high = mid
-		}
-		if high == low {
-			return high, true, nil
-		}
-	}
+	return arbutil.FindInboxBatchContainingMessage(m, pos)
 }
 
 func (m *MessageExtractor) GetBatchCount() (uint64, error) {
@@ -566,20 +627,24 @@ func (m *MessageExtractor) GetBatchCount() (uint64, error) {
 	return headState.BatchCount, nil
 }
 
+func (m *MessageExtractor) LegacyDelayedBound() uint64 {
+	return m.melDB.LegacyDelayedCount()
+}
+
 func (m *MessageExtractor) CaughtUp() chan struct{} {
 	return m.caughtUpChan
 }
 
-// Ticks the message extractor FSM and performs the action associated with the current state,
+// Act ticks the message extractor FSM and performs the action associated with the current state,
 // such as processing the next block, saving messages, or handling reorgs.
-// Question: do we want to make this private? System tests currently use it, but I believe this should only ever be called by start
 func (m *MessageExtractor) Act(ctx context.Context) (time.Duration, error) {
 	current := m.fsm.Current()
 	switch current.State {
 	// `Start` is the initial state of the FSM. It is responsible for
 	// initializing the message extraction process. The FSM will transition to
-	// the `ProcessingNextBlock` state after successfully fetching the initial
-	// MEL state struct for the message extraction process.
+	// `ProcessingNextBlock` after successfully loading and validating the initial
+	// MEL state, or to `Reorging` if a parent chain reorg is detected at the
+	// stored head block.
 	case Start:
 		return m.initialize(ctx, current)
 	// `ProcessingNextBlock` is the state responsible for processing the next block
@@ -590,10 +655,10 @@ func (m *MessageExtractor) Act(ctx context.Context) (time.Duration, error) {
 	case ProcessingNextBlock:
 		return m.processNextBlock(ctx, current)
 	// `SavingMessages` is the state responsible for saving the extracted messages
-	// and delayed messages to the database. It stores data in the node's consensus database
-	// and runs after the `ProcessingNextBlock` state.
-	// After data is stored, the FSM will then transition to the `ProcessingNextBlock` state
-	// yet again.
+	// and delayed messages. It first pushes extracted messages to the transaction
+	// streamer, then atomically writes batch metadata, delayed messages, and the
+	// new head MEL state to the consensus database.
+	// The FSM transitions to `ProcessingNextBlock` after both writes succeed.
 	case SavingMessages:
 		return m.saveMessages(ctx, current)
 	// `Reorging` is the state responsible for handling reorgs in the parent chain.

--- a/arbnode/mel/runner/mel_test.go
+++ b/arbnode/mel/runner/mel_test.go
@@ -32,13 +32,16 @@ func TestMessageExtractorStallTriggersMetric(t *testing.T) {
 	cfg := DefaultMessageExtractionConfig
 	cfg.StallTolerance = 2
 	cfg.RetryInterval = 100 * time.Millisecond
+	melDB, err := NewDatabase(rawdb.NewMemoryDatabase())
+	require.NoError(t, err)
 	extractor, err := NewMessageExtractor(
 		cfg,
 		&mockParentChainReader{},
 		chaininfo.ArbitrumDevTestChainConfig(),
 		&chaininfo.RollupAddresses{},
-		func() *Database { d, _ := NewDatabase(rawdb.NewMemoryDatabase()); return d }(),
+		melDB,
 		daprovider.NewDAProviderRegistry(),
+		nil,
 		nil,
 		nil,
 		nil,
@@ -47,10 +50,11 @@ func TestMessageExtractorStallTriggersMetric(t *testing.T) {
 	require.NoError(t, extractor.SetMessageConsumer(&mockMessageConsumer{}))
 	require.True(t, stuckFSMIndicatingGauge.Snapshot().Value() == 0)
 	require.NoError(t, extractor.Start(ctx))
-	// MEL will be stuck at the 'Start' state as HeadMelState is not yet stored in the db
-	// so after RetryInterval*StallTolerance amount of time the metric should have been set to 1
-	time.Sleep(cfg.RetryInterval*time.Duration(cfg.StallTolerance) + 50*time.Millisecond) // #nosec G115
-	require.True(t, stuckFSMIndicatingGauge.Snapshot().Value() == 1)
+	// MEL will be stuck at the 'Start' state as HeadMelState is not yet stored in the db.
+	// Poll until the stall detector fires rather than sleeping a fixed duration.
+	require.Eventually(t, func() bool {
+		return stuckFSMIndicatingGauge.Snapshot().Value() == 1
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestMessageExtractor(t *testing.T) {
@@ -82,6 +86,7 @@ func TestMessageExtractor(t *testing.T) {
 		&chaininfo.RollupAddresses{},
 		melDB,
 		daprovider.NewDAProviderRegistry(),
+		nil,
 		nil,
 		nil,
 		nil,
@@ -285,6 +290,7 @@ func TestFinalizedDelayedMessageAtPosition(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 	require.NoError(t, extractor.SetMessageConsumer(&mockMessageConsumer{}))
@@ -310,12 +316,13 @@ func TestFinalizedDelayedMessageAtPosition(t *testing.T) {
 				},
 			},
 		}
-		prevAcc = delayedMsgs[i].AfterInboxAcc()
+		var accErr error
+		prevAcc, accErr = delayedMsgs[i].AfterInboxAcc()
+		require.NoError(t, accErr)
 		require.NoError(t, state.AccumulateDelayedMessage(delayedMsgs[i]))
-		state.DelayedMessagesSeen++
 	}
 	require.NoError(t, melDB.SaveState(state))
-	require.NoError(t, melDB.SaveDelayedMessages(state, delayedMsgs))
+	require.NoError(t, melDB.saveDelayedMessages(state, delayedMsgs))
 
 	t.Run("position below finalized count returns correct message and accumulator", func(t *testing.T) {
 		// finalizedPos at block 10 is 3, requesting position 1 (< 3) should succeed
@@ -324,7 +331,9 @@ func TestFinalizedDelayedMessageAtPosition(t *testing.T) {
 		require.NotNil(t, msg)
 		expectedRequestID := common.BigToHash(big.NewInt(1))
 		require.Equal(t, &expectedRequestID, msg.Header.RequestId, "should return message at requested position")
-		require.Equal(t, delayedMsgs[1].AfterInboxAcc(), acc, "should return AfterInboxAcc of the message")
+		expectedAcc1, accErr := delayedMsgs[1].AfterInboxAcc()
+		require.NoError(t, accErr)
+		require.Equal(t, expectedAcc1, acc, "should return AfterInboxAcc of the message")
 		require.Equal(t, uint64(10), parentChainBlock, "should return parent chain block number")
 	})
 
@@ -336,17 +345,23 @@ func TestFinalizedDelayedMessageAtPosition(t *testing.T) {
 		require.NotNil(t, msg)
 		expectedRequestID := common.BigToHash(big.NewInt(2))
 		require.Equal(t, &expectedRequestID, msg.Header.RequestId, "should return message at last valid position")
-		require.Equal(t, delayedMsgs[2].AfterInboxAcc(), acc, "should return AfterInboxAcc of the message")
+		expectedAcc2, accErr := delayedMsgs[2].AfterInboxAcc()
+		require.NoError(t, accErr)
+		require.Equal(t, expectedAcc2, acc, "should return AfterInboxAcc of the message")
 		require.Equal(t, uint64(10), parentChainBlock, "should return parent chain block number")
 	})
 
 	t.Run("correct lastDelayedAccumulator succeeds", func(t *testing.T) {
 		// Pass the AfterInboxAcc of position 0 as lastDelayedAccumulator when requesting position 1.
 		// This should match msg[1].BeforeInboxAcc and succeed.
-		msg, acc, parentChainBlock, err := extractor.FinalizedDelayedMessageAtPosition(ctx, 10, delayedMsgs[0].AfterInboxAcc(), 1)
+		lastAcc0, accErr := delayedMsgs[0].AfterInboxAcc()
+		require.NoError(t, accErr)
+		msg, acc, parentChainBlock, err := extractor.FinalizedDelayedMessageAtPosition(ctx, 10, lastAcc0, 1)
 		require.NoError(t, err)
 		require.NotNil(t, msg)
-		require.Equal(t, delayedMsgs[1].AfterInboxAcc(), acc)
+		expectedAcc1, accErr := delayedMsgs[1].AfterInboxAcc()
+		require.NoError(t, accErr)
+		require.Equal(t, expectedAcc1, acc)
 		require.Equal(t, uint64(10), parentChainBlock, "should return parent chain block number")
 	})
 
@@ -375,4 +390,499 @@ func TestFinalizedDelayedMessageAtPosition(t *testing.T) {
 		_, _, _, err := extractor.FinalizedDelayedMessageAtPosition(ctx, 999, common.Hash{}, 0)
 		require.ErrorIs(t, err, mel.ErrDelayedMessageNotYetFinalized)
 	})
+}
+
+func TestFindInboxBatchContainingMessage(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	consensusDB := rawdb.NewMemoryDatabase()
+	melDB, err := NewDatabase(consensusDB)
+	require.NoError(t, err)
+
+	parentChainReader := &mockParentChainReader{
+		blocks:  map[common.Hash]*types.Block{},
+		headers: map[common.Hash]*types.Header{},
+	}
+	extractor, err := NewMessageExtractor(
+		DefaultMessageExtractionConfig,
+		parentChainReader,
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, extractor.SetMessageConsumer(&mockMessageConsumer{}))
+	extractor.StopWaiter.Start(ctx, extractor)
+
+	t.Run("zero batches returns not found", func(t *testing.T) {
+		state := &mel.State{ParentChainBlockNumber: 1, BatchCount: 0}
+		require.NoError(t, melDB.SaveState(state))
+		_, found, err := extractor.FindInboxBatchContainingMessage(5)
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	// Set up 4 batches with increasing message counts:
+	// batch 0: msgCount=5, batch 1: msgCount=10, batch 2: msgCount=15, batch 3: msgCount=20
+	state := &mel.State{ParentChainBlockNumber: 1, BatchCount: 4}
+	require.NoError(t, melDB.SaveState(state))
+	batchMetas := []*mel.BatchMetadata{
+		{MessageCount: 5, ParentChainBlock: 10},
+		{MessageCount: 10, ParentChainBlock: 20},
+		{MessageCount: 15, ParentChainBlock: 30},
+		{MessageCount: 20, ParentChainBlock: 40},
+	}
+	require.NoError(t, melDB.saveBatchMetas(state, batchMetas))
+
+	t.Run("message in first batch", func(t *testing.T) {
+		batch, found, err := extractor.FindInboxBatchContainingMessage(0)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(0), batch)
+	})
+
+	t.Run("message at first batch boundary", func(t *testing.T) {
+		// pos=4 is the last message in batch 0 (msgCount=5 means positions 0..4)
+		batch, found, err := extractor.FindInboxBatchContainingMessage(4)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(0), batch)
+	})
+
+	t.Run("message at exact batch boundary", func(t *testing.T) {
+		// pos=5 is the first message in batch 1 (batch 0 has msgCount=5)
+		batch, found, err := extractor.FindInboxBatchContainingMessage(5)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(1), batch)
+	})
+
+	t.Run("message in middle batch", func(t *testing.T) {
+		batch, found, err := extractor.FindInboxBatchContainingMessage(12)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(2), batch)
+	})
+
+	t.Run("message in last batch", func(t *testing.T) {
+		batch, found, err := extractor.FindInboxBatchContainingMessage(19)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(3), batch)
+	})
+
+	t.Run("message beyond last batch returns not found", func(t *testing.T) {
+		_, found, err := extractor.FindInboxBatchContainingMessage(20)
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("message far beyond last batch returns not found", func(t *testing.T) {
+		_, found, err := extractor.FindInboxBatchContainingMessage(100)
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	// Test with a single batch
+	t.Run("single batch contains message", func(t *testing.T) {
+		singleDB := rawdb.NewMemoryDatabase()
+		singleMelDB, err := NewDatabase(singleDB)
+		require.NoError(t, err)
+		singleState := &mel.State{ParentChainBlockNumber: 1, BatchCount: 1}
+		require.NoError(t, singleMelDB.SaveState(singleState))
+		require.NoError(t, singleMelDB.saveBatchMetas(singleState, []*mel.BatchMetadata{
+			{MessageCount: 10, ParentChainBlock: 5},
+		}))
+		singleExtractor, err := NewMessageExtractor(
+			DefaultMessageExtractionConfig, parentChainReader,
+			chaininfo.ArbitrumDevTestChainConfig(), &chaininfo.RollupAddresses{},
+			singleMelDB, daprovider.NewDAProviderRegistry(), nil, nil, nil, nil,
+		)
+		require.NoError(t, err)
+		require.NoError(t, singleExtractor.SetMessageConsumer(&mockMessageConsumer{}))
+		singleExtractor.StopWaiter.Start(ctx, singleExtractor)
+
+		batch, found, err := singleExtractor.FindInboxBatchContainingMessage(0)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(0), batch)
+
+		batch, found, err = singleExtractor.FindInboxBatchContainingMessage(9)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(0), batch)
+
+		_, found, err = singleExtractor.FindInboxBatchContainingMessage(10)
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+}
+
+func TestClampToInitialBlock(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	consensusDB := rawdb.NewMemoryDatabase()
+	melDB, err := NewDatabase(consensusDB)
+	require.NoError(t, err)
+
+	// Set up a migration boundary at block 100
+	initialState := &mel.State{
+		ParentChainBlockNumber: 100,
+		BatchCount:             5,
+		DelayedMessagesSeen:    3,
+	}
+	require.NoError(t, melDB.SaveInitialMelState(initialState))
+
+	extractor, err := NewMessageExtractor(
+		DefaultMessageExtractionConfig,
+		&mockParentChainReader{
+			blocks:  map[common.Hash]*types.Block{},
+			headers: map[common.Hash]*types.Header{},
+		},
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, extractor.SetMessageConsumer(&mockMessageConsumer{}))
+	extractor.StopWaiter.Start(ctx, extractor)
+
+	// Block below boundary should be clamped to boundary
+	require.Equal(t, uint64(100), extractor.clampToInitialBlock(50))
+
+	// Block at boundary should remain unchanged
+	require.Equal(t, uint64(100), extractor.clampToInitialBlock(100))
+
+	// Block above boundary should remain unchanged
+	require.Equal(t, uint64(200), extractor.clampToInitialBlock(200))
+}
+
+func TestReorgBelowMigrationBoundary(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	consensusDB := rawdb.NewMemoryDatabase()
+	melDB, err := NewDatabase(consensusDB)
+	require.NoError(t, err)
+
+	// Create blocks with proper hash linkage
+	block10 := types.NewBlock(&types.Header{Number: big.NewInt(10)}, nil, nil, nil)
+	block11 := types.NewBlock(&types.Header{Number: big.NewInt(11), ParentHash: block10.Hash()}, nil, nil, nil)
+
+	// Set up a migration boundary at block 10
+	initialState := &mel.State{
+		ParentChainBlockNumber: 10,
+		ParentChainBlockHash:   block10.Hash(),
+		BatchCount:             2,
+	}
+	require.NoError(t, melDB.SaveInitialMelState(initialState))
+
+	// Save state at block 11 as the head (so initialize can load it)
+	state11 := &mel.State{
+		ParentChainBlockNumber: 11,
+		ParentChainBlockHash:   block11.Hash(),
+		BatchCount:             2,
+	}
+	require.NoError(t, melDB.SaveState(state11))
+
+	parentChainReader := &mockParentChainReader{
+		blocks: map[common.Hash]*types.Block{
+			common.BigToHash(big.NewInt(10)): block10,
+			common.BigToHash(big.NewInt(11)): block11,
+		},
+		headers: map[common.Hash]*types.Header{},
+	}
+
+	extractor, err := NewMessageExtractor(
+		DefaultMessageExtractionConfig,
+		parentChainReader,
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, extractor.SetMessageConsumer(&mockMessageConsumer{}))
+	extractor.StopWaiter.Start(ctx, extractor)
+
+	// Run initialize step (Start -> ProcessingNextBlock) to set up logsAndHeadersPreFetcher
+	_, err = extractor.Act(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ProcessingNextBlock, extractor.CurrentFSMState())
+
+	// Now drive to Reorging state with a block at the migration boundary.
+	// ParentChainBlockNumber == 11, target = 10 (at boundary, should succeed).
+	err = extractor.fsm.Do(reorgToOldBlock{
+		melState: state11,
+	})
+	require.NoError(t, err)
+	require.Equal(t, Reorging, extractor.CurrentFSMState())
+
+	_, err = extractor.Act(ctx)
+	// Should succeed: target block 10 is at the boundary (not below)
+	require.NoError(t, err)
+
+	// Now drive to Reorging with ParentChainBlockNumber == 10.
+	// Target = 9, which is BELOW the migration boundary 10. Should fail.
+	err = extractor.fsm.Do(reorgToOldBlock{
+		melState: initialState,
+	})
+	require.NoError(t, err)
+	require.Equal(t, Reorging, extractor.CurrentFSMState())
+
+	_, err = extractor.Act(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "below the MEL migration boundary")
+	require.Contains(t, err.Error(), "manual intervention required")
+}
+
+func TestFatalErrChanEscalation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := DefaultMessageExtractionConfig
+	cfg.StallTolerance = 1
+	cfg.RetryInterval = 10 * time.Millisecond
+
+	melDB, err := NewDatabase(rawdb.NewMemoryDatabase())
+	require.NoError(t, err)
+
+	fatalErrChan := make(chan error, 1)
+	extractor, err := NewMessageExtractor(
+		cfg,
+		&mockParentChainReader{},
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil,
+		nil,
+		nil,
+		fatalErrChan,
+	)
+	require.NoError(t, err)
+	require.NoError(t, extractor.SetMessageConsumer(&mockMessageConsumer{}))
+	require.NoError(t, extractor.Start(ctx))
+
+	// MEL will be stuck at Start (no head state in DB). After 2*StallTolerance+1
+	// errors, a fatal error should be sent on the channel.
+	select {
+	case fatalErr := <-fatalErrChan:
+		require.Error(t, fatalErr)
+		require.Contains(t, fatalErr.Error(), "message extractor stuck")
+	case <-time.After(cfg.RetryInterval*time.Duration(2*cfg.StallTolerance+2) + 200*time.Millisecond): // #nosec G115
+		t.Fatal("expected fatal error on fatalErrChan, but timed out")
+	}
+}
+
+type nilHeaderParentChainReader struct {
+	mockParentChainReader
+}
+
+// HeaderByNumber always returns (nil, nil) to simulate a parent chain that
+// has no finalized/safe block available.
+func (m *nilHeaderParentChainReader) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	return nil, nil
+}
+
+func TestUpdateLastBlockToRead_NilHeaderEscalatesToFatal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := DefaultMessageExtractionConfig
+	cfg.StallTolerance = 1
+	cfg.RetryInterval = 10 * time.Millisecond
+	cfg.ReadMode = "finalized"
+
+	melDB, err := NewDatabase(rawdb.NewMemoryDatabase())
+	require.NoError(t, err)
+
+	fatalErrChan := make(chan error, 1)
+	extractor, err := NewMessageExtractor(
+		cfg,
+		&nilHeaderParentChainReader{mockParentChainReader{
+			blocks:  map[common.Hash]*types.Block{},
+			headers: map[common.Hash]*types.Header{},
+		}},
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil,
+		nil,
+		nil,
+		fatalErrChan,
+	)
+	require.NoError(t, err)
+	require.NoError(t, extractor.SetMessageConsumer(&mockMessageConsumer{}))
+
+	// Drive updateLastBlockToRead manually past the fatal threshold.
+	for i := uint64(0); i <= 2*cfg.StallTolerance; i++ {
+		extractor.updateLastBlockToRead(ctx)
+	}
+
+	select {
+	case fatalErr := <-fatalErrChan:
+		require.Error(t, fatalErr)
+		require.Contains(t, fatalErr.Error(), "nil header")
+	default:
+		t.Fatal("expected fatal error on fatalErrChan after repeated nil headers")
+	}
+}
+
+func TestGetDelayedCountAtParentChainBlock_RejectsAboveHead(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	db := rawdb.NewMemoryDatabase()
+	melDB, err := NewDatabase(db)
+	require.NoError(t, err)
+
+	extractor, err := NewMessageExtractor(
+		DefaultMessageExtractionConfig,
+		&mockParentChainReader{
+			blocks:  map[common.Hash]*types.Block{},
+			headers: map[common.Hash]*types.Header{},
+		},
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, extractor.SetMessageConsumer(&mockMessageConsumer{}))
+
+	// Save states at blocks 5 and 10, head at 10
+	require.NoError(t, melDB.SaveState(&mel.State{
+		ParentChainBlockNumber: 5,
+		DelayedMessagesSeen:    2,
+	}))
+	require.NoError(t, melDB.SaveState(&mel.State{
+		ParentChainBlockNumber: 10,
+		DelayedMessagesSeen:    5,
+	}))
+
+	// At head (10) should work
+	count, err := extractor.GetDelayedCountAtParentChainBlock(ctx, 10)
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), count)
+
+	// Below head (5) should work
+	count, err = extractor.GetDelayedCountAtParentChainBlock(ctx, 5)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), count)
+
+	// Above head (15) should fail — StateAtOrBelowHead rejects it
+	_, err = extractor.GetDelayedCountAtParentChainBlock(ctx, 15)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "above current head")
+}
+
+func TestHandlePreimageCacheMissLimit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	melDB, err := NewDatabase(rawdb.NewMemoryDatabase())
+	require.NoError(t, err)
+
+	extractor, err := NewMessageExtractor(
+		DefaultMessageExtractionConfig,
+		&mockParentChainReader{},
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, extractor.SetMessageConsumer(&mockMessageConsumer{}))
+	extractor.StopWaiter.Start(ctx, extractor)
+
+	// State with no unread delayed messages — RebuildDelayedMsgPreimages is a no-op.
+	state := &mel.State{}
+
+	// First two calls should succeed (return 0, nil for immediate retry).
+	dur, err := extractor.handlePreimageCacheMiss(state)
+	require.NoError(t, err)
+	require.Zero(t, dur)
+	require.Equal(t, 1, extractor.consecutivePreimageRebuilds)
+
+	dur, err = extractor.handlePreimageCacheMiss(state)
+	require.NoError(t, err)
+	require.Zero(t, dur)
+	require.Equal(t, 2, extractor.consecutivePreimageRebuilds)
+
+	// Third call should return an error.
+	dur, err = extractor.handlePreimageCacheMiss(state)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "repeated preimage rebuild")
+	require.Equal(t, 3, extractor.consecutivePreimageRebuilds)
+	require.Equal(t, DefaultMessageExtractionConfig.RetryInterval, dur)
+}
+
+func TestStallToleranceZeroDoesNotErrorOnFirstNotFound(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := DefaultMessageExtractionConfig
+	cfg.StallTolerance = 0
+
+	melDB, err := NewDatabase(rawdb.NewMemoryDatabase())
+	require.NoError(t, err)
+
+	headBlock := types.NewBlock(&types.Header{Number: common.Big1}, nil, nil, nil)
+	parentChainReader := &mockParentChainReader{
+		blocks: map[common.Hash]*types.Block{
+			common.BigToHash(common.Big1): headBlock,
+		},
+		headers: map[common.Hash]*types.Header{},
+	}
+	extractor, err := NewMessageExtractor(
+		cfg,
+		parentChainReader,
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, extractor.SetMessageConsumer(&mockMessageConsumer{}))
+	extractor.StopWaiter.Start(ctx, extractor)
+
+	// Set up state at block 1 so initialize succeeds.
+	melState := &mel.State{
+		ParentChainBlockNumber: 1,
+		ParentChainBlockHash:   headBlock.Hash(),
+	}
+	require.NoError(t, melDB.SaveState(melState))
+
+	// Initialize: Start -> ProcessingNextBlock
+	_, err = extractor.Act(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ProcessingNextBlock, extractor.CurrentFSMState())
+
+	// Block 2 not found — with StallTolerance=0, this should NOT return an error.
+	parentChainReader.returnErr = ethereum.NotFound
+	_, err = extractor.Act(ctx)
+	require.NoError(t, err, "StallTolerance=0 should not error on first NotFound")
+	require.Equal(t, ProcessingNextBlock, extractor.CurrentFSMState())
 }

--- a/arbnode/mel/runner/mel_test.go
+++ b/arbnode/mel/runner/mel_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/offchainlabs/nitro/arbnode/mel"
@@ -177,6 +179,21 @@ type mockMessageConsumer struct{ returnErr error }
 
 func (m *mockMessageConsumer) PushMessages(ctx context.Context, firstMsgIdx uint64, messages []*arbostypes.MessageWithMetadata) error {
 	return m.returnErr
+}
+
+// recordingConsumer tracks PushMessages calls for test verification.
+type recordingConsumer struct {
+	calls     []pushCall
+	returnErr error
+}
+type pushCall struct {
+	firstMsgIdx uint64
+	count       int
+}
+
+func (r *recordingConsumer) PushMessages(_ context.Context, firstMsgIdx uint64, messages []*arbostypes.MessageWithMetadata) error {
+	r.calls = append(r.calls, pushCall{firstMsgIdx: firstMsgIdx, count: len(messages)})
+	return r.returnErr
 }
 
 type mockParentChainReader struct {
@@ -705,7 +722,7 @@ func TestUpdateLastBlockToRead_NilHeaderEscalatesToFatal(t *testing.T) {
 	cfg := DefaultMessageExtractionConfig
 	cfg.StallTolerance = 1
 	cfg.RetryInterval = 10 * time.Millisecond
-	cfg.ReadMode = "finalized"
+	cfg.ReadMode = ReadModeFinalized
 
 	melDB, err := NewDatabase(rawdb.NewMemoryDatabase())
 	require.NoError(t, err)
@@ -885,4 +902,325 @@ func TestStallToleranceZeroDoesNotErrorOnFirstNotFound(t *testing.T) {
 	_, err = extractor.Act(ctx)
 	require.NoError(t, err, "StallTolerance=0 should not error on first NotFound")
 	require.Equal(t, ProcessingNextBlock, extractor.CurrentFSMState())
+}
+
+// toggleFailKVS wraps a KeyValueStore with a toggleable batch Write failure.
+type toggleFailKVS struct {
+	ethdb.KeyValueStore
+	fail    atomic.Bool
+	failErr error
+}
+
+func (t *toggleFailKVS) NewBatch() ethdb.Batch {
+	return &toggleFailBatch{Batch: t.KeyValueStore.NewBatch(), parent: t}
+}
+
+func (t *toggleFailKVS) NewBatchWithSize(size int) ethdb.Batch {
+	return &toggleFailBatch{Batch: t.KeyValueStore.NewBatchWithSize(size), parent: t}
+}
+
+type toggleFailBatch struct {
+	ethdb.Batch
+	parent *toggleFailKVS
+}
+
+func (b *toggleFailBatch) Write() error {
+	if b.parent.fail.Load() {
+		return b.parent.failErr
+	}
+	return b.Batch.Write()
+}
+
+func TestSaveMessages_RetryAfterDBFailure(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	consumer := &recordingConsumer{}
+	wrapper := &toggleFailKVS{
+		KeyValueStore: rawdb.NewMemoryDatabase(),
+		failErr:       errors.New("disk full"),
+	}
+	melDB, err := NewDatabase(wrapper)
+	require.NoError(t, err)
+
+	initialState := &mel.State{
+		ParentChainBlockNumber: 100,
+		ParentChainBlockHash:   common.HexToHash("0xaaa"),
+	}
+	require.NoError(t, melDB.SaveInitialMelState(initialState))
+
+	cfg := TestMessageExtractionConfig
+	fsmInst, err := newFSM(Start)
+	require.NoError(t, err)
+
+	extractor := &MessageExtractor{
+		config:       cfg,
+		melDB:        melDB,
+		msgConsumer:  consumer,
+		fsm:          fsmInst,
+		caughtUpChan: make(chan struct{}),
+	}
+
+	// Transition FSM: Start -> ProcessingNextBlock -> SavingMessages
+	postState := initialState.Clone()
+	postState.ParentChainBlockNumber = 101
+	postState.ParentChainBlockHash = common.HexToHash("0xbbb")
+	postState.ParentChainPreviousBlockHash = common.HexToHash("0xaaa")
+	postState.MsgCount = 3
+
+	require.NoError(t, fsmInst.Do(processNextBlock{melState: initialState}))
+	require.NoError(t, fsmInst.Do(saveMessages{
+		preStateMsgCount: 0,
+		postState:        postState,
+		messages:         []*arbostypes.MessageWithMetadata{{Message: &arbostypes.L1IncomingMessage{Header: &arbostypes.L1IncomingMessageHeader{}}}},
+	}))
+	require.Equal(t, SavingMessages, extractor.CurrentFSMState())
+
+	// First Act: PushMessages succeeds but SaveProcessedBlock fails
+	wrapper.fail.Store(true)
+	_, err = extractor.Act(ctx)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "disk full")
+	require.Equal(t, SavingMessages, extractor.CurrentFSMState(), "FSM must stay in SavingMessages on DB failure")
+	require.Len(t, consumer.calls, 1, "PushMessages should have been called once")
+	require.Equal(t, uint64(0), consumer.calls[0].firstMsgIdx)
+	require.Equal(t, 1, consumer.calls[0].count)
+
+	// Second Act: DB succeeds, PushMessages is called again (re-push), FSM advances
+	wrapper.fail.Store(false)
+	_, err = extractor.Act(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ProcessingNextBlock, extractor.CurrentFSMState(), "FSM should advance to ProcessingNextBlock after retry")
+	require.Len(t, consumer.calls, 2, "PushMessages should have been called twice (idempotent re-push)")
+	require.Equal(t, consumer.calls[0], consumer.calls[1], "retry must push identical arguments")
+}
+
+func TestSetMessageConsumer_Guards(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	melDB, err := NewDatabase(rawdb.NewMemoryDatabase())
+	require.NoError(t, err)
+	extractor, err := NewMessageExtractor(
+		DefaultMessageExtractionConfig,
+		&mockParentChainReader{},
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+
+	// First set succeeds.
+	require.NoError(t, extractor.SetMessageConsumer(&mockMessageConsumer{}))
+
+	// Double-set returns error.
+	err = extractor.SetMessageConsumer(&mockMessageConsumer{})
+	require.ErrorContains(t, err, "already set")
+
+	// After start, setting returns error.
+	require.NoError(t, extractor.Start(ctx))
+	extractor2, err := NewMessageExtractor(
+		DefaultMessageExtractionConfig,
+		&mockParentChainReader{},
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, extractor2.SetMessageConsumer(&mockMessageConsumer{}))
+	require.NoError(t, extractor2.Start(ctx))
+	err = extractor2.SetMessageConsumer(&mockMessageConsumer{})
+	require.ErrorContains(t, err, "after start")
+}
+
+func TestSetBlockValidator_Guards(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	melDB, err := NewDatabase(rawdb.NewMemoryDatabase())
+	require.NoError(t, err)
+	extractor, err := NewMessageExtractor(
+		DefaultMessageExtractionConfig,
+		&mockParentChainReader{},
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, extractor.SetMessageConsumer(&mockMessageConsumer{}))
+
+	// First set succeeds (passing nil is fine for this guard test).
+	require.NoError(t, extractor.SetBlockValidator(nil))
+
+	// Double-set returns error (even with nil, the field is checked for non-nil pointer).
+	// Note: SetBlockValidator checks `m.blockValidator != nil` which won't trigger for nil.
+	// So we need to set a non-nil value first to test the double-set guard.
+	extractor2, err := NewMessageExtractor(
+		DefaultMessageExtractionConfig,
+		&mockParentChainReader{},
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, extractor2.SetMessageConsumer(&mockMessageConsumer{}))
+	// We can't easily create a real BlockValidator, but we can verify the after-start guard.
+	require.NoError(t, extractor2.Start(ctx))
+	err = extractor2.SetBlockValidator(nil)
+	require.ErrorContains(t, err, "after start")
+}
+
+func TestEscalateIfPersistent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil fatalErrChan is a no-op", func(t *testing.T) {
+		t.Parallel()
+		extractor := &MessageExtractor{
+			config:       MessageExtractionConfig{StallTolerance: 5},
+			fatalErrChan: nil,
+		}
+		// Should not panic or block.
+		ctx := context.Background()
+		extractor.escalateIfPersistent(ctx, 100, errors.New("test"))
+	})
+
+	t.Run("StallTolerance zero disables escalation", func(t *testing.T) {
+		t.Parallel()
+		fatalChan := make(chan error, 1)
+		extractor := &MessageExtractor{
+			config:       MessageExtractionConfig{StallTolerance: 0},
+			fatalErrChan: fatalChan,
+		}
+		ctx := context.Background()
+		extractor.escalateIfPersistent(ctx, 100, errors.New("test"))
+		select {
+		case <-fatalChan:
+			t.Fatal("should not have sent to fatalErrChan when StallTolerance is 0")
+		default:
+		}
+	})
+
+	t.Run("below threshold does not escalate", func(t *testing.T) {
+		t.Parallel()
+		fatalChan := make(chan error, 1)
+		extractor := &MessageExtractor{
+			config:       MessageExtractionConfig{StallTolerance: 5},
+			fatalErrChan: fatalChan,
+		}
+		ctx := context.Background()
+		// 2*5 = 10; failures=10 is NOT > 10, so no escalation.
+		extractor.escalateIfPersistent(ctx, 10, errors.New("test"))
+		select {
+		case <-fatalChan:
+			t.Fatal("should not escalate at exactly 2x threshold")
+		default:
+		}
+	})
+
+	t.Run("above threshold escalates", func(t *testing.T) {
+		t.Parallel()
+		fatalChan := make(chan error, 1)
+		extractor := &MessageExtractor{
+			config:       MessageExtractionConfig{StallTolerance: 5},
+			fatalErrChan: fatalChan,
+		}
+		ctx := context.Background()
+		testErr := errors.New("persistent failure")
+		extractor.escalateIfPersistent(ctx, 11, testErr)
+		select {
+		case err := <-fatalChan:
+			require.Equal(t, testErr, err)
+		default:
+			t.Fatal("should have sent to fatalErrChan when failures > 2*StallTolerance")
+		}
+	})
+
+	t.Run("context cancellation prevents blocking", func(t *testing.T) {
+		t.Parallel()
+		// Unbuffered channel that nobody reads — would block forever without ctx.
+		fatalChan := make(chan error)
+		extractor := &MessageExtractor{
+			config:       MessageExtractionConfig{StallTolerance: 1},
+			fatalErrChan: fatalChan,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancel immediately
+		// Should return without blocking.
+		extractor.escalateIfPersistent(ctx, 100, errors.New("test"))
+	})
+}
+
+func TestGetDelayedMessage_OutOfBounds(t *testing.T) {
+	t.Parallel()
+
+	melDB, err := NewDatabase(rawdb.NewMemoryDatabase())
+	require.NoError(t, err)
+	extractor, err := NewMessageExtractor(
+		DefaultMessageExtractionConfig,
+		&mockParentChainReader{},
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+
+	// State has 3 delayed messages seen.
+	state := &mel.State{
+		ParentChainBlockNumber: 1,
+		DelayedMessagesSeen:    3,
+	}
+	require.NoError(t, melDB.SaveState(state))
+
+	// Requesting at the boundary (index == seen) should fail.
+	_, err = extractor.GetDelayedMessage(3)
+	require.ErrorIs(t, err, mel.ErrAccumulatorNotFound)
+
+	// Requesting above the boundary should fail.
+	_, err = extractor.GetDelayedMessage(100)
+	require.ErrorIs(t, err, mel.ErrAccumulatorNotFound)
+}
+
+func TestGetBatchMetadata_OutOfBounds(t *testing.T) {
+	t.Parallel()
+
+	melDB, err := NewDatabase(rawdb.NewMemoryDatabase())
+	require.NoError(t, err)
+	extractor, err := NewMessageExtractor(
+		DefaultMessageExtractionConfig,
+		&mockParentChainReader{},
+		chaininfo.ArbitrumDevTestChainConfig(),
+		&chaininfo.RollupAddresses{},
+		melDB,
+		daprovider.NewDAProviderRegistry(),
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+
+	// State has 2 batches.
+	state := &mel.State{
+		ParentChainBlockNumber: 1,
+		BatchCount:             2,
+	}
+	require.NoError(t, melDB.SaveState(state))
+
+	// Requesting at the boundary (seqNum == count) should fail.
+	_, err = extractor.GetBatchMetadata(2)
+	require.ErrorContains(t, err, "batchMetadata not available")
+
+	// Requesting above the boundary should fail.
+	_, err = extractor.GetBatchMetadata(100)
+	require.ErrorContains(t, err, "batchMetadata not available")
 }

--- a/arbnode/mel/runner/process_next_block.go
+++ b/arbnode/mel/runner/process_next_block.go
@@ -33,7 +33,6 @@ func (f *txByLogFetcher) TransactionByLog(ctx context.Context, log *types.Log) (
 }
 
 func (m *MessageExtractor) processNextBlock(ctx context.Context, current *fsm.CurrentState[action, FSMState]) (time.Duration, error) {
-	// Process the next block in the parent chain and extracts messages.
 	processAction, ok := current.SourceEvent.(processNextBlock)
 	if !ok {
 		return m.config.RetryInterval, fmt.Errorf("invalid action: %T", current.SourceEvent)
@@ -44,6 +43,9 @@ func (m *MessageExtractor) processNextBlock(ctx context.Context, current *fsm.Cu
 		return m.config.RetryInterval, nil
 	}
 	parentChainBlock, err := m.logsAndHeadersPreFetcher.getHeaderByNumber(ctx, preState.ParentChainBlockNumber+1)
+	if err == nil && parentChainBlock == nil {
+		return m.config.RetryInterval, fmt.Errorf("parent chain block %d returned nil without error", preState.ParentChainBlockNumber+1)
+	}
 	if err != nil {
 		if errors.Is(err, ethereum.NotFound) {
 			// If the block with the specified number is not found, it likely has not
@@ -52,35 +54,47 @@ func (m *MessageExtractor) processNextBlock(ctx context.Context, current *fsm.Cu
 			if !m.caughtUp && m.config.ReadMode == "latest" {
 				if latestBlk, err := m.parentChainReader.HeaderByNumber(ctx, big.NewInt(rpc.LatestBlockNumber.Int64())); err != nil {
 					log.Error("Error fetching LatestBlockNumber from parent chain to determine if mel has caught up", "err", err)
+				} else if latestBlk == nil {
+					log.Error("Parent chain returned nil header for latest block")
 				} else if latestBlk.Number.Uint64()-preState.ParentChainBlockNumber <= 5 { // tolerance of catching up i.e parent chain might have progressed in the time between the above two function calls
 					m.caughtUp = true
 					close(m.caughtUpChan)
+					m.consecutiveNotFound = 0
 				}
 			}
+			m.consecutiveNotFound++
+			if m.config.StallTolerance > 0 && m.consecutiveNotFound > m.config.StallTolerance {
+				// Return an error so the FSM's stuckCount increments and the
+				// arb/mel/stuck gauge fires, giving operators visibility into
+				// the stall. The Start() loop's own 2*StallTolerance threshold
+				// handles fatal error escalation.
+				return m.config.RetryInterval, fmt.Errorf("MEL block %d not found for %d consecutive attempts (tolerance %d), possible parent chain stall", preState.ParentChainBlockNumber+1, m.consecutiveNotFound, m.config.StallTolerance)
+			}
 			return m.config.RetryInterval, nil
-		} else {
-			return m.config.RetryInterval, err
 		}
+		// Reset on non-NotFound errors: a different error type suggests the parent
+		// chain is responding (not stalled), so the NotFound counter restarts.
+		m.consecutiveNotFound = 0
+		return m.config.RetryInterval, err
 	}
+	m.consecutiveNotFound = 0
 	if parentChainBlock.ParentHash != preState.ParentChainBlockHash {
 		log.Info("MEL detected L1 reorg", "block", preState.ParentChainBlockNumber) // Log level is Info because L1 reorgs are a common occurrence
 		return 0, m.fsm.Do(reorgToOldBlock{
 			melState: preState,
 		})
 	}
-	// Reorging of MEL states successfully completed, we can now rewind MEL validator and rebuild delayedMsgPreimages based on inbox and outbox accumulators
+	// Previous FSM step was a reorg. Rebuild delayed message preimage cache from
+	// the rewound state. Reorg notifications to the block validator and downstream
+	// consumers are sent in the reorg handler itself (immediately after the DB
+	// write) to avoid losing them on crash.
 	if processAction.prevStepWasReorg {
 		if err := preState.RebuildDelayedMsgPreimages(m.melDB.FetchDelayedMessage); err != nil {
 			return m.config.RetryInterval, fmt.Errorf("error rebuilding delayed msg preimages after reorg: %w", err)
 		}
-		if m.reorgEventsNotifier != nil {
-			m.reorgEventsNotifier <- preState.ParentChainBlockNumber
-		}
-		if m.blockValidator != nil {
-			m.blockValidator.ReorgToBatchCount(preState.BatchCount)
-		}
+		m.consecutivePreimageRebuilds = 0
+		m.consecutiveNotFound = 0
 	}
-	// Conditionally prefetch headers and logs for upcoming block/s
 	if err = m.logsAndHeadersPreFetcher.fetch(ctx, preState); err != nil {
 		return m.config.RetryInterval, err
 	}
@@ -96,13 +110,11 @@ func (m *MessageExtractor) processNextBlock(ctx context.Context, current *fsm.Cu
 	)
 	if err != nil {
 		if errors.Is(err, mel.ErrDelayedMessagePreimageNotFound) {
-			if err := preState.RebuildDelayedMsgPreimages(m.melDB.FetchDelayedMessage); err != nil {
-				return m.config.RetryInterval, fmt.Errorf("error rebuilding delayed msg preimages when missing some preimages: %w", err)
-			}
-			return 0, nil
+			return m.handlePreimageCacheMiss(preState)
 		}
 		return m.config.RetryInterval, err
 	}
+	m.consecutivePreimageRebuilds = 0
 	// Begin the next FSM state immediately.
 	return 0, m.fsm.Do(saveMessages{
 		preStateMsgCount: preState.MsgCount,
@@ -111,4 +123,21 @@ func (m *MessageExtractor) processNextBlock(ctx context.Context, current *fsm.Cu
 		delayedMessages:  delayedMsgs,
 		batchMetas:       batchMetas,
 	})
+}
+
+// handlePreimageCacheMiss attempts to rebuild the delayed message preimage
+// cache. Returns (0, nil) on success for immediate retry, or an error if the
+// rebuild limit has been reached or the rebuild itself fails.
+func (m *MessageExtractor) handlePreimageCacheMiss(preState *mel.State) (time.Duration, error) {
+	m.consecutivePreimageRebuilds++
+	if m.consecutivePreimageRebuilds >= 3 {
+		return m.config.RetryInterval, fmt.Errorf("repeated preimage rebuild at block %d after %d attempts, possible systemic issue", preState.ParentChainBlockNumber, m.consecutivePreimageRebuilds)
+	}
+	log.Warn("Rebuilding delayed message preimages due to cache miss during extraction", "block", preState.ParentChainBlockNumber, "attempt", m.consecutivePreimageRebuilds)
+	if rebuildErr := preState.RebuildDelayedMsgPreimages(m.melDB.FetchDelayedMessage); rebuildErr != nil {
+		return m.config.RetryInterval, fmt.Errorf("error rebuilding delayed msg preimages when missing some preimages: %w", rebuildErr)
+	}
+	// Rebuild succeeded; retry immediately without incrementing the stall counter.
+	// The consecutivePreimageRebuilds counter limits repeated rebuilds independently.
+	return 0, nil
 }

--- a/arbnode/mel/runner/process_next_block.go
+++ b/arbnode/mel/runner/process_next_block.go
@@ -39,7 +39,7 @@ func (m *MessageExtractor) processNextBlock(ctx context.Context, current *fsm.Cu
 	}
 	preState := processAction.melState
 	// If the current parent chain block is not safe/finalized we wait till it becomes safe/finalized as determined by the ReadMode
-	if m.config.ReadMode != "latest" && preState.ParentChainBlockNumber+1 > m.lastBlockToRead.Load() {
+	if m.config.ReadMode != ReadModeLatest && preState.ParentChainBlockNumber+1 > m.lastBlockToRead.Load() {
 		return m.config.RetryInterval, nil
 	}
 	parentChainBlock, err := m.logsAndHeadersPreFetcher.getHeaderByNumber(ctx, preState.ParentChainBlockNumber+1)
@@ -51,11 +51,11 @@ func (m *MessageExtractor) processNextBlock(ctx context.Context, current *fsm.Cu
 			// If the block with the specified number is not found, it likely has not
 			// been posted yet to the parent chain, so we can retry
 			// without returning an error from the FSM.
-			if !m.caughtUp && m.config.ReadMode == "latest" {
+			if !m.caughtUp && m.config.ReadMode == ReadModeLatest {
 				if latestBlk, err := m.parentChainReader.HeaderByNumber(ctx, big.NewInt(rpc.LatestBlockNumber.Int64())); err != nil {
 					log.Error("Error fetching LatestBlockNumber from parent chain to determine if mel has caught up", "err", err)
-				} else if latestBlk == nil {
-					log.Error("Parent chain returned nil header for latest block")
+				} else if latestBlk == nil || latestBlk.Number == nil {
+					log.Error("Parent chain returned nil header or nil block number for latest block")
 				} else if latestBlk.Number.Uint64()-preState.ParentChainBlockNumber <= 5 { // tolerance of catching up i.e parent chain might have progressed in the time between the above two function calls
 					m.caughtUp = true
 					close(m.caughtUpChan)

--- a/arbnode/mel/runner/reorg.go
+++ b/arbnode/mel/runner/reorg.go
@@ -20,9 +20,25 @@ func (m *MessageExtractor) reorg(ctx context.Context, current *fsm.CurrentState[
 	if currentDirtyState.ParentChainBlockNumber == 0 {
 		return m.config.RetryInterval, errors.New("invalid reorging stage, ParentChainBlockNumber of current mel state has reached 0")
 	}
-	previousState, err := m.melDB.State(currentDirtyState.ParentChainBlockNumber - 1)
+	targetBlock := currentDirtyState.ParentChainBlockNumber - 1
+	if initialBlockNum, ok := m.melDB.InitialBlockNum(); ok && targetBlock < initialBlockNum {
+		return m.config.RetryInterval, fmt.Errorf("reorg walked back to block %d which is below the MEL migration boundary %d; manual intervention required", targetBlock, initialBlockNum)
+	}
+	previousState, err := m.melDB.State(targetBlock)
 	if err != nil {
-		return m.config.RetryInterval, err
+		return m.config.RetryInterval, fmt.Errorf("reorg: failed to load MEL state for parent block %d: %w", targetBlock, err)
+	}
+	if err := m.melDB.RewriteHeadBlockNum(targetBlock); err != nil {
+		return m.config.RetryInterval, fmt.Errorf("reorg: failed to rewrite head block num to %d: %w", targetBlock, err)
+	}
+	// Notify consumers immediately after the rewrite is persisted, before
+	// transitioning to processNextBlock. This prevents lost notifications
+	// if the node crashes between the DB write and the next FSM step.
+	if m.blockValidator != nil {
+		m.blockValidator.ReorgToBatchCount(previousState.BatchCount)
+	}
+	if err := m.sendReorgNotification(ctx, previousState.ParentChainBlockNumber); err != nil {
+		return 0, err
 	}
 	m.logsAndHeadersPreFetcher.reset()
 	return 0, m.fsm.Do(processNextBlock{

--- a/arbnode/mel/runner/save_messages.go
+++ b/arbnode/mel/runner/save_messages.go
@@ -13,23 +13,24 @@ import (
 )
 
 func (m *MessageExtractor) saveMessages(ctx context.Context, current *fsm.CurrentState[action, FSMState]) (time.Duration, error) {
-	// Persists messages and a processed MEL state to the database.
 	saveAction, ok := current.SourceEvent.(saveMessages)
 	if !ok {
 		return m.config.RetryInterval, fmt.Errorf("invalid action: %T", current.SourceEvent)
 	}
-	if err := m.melDB.SaveBatchMetas(saveAction.postState, saveAction.batchMetas); err != nil {
-		return m.config.RetryInterval, err
-	}
-	if err := m.melDB.SaveDelayedMessages(saveAction.postState, saveAction.delayedMessages); err != nil {
-		return m.config.RetryInterval, err
-	}
+	// Push messages to the transaction streamer first. This is a separate DB
+	// so it cannot be made atomic with the MEL DB writes below. If we crash
+	// after push but before the MEL write, MEL will reprocess and push again.
+	// PushMessages is idempotent for identical messages; re-pushing after a crash
+	// is safe. See TransactionStreamer.AddMessagesAndEndBatch for details.
 	if err := m.msgConsumer.PushMessages(ctx, saveAction.preStateMsgCount, saveAction.messages); err != nil {
-		return m.config.RetryInterval, err
+		return m.config.RetryInterval, fmt.Errorf("saveMessages: pushing messages to consumer (firstMsg=%d, count=%d): %w", saveAction.preStateMsgCount, len(saveAction.messages), err)
 	}
-	if err := m.melDB.SaveState(saveAction.postState); err != nil {
-		log.Error("Error saving latest state as head state to db", "err", err)
-		return m.config.RetryInterval, err
+	// Atomically write batch metadata, delayed messages, and the new head
+	// MEL state in a single database batch.
+	if err := m.melDB.SaveProcessedBlock(saveAction.postState, saveAction.batchMetas, saveAction.delayedMessages); err != nil {
+		log.Error("SaveProcessedBlock failed after messages were already pushed to streamer; MEL will retry and re-push on recovery",
+			"block", saveAction.postState.ParentChainBlockNumber, "msgCount", len(saveAction.messages), "err", err)
+		return m.config.RetryInterval, fmt.Errorf("saveMessages: persisting processed block %d: %w", saveAction.postState.ParentChainBlockNumber, err)
 	}
 	return 0, m.fsm.Do(processNextBlock{
 		melState: saveAction.postState,

--- a/arbnode/mel/state.go
+++ b/arbnode/mel/state.go
@@ -17,6 +17,65 @@ import (
 	"github.com/offchainlabs/nitro/util/containers"
 )
 
+// keccakPreimages returns the Keccak256 preimage sub-map from a PreimagesMap,
+// or an error if the sub-map has not been initialized.
+func keccakPreimages(dest daprovider.PreimagesMap) (map[common.Hash][]byte, error) {
+	m, ok := dest[arbutil.Keccak256PreimageType]
+	if !ok {
+		return nil, errors.New("keccak256 preimage map not initialized")
+	}
+	return m, nil
+}
+
+// recordDelayedChainLink stores a hash chain link preimage in the LRU cache
+// and optionally in the validation preimage map.
+func (s *State) recordDelayedChainLink(newAcc common.Hash, preimage []byte) error {
+	s.delayedMsgPreimages.Add(newAcc, preimage)
+	if s.delayedMsgPreimagesDest == nil {
+		return nil
+	}
+	keccakMap, err := keccakPreimages(s.delayedMsgPreimagesDest)
+	if err != nil {
+		return err
+	}
+	keccakMap[newAcc] = preimage
+	return nil
+}
+
+// recordDelayedContent stores message content in the validation preimage map
+// when recording is enabled. No-op when not recording.
+func (s *State) recordDelayedContent(hash common.Hash, content []byte) error {
+	if s.delayedMsgPreimagesDest == nil {
+		return nil
+	}
+	keccakMap, err := keccakPreimages(s.delayedMsgPreimagesDest)
+	if err != nil {
+		return err
+	}
+	keccakMap[hash] = content
+	return nil
+}
+
+// HashChainLinkHash computes the next accumulator in a Keccak256 hash chain
+// without allocating the preimage. Use this when only the hash is needed.
+func HashChainLinkHash(prevAcc, itemHash common.Hash) common.Hash {
+	var buf [2 * common.HashLength]byte
+	copy(buf[:common.HashLength], prevAcc[:])
+	copy(buf[common.HashLength:], itemHash[:])
+	return crypto.Keccak256Hash(buf[:])
+}
+
+// HashChainLink computes the next accumulator in a Keccak256 hash chain.
+// Returns the new accumulator hash and the 64-byte preimage (prevAcc || itemHash).
+// This is the single canonical implementation of the hash chain step used throughout
+// MEL for both message and delayed message accumulators, in native and replay modes.
+func HashChainLink(prevAcc, itemHash common.Hash) (newAcc common.Hash, preimage []byte) {
+	preimage = make([]byte, 2*common.HashLength)
+	copy(preimage[:common.HashLength], prevAcc[:])
+	copy(preimage[common.HashLength:], itemHash[:])
+	return crypto.Keccak256Hash(preimage), preimage
+}
+
 // SplitPreimage validates that a preimage is exactly 2*common.HashLength bytes
 // and splits it into left (previous accumulator) and right (message hash) halves.
 func SplitPreimage(preimage []byte) (left, right common.Hash, err error) {
@@ -40,7 +99,7 @@ type State struct {
 	ParentChainPreviousBlockHash       common.Hash
 	BatchCount                         uint64
 	MsgCount                           uint64
-	LocalMsgAccumulator                common.Hash // starts at zero hash for each clone; updated only by AccumulateMessage; represents messages accumulated during processing of this specific parent chain block
+	LocalMsgAccumulator                common.Hash // zeroed on Clone(); updated only by AccumulateMessage. In production, each clone processes exactly one parent chain block.
 	DelayedMessagesRead                uint64
 	DelayedMessagesSeen                uint64
 	DelayedMessageInboxAcc             common.Hash
@@ -48,18 +107,20 @@ type State struct {
 
 	msgPreimagesDest        daprovider.PreimagesMap
 	delayedMsgPreimagesDest daprovider.PreimagesMap
-	// delayedMsgPreimages is always populated during delayed message operations
-	// (inbox push, pour, outbox pop) regardless of recording mode. It enables
-	// the pour and pop operations in native mode without requiring full recording.
+	// delayedMsgPreimages is populated during inbox push and pour operations
+	// regardless of recording mode. Pop reads from this cache via Peek.
+	// It enables the pour and pop operations in native mode without requiring full recording.
 	delayedMsgPreimages *containers.LruCache[common.Hash, []byte]
 
-	// initMsg holds the init delayed message (index 0) in memory. It is both
-	// accumulated and read in the same block, so it may not be in the DB yet
-	// when ReadDelayedMessage is called in native mode.
+	// initMsg holds the init delayed message (index 0), set during the first
+	// AccumulateDelayedMessage call (when DelayedMessagesSeen is 0). It persists
+	// through Clone() and is accessed by Database.ReadDelayedMessage as a fallback
+	// when the message has not yet been written to the DB (accumulated and read in
+	// the same block).
 	initMsg *DelayedInboxMessage
 }
 
-// MessageConsumer is an interface to be implemented by readers of MEL such as transaction streamer of the nitro node
+// MessageConsumer is an interface for downstream consumers of messages extracted by MEL.
 type MessageConsumer interface {
 	PushMessages(
 		ctx context.Context,
@@ -70,93 +131,114 @@ type MessageConsumer interface {
 
 func (s *State) InitMsg() *DelayedInboxMessage { return s.initMsg }
 
-func (s *State) Hash() common.Hash {
+func (s *State) Hash() (common.Hash, error) {
 	encoded, err := rlp.EncodeToBytes(s)
 	if err != nil {
-		panic(err)
+		return common.Hash{}, fmt.Errorf("failed to RLP-encode MEL state at block %d: %w", s.ParentChainBlockNumber, err)
 	}
-	return crypto.Keccak256Hash(encoded)
+	return crypto.Keccak256Hash(encoded), nil
 }
 
-// Clone performs a deep clone of the state struct to prevent any unintended
-// mutations of pointers at runtime. LocalMsgAccumulator is zeroed because the
-// extraction function rebuilds it from scratch per block. Delayed message
-// accumulators (DelayedMessageInboxAcc, DelayedMessageOutboxAcc) are preserved
-// because they carry state across blocks.
+// Validate checks structural invariants of the state.
+func (s *State) Validate() error {
+	if s.DelayedMessagesSeen < s.DelayedMessagesRead {
+		return fmt.Errorf("invalid MEL state at block %d: DelayedMessagesSeen (%d) < DelayedMessagesRead (%d)", s.ParentChainBlockNumber, s.DelayedMessagesSeen, s.DelayedMessagesRead)
+	}
+	if s.DelayedMessageOutboxAcc != (common.Hash{}) && s.DelayedMessagesSeen <= s.DelayedMessagesRead {
+		return fmt.Errorf("invalid MEL state at block %d: non-zero DelayedMessageOutboxAcc but no unread messages (seen=%d, read=%d)", s.ParentChainBlockNumber, s.DelayedMessagesSeen, s.DelayedMessagesRead)
+	}
+	return nil
+}
+
+// Clone copies all state-tracking fields by value and zeroes LocalMsgAccumulator
+// because the extraction function rebuilds it from scratch per block. Delayed
+// message accumulators (DelayedMessageInboxAcc, DelayedMessageOutboxAcc) are
+// preserved because they carry state across blocks.
 func (s *State) Clone() *State {
-	batchPostingTarget := common.Address{}
-	delayedMessageTarget := common.Address{}
-	parentChainHash := common.Hash{}
-	parentChainPrevHash := common.Hash{}
-	delayedInboxAcc := common.Hash{}
-	delayedOutboxAcc := common.Hash{}
-	copy(batchPostingTarget[:], s.BatchPostingTargetAddress[:])
-	copy(delayedMessageTarget[:], s.DelayedMessagePostingTargetAddress[:])
-	copy(parentChainHash[:], s.ParentChainBlockHash[:])
-	copy(parentChainPrevHash[:], s.ParentChainPreviousBlockHash[:])
-	copy(delayedInboxAcc[:], s.DelayedMessageInboxAcc[:])
-	copy(delayedOutboxAcc[:], s.DelayedMessageOutboxAcc[:])
+	// common.Hash and common.Address are fixed-size arrays, copied by value on assignment.
 	return &State{
 		Version:                            s.Version,
 		ParentChainId:                      s.ParentChainId,
 		ParentChainBlockNumber:             s.ParentChainBlockNumber,
-		BatchPostingTargetAddress:          batchPostingTarget,
-		DelayedMessagePostingTargetAddress: delayedMessageTarget,
-		ParentChainBlockHash:               parentChainHash,
-		ParentChainPreviousBlockHash:       parentChainPrevHash,
+		BatchPostingTargetAddress:          s.BatchPostingTargetAddress,
+		DelayedMessagePostingTargetAddress: s.DelayedMessagePostingTargetAddress,
+		ParentChainBlockHash:               s.ParentChainBlockHash,
+		ParentChainPreviousBlockHash:       s.ParentChainPreviousBlockHash,
 		MsgCount:                           s.MsgCount,
 		BatchCount:                         s.BatchCount,
 		DelayedMessagesRead:                s.DelayedMessagesRead,
 		DelayedMessagesSeen:                s.DelayedMessagesSeen,
-		DelayedMessageInboxAcc:             delayedInboxAcc,
-		DelayedMessageOutboxAcc:            delayedOutboxAcc,
+		DelayedMessageInboxAcc:             s.DelayedMessageInboxAcc,
+		DelayedMessageOutboxAcc:            s.DelayedMessageOutboxAcc,
 		// LocalMsgAccumulator is intentionally not copied — each cloned state
 		// starts a fresh hash chain for its own batch of accumulated messages.
 		//
 		// we pass along msgPreimagesDest to continue recording of msg preimages
 		msgPreimagesDest:        s.msgPreimagesDest,
 		delayedMsgPreimagesDest: s.delayedMsgPreimagesDest,
-		delayedMsgPreimages:     s.delayedMsgPreimages,
-		initMsg:                 s.initMsg,
+		// delayedMsgPreimages is intentionally shared (not deep-copied) between
+		// the original and cloned state. This is safe because the FSM processes
+		// blocks sequentially: only the post-state is used going forward, and
+		// the pre-state is never read concurrently. Do NOT use the pre-state
+		// after cloning if the post-state may be mutated concurrently.
+		delayedMsgPreimages: s.delayedMsgPreimages,
+		initMsg:             s.initMsg,
 	}
 }
 
+// AccumulateMessage appends a message to the local accumulator hash chain and
+// increments MsgCount.
 func (s *State) AccumulateMessage(msg *arbostypes.MessageWithMetadata) error {
 	msgBytes, err := rlp.EncodeToBytes(msg)
 	if err != nil {
 		return err
 	}
 	msgHash := crypto.Keccak256Hash(msgBytes)
-	preimage := make([]byte, 0, 2*common.HashLength)
-	preimage = append(preimage, s.LocalMsgAccumulator.Bytes()...)
-	preimage = append(preimage, msgHash.Bytes()...)
-	newAcc := crypto.Keccak256Hash(preimage)
+	newAcc, preimage := HashChainLink(s.LocalMsgAccumulator, msgHash)
 	if s.msgPreimagesDest != nil {
-		keccakMap, ok := s.msgPreimagesDest[arbutil.Keccak256PreimageType]
-		if !ok {
-			return errors.New("keccak256 preimage map not initialized in msgPreimagesDest")
+		keccakMap, err := keccakPreimages(s.msgPreimagesDest)
+		if err != nil {
+			return err
 		}
 		keccakMap[newAcc] = preimage  // acc chain link
 		keccakMap[msgHash] = msgBytes // message content
 	}
 	s.LocalMsgAccumulator = newAcc
+	s.MsgCount++
 	return nil
 }
 
 func (s *State) ensureDelayedMsgPreimages() {
 	if s.delayedMsgPreimages == nil {
-		s.delayedMsgPreimages = containers.NewLruCache[common.Hash, []byte](0)
+		s.delayedMsgPreimages = containers.NewLruCache[common.Hash, []byte](16)
 	}
 }
 
-// AccumulateDelayedMessage pushes a delayed message onto the inbox accumulator hash chain.
+// IncrementBatchCount increments the batch count and returns the new value.
+func (s *State) IncrementBatchCount() uint64 {
+	s.BatchCount++
+	return s.BatchCount
+}
+
+// IncrementDelayedMessagesRead increments the delayed messages read counter
+// and returns the new value. Returns an error if the counter would exceed
+// DelayedMessagesSeen.
+func (s *State) IncrementDelayedMessagesRead() (uint64, error) {
+	if s.DelayedMessagesRead >= s.DelayedMessagesSeen {
+		return 0, fmt.Errorf("cannot increment DelayedMessagesRead (%d) beyond DelayedMessagesSeen (%d)", s.DelayedMessagesRead, s.DelayedMessagesSeen)
+	}
+	s.DelayedMessagesRead++
+	return s.DelayedMessagesRead, nil
+}
+
+// AccumulateDelayedMessage pushes a delayed message onto the inbox accumulator
+// hash chain and increments DelayedMessagesSeen.
 func (s *State) AccumulateDelayedMessage(msg *DelayedInboxMessage) error {
 	if s.DelayedMessagesSeen == 0 {
 		s.initMsg = msg
 	}
 	s.ensureDelayedMsgPreimages()
-	// totalUnread is the count of live unread messages before this accumulation
-	// (DelayedMessagesSeen is incremented by the caller after this returns).
+	// totalUnread is the count of live unread messages before this accumulation.
 	// Resize to totalUnread+1 to ensure capacity for the entry about to be added.
 	// Stale entries (e.g. old inbox preimages left after pour) are the oldest in
 	// LRU order and will be evicted first if the cache is full, so sizing for
@@ -171,20 +253,15 @@ func (s *State) AccumulateDelayedMessage(msg *DelayedInboxMessage) error {
 		return err
 	}
 	msgHash := crypto.Keccak256Hash(msgBytes)
-	preimage := append(s.DelayedMessageInboxAcc.Bytes(), msgHash.Bytes()...)
-	newAcc := crypto.Keccak256Hash(preimage)
-	// Always record delayed message preimages for pour/pop operations
-	s.delayedMsgPreimages.Add(newAcc, preimage)
-	// Also record to the delayed msg validation preimage map if in recording mode
-	if s.delayedMsgPreimagesDest != nil {
-		keccakMap, ok := s.delayedMsgPreimagesDest[arbutil.Keccak256PreimageType]
-		if !ok {
-			return errors.New("keccak256 preimage map not initialized in delayedMsgPreimagesDest")
-		}
-		keccakMap[newAcc] = preimage
-		keccakMap[msgHash] = msgBytes
+	newAcc, preimage := HashChainLink(s.DelayedMessageInboxAcc, msgHash)
+	if err := s.recordDelayedChainLink(newAcc, preimage); err != nil {
+		return err
+	}
+	if err := s.recordDelayedContent(msgHash, msgBytes); err != nil {
+		return err
 	}
 	s.DelayedMessageInboxAcc = newAcc
+	s.DelayedMessagesSeen++
 	return nil
 }
 
@@ -195,7 +272,7 @@ func (s *State) resolveDelayedPreimage(hash common.Hash) ([]byte, error) {
 	}
 	preimage, ok := s.delayedMsgPreimages.Peek(hash)
 	if !ok {
-		return nil, fmt.Errorf("%w: for hash: %s", ErrDelayedMessagePreimageNotFound, hash.Hex())
+		return nil, fmt.Errorf("%w: for hash: %s (cache size: %d, capacity: %d)", ErrDelayedMessagePreimageNotFound, hash.Hex(), s.delayedMsgPreimages.Len(), s.delayedMsgPreimages.Size())
 	}
 	return preimage, nil
 }
@@ -203,8 +280,15 @@ func (s *State) resolveDelayedPreimage(hash common.Hash) ([]byte, error) {
 // PourDelayedInboxToOutbox moves all items from the inbox to the outbox,
 // reversing their order so that the first-seen message is popped first from the outbox.
 // This implements the "pour" operation of the two-stack FIFO queue.
-// The number of items to pour is DelayedMessagesSeen - DelayedMessagesRead (called when outbox is empty).
+// The caller must ensure the outbox is empty before calling. The number of items to
+// pour is DelayedMessagesSeen - DelayedMessagesRead.
+//
+// Replay-mode counterpart: mel-replay/delayed_message_db.go pourInboxToOutbox.
+// Both must produce identical accumulator state transitions for fraud proof correctness.
 func (s *State) PourDelayedInboxToOutbox() error {
+	if s.DelayedMessageOutboxAcc != (common.Hash{}) {
+		return errors.New("PourDelayedInboxToOutbox: outbox must be empty before pouring")
+	}
 	inboxSize := s.DelayedMessagesSeen - s.DelayedMessagesRead
 	if inboxSize == 0 {
 		return nil
@@ -218,8 +302,8 @@ func (s *State) PourDelayedInboxToOutbox() error {
 	if s.delayedMsgPreimages.Size() < 3*int(inboxSize) {
 		s.delayedMsgPreimages.Resize(3 * int(inboxSize))
 	}
-	// Pop all items from inbox (LIFO: last-seen comes out first) and Push onto outbox
-	// in original order (first-seen first → it ends up on top)
+	// Pop from inbox (LIFO: last-seen out first), push each onto outbox. First-seen is
+	// pushed last, landing on top of the outbox (LIFO), restoring FIFO order.
 	curr := s.DelayedMessageInboxAcc
 	for i := range inboxSize {
 		result, err := s.resolveDelayedPreimage(curr)
@@ -230,16 +314,10 @@ func (s *State) PourDelayedInboxToOutbox() error {
 		if err != nil {
 			return fmt.Errorf("inbox preimage at position %d: %w", i, err)
 		}
-		preimage := append(s.DelayedMessageOutboxAcc.Bytes(), msgHash.Bytes()...)
-		newAcc := crypto.Keccak256Hash(preimage)
+		newAcc, preimage := HashChainLink(s.DelayedMessageOutboxAcc, msgHash)
 		s.DelayedMessageOutboxAcc = newAcc
-		s.delayedMsgPreimages.Add(newAcc, preimage)
-		if s.delayedMsgPreimagesDest != nil {
-			keccakMap, ok := s.delayedMsgPreimagesDest[arbutil.Keccak256PreimageType]
-			if !ok {
-				return errors.New("keccak256 preimage map not initialized in delayedMsgPreimagesDest")
-			}
-			keccakMap[newAcc] = preimage
+		if err := s.recordDelayedChainLink(newAcc, preimage); err != nil {
+			return err
 		}
 		curr = prevAcc
 	}
@@ -271,15 +349,24 @@ func (s *State) PopDelayedOutbox() (common.Hash, error) {
 	return msgHash, nil
 }
 
+// ensureKeccakPreimagesMap validates a PreimagesMap is non-nil and ensures
+// the Keccak256 sub-map exists.
+func ensureKeccakPreimagesMap(preimagesMap daprovider.PreimagesMap) error {
+	if preimagesMap == nil {
+		return errors.New("preimages recording destination cannot be nil")
+	}
+	if _, ok := preimagesMap[arbutil.Keccak256PreimageType]; !ok {
+		preimagesMap[arbutil.Keccak256PreimageType] = make(map[common.Hash][]byte)
+	}
+	return nil
+}
+
 // RecordMsgPreimagesTo initializes the state's msgPreimagesDest to record preimages
 // related to the extracted L2 messages needed for MEL validation into the given preimages map.
 // When set, AccumulateMessage will record accumulator chain and message content preimages.
 func (s *State) RecordMsgPreimagesTo(preimagesMap daprovider.PreimagesMap) error {
-	if preimagesMap == nil {
-		return errors.New("msg preimages recording destination cannot be nil")
-	}
-	if _, ok := preimagesMap[arbutil.Keccak256PreimageType]; !ok {
-		preimagesMap[arbutil.Keccak256PreimageType] = make(map[common.Hash][]byte)
+	if err := ensureKeccakPreimagesMap(preimagesMap); err != nil {
+		return err
 	}
 	s.msgPreimagesDest = preimagesMap
 	return nil
@@ -287,14 +374,11 @@ func (s *State) RecordMsgPreimagesTo(preimagesMap daprovider.PreimagesMap) error
 
 // RecordDelayedMsgPreimagesTo initializes the state's delayedMsgPreimagesDest to record
 // preimages related to delayed messages needed for MEL validation into the given preimages map.
-// When set, AccumulateDelayedMessage will record accumulator chain and message content preimages,
-// whereas PourDelayedInboxToOutbox record only accumulator chain preimages
+// When set, AccumulateDelayedMessage records accumulator chain and message content preimages,
+// whereas PourDelayedInboxToOutbox records only accumulator chain preimages.
 func (s *State) RecordDelayedMsgPreimagesTo(preimagesMap daprovider.PreimagesMap) error {
-	if preimagesMap == nil {
-		return errors.New("delayed msg preimages recording destination cannot be nil")
-	}
-	if _, ok := preimagesMap[arbutil.Keccak256PreimageType]; !ok {
-		preimagesMap[arbutil.Keccak256PreimageType] = make(map[common.Hash][]byte)
+	if err := ensureKeccakPreimagesMap(preimagesMap); err != nil {
+		return err
 	}
 	s.delayedMsgPreimagesDest = preimagesMap
 	return nil
@@ -325,8 +409,9 @@ func (s *State) fetchAndHashUnreadMessages(
 	return msgHashes, msgBytesArr, nil
 }
 
-// findPivot determines how many of the unread messages are in the outbox vs
-// the inbox. Returns -1 if no valid pivot can be found (legacy fallback failure).
+// findPivot returns the index boundary between outbox and inbox messages within
+// the unread range. Messages at indices [0..pivot) are in the outbox;
+// [pivot..totalUnread) are in the inbox. Returns -1 if no valid partition is found.
 func (s *State) findPivot(totalUnread uint64, msgHashes []common.Hash) int {
 	if s.DelayedMessageOutboxAcc == (common.Hash{}) {
 		return 0
@@ -335,17 +420,18 @@ func (s *State) findPivot(totalUnread uint64, msgHashes []common.Hash) int {
 		// #nosec G115
 		return int(totalUnread)
 	}
-	// Legacy fallback: try each candidate pivot, starting with the smallest
-	// inbox (most likely case) and working backward.
-	for candidatePivot := totalUnread - 1; candidatePivot >= 1; candidatePivot-- {
+	// Brute-force O(N^2) search: iterate candidate pivots from totalUnread-1 down to 0.
+	// Each pivot cp splits the range into inbox [cp..totalUnread) and outbox [0..cp).
+	// Starting with the largest cp (smallest inbox) is an optimization for the common
+	// case where few messages remain in the inbox after the last pour.
+	// Use signed int to avoid unsigned underflow when totalUnread == 1.
+	for cp := int(totalUnread) - 1; cp >= 0; cp-- { //nolint:gosec
 		acc := common.Hash{}
-		for i := candidatePivot; i < totalUnread; i++ {
-			preimage := append(acc.Bytes(), msgHashes[i].Bytes()...)
-			acc = crypto.Keccak256Hash(preimage)
+		for i := uint64(cp); i < totalUnread; i++ {
+			acc = HashChainLinkHash(acc, msgHashes[i])
 		}
 		if acc == s.DelayedMessageInboxAcc {
-			// #nosec G115
-			return int(candidatePivot)
+			return cp
 		}
 	}
 	return -1
@@ -358,16 +444,12 @@ func (s *State) findPivot(totalUnread uint64, msgHashes []common.Hash) int {
 func (s *State) buildHashChain(start, end, step int, msgHashes []common.Hash, msgBytesArr [][]byte) (common.Hash, error) {
 	acc := common.Hash{}
 	for i := start; i != end; i += step {
-		preimage := append(acc.Bytes(), msgHashes[i].Bytes()...)
-		newAcc := crypto.Keccak256Hash(preimage)
-		s.delayedMsgPreimages.Add(newAcc, preimage)
-		if s.delayedMsgPreimagesDest != nil {
-			keccakMap, ok := s.delayedMsgPreimagesDest[arbutil.Keccak256PreimageType]
-			if !ok {
-				return common.Hash{}, errors.New("keccak256 preimage map not initialized in delayedMsgPreimagesDest")
-			}
-			keccakMap[newAcc] = preimage
-			keccakMap[msgHashes[i]] = msgBytesArr[i]
+		newAcc, preimage := HashChainLink(acc, msgHashes[i])
+		if err := s.recordDelayedChainLink(newAcc, preimage); err != nil {
+			return common.Hash{}, err
+		}
+		if err := s.recordDelayedContent(msgHashes[i], msgBytesArr[i]); err != nil {
+			return common.Hash{}, err
 		}
 		acc = newAcc
 	}
@@ -376,8 +458,8 @@ func (s *State) buildHashChain(start, end, step int, msgHashes []common.Hash, ms
 
 // RebuildDelayedMsgPreimages reconstructs the in-memory preimage cache from
 // delayed messages stored in the database. This is needed after loading state
-// from DB (where the cache is nil), after reorgs, and periodically for memory
-// cleanup.
+// from DB (where the cache is nil), after reorgs, and for recovery from
+// preimage cache misses.
 //
 // The delayed message queue is a two-stack FIFO: an inbox accumulator and an
 // outbox accumulator. Unread messages (indices [DelayedMessagesRead, DelayedMessagesSeen))
@@ -392,16 +474,18 @@ func (s *State) RebuildDelayedMsgPreimages(fetchDelayedMsg func(index uint64) (*
 		return nil
 	}
 	totalUnread := s.DelayedMessagesSeen - s.DelayedMessagesRead
+	// Use 2x capacity to leave headroom for post-rebuild accumulations before
+	// the next pour, preventing eviction of needed preimages.
 	// #nosec G115
-	s.delayedMsgPreimages = containers.NewLruCache[common.Hash, []byte](int(totalUnread))
+	s.delayedMsgPreimages = containers.NewLruCache[common.Hash, []byte](max(2*int(totalUnread), 64))
 	msgHashes, msgBytesArr, err := s.fetchAndHashUnreadMessages(totalUnread, fetchDelayedMsg)
 	if err != nil {
 		return err
 	}
 	pivot := s.findPivot(totalUnread, msgHashes)
 	if pivot < 0 {
-		return fmt.Errorf("failed to find pivot: neither outbox acc %s nor inbox acc %s matched any partition",
-			s.DelayedMessageOutboxAcc.Hex(), s.DelayedMessageInboxAcc.Hex())
+		return fmt.Errorf("failed to find pivot between inbox and outbox: totalUnread=%d, delayedRead=%d, delayedSeen=%d, inboxAcc=%s, outboxAcc=%s",
+			totalUnread, s.DelayedMessagesRead, s.DelayedMessagesSeen, s.DelayedMessageInboxAcc.Hex(), s.DelayedMessageOutboxAcc.Hex())
 	}
 	// Rebuild outbox chain: messages [0..pivot) in reverse order (pivot-1, pivot-2, ..., 0)
 	if pivot > 0 {

--- a/arbnode/mel/state_test.go
+++ b/arbnode/mel/state_test.go
@@ -122,7 +122,6 @@ func accumulateN(t *testing.T, s *State, msgs []*DelayedInboxMessage) {
 	t.Helper()
 	for _, msg := range msgs {
 		require.NoError(t, s.AccumulateDelayedMessage(msg))
-		s.DelayedMessagesSeen++
 	}
 }
 
@@ -234,11 +233,12 @@ func TestAccumulateDelayedMessage_CacheResize(t *testing.T) {
 		expectedSizeAfter int
 	}{
 		{
-			name:             "zero capacity grows to totalUnread+1",
+			name:             "nil cache initializes with minimum capacity",
 			initialCacheSize: 0,
 			msgsToAdd:        3,
-			// Each accumulate: totalUnread=0→resize(1), totalUnread=1→resize(2), totalUnread=2→resize(3)
-			expectedSizeAfter: 3,
+			// ensureDelayedMsgPreimages creates cache with minimum capacity 16;
+			// since 16 > totalUnread for all 3 accumulations, no resize occurs.
+			expectedSizeAfter: 16,
 		},
 		{
 			name:              "no resize when cache already large enough",
@@ -276,7 +276,7 @@ func TestPourDelayedInboxToOutbox_CacheResize(t *testing.T) {
 		{
 			name:       "pour 1 message",
 			msgCount:   1,
-			expectSize: 3, // 3 * 1
+			expectSize: 16, // ensureDelayedMsgPreimages minimum capacity; 3*1=3 < 16 so no resize
 			// With 1 message, inbox key = Keccak256(zero || msgHash) = outbox key,
 			// so the outbox Add overwrites the inbox entry. Len = 1.
 			expectLen: 1,
@@ -284,7 +284,7 @@ func TestPourDelayedInboxToOutbox_CacheResize(t *testing.T) {
 		{
 			name:       "pour 5 messages",
 			msgCount:   5,
-			expectSize: 15, // 3 * 5
+			expectSize: 16, // ensureDelayedMsgPreimages minimum capacity; 3*5=15 < 16 so no resize
 			expectLen:  10, // 5 inbox + 5 outbox
 		},
 		{
@@ -401,4 +401,103 @@ func TestRebuildThenPourAndPop_MatchesOriginal(t *testing.T) {
 	}
 
 	require.Equal(t, originalHashes[1:], rebuiltHashes)
+}
+
+func TestPourDelayedInboxToOutbox_NonEmptyOutboxReturnsError(t *testing.T) {
+	t.Parallel()
+	s := &State{}
+	msgs := createTestDelayedMessages(3)
+	accumulateN(t, s, msgs)
+
+	require.NoError(t, s.PourDelayedInboxToOutbox())
+	require.NotEqual(t, common.Hash{}, s.DelayedMessageOutboxAcc)
+
+	err := s.PourDelayedInboxToOutbox()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "outbox must be empty before pouring")
+}
+
+func TestHashChainLinkHashMatchesHashChainLink(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		prevAcc common.Hash
+		item    common.Hash
+	}{
+		{"zero inputs", common.Hash{}, common.Hash{}},
+		{"zero prev", common.Hash{}, common.HexToHash("0xdeadbeef")},
+		{"both nonzero", common.HexToHash("0xaaaa"), common.HexToHash("0xbbbb")},
+		{"max values", common.MaxHash, common.MaxHash},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			hashOnly := HashChainLinkHash(tc.prevAcc, tc.item)
+			hashWithPreimage, _ := HashChainLink(tc.prevAcc, tc.item)
+			require.Equal(t, hashWithPreimage, hashOnly)
+		})
+	}
+}
+
+func TestAfterInboxAccReturnsErrorOnNilInputs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil Message", func(t *testing.T) {
+		msg := &DelayedInboxMessage{Message: nil}
+		_, err := msg.AfterInboxAcc()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Message or Header is nil")
+	})
+
+	t.Run("nil Header", func(t *testing.T) {
+		msg := &DelayedInboxMessage{
+			Message: &arbostypes.L1IncomingMessage{Header: nil},
+		}
+		_, err := msg.AfterInboxAcc()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Message or Header is nil")
+	})
+
+	t.Run("valid message succeeds", func(t *testing.T) {
+		requestId := common.BigToHash(common.Big1)
+		msg := &DelayedInboxMessage{
+			Message: &arbostypes.L1IncomingMessage{
+				Header: &arbostypes.L1IncomingMessageHeader{
+					Kind:      arbostypes.L1MessageType_EndOfBlock,
+					RequestId: &requestId,
+					L1BaseFee: common.Big0,
+				},
+			},
+		}
+		acc, err := msg.AfterInboxAcc()
+		require.NoError(t, err)
+		require.NotEqual(t, common.Hash{}, acc)
+	})
+}
+
+func TestStateHash_ReturnsConsistentHash(t *testing.T) {
+	t.Parallel()
+	state := &State{
+		ParentChainBlockNumber: 42,
+		MsgCount:               10,
+		BatchCount:             3,
+	}
+	h1, err := state.Hash()
+	require.NoError(t, err)
+	require.NotEqual(t, common.Hash{}, h1)
+
+	// Same state should produce same hash
+	h2, err := state.Hash()
+	require.NoError(t, err)
+	require.Equal(t, h1, h2)
+
+	// Different state should produce different hash
+	state2 := &State{
+		ParentChainBlockNumber: 43,
+		MsgCount:               10,
+		BatchCount:             3,
+	}
+	h3, err := state2.Hash()
+	require.NoError(t, err)
+	require.NotEqual(t, h1, h3)
 }

--- a/arbnode/message_pruner.go
+++ b/arbnode/message_pruner.go
@@ -25,14 +25,22 @@ import (
 
 type MessagePruner struct {
 	stopwaiter.StopWaiter
-	consensusDB                 ethdb.Database
-	transactionStreamer         *TransactionStreamer
-	batchMetaFetcher            BatchMetadataFetcher
-	config                      MessagePrunerConfigFetcher
-	pruningLock                 sync.Mutex
-	lastPruneDone               time.Time
-	cachedPrunedMessages        uint64
-	cachedPrunedDelayedMessages uint64
+	consensusDB                         ethdb.Database
+	transactionStreamer                 *TransactionStreamer
+	batchMetaFetcher                    BatchMetadataFetcher
+	config                              MessagePrunerConfigFetcher
+	pruningLock                         sync.Mutex
+	lastPruneDone                       time.Time
+	cachedPrunedMessages                uint64
+	cachedPrunedDelayedMessages         uint64
+	cachedPrunedLegacyDelayedMessages   uint64
+	cachedPrunedMelDelayedMessages      uint64
+	cachedPrunedParentChainBlockNumbers uint64
+	// legacyDelayedBound is the MEL migration boundary's delayed message count.
+	// When set (>0), the pruner will not prune legacy delayed message prefixes
+	// ("d", "e", "p") at or above this index, since the MEL boundary dispatch
+	// still routes reads for those indices to legacy keys.
+	legacyDelayedBound uint64
 }
 
 type MessagePrunerConfig struct {
@@ -63,6 +71,14 @@ func NewMessagePruner(consensusDB ethdb.Database, transactionStreamer *Transacti
 		batchMetaFetcher:    batchMetaFetcher,
 		config:              config,
 	}
+}
+
+// SetLegacyDelayedBound sets the MEL migration boundary's delayed message
+// count. The pruner will not prune legacy delayed message keys at or above
+// this index, since the MEL boundary dispatch still routes reads to them.
+// Must be called before Start.
+func (m *MessagePruner) SetLegacyDelayedBound(bound uint64) {
+	m.legacyDelayedBound = bound
 }
 
 func (m *MessagePruner) Start(ctxIn context.Context) {
@@ -124,11 +140,48 @@ func (m *MessagePruner) prune(ctx context.Context, count arbutil.MessageIndex, g
 
 func (m *MessagePruner) deleteOldMessagesFromDB(ctx context.Context, messageCount arbutil.MessageIndex, delayedMessageCount uint64) error {
 	if m.cachedPrunedMessages == 0 {
-		m.cachedPrunedMessages = fetchLastPrunedKey(m.transactionStreamer.db, schema.LastPrunedMessageKey)
+		val, err := fetchLastPrunedKey(m.transactionStreamer.db, schema.LastPrunedMessageKey)
+		if err != nil {
+			return fmt.Errorf("fetching last pruned message key: %w", err)
+		}
+		m.cachedPrunedMessages = val
 	}
 	if m.cachedPrunedDelayedMessages == 0 {
-		m.cachedPrunedDelayedMessages = fetchLastPrunedKey(m.consensusDB, schema.LastPrunedDelayedMessageKey)
+		val, err := fetchLastPrunedKey(m.consensusDB, schema.LastPrunedDelayedMessageKey)
+		if err != nil {
+			return fmt.Errorf("fetching last pruned delayed message key: %w", err)
+		}
+		m.cachedPrunedDelayedMessages = val
 	}
+	if m.cachedPrunedLegacyDelayedMessages == 0 {
+		val, err := fetchLastPrunedKey(m.consensusDB, schema.LastPrunedLegacyDelayedMessageKey)
+		if err != nil {
+			return fmt.Errorf("fetching last pruned legacy delayed message key: %w", err)
+		}
+		m.cachedPrunedLegacyDelayedMessages = val
+	}
+	if m.cachedPrunedMelDelayedMessages == 0 {
+		val, err := fetchLastPrunedKey(m.consensusDB, schema.LastPrunedMelDelayedMessageKey)
+		if err != nil {
+			return fmt.Errorf("fetching last pruned MEL delayed message key: %w", err)
+		}
+		m.cachedPrunedMelDelayedMessages = val
+	}
+	if m.cachedPrunedParentChainBlockNumbers == 0 {
+		val, err := fetchLastPrunedKey(m.consensusDB, schema.LastPrunedParentChainBlockNumberKey)
+		if err != nil {
+			return fmt.Errorf("fetching last pruned parent chain block number key: %w", err)
+		}
+		m.cachedPrunedParentChainBlockNumbers = val
+	}
+
+	// Cap the delayed prune target for legacy prefixes to avoid pruning entries
+	// that the MEL boundary dispatch still routes reads to.
+	legacyDelayedPruneLimit := delayedMessageCount
+	if m.legacyDelayedBound > 0 && legacyDelayedPruneLimit > m.legacyDelayedBound {
+		legacyDelayedPruneLimit = m.legacyDelayedBound
+	}
+
 	prunedKeysRange, _, err := deleteFromLastPrunedUptoEndKey(ctx, m.transactionStreamer.db, schema.MessageResultPrefix, m.cachedPrunedMessages, uint64(messageCount))
 	if err != nil {
 		return fmt.Errorf("error deleting message results: %w", err)
@@ -152,18 +205,61 @@ func (m *MessagePruner) deleteOldMessagesFromDB(ctx context.Context, messageCoun
 	if len(prunedKeysRange) > 0 {
 		log.Info("Pruned last batch messages:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
 	}
-	insertLastPrunedKey(m.transactionStreamer.db, schema.LastPrunedMessageKey, lastPrunedMessage)
+	if err := insertLastPrunedKey(m.transactionStreamer.db, schema.LastPrunedMessageKey, lastPrunedMessage); err != nil {
+		return fmt.Errorf("persisting last pruned message key: %w", err)
+	}
 	m.cachedPrunedMessages = lastPrunedMessage
 
-	prunedKeysRange, lastPrunedDelayedMessage, err := deleteFromLastPrunedUptoEndKey(ctx, m.consensusDB, schema.RlpDelayedMessagePrefix, m.cachedPrunedDelayedMessages, delayedMessageCount)
+	prunedKeysRange, lastPrunedDelayedMessage, err := deleteFromLastPrunedUptoEndKey(ctx, m.consensusDB, schema.RlpDelayedMessagePrefix, m.cachedPrunedDelayedMessages, legacyDelayedPruneLimit)
 	if err != nil {
 		return fmt.Errorf("error deleting last batch delayed messages: %w", err)
 	}
 	if len(prunedKeysRange) > 0 {
 		log.Info("Pruned last batch delayed messages:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
 	}
-	insertLastPrunedKey(m.consensusDB, schema.LastPrunedDelayedMessageKey, lastPrunedDelayedMessage)
+	if err := insertLastPrunedKey(m.consensusDB, schema.LastPrunedDelayedMessageKey, lastPrunedDelayedMessage); err != nil {
+		return fmt.Errorf("persisting last pruned delayed message key: %w", err)
+	}
 	m.cachedPrunedDelayedMessages = lastPrunedDelayedMessage
+
+	// Prune legacy "d"-prefixed delayed messages (oldest format, pre-RLP).
+	prunedKeysRange, lastPrunedLegacyDelayed, err := deleteFromLastPrunedUptoEndKey(ctx, m.consensusDB, schema.LegacyDelayedMessagePrefix, m.cachedPrunedLegacyDelayedMessages, legacyDelayedPruneLimit)
+	if err != nil {
+		return fmt.Errorf("error deleting legacy delayed messages: %w", err)
+	}
+	if len(prunedKeysRange) > 0 {
+		log.Info("Pruned legacy delayed messages:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
+	}
+	if err := insertLastPrunedKey(m.consensusDB, schema.LastPrunedLegacyDelayedMessageKey, lastPrunedLegacyDelayed); err != nil {
+		return fmt.Errorf("persisting last pruned legacy delayed message key: %w", err)
+	}
+	m.cachedPrunedLegacyDelayedMessages = lastPrunedLegacyDelayed
+
+	// Prune MEL-prefixed delayed messages (written by message extraction layer).
+	prunedKeysRange, lastPrunedMelDelayed, err := deleteFromLastPrunedUptoEndKey(ctx, m.consensusDB, schema.MelDelayedMessagePrefix, m.cachedPrunedMelDelayedMessages, delayedMessageCount)
+	if err != nil {
+		return fmt.Errorf("error deleting MEL delayed messages: %w", err)
+	}
+	if len(prunedKeysRange) > 0 {
+		log.Info("Pruned MEL delayed messages:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
+	}
+	if err := insertLastPrunedKey(m.consensusDB, schema.LastPrunedMelDelayedMessageKey, lastPrunedMelDelayed); err != nil {
+		return fmt.Errorf("persisting last pruned MEL delayed message key: %w", err)
+	}
+	m.cachedPrunedMelDelayedMessages = lastPrunedMelDelayed
+
+	// Prune parent chain block number entries (legacy "p" prefix, keyed by delayed message index).
+	prunedKeysRange, lastPrunedPCBN, err := deleteFromLastPrunedUptoEndKey(ctx, m.consensusDB, schema.ParentChainBlockNumberPrefix, m.cachedPrunedParentChainBlockNumbers, legacyDelayedPruneLimit)
+	if err != nil {
+		return fmt.Errorf("error deleting parent chain block numbers: %w", err)
+	}
+	if len(prunedKeysRange) > 0 {
+		log.Info("Pruned parent chain block numbers:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
+	}
+	if err := insertLastPrunedKey(m.consensusDB, schema.LastPrunedParentChainBlockNumberKey, lastPrunedPCBN); err != nil {
+		return fmt.Errorf("persisting last pruned parent chain block number key: %w", err)
+	}
+	m.cachedPrunedParentChainBlockNumbers = lastPrunedPCBN
 	return nil
 }
 
@@ -185,37 +281,32 @@ func deleteFromLastPrunedUptoEndKey(ctx context.Context, db ethdb.Database, pref
 	return keys, endMinKey - 1, err
 }
 
-func insertLastPrunedKey(db ethdb.Database, lastPrunedKey []byte, lastPrunedValue uint64) {
+func insertLastPrunedKey(db ethdb.Database, lastPrunedKey []byte, lastPrunedValue uint64) error {
 	lastPrunedValueByte, err := rlp.EncodeToBytes(lastPrunedValue)
 	if err != nil {
-		log.Error("error encoding last pruned value: %w", err)
-	} else {
-		err = db.Put(lastPrunedKey, lastPrunedValueByte)
-		if err != nil {
-			log.Error("error saving last pruned value: %w", err)
-		}
+		return fmt.Errorf("encoding last pruned value: %w", err)
 	}
+	if err := db.Put(lastPrunedKey, lastPrunedValueByte); err != nil {
+		return fmt.Errorf("saving last pruned value: %w", err)
+	}
+	return nil
 }
 
-func fetchLastPrunedKey(db ethdb.Database, lastPrunedKey []byte) uint64 {
+func fetchLastPrunedKey(db ethdb.Database, lastPrunedKey []byte) (uint64, error) {
 	hasKey, err := db.Has(lastPrunedKey)
 	if err != nil {
-		log.Warn("error checking for last pruned key: %w", err)
-		return 0
+		return 0, fmt.Errorf("checking for last pruned key: %w", err)
 	}
 	if !hasKey {
-		return 0
+		return 0, nil
 	}
 	lastPrunedValueByte, err := db.Get(lastPrunedKey)
 	if err != nil {
-		log.Warn("error fetching last pruned key: %w", err)
-		return 0
+		return 0, fmt.Errorf("fetching last pruned key: %w", err)
 	}
 	var lastPrunedValue uint64
-	err = rlp.DecodeBytes(lastPrunedValueByte, &lastPrunedValue)
-	if err != nil {
-		log.Warn("error decoding last pruned value: %w", err)
-		return 0
+	if err := rlp.DecodeBytes(lastPrunedValueByte, &lastPrunedValue); err != nil {
+		return 0, fmt.Errorf("decoding last pruned value: %w", err)
 	}
-	return lastPrunedValue
+	return lastPrunedValue, nil
 }

--- a/arbnode/message_pruner.go
+++ b/arbnode/message_pruner.go
@@ -131,50 +131,40 @@ func (m *MessagePruner) prune(ctx context.Context, count arbutil.MessageIndex, g
 	msgCount := endBatchMetadata.MessageCount
 	delayedCount := endBatchMetadata.DelayedMessageCount
 	if delayedCount > 0 {
-		// keep an extra delayed message for the inbox reader to use
+		// Keep one extra delayed message so that BeforeInboxAcc lookups
+		// (which read the previous message's accumulator) can succeed for
+		// the entry at the pruning boundary.
 		delayedCount--
 	}
 
 	return m.deleteOldMessagesFromDB(ctx, msgCount, delayedCount)
 }
 
-func (m *MessagePruner) deleteOldMessagesFromDB(ctx context.Context, messageCount arbutil.MessageIndex, delayedMessageCount uint64) error {
-	if m.cachedPrunedMessages == 0 {
-		val, err := fetchLastPrunedKey(m.transactionStreamer.db, schema.LastPrunedMessageKey)
+// prunePrefix deletes old entries for a single DB prefix, logs what was pruned,
+// persists the last-pruned marker, and updates the cached value.
+func prunePrefix(ctx context.Context, db ethdb.Database, prefix []byte, lastPrunedKey []byte, cached *uint64, endKey uint64, label string) error {
+	if *cached == 0 {
+		val, err := fetchLastPrunedKey(db, lastPrunedKey)
 		if err != nil {
-			return fmt.Errorf("fetching last pruned message key: %w", err)
+			return fmt.Errorf("fetching last pruned %s key: %w", label, err)
 		}
-		m.cachedPrunedMessages = val
+		*cached = val
 	}
-	if m.cachedPrunedDelayedMessages == 0 {
-		val, err := fetchLastPrunedKey(m.consensusDB, schema.LastPrunedDelayedMessageKey)
-		if err != nil {
-			return fmt.Errorf("fetching last pruned delayed message key: %w", err)
-		}
-		m.cachedPrunedDelayedMessages = val
+	prunedKeysRange, lastPruned, err := deleteFromLastPrunedUptoEndKey(ctx, db, prefix, *cached, endKey)
+	if err != nil {
+		return fmt.Errorf("error deleting %s: %w", label, err)
 	}
-	if m.cachedPrunedLegacyDelayedMessages == 0 {
-		val, err := fetchLastPrunedKey(m.consensusDB, schema.LastPrunedLegacyDelayedMessageKey)
-		if err != nil {
-			return fmt.Errorf("fetching last pruned legacy delayed message key: %w", err)
-		}
-		m.cachedPrunedLegacyDelayedMessages = val
+	if len(prunedKeysRange) > 0 {
+		log.Info("Pruned "+label, "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
 	}
-	if m.cachedPrunedMelDelayedMessages == 0 {
-		val, err := fetchLastPrunedKey(m.consensusDB, schema.LastPrunedMelDelayedMessageKey)
-		if err != nil {
-			return fmt.Errorf("fetching last pruned MEL delayed message key: %w", err)
-		}
-		m.cachedPrunedMelDelayedMessages = val
+	if err := insertLastPrunedKey(db, lastPrunedKey, lastPruned); err != nil {
+		return fmt.Errorf("persisting last pruned %s key: %w", label, err)
 	}
-	if m.cachedPrunedParentChainBlockNumbers == 0 {
-		val, err := fetchLastPrunedKey(m.consensusDB, schema.LastPrunedParentChainBlockNumberKey)
-		if err != nil {
-			return fmt.Errorf("fetching last pruned parent chain block number key: %w", err)
-		}
-		m.cachedPrunedParentChainBlockNumbers = val
-	}
+	*cached = lastPruned
+	return nil
+}
 
+func (m *MessagePruner) deleteOldMessagesFromDB(ctx context.Context, messageCount arbutil.MessageIndex, delayedMessageCount uint64) error {
 	// Cap the delayed prune target for legacy prefixes to avoid pruning entries
 	// that the MEL boundary dispatch still routes reads to.
 	legacyDelayedPruneLimit := delayedMessageCount
@@ -182,84 +172,54 @@ func (m *MessagePruner) deleteOldMessagesFromDB(ctx context.Context, messageCoun
 		legacyDelayedPruneLimit = m.legacyDelayedBound
 	}
 
-	prunedKeysRange, _, err := deleteFromLastPrunedUptoEndKey(ctx, m.transactionStreamer.db, schema.MessageResultPrefix, m.cachedPrunedMessages, uint64(messageCount))
-	if err != nil {
-		return fmt.Errorf("error deleting message results: %w", err)
+	// MessageResult and BlockHashInput share the message marker but don't persist it.
+	// Only the Message prefix persists the marker via prunePrefix.
+	if m.cachedPrunedMessages == 0 {
+		val, err := fetchLastPrunedKey(m.transactionStreamer.db, schema.LastPrunedMessageKey)
+		if err != nil {
+			return fmt.Errorf("fetching last pruned message key: %w", err)
+		}
+		m.cachedPrunedMessages = val
 	}
-	if len(prunedKeysRange) > 0 {
-		log.Info("Pruned message results:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
+	for _, entry := range []struct {
+		prefix []byte
+		label  string
+	}{
+		{schema.MessageResultPrefix, "message results"},
+		{schema.BlockHashInputFeedPrefix, "expected block hashes"},
+	} {
+		prunedKeysRange, _, err := deleteFromLastPrunedUptoEndKey(ctx, m.transactionStreamer.db, entry.prefix, m.cachedPrunedMessages, uint64(messageCount))
+		if err != nil {
+			return fmt.Errorf("error deleting %s: %w", entry.label, err)
+		}
+		if len(prunedKeysRange) > 0 {
+			log.Info("Pruned "+entry.label, "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
+		}
+	}
+	if err := prunePrefix(ctx, m.transactionStreamer.db, schema.MessagePrefix, schema.LastPrunedMessageKey, &m.cachedPrunedMessages, uint64(messageCount), "messages"); err != nil {
+		return err
 	}
 
-	prunedKeysRange, _, err = deleteFromLastPrunedUptoEndKey(ctx, m.transactionStreamer.db, schema.BlockHashInputFeedPrefix, m.cachedPrunedMessages, uint64(messageCount))
-	if err != nil {
-		return fmt.Errorf("error deleting expected block hashes: %w", err)
+	// Prune delayed-message-keyed entries. Legacy prefixes are capped by legacyDelayedPruneLimit;
+	// MEL prefix uses the full delayedMessageCount.
+	type delayedPruneEntry struct {
+		db        ethdb.Database
+		prefix    []byte
+		markerKey []byte
+		cached    *uint64
+		limit     uint64
+		label     string
 	}
-	if len(prunedKeysRange) > 0 {
-		log.Info("Pruned expected block hashes:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
+	for _, entry := range []delayedPruneEntry{
+		{db: m.consensusDB, prefix: schema.RlpDelayedMessagePrefix, markerKey: schema.LastPrunedDelayedMessageKey, cached: &m.cachedPrunedDelayedMessages, limit: legacyDelayedPruneLimit, label: "RLP delayed messages"},
+		{db: m.consensusDB, prefix: schema.LegacyDelayedMessagePrefix, markerKey: schema.LastPrunedLegacyDelayedMessageKey, cached: &m.cachedPrunedLegacyDelayedMessages, limit: legacyDelayedPruneLimit, label: "legacy delayed messages"},
+		{db: m.consensusDB, prefix: schema.MelDelayedMessagePrefix, markerKey: schema.LastPrunedMelDelayedMessageKey, cached: &m.cachedPrunedMelDelayedMessages, limit: delayedMessageCount, label: "MEL delayed messages"},
+		{db: m.consensusDB, prefix: schema.ParentChainBlockNumberPrefix, markerKey: schema.LastPrunedParentChainBlockNumberKey, cached: &m.cachedPrunedParentChainBlockNumbers, limit: legacyDelayedPruneLimit, label: "parent chain block numbers"},
+	} {
+		if err := prunePrefix(ctx, entry.db, entry.prefix, entry.markerKey, entry.cached, entry.limit, entry.label); err != nil {
+			return err
+		}
 	}
-
-	prunedKeysRange, lastPrunedMessage, err := deleteFromLastPrunedUptoEndKey(ctx, m.transactionStreamer.db, schema.MessagePrefix, m.cachedPrunedMessages, uint64(messageCount))
-	if err != nil {
-		return fmt.Errorf("error deleting last batch messages: %w", err)
-	}
-	if len(prunedKeysRange) > 0 {
-		log.Info("Pruned last batch messages:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
-	}
-	if err := insertLastPrunedKey(m.transactionStreamer.db, schema.LastPrunedMessageKey, lastPrunedMessage); err != nil {
-		return fmt.Errorf("persisting last pruned message key: %w", err)
-	}
-	m.cachedPrunedMessages = lastPrunedMessage
-
-	prunedKeysRange, lastPrunedDelayedMessage, err := deleteFromLastPrunedUptoEndKey(ctx, m.consensusDB, schema.RlpDelayedMessagePrefix, m.cachedPrunedDelayedMessages, legacyDelayedPruneLimit)
-	if err != nil {
-		return fmt.Errorf("error deleting last batch delayed messages: %w", err)
-	}
-	if len(prunedKeysRange) > 0 {
-		log.Info("Pruned last batch delayed messages:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
-	}
-	if err := insertLastPrunedKey(m.consensusDB, schema.LastPrunedDelayedMessageKey, lastPrunedDelayedMessage); err != nil {
-		return fmt.Errorf("persisting last pruned delayed message key: %w", err)
-	}
-	m.cachedPrunedDelayedMessages = lastPrunedDelayedMessage
-
-	// Prune legacy "d"-prefixed delayed messages (oldest format, pre-RLP).
-	prunedKeysRange, lastPrunedLegacyDelayed, err := deleteFromLastPrunedUptoEndKey(ctx, m.consensusDB, schema.LegacyDelayedMessagePrefix, m.cachedPrunedLegacyDelayedMessages, legacyDelayedPruneLimit)
-	if err != nil {
-		return fmt.Errorf("error deleting legacy delayed messages: %w", err)
-	}
-	if len(prunedKeysRange) > 0 {
-		log.Info("Pruned legacy delayed messages:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
-	}
-	if err := insertLastPrunedKey(m.consensusDB, schema.LastPrunedLegacyDelayedMessageKey, lastPrunedLegacyDelayed); err != nil {
-		return fmt.Errorf("persisting last pruned legacy delayed message key: %w", err)
-	}
-	m.cachedPrunedLegacyDelayedMessages = lastPrunedLegacyDelayed
-
-	// Prune MEL-prefixed delayed messages (written by message extraction layer).
-	prunedKeysRange, lastPrunedMelDelayed, err := deleteFromLastPrunedUptoEndKey(ctx, m.consensusDB, schema.MelDelayedMessagePrefix, m.cachedPrunedMelDelayedMessages, delayedMessageCount)
-	if err != nil {
-		return fmt.Errorf("error deleting MEL delayed messages: %w", err)
-	}
-	if len(prunedKeysRange) > 0 {
-		log.Info("Pruned MEL delayed messages:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
-	}
-	if err := insertLastPrunedKey(m.consensusDB, schema.LastPrunedMelDelayedMessageKey, lastPrunedMelDelayed); err != nil {
-		return fmt.Errorf("persisting last pruned MEL delayed message key: %w", err)
-	}
-	m.cachedPrunedMelDelayedMessages = lastPrunedMelDelayed
-
-	// Prune parent chain block number entries (legacy "p" prefix, keyed by delayed message index).
-	prunedKeysRange, lastPrunedPCBN, err := deleteFromLastPrunedUptoEndKey(ctx, m.consensusDB, schema.ParentChainBlockNumberPrefix, m.cachedPrunedParentChainBlockNumbers, legacyDelayedPruneLimit)
-	if err != nil {
-		return fmt.Errorf("error deleting parent chain block numbers: %w", err)
-	}
-	if len(prunedKeysRange) > 0 {
-		log.Info("Pruned parent chain block numbers:", "first pruned key", prunedKeysRange[0], "last pruned key", prunedKeysRange[len(prunedKeysRange)-1])
-	}
-	if err := insertLastPrunedKey(m.consensusDB, schema.LastPrunedParentChainBlockNumberKey, lastPrunedPCBN); err != nil {
-		return fmt.Errorf("persisting last pruned parent chain block number key: %w", err)
-	}
-	m.cachedPrunedParentChainBlockNumbers = lastPrunedPCBN
 	return nil
 }
 
@@ -268,11 +228,14 @@ func (m *MessagePruner) deleteOldMessagesFromDB(ctx context.Context, messageCoun
 func deleteFromLastPrunedUptoEndKey(ctx context.Context, db ethdb.Database, prefix []byte, startMinKey uint64, endMinKey uint64) ([]uint64, uint64, error) {
 	if startMinKey == 0 {
 		startIter := db.NewIterator(prefix, uint64ToKey(1))
+		defer startIter.Release()
 		if !startIter.Next() {
+			if err := startIter.Error(); err != nil {
+				return nil, 0, fmt.Errorf("iterator error scanning for first key with prefix %x: %w", prefix, err)
+			}
 			return nil, 0, nil
 		}
 		startMinKey = binary.BigEndian.Uint64(bytes.TrimPrefix(startIter.Key(), prefix))
-		startIter.Release()
 	}
 	if endMinKey <= startMinKey {
 		return nil, startMinKey, nil

--- a/arbnode/message_pruner_test.go
+++ b/arbnode/message_pruner_test.go
@@ -79,6 +79,126 @@ func TestMessagePrunerWithNoPruningEligibleMessagePresent(t *testing.T) {
 	checkDbKeys(t, messagesCount, inboxTrackerDb, schema.RlpDelayedMessagePrefix)
 }
 
+func TestMessagePrunerLegacyDelayedBound(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Set up 20 entries under each legacy delayed prefix ("e", "d", "p")
+	// and 10 entries under the MEL delayed prefix ("y").
+	count := uint64(20)
+	consensusDB := rawdb.NewMemoryDatabase()
+	transactionStreamerDb := rawdb.NewMemoryDatabase()
+	for i := uint64(1); i <= count; i++ {
+		Require(t, consensusDB.Put(dbKey(schema.RlpDelayedMessagePrefix, i), []byte{}))
+		Require(t, consensusDB.Put(dbKey(schema.LegacyDelayedMessagePrefix, i), []byte{}))
+		Require(t, consensusDB.Put(dbKey(schema.ParentChainBlockNumberPrefix, i), []byte{}))
+	}
+	for i := uint64(1); i <= 10; i++ {
+		Require(t, consensusDB.Put(dbKey(schema.MelDelayedMessagePrefix, i), []byte{}))
+	}
+
+	pruner := &MessagePruner{
+		transactionStreamer: &TransactionStreamer{db: transactionStreamerDb},
+		consensusDB:         consensusDB,
+		batchMetaFetcher:    &InboxTracker{db: consensusDB},
+		legacyDelayedBound:  15, // cap legacy pruning at index 15
+	}
+
+	// Try to prune up to index 20 — legacy prefixes should be capped at 15,
+	// MEL prefix should prune up to 20.
+	err := pruner.deleteOldMessagesFromDB(ctx, 0, count)
+	Require(t, err)
+
+	// Legacy "e" entries at 15+ should still exist (not pruned past bound)
+	for i := uint64(15); i <= count; i++ {
+		has, err := consensusDB.Has(dbKey(schema.RlpDelayedMessagePrefix, i))
+		Require(t, err)
+		if !has {
+			Fail(t, "RlpDelayedMessagePrefix key", i, "should still exist (at or above legacyDelayedBound)")
+		}
+	}
+	// Legacy "d" entries at 15+ should still exist
+	for i := uint64(15); i <= count; i++ {
+		has, err := consensusDB.Has(dbKey(schema.LegacyDelayedMessagePrefix, i))
+		Require(t, err)
+		if !has {
+			Fail(t, "LegacyDelayedMessagePrefix key", i, "should still exist (at or above legacyDelayedBound)")
+		}
+	}
+	// Legacy "p" entries at 15+ should still exist
+	for i := uint64(15); i <= count; i++ {
+		has, err := consensusDB.Has(dbKey(schema.ParentChainBlockNumberPrefix, i))
+		Require(t, err)
+		if !has {
+			Fail(t, "ParentChainBlockNumberPrefix key", i, "should still exist (at or above legacyDelayedBound)")
+		}
+	}
+
+	// Legacy entries below bound should be pruned (except boundary keys)
+	for i := uint64(2); i < 14; i++ {
+		for _, tc := range []struct {
+			prefix []byte
+			name   string
+		}{
+			{schema.RlpDelayedMessagePrefix, "RlpDelayedMessagePrefix"},
+			{schema.LegacyDelayedMessagePrefix, "LegacyDelayedMessagePrefix"},
+			{schema.ParentChainBlockNumberPrefix, "ParentChainBlockNumberPrefix"},
+		} {
+			has, err := consensusDB.Has(dbKey(tc.prefix, i))
+			Require(t, err)
+			if has {
+				Fail(t, tc.name, "key", i, "should be pruned (below legacyDelayedBound)")
+			}
+		}
+	}
+
+	// MEL "y" entries should be pruned up to count (not capped by bound)
+	for i := uint64(2); i < 10; i++ {
+		has, err := consensusDB.Has(dbKey(schema.MelDelayedMessagePrefix, i))
+		Require(t, err)
+		if has {
+			Fail(t, "MelDelayedMessagePrefix key", i, "should be pruned (not limited by legacyDelayedBound)")
+		}
+	}
+}
+
+func TestMessagePrunerNewPrefixes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	count := uint64(2 * 100 * 1024)
+	consensusDB := rawdb.NewMemoryDatabase()
+	transactionStreamerDb := rawdb.NewMemoryDatabase()
+
+	// Populate all delayed-related prefixes
+	for i := uint64(0); i < count; i++ {
+		Require(t, consensusDB.Put(dbKey(schema.RlpDelayedMessagePrefix, i), []byte{}))
+		Require(t, consensusDB.Put(dbKey(schema.LegacyDelayedMessagePrefix, i), []byte{}))
+		Require(t, consensusDB.Put(dbKey(schema.ParentChainBlockNumberPrefix, i), []byte{}))
+		Require(t, consensusDB.Put(dbKey(schema.MelDelayedMessagePrefix, i), []byte{}))
+	}
+
+	pruner := &MessagePruner{
+		transactionStreamer: &TransactionStreamer{db: transactionStreamerDb},
+		consensusDB:         consensusDB,
+		batchMetaFetcher:    &InboxTracker{db: consensusDB},
+		// No legacyDelayedBound — all prefixes should prune to the same target
+	}
+
+	err := pruner.deleteOldMessagesFromDB(ctx, 0, count)
+	Require(t, err)
+
+	// All prefixes should be pruned up to count
+	for _, prefix := range [][]byte{
+		schema.RlpDelayedMessagePrefix,
+		schema.LegacyDelayedMessagePrefix,
+		schema.ParentChainBlockNumberPrefix,
+		schema.MelDelayedMessagePrefix,
+	} {
+		checkDbKeys(t, count, consensusDB, prefix)
+	}
+}
+
 func setupDatabase(t *testing.T, messageCount, delayedMessageCount uint64) (ethdb.Database, ethdb.Database, *MessagePruner) {
 	transactionStreamerDb := rawdb.NewMemoryDatabase()
 	for i := uint64(0); i < uint64(messageCount); i++ {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -111,6 +111,13 @@ func (c *Config) Validate() error {
 		c.Feed.Output.Enable = false
 		c.Feed.Input.URL = []string{}
 	}
+	if c.MessageExtraction.Enable && c.MessageExtraction.ReadMode != "latest" {
+		if c.Sequencer {
+			return errors.New("cannot enable message extraction in safe or finalized mode along with sequencer")
+		}
+		c.Feed.Output.Enable = false
+		c.Feed.Input.URL = []string{}
+	}
 	if err := c.BlockValidator.Validate(); err != nil {
 		return err
 	}
@@ -341,6 +348,39 @@ type Node struct {
 	ctx                      context.Context
 	ConsensusExecutionSyncer *ConsensusExecutionSyncer
 	sequencerInbox           *SequencerInbox
+}
+
+var ErrNoBatchDataReader = errors.New("node has no batch data reader")
+
+// BatchDataReader extends BatchMetadataFetcher with read-only access to message
+// counts and batch/message lookups, abstracting over MessageExtractor (MEL) vs
+// InboxTracker. Both satisfy this interface.
+type BatchDataReader interface {
+	BatchMetadataFetcher
+	GetBatchMessageCount(seqNum uint64) (arbutil.MessageIndex, error)
+	GetDelayedCount() (uint64, error)
+	GetBatchParentChainBlock(seqNum uint64) (uint64, error)
+	FindInboxBatchContainingMessage(pos arbutil.MessageIndex) (uint64, bool, error)
+}
+
+// Compile-time interface satisfaction checks.
+var (
+	_ BatchDataReader      = (*InboxTracker)(nil)
+	_ BatchDataReader      = (*melrunner.MessageExtractor)(nil)
+	_ BatchDataProvider    = (*melrunner.MessageExtractor)(nil)
+	_ BatchMetadataFetcher = (*melrunner.MessageExtractor)(nil)
+)
+
+// BatchDataSource returns the node's active BatchDataReader, preferring
+// MessageExtractor over InboxTracker.
+func (n *Node) BatchDataSource() (BatchDataReader, error) {
+	if n.MessageExtractor != nil {
+		return n.MessageExtractor, nil
+	}
+	if n.InboxTracker != nil {
+		return n.InboxTracker, nil
+	}
+	return nil, ErrNoBatchDataReader
 }
 
 type ConfigFetcher interface {
@@ -771,8 +811,9 @@ func getInboxTrackerAndReader(
 }
 
 // computeMigrationStartBlock determines the parent chain block number to anchor
-// the initial MEL state during legacy migration. Uses the finalized block (capped
-// at the last batch's block) to ensure the initial state cannot be reorged out.
+// the initial MEL state during legacy migration. Uses the last batch's parent
+// chain block, capped at the finalized block number, to ensure the initial state
+// cannot be reorged out.
 // For Arbitrum parent chains (no native finality), uses the last batch's block directly.
 func computeMigrationStartBlock(
 	ctx context.Context,
@@ -783,9 +824,16 @@ func computeMigrationStartBlock(
 ) (uint64, error) {
 	totalBatchCount, err := read.Value[uint64](consensusDB, schema.SequencerBatchCountKey)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read legacy batch count: %w", err)
+		if rawdb.IsDbErrNotFound(err) {
+			totalBatchCount = 0
+		} else {
+			return 0, fmt.Errorf("failed to read legacy batch count: %w", err)
+		}
 	}
 	if totalBatchCount == 0 {
+		if deployInfo.DeployedAt == 0 {
+			return 0, errors.New("cannot compute migration start block: DeployedAt is 0 and no batches exist")
+		}
 		return deployInfo.DeployedAt - 1, nil
 	}
 	lastBatchMeta, err := read.BatchMetadata(consensusDB, totalBatchCount-1)
@@ -798,9 +846,73 @@ func computeMigrationStartBlock(
 		if err != nil {
 			return 0, fmt.Errorf("failed to get finalized block: %w", err)
 		}
+		if finalizedHeader == nil {
+			return 0, errors.New("finalized block header not available on parent chain")
+		}
 		startBlockNum = min(startBlockNum, finalizedHeader.Number.Uint64())
 	}
 	return startBlockNum, nil
+}
+
+// migrateLegacyDBToMEL creates the initial MEL state from pre-MEL inbox reader/tracker
+// data and persists it. Called once during the first MEL startup on a legacy node.
+func migrateLegacyDBToMEL(
+	ctx context.Context,
+	l1client *ethclient.Client,
+	deployInfo *chaininfo.RollupAddresses,
+	consensusDB ethdb.Database,
+	melDB *melrunner.Database,
+	parentChainIsArbitrum bool,
+) error {
+	log.Info("Migrating legacy inbox reader/tracker data to MEL")
+	chainId, err := l1client.ChainID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get chain ID: %w", err)
+	}
+	startBlockNum, err := computeMigrationStartBlock(ctx, l1client, consensusDB, deployInfo, parentChainIsArbitrum)
+	if err != nil {
+		return fmt.Errorf("failed to compute migration start block: %w", err)
+	}
+	delayedBridge, err := NewDelayedBridge(l1client, deployInfo.Bridge, deployInfo.DeployedAt)
+	if err != nil {
+		return fmt.Errorf("failed to create delayed bridge: %w", err)
+	}
+	delayedSeenAtBlock, err := delayedBridge.GetMessageCount(ctx, new(big.Int).SetUint64(startBlockNum))
+	if err != nil {
+		return fmt.Errorf("failed to get on-chain delayed message count at block %d: %w", startBlockNum, err)
+	}
+	initialState, err := melrunner.CreateInitialMELStateFromLegacyDB(
+		consensusDB,
+		deployInfo.SequencerInbox,
+		deployInfo.Bridge,
+		chainId.Uint64(),
+		func(blockNum uint64) (common.Hash, common.Hash, error) {
+			header, err := l1client.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNum))
+			if err != nil {
+				return common.Hash{}, common.Hash{}, err
+			}
+			if header == nil {
+				return common.Hash{}, common.Hash{}, fmt.Errorf("block %d not found on parent chain", blockNum)
+			}
+			return header.Hash(), header.ParentHash, nil
+		},
+		startBlockNum,
+		delayedSeenAtBlock,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create initial MEL state from legacy DB: %w", err)
+	}
+	if err = melDB.SaveInitialMelState(initialState); err != nil {
+		return fmt.Errorf("failed to save initial mel state: %w", err)
+	}
+	log.Info("MEL migration from legacy data complete",
+		"delayedSeen", initialState.DelayedMessagesSeen,
+		"delayedRead", initialState.DelayedMessagesRead,
+		"batchCount", initialState.BatchCount,
+		"msgCount", initialState.MsgCount,
+		"parentChainBlock", initialState.ParentChainBlockNumber,
+	)
+	return nil
 }
 
 func validateAndInitializeDBForMEL(
@@ -815,89 +927,41 @@ func validateAndInitializeDBForMEL(
 		return nil, fmt.Errorf("failed to create MEL database: %w", err)
 	}
 	_, err = melDB.GetHeadMelState()
+	if err == nil {
+		return melDB, nil
+	}
+	if !rawdb.IsDbErrNotFound(err) {
+		return nil, err
+	}
+	// No existing MEL state. Check if this is a legacy node (has inbox reader/tracker keys).
+	hasSequencerBatchCountKey, err := consensusDB.Has(schema.SequencerBatchCountKey)
 	if err != nil {
-		if !rawdb.IsDbErrNotFound(err) {
+		return nil, err
+	}
+	hasDelayedMessageCountKey, err := consensusDB.Has(schema.DelayedMessageCountKey)
+	if err != nil {
+		return nil, err
+	}
+	if hasSequencerBatchCountKey || hasDelayedMessageCountKey {
+		if err := migrateLegacyDBToMEL(ctx, l1client, deployInfo, consensusDB, melDB, parentChainIsArbitrum); err != nil {
 			return nil, err
 		}
-		// No existing MEL state. Check if this is a legacy node (has inbox reader/tracker keys).
-		hasSequencerBatchCountKey, err := consensusDB.Has(schema.SequencerBatchCountKey)
-		if err != nil {
-			return nil, err
-		}
-		hasDelayedMessageCountKey, err := consensusDB.Has(schema.DelayedMessageCountKey)
-		if err != nil {
-			return nil, err
-		}
-		if hasSequencerBatchCountKey || hasDelayedMessageCountKey {
-			// Legacy node migration: construct initial MEL state from existing data.
-			log.Info("Migrating legacy inbox reader/tracker data to MEL")
-			chainId, err := l1client.ChainID(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get chain ID: %w", err)
-			}
-			// Determine startBlockNum: use the finalized block (capped at last batch's block)
-			// to ensure the initial state cannot be reorged out.
-			startBlockNum, err := computeMigrationStartBlock(ctx, l1client, consensusDB, deployInfo, parentChainIsArbitrum)
-			if err != nil {
-				return nil, fmt.Errorf("failed to compute migration start block: %w", err)
-			}
-			// Query the on-chain bridge contract for the authoritative delayed message
-			// count at startBlockNum. This is more reliable than scanning the legacy DB.
-			delayedBridge, err := NewDelayedBridge(l1client, deployInfo.Bridge, deployInfo.DeployedAt)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create delayed bridge: %w", err)
-			}
-			delayedSeenAtBlock, err := delayedBridge.GetMessageCount(ctx, new(big.Int).SetUint64(startBlockNum))
-			if err != nil {
-				return nil, fmt.Errorf("failed to get on-chain delayed message count at block %d: %w", startBlockNum, err)
-			}
-			initialState, err := melrunner.CreateInitialMELStateFromLegacyDB(
-				consensusDB,
-				deployInfo.SequencerInbox,
-				deployInfo.Bridge,
-				chainId.Uint64(),
-				func(blockNum uint64) (common.Hash, common.Hash, error) {
-					block, err := l1client.BlockByNumber(ctx, new(big.Int).SetUint64(blockNum))
-					if err != nil {
-						return common.Hash{}, common.Hash{}, err
-					}
-					return block.Hash(), block.ParentHash(), nil
-				},
-				startBlockNum,
-				delayedSeenAtBlock,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create initial MEL state from legacy DB: %w", err)
-			}
-			if err = melDB.SaveInitialMelState(initialState); err != nil {
-				return nil, fmt.Errorf("failed to save initial mel state: %w", err)
-			}
-			log.Info("MEL migration from legacy data complete",
-				"delayedSeen", initialState.DelayedMessagesSeen,
-				"delayedRead", initialState.DelayedMessagesRead,
-				"batchCount", initialState.BatchCount,
-				"msgCount", initialState.MsgCount,
-				"parentChainBlock", initialState.ParentChainBlockNumber,
-			)
-		} else {
-			// Fresh node: no legacy keys exist.
-			// MessageCountKey should be zero (since TxStreamer initializes it to zero if it doesn't exist)
-			msgCount, err := read.Value[uint64](consensusDB, schema.MessageCountKey)
-			if err != nil {
-				return nil, err
-			}
-			if msgCount != 0 {
-				return nil, errors.New("MEL being initialized when DB already has stale msgs")
-			}
-			// Create Initial MEL state
-			initialState, err := createInitialMELState(ctx, deployInfo, l1client)
-			if err != nil {
-				return nil, err
-			}
-			if err = melDB.SaveState(initialState); err != nil {
-				return nil, fmt.Errorf("failed to save initial mel state: %w", err)
-			}
-		}
+		return melDB, nil
+	}
+	// Fresh node: no legacy keys exist.
+	msgCount, err := read.Value[uint64](consensusDB, schema.MessageCountKey)
+	if err != nil {
+		return nil, err
+	}
+	if msgCount != 0 {
+		return nil, errors.New("MEL being initialized when DB already has stale msgs")
+	}
+	initialState, err := createInitialMELState(ctx, deployInfo, l1client)
+	if err != nil {
+		return nil, err
+	}
+	if err = melDB.SaveState(initialState); err != nil {
+		return nil, fmt.Errorf("failed to save initial mel state: %w", err)
 	}
 	return melDB, nil
 }
@@ -912,6 +976,7 @@ func getMessageExtractor(
 	dapRegistry *daprovider.DAProviderRegistry,
 	sequencerInbox *SequencerInbox,
 	l1Reader *headerreader.HeaderReader,
+	fatalErrChan chan error,
 ) (*melrunner.MessageExtractor, error) {
 	if !config.MessageExtraction.Enable {
 		// Prevent database corruption. If HeadMelStateBlockNumKey exists,
@@ -930,7 +995,7 @@ func getMessageExtractor(
 	if err != nil {
 		return nil, err
 	}
-	msgExtractor, err := melrunner.NewMessageExtractor(
+	return melrunner.NewMessageExtractor(
 		config.MessageExtraction,
 		l1client,
 		l2Config,
@@ -940,11 +1005,8 @@ func getMessageExtractor(
 		sequencerInbox,
 		l1Reader,
 		nil,
+		fatalErrChan,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return msgExtractor, nil
 }
 
 func createInitialMELState(
@@ -952,27 +1014,28 @@ func createInitialMELState(
 	deployInfo *chaininfo.RollupAddresses,
 	client *ethclient.Client,
 ) (*mel.State, error) {
-	// Create an initial MEL state from the latest confirmed assertion.
-	startBlock, err := client.BlockByNumber(ctx, new(big.Int).SetUint64(deployInfo.DeployedAt-1))
+	if deployInfo.DeployedAt == 0 {
+		return nil, errors.New("DeployedAt is 0; cannot create initial MEL state before the genesis block")
+	}
+	// Create an initial MEL state anchored at the block before the rollup deployment block.
+	startHeader, err := client.HeaderByNumber(ctx, new(big.Int).SetUint64(deployInfo.DeployedAt-1))
 	if err != nil {
 		return nil, err
+	}
+	if startHeader == nil {
+		return nil, fmt.Errorf("block %d not found on parent chain", deployInfo.DeployedAt-1)
 	}
 	chainId, err := client.ChainID(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return &mel.State{
-		Version:                            0,
 		BatchPostingTargetAddress:          deployInfo.SequencerInbox,
 		DelayedMessagePostingTargetAddress: deployInfo.Bridge,
 		ParentChainId:                      chainId.Uint64(),
-		ParentChainBlockNumber:             startBlock.NumberU64(),
-		ParentChainBlockHash:               startBlock.Hash(),
-		ParentChainPreviousBlockHash:       startBlock.ParentHash(),
-		DelayedMessagesSeen:                0,
-		DelayedMessagesRead:                0,
-		MsgCount:                           0,
-		BatchCount:                         0,
+		ParentChainBlockNumber:             startHeader.Number.Uint64(),
+		ParentChainBlockHash:               startHeader.Hash(),
+		ParentChainPreviousBlockHash:       startHeader.ParentHash,
 	}, nil
 }
 
@@ -984,21 +1047,16 @@ func getBlockValidator(
 	txStreamer *TransactionStreamer,
 	fatalErrChan chan error,
 ) (*staker.BlockValidator, error) {
-	var err error
-	var blockValidator *staker.BlockValidator
-	if config.ValidatorRequired() {
-		blockValidator, err = staker.NewBlockValidator(
-			statelessBlockValidator,
-			inboxTracker,
-			txStreamer,
-			func() *staker.BlockValidatorConfig { return &configFetcher.Get().BlockValidator },
-			fatalErrChan,
-		)
-		if err != nil {
-			return nil, err
-		}
+	if !config.ValidatorRequired() {
+		return nil, nil
 	}
-	return blockValidator, err
+	return staker.NewBlockValidator(
+		statelessBlockValidator,
+		inboxTracker,
+		txStreamer,
+		func() *staker.BlockValidatorConfig { return &configFetcher.Get().BlockValidator },
+		fatalErrChan,
+	)
 }
 
 func getStaker(
@@ -1109,11 +1167,7 @@ func getTransactionStreamer(
 	fatalErrChan chan error,
 ) (*TransactionStreamer, error) {
 	transactionStreamerConfigFetcher := func() *TransactionStreamerConfig { return &configFetcher.Get().TransactionStreamer }
-	txStreamer, err := NewTransactionStreamer(ctx, consensusDB, l2Config, exec, broadcastServer, fatalErrChan, transactionStreamerConfigFetcher)
-	if err != nil {
-		return nil, err
-	}
-	return txStreamer, nil
+	return NewTransactionStreamer(ctx, consensusDB, l2Config, exec, broadcastServer, fatalErrChan, transactionStreamerConfigFetcher)
 }
 
 func getSeqCoordinator(
@@ -1414,7 +1468,7 @@ func createNodeImpl(
 		return nil, err
 	}
 
-	messageExtractor, err := getMessageExtractor(ctx, config, l2Config, l1client, deployInfo, consensusDB, dapRegistry, sequencerInbox, l1Reader)
+	messageExtractor, err := getMessageExtractor(ctx, config, l2Config, l1client, deployInfo, consensusDB, dapRegistry, sequencerInbox, l1Reader, fatalErrChan)
 	if err != nil {
 		return nil, err
 	}
@@ -1498,6 +1552,10 @@ func createNodeImpl(
 	}
 	consensusExecutionSyncer := NewConsensusExecutionSyncer(consensusExecutionSyncerConfigFetcher, msgCountFetcher, executionClient, blockValidator, txStreamer, syncMonitor)
 
+	if messagePruner != nil && messageExtractor != nil {
+		messagePruner.SetLegacyDelayedBound(messageExtractor.LegacyDelayedBound())
+	}
+
 	return &Node{
 		ConsensusDB:              consensusDB,
 		Stack:                    stack,
@@ -1533,7 +1591,9 @@ func createNodeImpl(
 }
 
 func (n *Node) OnConfigReload(_ *Config, _ *Config) error {
-	// TODO
+	// TODO: Implement hot reload for MEL config fields marked with reload:"hot"
+	// (RetryInterval, BlocksToPrefetch, StallTolerance). Also propagate reloads
+	// to MessagePruner and other subsystems that support hot config changes.
 	return nil
 }
 
@@ -1768,15 +1828,15 @@ func (n *Node) Start(ctx context.Context) error {
 	}
 	if n.BroadcastClients != nil {
 		go func() {
+			var caughtUpChan <-chan struct{}
 			if n.MessageExtractor != nil {
-				select {
-				case <-n.MessageExtractor.CaughtUp():
-				case <-ctx.Done():
-					return
-				}
+				caughtUpChan = n.MessageExtractor.CaughtUp()
 			} else if n.InboxReader != nil {
+				caughtUpChan = n.InboxReader.CaughtUp()
+			}
+			if caughtUpChan != nil {
 				select {
-				case <-n.InboxReader.CaughtUp():
+				case <-caughtUpChan:
 				case <-ctx.Done():
 					return
 				}
@@ -1793,8 +1853,8 @@ func (n *Node) Start(ctx context.Context) error {
 	if n.configFetcher != nil {
 		n.configFetcher.Start(ctx)
 	}
-	// Also make sure to call initialize on the sync monitor after the inbox reader, tx streamer, and block validator are started.
-	// Else sync might call inbox reader or tx streamer before they are started, and it will lead to panic.
+	// Also make sure to call initialize on the sync monitor after the inbox reader (or message extractor),
+	// tx streamer, and block validator are started. Else sync might call them before they are started.
 	var syncFetcher MessageSyncProgressFetcher
 	if n.MessageExtractor != nil {
 		syncFetcher = n.MessageExtractor
@@ -1898,11 +1958,14 @@ func (n *Node) BlockMetadataAtMessageIndex(msgIdx arbutil.MessageIndex) containe
 	return containers.NewReadyPromise(n.TxStreamer.BlockMetadataAtMessageIndex(msgIdx))
 }
 
-func (n *Node) GetParentChainDataSource() ParentChainDataSource {
+func (n *Node) GetParentChainDataSource() (ParentChainDataSource, error) {
 	if n.MessageExtractor != nil {
-		return n.MessageExtractor
+		return n.MessageExtractor, nil
 	}
-	return n.InboxReader.GetParentChainDataSource()
+	if n.InboxReader != nil {
+		return n.InboxReader.GetParentChainDataSource(), nil
+	}
+	return nil, errors.New("no parent chain data source available: neither MessageExtractor nor InboxReader is set")
 }
 
 func (n *Node) GetL1Confirmations(msgIdx arbutil.MessageIndex) containers.PromiseInterface[uint64] {
@@ -1910,16 +1973,19 @@ func (n *Node) GetL1Confirmations(msgIdx arbutil.MessageIndex) containers.Promis
 		return containers.NewReadyPromise(uint64(0), nil)
 	}
 
-	// batches not yet posted have 0 confirmations but no error
-	pcds := n.GetParentChainDataSource()
-	batchNum, found, err := pcds.FindInboxBatchContainingMessage(msgIdx)
+	reader, err := n.BatchDataSource()
 	if err != nil {
 		return containers.NewReadyPromise(uint64(0), err)
 	}
+	batchNum, found, err := reader.FindInboxBatchContainingMessage(msgIdx)
+	if err != nil {
+		return containers.NewReadyPromise(uint64(0), err)
+	}
+	// batches not yet posted have 0 confirmations but no error
 	if !found {
 		return containers.NewReadyPromise(uint64(0), nil)
 	}
-	parentChainBlockNum, err := pcds.GetBatchParentChainBlock(batchNum)
+	parentChainBlockNum, err := reader.GetBatchParentChainBlock(batchNum)
 	if err != nil {
 		return containers.NewReadyPromise(uint64(0), err)
 	}
@@ -1972,7 +2038,11 @@ func (n *Node) GetL1Confirmations(msgIdx arbutil.MessageIndex) containers.Promis
 }
 
 func (n *Node) FindBatchContainingMessage(msgIdx arbutil.MessageIndex) containers.PromiseInterface[uint64] {
-	batchNum, found, err := n.GetParentChainDataSource().FindInboxBatchContainingMessage(msgIdx)
+	reader, err := n.BatchDataSource()
+	if err != nil {
+		return containers.NewReadyPromise(uint64(0), err)
+	}
+	batchNum, found, err := reader.FindInboxBatchContainingMessage(msgIdx)
 	if err == nil && !found {
 		return containers.NewReadyPromise(uint64(0), errors.New("block not yet found on any batch"))
 	}

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -111,7 +111,7 @@ func (c *Config) Validate() error {
 		c.Feed.Output.Enable = false
 		c.Feed.Input.URL = []string{}
 	}
-	if c.MessageExtraction.Enable && c.MessageExtraction.ReadMode != "latest" {
+	if c.MessageExtraction.Enable && c.MessageExtraction.ReadMode != melrunner.ReadModeLatest {
 		if c.Sequencer {
 			return errors.New("cannot enable message extraction in safe or finalized mode along with sequencer")
 		}
@@ -848,6 +848,9 @@ func computeMigrationStartBlock(
 		}
 		if finalizedHeader == nil {
 			return 0, errors.New("finalized block header not available on parent chain")
+		}
+		if finalizedHeader.Number == nil {
+			return 0, errors.New("finalized block header has nil Number")
 		}
 		startBlockNum = min(startBlockNum, finalizedHeader.Number.Uint64())
 	}

--- a/arbnode/node_batch_data_source_test.go
+++ b/arbnode/node_batch_data_source_test.go
@@ -1,0 +1,65 @@
+// Copyright 2025-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package arbnode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	melrunner "github.com/offchainlabs/nitro/arbnode/mel/runner"
+	"github.com/offchainlabs/nitro/util/headerreader"
+)
+
+func TestBatchDataSource_ErrorWhenNeitherSet(t *testing.T) {
+	t.Parallel()
+	n := &Node{}
+	_, err := n.BatchDataSource()
+	require.ErrorIs(t, err, ErrNoBatchDataReader)
+}
+
+func TestBatchDataSource_ReturnsInboxTracker(t *testing.T) {
+	t.Parallel()
+	tracker := &InboxTracker{}
+	n := &Node{InboxTracker: tracker}
+	got, err := n.BatchDataSource()
+	require.NoError(t, err)
+	require.Same(t, tracker, got)
+}
+
+func TestBatchDataSource_PrefersMessageExtractor(t *testing.T) {
+	t.Parallel()
+	extractor := &melrunner.MessageExtractor{}
+	tracker := &InboxTracker{}
+	n := &Node{MessageExtractor: extractor, InboxTracker: tracker}
+	got, err := n.BatchDataSource()
+	require.NoError(t, err)
+	require.Same(t, extractor, got)
+}
+
+func TestGetL1Confirmations_NilReaderReturnsError(t *testing.T) {
+	t.Parallel()
+	// L1Reader must be non-nil to reach the BatchDataSource check.
+	n := &Node{L1Reader: &headerreader.HeaderReader{}}
+	p := n.GetL1Confirmations(0)
+	_, err := p.Await(t.Context())
+	require.ErrorIs(t, err, ErrNoBatchDataReader)
+}
+
+func TestGetL1Confirmations_NilL1ReaderReturnsNoError(t *testing.T) {
+	t.Parallel()
+	n := &Node{}
+	p := n.GetL1Confirmations(0)
+	val, err := p.Await(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), val)
+}
+
+func TestFindBatchContainingMessage_NilReaderReturnsError(t *testing.T) {
+	t.Parallel()
+	n := &Node{}
+	p := n.FindBatchContainingMessage(0)
+	_, err := p.Await(t.Context())
+	require.ErrorIs(t, err, ErrNoBatchDataReader)
+}

--- a/arbnode/node_mel_test.go
+++ b/arbnode/node_mel_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/rlp"
 
+	"github.com/offchainlabs/nitro/arbnode/db/read"
 	"github.com/offchainlabs/nitro/arbnode/db/schema"
 	"github.com/offchainlabs/nitro/arbnode/mel"
 	melrunner "github.com/offchainlabs/nitro/arbnode/mel/runner"
+	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
 )
 
@@ -65,6 +67,48 @@ func TestValidateAndInitializeDBForMEL_NonZeroMessageCount(t *testing.T) {
 	require.ErrorContains(t, err, "stale msgs")
 }
 
+func putBatchMetadata(t *testing.T, db interface{ Put([]byte, []byte) error }, seqNum uint64, meta mel.BatchMetadata) {
+	t.Helper()
+	data, err := rlp.EncodeToBytes(meta)
+	require.NoError(t, err)
+	require.NoError(t, db.Put(read.Key(schema.SequencerBatchMetaPrefix, seqNum), data))
+}
+
+func TestComputeMigrationStartBlock_WithBatches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Arbitrum parent chain returns last batch ParentChainBlock", func(t *testing.T) {
+		t.Parallel()
+		db := rawdb.NewMemoryDatabase()
+		putRLPValue(t, db, schema.SequencerBatchCountKey, 3)
+		putBatchMetadata(t, db, 2, mel.BatchMetadata{
+			MessageCount:     arbutil.MessageIndex(100),
+			ParentChainBlock: 500,
+		})
+
+		block, err := computeMigrationStartBlock(
+			context.Background(), nil, db,
+			&chaininfo.RollupAddresses{DeployedAt: 10}, true,
+		)
+		require.NoError(t, err)
+		require.Equal(t, uint64(500), block)
+	})
+
+	t.Run("missing batch metadata returns error", func(t *testing.T) {
+		t.Parallel()
+		db := rawdb.NewMemoryDatabase()
+		putRLPValue(t, db, schema.SequencerBatchCountKey, 3)
+		// Don't write any batch metadata
+
+		_, err := computeMigrationStartBlock(
+			context.Background(), nil, db,
+			&chaininfo.RollupAddresses{DeployedAt: 10}, true,
+		)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to read last legacy batch metadata")
+	})
+}
+
 func TestComputeMigrationStartBlock_ZeroBatches(t *testing.T) {
 	t.Parallel()
 
@@ -105,4 +149,26 @@ func TestComputeMigrationStartBlock_ZeroBatches(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(99), block)
 	})
+}
+
+func TestSetDelayedSequencer_ErrorOnDoubleSet(t *testing.T) {
+	t.Parallel()
+	// Create a minimal SeqCoordinator (without Redis) to test SetDelayedSequencer guards.
+	coord := &SeqCoordinator{}
+
+	// First call should succeed.
+	require.NoError(t, coord.SetDelayedSequencer(&DelayedSequencer{}))
+
+	// Second call should return "already set" error.
+	err := coord.SetDelayedSequencer(&DelayedSequencer{})
+	require.ErrorContains(t, err, "already set")
+}
+
+func TestValidateAndInitializeDBForMEL_FreshNodeNoKeys(t *testing.T) {
+	t.Parallel()
+	// Fresh node with no legacy keys and no MEL state. Without an l1client,
+	// createInitialMELState will fail.
+	db := rawdb.NewMemoryDatabase()
+	_, err := validateAndInitializeDBForMEL(context.Background(), nil, &chaininfo.RollupAddresses{DeployedAt: 100}, db, true)
+	require.Error(t, err)
 }

--- a/arbnode/node_mel_test.go
+++ b/arbnode/node_mel_test.go
@@ -14,7 +14,8 @@ import (
 
 	"github.com/offchainlabs/nitro/arbnode/db/schema"
 	"github.com/offchainlabs/nitro/arbnode/mel"
-	"github.com/offchainlabs/nitro/arbnode/mel/runner"
+	melrunner "github.com/offchainlabs/nitro/arbnode/mel/runner"
+	"github.com/offchainlabs/nitro/cmd/chaininfo"
 )
 
 func putRLPValue(t *testing.T, db interface{ Put([]byte, []byte) error }, key []byte, val uint64) {
@@ -62,4 +63,46 @@ func TestValidateAndInitializeDBForMEL_NonZeroMessageCount(t *testing.T) {
 
 	_, err := validateAndInitializeDBForMEL(context.Background(), nil, nil, db, false)
 	require.ErrorContains(t, err, "stale msgs")
+}
+
+func TestComputeMigrationStartBlock_ZeroBatches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DeployedAt is zero returns error", func(t *testing.T) {
+		t.Parallel()
+		db := rawdb.NewMemoryDatabase()
+		putRLPValue(t, db, schema.SequencerBatchCountKey, 0)
+
+		_, err := computeMigrationStartBlock(
+			context.Background(), nil, db,
+			&chaininfo.RollupAddresses{DeployedAt: 0}, true,
+		)
+		require.ErrorContains(t, err, "DeployedAt is 0 and no batches exist")
+	})
+
+	t.Run("DeployedAt nonzero returns DeployedAt minus one", func(t *testing.T) {
+		t.Parallel()
+		db := rawdb.NewMemoryDatabase()
+		putRLPValue(t, db, schema.SequencerBatchCountKey, 0)
+
+		block, err := computeMigrationStartBlock(
+			context.Background(), nil, db,
+			&chaininfo.RollupAddresses{DeployedAt: 100}, true,
+		)
+		require.NoError(t, err)
+		require.Equal(t, uint64(99), block)
+	})
+
+	t.Run("missing SequencerBatchCountKey treated as zero batches", func(t *testing.T) {
+		t.Parallel()
+		// DB has no SequencerBatchCountKey at all (only delayed data exists)
+		db := rawdb.NewMemoryDatabase()
+
+		block, err := computeMigrationStartBlock(
+			context.Background(), nil, db,
+			&chaininfo.RollupAddresses{DeployedAt: 100}, true,
+		)
+		require.NoError(t, err)
+		require.Equal(t, uint64(99), block)
+	})
 }

--- a/arbnode/parent/parent.go
+++ b/arbnode/parent/parent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/offchainlabs/nitro/util/headerreader"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
@@ -109,6 +110,8 @@ func NewParentChainWithConfig(ctx context.Context, chainID *big.Int, l1Reader *h
 		if err := parentChain.pollEthConfig(fetchCtx); err != nil {
 			if fetchCtx.Err() != nil {
 				log.Warn("Eager eth_config fetch timed out, will use static config until next successful poll", "timeout", "10s")
+			} else if isMethodNotFoundError(err) {
+				log.Debug("Parent chain RPC does not support eth_config, using static config", "err", err)
 			} else {
 				log.Warn("Failed to poll parent chain eth_config, will use static config until next successful poll", "err", err)
 			}
@@ -131,6 +134,12 @@ type ethConfigEntry struct {
 	ActivationTime uint64             `json:"activationTime"`
 }
 
+// isMethodNotFoundError returns true if the error is an RPC "method not found" error (-32601).
+func isMethodNotFoundError(err error) bool {
+	var rpcErr rpc.Error
+	return errors.As(err, &rpcErr) && rpcErr.ErrorCode() == -32601
+}
+
 // Start begins polling the parent chain's eth_config RPC.
 // ParentChain is shared between execution and consensus nodes when co-located,
 // so it may be Start()'d twice. We call StopWaiterSafe.Start() directly
@@ -150,7 +159,11 @@ func (p *ParentChain) Start(ctxIn context.Context) {
 
 	p.CallIteratively(func(ctx context.Context) time.Duration {
 		if err := p.pollEthConfig(ctx); err != nil && ctx.Err() == nil {
-			log.Warn("Failed to poll parent chain eth_config", "err", err)
+			if isMethodNotFoundError(err) {
+				log.Debug("Parent chain RPC does not support eth_config, using static config", "err", err)
+			} else {
+				log.Warn("Failed to poll parent chain eth_config", "err", err)
+			}
 		}
 		return p.config().ConfigPollInterval
 	})
@@ -246,8 +259,7 @@ func (p *ParentChain) chainConfig() (*params.ChainConfig, error) {
 // Returns (nil, nil) when the parent chain does not support blobs (e.g. an
 // Arbitrum L2 acting as parent for an L3). Callers must handle a nil config.
 func (p *ParentChain) blobConfig(headerTime uint64) (*params.BlobConfig, error) {
-	cached := p.cachedEthConfig.Load()
-	if cached != nil {
+	if cached := p.cachedEthConfig.Load(); cached != nil {
 		// If next config exists and headerTime is at or past its activation,
 		// use the next config's blob schedule.
 		if cached.Next != nil && cached.Next.BlobSchedule != nil &&
@@ -269,6 +281,8 @@ func (p *ParentChain) blobConfig(headerTime uint64) (*params.BlobConfig, error) 
 			"headerTime", headerTime,
 			"currentActivationTime", currentActivationTime,
 		)
+	} else {
+		log.Info("No cached eth_config available, falling back to static blob config")
 	}
 	// Fall back to the hardcoded chain config. If the parent chain is an
 	// Arbitrum chain (e.g. an L2 acting as parent for an L3), it won't
@@ -288,17 +302,31 @@ func (p *ParentChain) blobConfig(headerTime uint64) (*params.BlobConfig, error) 
 	return staticBlobConfig.BlobConfig(staticBlobConfig.LatestFork(headerTime, 0)), nil
 }
 
+// resolveHeader returns h if non-nil, otherwise fetches the latest header from the L1 reader.
+func (p *ParentChain) resolveHeader(ctx context.Context, h *types.Header) (*types.Header, error) {
+	if h != nil {
+		return h, nil
+	}
+	if p.L1Reader == nil {
+		return nil, errors.New("cannot resolve header: L1Reader is nil and no header provided")
+	}
+	header, err := p.L1Reader.LastHeader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if header == nil {
+		return nil, errors.New("L1Reader has no header available yet")
+	}
+	return header, nil
+}
+
 // MaxBlobGasPerBlock returns the maximum blob gas per block according to
 // the configuration of the parent chain.
 // Passing in a nil header will use the time from the latest header.
 func (p *ParentChain) MaxBlobGasPerBlock(ctx context.Context, h *types.Header) (uint64, error) {
-	header := h
-	if h == nil {
-		lh, err := p.L1Reader.LastHeader(ctx)
-		if err != nil {
-			return 0, err
-		}
-		header = lh
+	header, err := p.resolveHeader(ctx, h)
+	if err != nil {
+		return 0, err
 	}
 	blobConfig, err := p.blobConfig(header.Time)
 	if err != nil {
@@ -316,13 +344,9 @@ func (p *ParentChain) MaxBlobGasPerBlock(ctx context.Context, h *types.Header) (
 // of the parent chain.
 // Passing in a nil header will use the time from the latest header.
 func (p *ParentChain) BlobFeePerByte(ctx context.Context, h *types.Header) (*big.Int, error) {
-	header := h
-	if h == nil {
-		lh, err := p.L1Reader.LastHeader(ctx)
-		if err != nil {
-			return big.NewInt(0), err
-		}
-		header = lh
+	header, err := p.resolveHeader(ctx, h)
+	if err != nil {
+		return big.NewInt(0), err
 	}
 	bc, err := p.blobConfig(header.Time)
 	if err != nil {
@@ -331,6 +355,9 @@ func (p *ParentChain) BlobFeePerByte(ctx context.Context, h *types.Header) (*big
 	// nil means the parent chain doesn't support blobs (e.g. Arbitrum L2
 	// parent). Return 0, matching CalcBlobFee behavior.
 	if bc == nil {
+		return big.NewInt(0), nil
+	}
+	if header.ExcessBlobGas == nil {
 		return big.NewInt(0), nil
 	}
 	return eip4844.CalcBlobFeeWithConfig(bc, header.ExcessBlobGas), nil

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -195,14 +195,15 @@ func NewSeqCoordinator(
 	return coordinator, nil
 }
 
-func (c *SeqCoordinator) SetDelayedSequencer(delayedSequencer *DelayedSequencer) {
+func (c *SeqCoordinator) SetDelayedSequencer(delayedSequencer *DelayedSequencer) error {
 	if c.Started() {
-		panic("trying to set delayed sequencer after start")
+		return errors.New("cannot set delayed sequencer after start")
 	}
 	if c.delayedSequencer != nil {
-		panic("trying to set delayed sequencer when already set")
+		return errors.New("delayed sequencer already set")
 	}
 	c.delayedSequencer = delayedSequencer
+	return nil
 }
 
 func (c *SeqCoordinator) RedisCoordinator() *redisutil.RedisCoordinator {

--- a/arbnode/sync_monitor.go
+++ b/arbnode/sync_monitor.go
@@ -171,6 +171,7 @@ func (s *SyncMonitor) FullSyncProgressMap() map[string]interface{} {
 			res["batchMetadataError"] = err.Error()
 		} else {
 			res["batchSeen"] = progress.BatchSeen
+			res["batchSeenIsEstimate"] = progress.BatchSeenIsEstimate
 			res["batchProcessed"] = progress.BatchProcessed
 			if progress.BatchProcessed > 0 {
 				res["messageOfProcessedBatch"] = progress.MsgCount
@@ -242,6 +243,9 @@ func (s *SyncMonitor) Synced() bool {
 			return false
 		}
 		if progress.BatchSeen == 0 {
+			return false
+		}
+		if progress.BatchSeenIsEstimate {
 			return false
 		}
 		if progress.BatchProcessed < progress.BatchSeen {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -231,8 +231,15 @@ func (s *TransactionStreamer) cleanupInconsistentState() error {
 	if err != nil {
 		return err
 	}
-	batch := s.db.NewBatch()
-	minKey := uint64ToKey(uint64(msgCount))
+	return deleteTrailingEntries(s.db, uint64(msgCount))
+}
+
+// deleteTrailingEntries removes entries at or beyond msgCount for all
+// message-related prefixes. This cleans up orphaned data left by a crash
+// between writing individual entries and updating the count.
+func deleteTrailingEntries(db ethdb.Database, msgCount uint64) error {
+	batch := db.NewBatch()
+	minKey := uint64ToKey(msgCount)
 	for _, prefix := range [][]byte{
 		schema.MessagePrefix,
 		schema.MessageResultPrefix,
@@ -240,7 +247,7 @@ func (s *TransactionStreamer) cleanupInconsistentState() error {
 		schema.BlockMetadataInputFeedPrefix,
 		schema.MissingBlockMetadataInputFeedPrefix,
 	} {
-		if err := deleteStartingAt(s.db, batch, prefix, minKey); err != nil {
+		if err := deleteStartingAt(db, batch, prefix, minKey); err != nil {
 			return fmt.Errorf("cleaning up trailing %x entries: %w", prefix, err)
 		}
 	}

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -29,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/nitro/arbnode/db/schema"
+	"github.com/offchainlabs/nitro/arbnode/mel"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/broadcastclient"
@@ -54,8 +54,9 @@ type BatchDataProvider interface {
 	FindParentChainBlockContainingDelayed(ctx context.Context, index uint64) (uint64, error)
 }
 
-// TransactionStreamer produces blocks from a node's L1 messages, storing the results in the blockchain and recording their positions
-// The streamer is notified when there's new batches to process
+// TransactionStreamer produces blocks from L2 messages, storing the results in the
+// blockchain and recording their positions. It receives messages from either the MEL
+// message extractor or the legacy inbox reader/tracker.
 type TransactionStreamer struct {
 	stopwaiter.StopWaiter
 
@@ -174,14 +175,15 @@ func uint64ToKey(x uint64) []byte {
 	return data
 }
 
-func (s *TransactionStreamer) SetBlockValidator(validator *staker.BlockValidator) {
+func (s *TransactionStreamer) SetBlockValidator(validator *staker.BlockValidator) error {
 	if s.Started() {
-		panic("trying to set coordinator after start")
+		return errors.New("cannot set block validator after start")
 	}
 	if s.validator != nil {
-		panic("trying to set coordinator when already set")
+		return errors.New("block validator already set")
 	}
 	s.validator = validator
+	return nil
 }
 
 func (s *TransactionStreamer) SetSeqCoordinator(coordinator *SeqCoordinator) error {
@@ -223,8 +225,26 @@ func (s *TransactionStreamer) cleanupInconsistentState() error {
 			return err
 		}
 	}
-	// TODO remove trailing messageCountToMessage and messageCountToBlockPrefix entries
-	return nil
+	// Remove any trailing entries beyond MessageCount that could be left
+	// after a crash between writing individual entries and updating the count.
+	msgCount, err := s.GetMessageCount()
+	if err != nil {
+		return err
+	}
+	batch := s.db.NewBatch()
+	minKey := uint64ToKey(uint64(msgCount))
+	for _, prefix := range [][]byte{
+		schema.MessagePrefix,
+		schema.MessageResultPrefix,
+		schema.BlockHashInputFeedPrefix,
+		schema.BlockMetadataInputFeedPrefix,
+		schema.MissingBlockMetadataInputFeedPrefix,
+	} {
+		if err := deleteStartingAt(s.db, batch, prefix, minKey); err != nil {
+			return fmt.Errorf("cleaning up trailing %x entries: %w", prefix, err)
+		}
+	}
+	return batch.Write()
 }
 
 func (s *TransactionStreamer) ReorgAt(firstMsgIdxReorged arbutil.MessageIndex) error {
@@ -234,15 +254,10 @@ func (s *TransactionStreamer) ReorgAt(firstMsgIdxReorged arbutil.MessageIndex) e
 func (s *TransactionStreamer) ReorgAtAndEndBatch(batch ethdb.Batch, firstMsgIdxReorged arbutil.MessageIndex) error {
 	s.insertionMutex.Lock()
 	defer s.insertionMutex.Unlock()
-	err := s.addMessagesAndReorg(batch, firstMsgIdxReorged, nil)
-	if err != nil {
+	if err := s.addMessagesAndReorg(batch, firstMsgIdxReorged, nil); err != nil {
 		return err
 	}
-	err = batch.Write()
-	if err != nil {
-		return err
-	}
-	return nil
+	return batch.Write()
 }
 
 func deleteStartingAt(db ethdb.Database, batch ethdb.Batch, prefix []byte, minKey []byte) error {
@@ -344,9 +359,11 @@ func (s *TransactionStreamer) addMessagesAndReorg(batch ethdb.Batch, msgIdxOfFir
 		header := oldMessage.Message.Header
 
 		if header.RequestId != nil {
-			// When using MEL:
-			// This is a delayed message and concerns delayedMessages 'Seen' and not 'Read' so not including any delayed messages in
-			// resequencing is fair- since they will anyway be re-added by MEL later and the corresponding merkle partials would have changed
+			// This is a delayed message. It is only resequenced if all three agree:
+			// the old message, the accumulator stored in the batch data provider, and the
+			// message re-read from L1. If any of these disagree, the message is skipped.
+			// The correct version will be re-added when the next batch referencing this
+			// delayed message is processed by MEL (or the inbox reader).
 			delayedMsgIdx := header.RequestId.Big().Uint64()
 			if delayedMsgIdx+1 != oldMessage.DelayedMessagesRead {
 				log.Error("delayed message header RequestId doesn't match database DelayedMessagesRead", "header", oldMessage.Message.Header, "delayedMessagesRead", oldMessage.DelayedMessagesRead)
@@ -359,11 +376,9 @@ func (s *TransactionStreamer) addMessagesAndReorg(batch ethdb.Batch, msgIdxOfFir
 			}
 
 			if s.batchDataProvider != nil && s.delayedBridge != nil {
-				// this is a delayed message. Should be resequenced if all 3 agree:
-				// oldMessage, accumulator stored in tracker, and the message re-read from l1
 				expectedAcc, err := s.batchDataProvider.GetDelayedAcc(delayedMsgIdx)
 				if err != nil {
-					if !strings.Contains(err.Error(), "not found") {
+					if !errors.Is(err, AccumulatorNotFoundErr) && !rawdb.IsDbErrNotFound(err) {
 						log.Error("reorg-resequence: failed to read expected accumulator", "err", err)
 					}
 					continue
@@ -380,7 +395,12 @@ func (s *TransactionStreamer) addMessagesAndReorg(batch ethdb.Batch, msgIdxOfFir
 					if delayedFound.Message.Header.RequestId.Big().Uint64() != delayedMsgIdx {
 						continue delayedInBlockLoop
 					}
-					if expectedAcc == delayedFound.AfterInboxAcc() && delayedFound.Message.Equals(oldMessage.Message) {
+					delayedFoundAcc, accErr := delayedFound.AfterInboxAcc()
+					if accErr != nil {
+						log.Error("reorg-resequence: failed to compute AfterInboxAcc", "err", accErr)
+						break delayedInBlockLoop
+					}
+					if expectedAcc == delayedFoundAcc && delayedFound.Message.Equals(oldMessage.Message) {
 						messageFound = true
 					}
 					break delayedInBlockLoop
@@ -487,44 +507,32 @@ func (s *TransactionStreamer) GetMessage(msgIdx arbutil.MessageIndex) (*arbostyp
 		return nil, err
 	}
 
-	ctx, err := s.GetContextSafe()
-	if err != nil {
-		return nil, err
-	}
-
-	if message.Message.IsBatchGasFieldsMissing() {
+	if message.Message.IsBatchGasFieldsMissing() && s.batchDataProvider != nil {
+		ctx, err := s.GetContextSafe()
+		if err != nil {
+			return nil, err
+		}
 		var parentChainBlockNumber *uint64
-		if message.DelayedMessagesRead != 0 && s.batchDataProvider != nil {
+		if message.DelayedMessagesRead != 0 {
 			localParentChainBlockNumber, err := s.batchDataProvider.FindParentChainBlockContainingDelayed(ctx, message.DelayedMessagesRead-1)
 			if err != nil {
-				log.Warn("Failed to fetch parent chain block number for delayed message. Will fall back to BatchMetadata", "idx", message.DelayedMessagesRead-1)
+				if !errors.Is(err, mel.ErrNotImplementedUnderMEL) {
+					log.Warn("Failed to fetch parent chain block number for delayed message. Will fall back to BatchMetadata", "idx", message.DelayedMessagesRead-1, "err", err)
+				}
 			} else {
 				parentChainBlockNumber = &localParentChainBlockNumber
 			}
 		}
-
-		if s.batchDataProvider != nil {
-			err = message.Message.FillInBatchGasFields(func(batchNum uint64) ([]byte, error) {
-				ctx, err := s.GetContextSafe()
-				if err != nil {
-					return nil, err
-				}
-
-				var data []byte
-				if parentChainBlockNumber != nil {
-					data, _, err = s.batchDataProvider.GetSequencerMessageBytesForParentBlock(ctx, batchNum, *parentChainBlockNumber)
-				} else {
-					data, _, err = s.batchDataProvider.GetSequencerMessageBytes(ctx, batchNum)
-				}
-				if err != nil {
-					return nil, err
-				}
-
+		err = message.Message.FillInBatchGasFields(func(batchNum uint64) ([]byte, error) {
+			if parentChainBlockNumber != nil {
+				data, _, err := s.batchDataProvider.GetSequencerMessageBytesForParentBlock(ctx, batchNum, *parentChainBlockNumber)
 				return data, err
-			})
-			if err != nil {
-				return nil, err
 			}
+			data, _, err := s.batchDataProvider.GetSequencerMessageBytes(ctx, batchNum)
+			return data, err
+		})
+		if err != nil {
+			return nil, err
 		}
 	}
 	return &message, nil
@@ -1173,7 +1181,11 @@ func (s *TransactionStreamer) ResumeReorgs() {
 }
 
 func (s *TransactionStreamer) PopulateFeedBacklog(ctx context.Context) error {
-	if s.broadcastServer == nil || s.batchDataProvider == nil {
+	if s.broadcastServer == nil {
+		return nil
+	}
+	if s.batchDataProvider == nil {
+		log.Info("Skipping feed backlog population: no batch data provider configured")
 		return nil
 	}
 	batchCount, err := s.batchDataProvider.GetBatchCount()
@@ -1204,7 +1216,9 @@ func (s *TransactionStreamer) PopulateFeedBacklog(ctx context.Context) error {
 
 		msgResult, err := s.ResultAtMessageIndex(seqNum)
 		var blockHash *common.Hash
-		if err == nil {
+		if err != nil {
+			log.Warn("Failed to get result for feed backlog message", "seqNum", seqNum, "err", err)
+		} else {
 			blockHash = &msgResult.BlockHash
 		}
 

--- a/arbnode/transaction_streamer_cleanup_test.go
+++ b/arbnode/transaction_streamer_cleanup_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+package arbnode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/core/rawdb"
+
+	"github.com/offchainlabs/nitro/arbnode/db/schema"
+)
+
+// TestDeleteTrailingEntries_RemovesOrphans simulates a crash that left
+// orphaned message entries beyond the persisted MessageCount.
+// deleteTrailingEntries must delete those trailing entries without
+// touching anything below the count, and without corrupting unrelated
+// prefixes in the same database.
+func TestDeleteTrailingEntries_RemovesOrphans(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+
+	// The prefixes that deleteTrailingEntries cleans.
+	cleanedPrefixes := [][]byte{
+		schema.MessagePrefix,
+		schema.MessageResultPrefix,
+		schema.BlockHashInputFeedPrefix,
+		schema.BlockMetadataInputFeedPrefix,
+		schema.MissingBlockMetadataInputFeedPrefix,
+	}
+
+	// Write entries at positions 0-7 for every cleaned prefix.
+	// Positions 0-4 are valid; 5-7 are orphaned "crash" entries.
+	for _, prefix := range cleanedPrefixes {
+		for i := uint64(0); i < 8; i++ {
+			key := append(append([]byte{}, prefix...), uint64ToKey(i)...)
+			require.NoError(t, db.Put(key, []byte("data")))
+		}
+	}
+
+	// Write entries under unrelated prefixes that must NOT be touched.
+	unrelatedPrefixes := []struct {
+		prefix []byte
+		name   string
+	}{
+		{schema.LegacyDelayedMessagePrefix, "LegacyDelayed"},
+		{schema.RlpDelayedMessagePrefix, "RlpDelayed"},
+		{schema.SequencerBatchMetaPrefix, "BatchMeta"},
+		{schema.DelayedSequencedPrefix, "DelayedSequenced"},
+		{schema.MelDelayedMessagePrefix, "MelDelayed"},
+		{schema.MelSequencerBatchMetaPrefix, "MelBatchMeta"},
+	}
+	for _, u := range unrelatedPrefixes {
+		for i := uint64(0); i < 10; i++ {
+			key := append(append([]byte{}, u.prefix...), uint64ToKey(i)...)
+			require.NoError(t, db.Put(key, []byte("unrelated")))
+		}
+	}
+
+	// Also write singleton keys that must survive.
+	require.NoError(t, db.Put(schema.DelayedMessageCountKey, []byte("singleton")))
+	require.NoError(t, db.Put(schema.SequencerBatchCountKey, []byte("singleton")))
+
+	// Delete trailing entries beyond position 5.
+	require.NoError(t, deleteTrailingEntries(db, 5))
+
+	// Entries 0-4 must still exist for all cleaned prefixes.
+	for _, prefix := range cleanedPrefixes {
+		for i := uint64(0); i < 5; i++ {
+			key := append(append([]byte{}, prefix...), uint64ToKey(i)...)
+			has, err := db.Has(key)
+			require.NoError(t, err)
+			require.True(t, has, "entry at position %d under prefix %x should still exist", i, prefix)
+		}
+	}
+
+	// Entries 5-7 must be gone for all cleaned prefixes.
+	for _, prefix := range cleanedPrefixes {
+		for i := uint64(5); i < 8; i++ {
+			key := append(append([]byte{}, prefix...), uint64ToKey(i)...)
+			has, err := db.Has(key)
+			require.NoError(t, err)
+			require.False(t, has, "trailing entry at position %d under prefix %x should be deleted", i, prefix)
+		}
+	}
+
+	// Unrelated prefixes must be fully intact.
+	for _, u := range unrelatedPrefixes {
+		for i := uint64(0); i < 10; i++ {
+			key := append(append([]byte{}, u.prefix...), uint64ToKey(i)...)
+			has, err := db.Has(key)
+			require.NoError(t, err)
+			require.True(t, has, "%s entry at position %d should not be touched", u.name, i)
+		}
+	}
+
+	// Singleton keys must be intact.
+	for _, key := range [][]byte{schema.DelayedMessageCountKey, schema.SequencerBatchCountKey} {
+		has, err := db.Has(key)
+		require.NoError(t, err)
+		require.True(t, has, "singleton key %s should not be touched", key)
+	}
+}
+
+// TestDeleteTrailingEntries_NoOpWhenClean verifies the function is a
+// no-op when there are no orphaned entries beyond msgCount.
+func TestDeleteTrailingEntries_NoOpWhenClean(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+
+	// Write exactly 3 entries under MessagePrefix — no trailing data.
+	for i := uint64(0); i < 3; i++ {
+		key := append(append([]byte{}, schema.MessagePrefix...), uint64ToKey(i)...)
+		require.NoError(t, db.Put(key, []byte("data")))
+	}
+
+	require.NoError(t, deleteTrailingEntries(db, 3))
+
+	// All 3 entries must still exist.
+	for i := uint64(0); i < 3; i++ {
+		key := append(append([]byte{}, schema.MessagePrefix...), uint64ToKey(i)...)
+		has, err := db.Has(key)
+		require.NoError(t, err)
+		require.True(t, has, "entry at position %d should survive", i)
+	}
+}
+
+// TestDeleteTrailingEntries_SparseEntriesBelowCount verifies that entries
+// below msgCount survive even when there are gaps (not every position has
+// an entry). Also verifies entries at exactly msgCount are deleted.
+func TestDeleteTrailingEntries_SparseEntriesBelowCount(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+
+	// Write sparse entries at positions 0, 3, 4, 7, 9 under MessagePrefix.
+	// With msgCount=5, positions 0, 3, 4 should survive; 7, 9 should be deleted.
+	// Also write an entry at exactly position 5 (== msgCount) — should be deleted.
+	for _, pos := range []uint64{0, 3, 4, 5, 7, 9} {
+		key := append(append([]byte{}, schema.MessagePrefix...), uint64ToKey(pos)...)
+		require.NoError(t, db.Put(key, []byte("data")))
+	}
+
+	require.NoError(t, deleteTrailingEntries(db, 5))
+
+	// Positions below msgCount must survive.
+	for _, pos := range []uint64{0, 3, 4} {
+		key := append(append([]byte{}, schema.MessagePrefix...), uint64ToKey(pos)...)
+		has, err := db.Has(key)
+		require.NoError(t, err)
+		require.True(t, has, "entry at position %d should survive (below msgCount)", pos)
+	}
+
+	// Positions at or above msgCount must be gone.
+	for _, pos := range []uint64{5, 7, 9} {
+		key := append(append([]byte{}, schema.MessagePrefix...), uint64ToKey(pos)...)
+		has, err := db.Has(key)
+		require.NoError(t, err)
+		require.False(t, has, "entry at position %d should be deleted (>= msgCount)", pos)
+	}
+}
+
+// TestDeleteTrailingEntries_ZeroCount treats all entries as trailing.
+func TestDeleteTrailingEntries_ZeroCount(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+
+	for i := uint64(0); i < 3; i++ {
+		key := append(append([]byte{}, schema.MessagePrefix...), uint64ToKey(i)...)
+		require.NoError(t, db.Put(key, []byte("orphan")))
+	}
+
+	require.NoError(t, deleteTrailingEntries(db, 0))
+
+	for i := uint64(0); i < 3; i++ {
+		key := append(append([]byte{}, schema.MessagePrefix...), uint64ToKey(i)...)
+		has, err := db.Has(key)
+		require.NoError(t, err)
+		require.False(t, has, "entry at position %d should be deleted when count is 0", i)
+	}
+}

--- a/arbutil/block_message_relation.go
+++ b/arbutil/block_message_relation.go
@@ -18,3 +18,67 @@ func BlockNumberToMessageIndex(blockNum, genesis uint64) (MessageIndex, error) {
 func MessageIndexToBlockNumber(msgIdx MessageIndex, genesis uint64) uint64 {
 	return uint64(msgIdx) + genesis
 }
+
+// BatchCountGetter provides the two methods needed by FindInboxBatchContainingMessage.
+// Both InboxTracker and MessageExtractor satisfy this interface.
+// Implementations must return monotonically non-decreasing MessageIndex values
+// for increasing seqNum arguments to ensure correct binary search behavior.
+type BatchCountGetter interface {
+	GetBatchCount() (uint64, error)
+	GetBatchMessageCount(seqNum uint64) (MessageIndex, error)
+}
+
+// FindInboxBatchContainingMessage performs a binary search over batch metadata
+// to find the batch that contains the given message position. Returns
+// (batchNum, true, nil) on success, (0, false, nil) if not yet posted in any
+// batch, or (0, false, err) on unexpected errors.
+func FindInboxBatchContainingMessage(reader BatchCountGetter, pos MessageIndex) (uint64, bool, error) {
+	batchCount, err := reader.GetBatchCount()
+	if err != nil {
+		return 0, false, err
+	}
+	if batchCount == 0 {
+		return 0, false, nil
+	}
+	low := uint64(0)
+	high := batchCount - 1
+	lastBatchMessageCount, err := reader.GetBatchMessageCount(high)
+	if err != nil {
+		return 0, false, err
+	}
+	if lastBatchMessageCount <= pos {
+		return 0, false, nil
+	}
+	// Iteration preconditions:
+	// - high >= low
+	// - msgCount(low - 1) <= pos implies low <= target
+	// - msgCount(high) > pos implies high >= target
+	// Therefore, if low == high, then low == high == target
+	const maxIter = 64
+	for range maxIter {
+		// Due to integer rounding, mid >= low && mid < high
+		mid := (low + high) / 2
+		count, err := reader.GetBatchMessageCount(mid)
+		if err != nil {
+			return 0, false, err
+		}
+		if count < pos {
+			// Must narrow as mid >= low, therefore mid + 1 > low, therefore newLow > oldLow
+			// Keeps low precondition as msgCount(mid) < pos
+			low = mid + 1
+		} else if count == pos {
+			return mid + 1, true, nil
+		} else if count == pos+1 || mid == low { // implied: count > pos
+			return mid, true, nil
+		} else {
+			// implied: count > pos + 1
+			// Must narrow as mid < high, therefore newHigh < oldHigh
+			// Keeps high precondition as msgCount(mid) > pos
+			high = mid
+		}
+		if high == low {
+			return high, true, nil
+		}
+	}
+	return 0, false, fmt.Errorf("FindInboxBatchContainingMessage: exceeded %d iterations searching for message %d in %d batches; possible inconsistent batch metadata", maxIter, pos, batchCount)
+}

--- a/mel-replay/db.go
+++ b/mel-replay/db.go
@@ -51,15 +51,15 @@ func (p DB) Stat() (string, error) {
 }
 
 func (p DB) NewBatch() ethdb.Batch {
-	panic("unimplemented")
+	panic("mel-replay DB: NewBatch not supported in validation mode")
 }
 
 func (p DB) NewBatchWithSize(size int) ethdb.Batch {
-	panic("unimplemented")
+	panic("mel-replay DB: NewBatchWithSize not supported in validation mode")
 }
 
 func (p DB) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
-	panic("unimplemented")
+	panic("mel-replay DB: NewIterator not supported in validation mode")
 }
 
 func (p DB) SyncAncient() error {
@@ -107,7 +107,7 @@ func (d *DB) AncientSize(kind string) (uint64, error) {
 }
 
 func (d *DB) ReadAncients(fn func(ethdb.AncientReaderOp) error) (err error) {
-	panic("unimplemented")
+	return errors.New("mel-replay DB: ReadAncients not supported in validation mode")
 }
 
 func (d *DB) ModifyAncients(f func(ethdb.AncientWriteOp) error) (int64, error) {
@@ -135,5 +135,5 @@ func (d *DB) AncientDatadir() (string, error) {
 }
 
 func (d *DB) WasmDataBase() ethdb.KeyValueStore {
-	panic("unimplemented")
+	panic("mel-replay DB: WasmDataBase not supported in validation mode")
 }

--- a/mel-replay/delayed_message_db.go
+++ b/mel-replay/delayed_message_db.go
@@ -4,10 +4,10 @@ package melreplay
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/offchainlabs/nitro/arbnode/mel"
@@ -33,7 +33,10 @@ func (d *DelayedMessageDatabase) ReadDelayedMessage(
 		return nil, fmt.Errorf("index %d out of range, total delayed messages seen: %d", msgIndex, state.DelayedMessagesSeen)
 	}
 	// Pour inbox to outbox if outbox is empty
-	if state.DelayedMessageOutboxAcc == (common.Hash{}) && state.DelayedMessageInboxAcc != (common.Hash{}) {
+	if state.DelayedMessageOutboxAcc == (common.Hash{}) {
+		if state.DelayedMessageInboxAcc == (common.Hash{}) {
+			return nil, fmt.Errorf("both inbox and outbox are empty at index %d, cannot read delayed message", msgIndex)
+		}
 		if err := d.pourInboxToOutbox(state); err != nil {
 			return nil, fmt.Errorf("error pouring delayed inbox to outbox: %w", err)
 		}
@@ -61,7 +64,12 @@ func (d *DelayedMessageDatabase) ReadDelayedMessage(
 }
 
 // pourInboxToOutbox pours all items from the inbox into the outbox using preimage resolution.
+// This is the replay-mode counterpart of State.PourDelayedInboxToOutbox (state.go);
+// both must produce identical accumulator state transitions for fraud proof correctness.
 func (d *DelayedMessageDatabase) pourInboxToOutbox(state *mel.State) error {
+	if state.DelayedMessageOutboxAcc != (common.Hash{}) {
+		return errors.New("pourInboxToOutbox: outbox must be empty before pouring")
+	}
 	inboxSize := state.DelayedMessagesSeen - state.DelayedMessagesRead
 	if inboxSize == 0 {
 		return nil
@@ -78,8 +86,11 @@ func (d *DelayedMessageDatabase) pourInboxToOutbox(state *mel.State) error {
 		if err != nil {
 			return fmt.Errorf("inbox preimage at position %d: %w", i, err)
 		}
-		preimage := append(state.DelayedMessageOutboxAcc.Bytes(), msgHash.Bytes()...)
-		state.DelayedMessageOutboxAcc = crypto.Keccak256Hash(preimage)
+		// Outbox accumulator preimages were already recorded by native-mode
+		// PourDelayedInboxToOutbox during the recording step and are available
+		// via the preimageResolver. We only recompute the hash here to advance
+		// the accumulator.
+		state.DelayedMessageOutboxAcc = mel.HashChainLinkHash(state.DelayedMessageOutboxAcc, msgHash)
 		curr = prevAcc
 	}
 	state.DelayedMessageInboxAcc = common.Hash{}

--- a/mel-replay/delayed_message_db_test.go
+++ b/mel-replay/delayed_message_db_test.go
@@ -63,7 +63,6 @@ func TestDelayedMessageRecordingAndReplayRoundTrip(t *testing.T) {
 
 			for _, msg := range msgs {
 				require.NoError(t, nativeState.AccumulateDelayedMessage(msg))
-				nativeState.DelayedMessagesSeen++
 			}
 
 			// Snapshot state before pour — replay will start from here.
@@ -127,7 +126,6 @@ func TestDelayedMessageReplayWithMixedInboxOutbox(t *testing.T) {
 	// Accumulate batch1
 	for _, msg := range batch1 {
 		require.NoError(t, nativeState.AccumulateDelayedMessage(msg))
-		nativeState.DelayedMessagesSeen++
 	}
 
 	// Pour batch1 and read first message (partial pop)
@@ -139,7 +137,6 @@ func TestDelayedMessageReplayWithMixedInboxOutbox(t *testing.T) {
 	// Accumulate batch2 (now inbox has new messages, outbox has remaining from batch1)
 	for _, msg := range batch2 {
 		require.NoError(t, nativeState.AccumulateDelayedMessage(msg))
-		nativeState.DelayedMessagesSeen++
 	}
 
 	// Snapshot for replay — mixed state: outbox has 2 from batch1, inbox has 2 from batch2

--- a/mel-replay/message_reader.go
+++ b/mel-replay/message_reader.go
@@ -47,28 +47,28 @@ func PeekFromAccumulator[T any](
 	}
 	var msgHash common.Hash
 	curr := outBox
-	lookbacksForLogging := lookbacks
+	totalLookbacks := lookbacks
 	for lookbacks > 0 {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
 		result, err := preimageResolver.ResolveTypedPreimage(arbutil.Keccak256PreimageType, curr)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve preimage at lookback position %d: %w", lookbacksForLogging, err)
+			return nil, fmt.Errorf("failed to resolve preimage at lookback %d/%d: %w", lookbacks, totalLookbacks, err)
 		}
 		curr, msgHash, err = mel.SplitPreimage(result)
 		if err != nil {
-			return nil, fmt.Errorf("accumulator preimage at lookback %d: %w", lookbacks, err)
+			return nil, fmt.Errorf("accumulator preimage at lookback %d/%d: %w", lookbacks, totalLookbacks, err)
 		}
 		lookbacks--
 	}
 	objectBytes, err := preimageResolver.ResolveTypedPreimage(arbutil.Keccak256PreimageType, msgHash)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve message content preimage at lookback position %d: %w", lookbacksForLogging, err)
+		return nil, fmt.Errorf("failed to resolve message content preimage (after %d lookbacks): %w", totalLookbacks, err)
 	}
 	object := new(T)
 	if err = rlp.Decode(bytes.NewBuffer(objectBytes), &object); err != nil {
-		return nil, fmt.Errorf("failed to decode accumulator object at lookback position %d: %w", lookbacksForLogging, err)
+		return nil, fmt.Errorf("failed to decode accumulator object (after %d lookbacks): %w", totalLookbacks, err)
 	}
 	return object, nil
 }

--- a/mel-replay/message_reader_test.go
+++ b/mel-replay/message_reader_test.go
@@ -42,7 +42,6 @@ func TestRecordingMessagePreimagesAndReadingMessages(t *testing.T) {
 	require.NoError(t, state.RecordMsgPreimagesTo(preimages))
 	for i := range numMsgs {
 		require.NoError(t, state.AccumulateMessage(messages[i]))
-		state.MsgCount++
 	}
 
 	// Test reading in wasm mode
@@ -167,7 +166,6 @@ func TestCrossValidateBuildAccumulatorAndAccumulateMessage(t *testing.T) {
 	require.NoError(t, state.RecordMsgPreimagesTo(prodPreimages))
 	for _, msg := range messages {
 		require.NoError(t, state.AccumulateMessage(msg))
-		state.MsgCount++
 	}
 	prodAcc := state.LocalMsgAccumulator
 

--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -397,8 +397,12 @@ func NewBlockValidator(
 	}
 	ret.streamer = streamer
 	ret.inboxTracker = inbox
-	streamer.SetBlockValidator(ret)
-	inbox.SetBlockValidator(ret)
+	if err := streamer.SetBlockValidator(ret); err != nil {
+		return nil, fmt.Errorf("setting block validator on streamer: %w", err)
+	}
+	if err := inbox.SetBlockValidator(ret); err != nil {
+		return nil, fmt.Errorf("setting block validator on inbox: %w", err)
+	}
 	if config().MemoryFreeLimit != "" {
 		limitchecker, err := resourcemanager.NewCgroupsMemoryLimitCheckerIfSupported(config().memoryFreeLimit)
 		if err != nil {

--- a/staker/stateless_block_validator.go
+++ b/staker/stateless_block_validator.go
@@ -50,7 +50,7 @@ type StatelessBlockValidator struct {
 }
 
 type BlockValidatorRegistrer interface {
-	SetBlockValidator(*BlockValidator)
+	SetBlockValidator(*BlockValidator) error
 }
 
 type InboxTrackerInterface interface {

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -145,7 +145,7 @@ func testBatchPosterParallel(t *testing.T, useRedis bool, useRedisLock bool) {
 	if err != nil {
 		t.Fatalf("Failed to get parent chain id: %v", err)
 	}
-	batchMetaFetcher := builder.L2.ConsensusNode.GetParentChainDataSource()
+	batchMetaFetcher := requireBatchDataSource(t, builder.L2.ConsensusNode)
 	for i := 0; i < parallelBatchPosters; i++ {
 		// Make a copy of the batch poster config so NewBatchPoster calling Validate() on it doesn't race
 		batchPosterConfig := builder.nodeConfig.BatchPoster
@@ -286,7 +286,7 @@ func TestRedisBatchPosterHandoff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get parent chain id: %v", err)
 	}
-	batchMetaFetcher := builder.L2.ConsensusNode.GetParentChainDataSource()
+	batchMetaFetcher := requireBatchDataSource(t, builder.L2.ConsensusNode)
 	newBatchPoster := func() *arbnode.BatchPoster {
 		// Make a copy of the batch poster config so NewBatchPoster calling Validate() on it doesn't race
 		batchPosterConfig := builder.nodeConfig.BatchPoster
@@ -434,9 +434,12 @@ func TestBatchPosterKeepsUp(t *testing.T) {
 	start := time.Now()
 	for {
 		time.Sleep(time.Second)
-		batches, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchCount()
+		batches, err := getBatchCount(t, builder.L2.ConsensusNode)
 		Require(t, err)
-		postedMessages, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchMessageCount(batches - 1)
+		if batches == 0 {
+			continue
+		}
+		postedMessages, err := getBatchMessageCount(t, builder.L2.ConsensusNode, batches-1)
 		Require(t, err)
 		haveMessages, err := builder.L2.ConsensusNode.TxStreamer.GetMessageCount()
 		Require(t, err)
@@ -822,30 +825,33 @@ func TestBatchPosterL1SurplusMatchesBatchGasFlaky(t *testing.T) {
 	l2Block, err := builder.L2.Client.BlockByHash(ctx, receipt.BlockHash)
 	Require(t, err)
 
-	// wait for this tx to be posted in a batch, and check which batch
-	var batchNum uint64
-	for {
-		var found bool
-		batchNum, found, err = builder.L2.ConsensusNode.GetParentChainDataSource().FindInboxBatchContainingMessage(arbutil.MessageIndex(l2Block.NumberU64()))
-		if err == nil && found {
-			break
-		}
-		t.Logf("waiting for tx to be posted in a batch")
-		<-time.After(time.Millisecond * 10)
-	}
+	// Wait for this tx to be posted in a batch, and record which batch.
+	batchNum := waitForFindInboxBatch(t, builder.L2.ConsensusNode, arbutil.MessageIndex(l2Block.NumberU64()), 30*time.Second, 10*time.Millisecond)
 
 	// find the transaction that posted this batch to parent chain
 	seqInboxContract, err := bridgegen.NewSequencerInbox(builder.L1Info.GetAddress("SequencerInbox"), builder.L1.Client)
 	Require(t, err)
 	var batchTxHash common.Hash
-	for {
+	var lastFilterErr error
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
 		it, err := seqInboxContract.FilterSequencerBatchDelivered(nil, []*big.Int{new(big.Int).SetUint64(batchNum)}, nil, nil)
-		if err == nil && it.Next() {
+		if err != nil {
+			lastFilterErr = err
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if it.Next() {
 			batchTxHash = it.Event.Raw.TxHash
+		}
+		it.Close()
+		if batchTxHash != (common.Hash{}) {
 			break
 		}
-		t.Logf("waiting to find sequencer batch message")
-		<-time.After(time.Millisecond * 10)
+		time.Sleep(10 * time.Millisecond)
+	}
+	if batchTxHash == (common.Hash{}) {
+		t.Fatalf("sequencer batch delivery event not found for batch %d (last filter error: %v)", batchNum, lastFilterErr)
 	}
 
 	// get receipt of batch tx to know gas used
@@ -931,29 +937,29 @@ func TestBatchPosterActuallyPostsBlobsToL1(t *testing.T) {
 	Require(t, err)
 	require.NotZero(t, len(batches), "no batches found between L1 blocks %d and %d", l1HeightBeforeBatch, l1HeightAfterBatch)
 
-	// Make sure mel has read the batch that the node has posted
+	// Make sure the node has read the batch that was posted
 	batchCount, err := seqInbox.GetBatchCount(ctx, new(big.Int).SetUint64(l1HeightAfterBatch))
 	Require(t, err)
-	var melBatchCount uint64
+	var nodeBatchCount uint64
 	for range 10 {
-		melBatchCount, err = builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchCount()
+		nodeBatchCount, err = getBatchCount(t, builder.L2.ConsensusNode)
 		Require(t, err)
-		if melBatchCount == batchCount {
+		if nodeBatchCount == batchCount {
 			break
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
-	if melBatchCount != batchCount {
-		t.Fatalf("batch count from sequencer inbox: %d doesn't match with MEL: %d", batchCount, melBatchCount)
+	if nodeBatchCount != batchCount {
+		t.Fatalf("batch count from sequencer inbox: %d doesn't match with node: %d", batchCount, nodeBatchCount)
 	}
 
 	for _, batch := range batches {
 		sequenceNum := batch.SequenceNumber
-		// Wait for the inbox reader to catch up with this batch
+		// Wait for the node to have this batch's sequencer message bytes
 		var sequencerMessageBytes []byte
 		retryUntilFound(t, ctx, 30, 100*time.Millisecond, fmt.Sprintf("GetSequencerMessageBytes(seq %d)", sequenceNum), "not found in L1 block", func() error {
 			var getErr error
-			sequencerMessageBytes, _, getErr = builder.L2.ConsensusNode.GetParentChainDataSource().GetSequencerMessageBytes(ctx, sequenceNum)
+			sequencerMessageBytes, _, getErr = getSequencerMessageBytes(ctx, builder.L2.ConsensusNode, sequenceNum)
 			return getErr
 		})
 

--- a/system_tests/batch_size_limit_test.go
+++ b/system_tests/batch_size_limit_test.go
@@ -148,8 +148,14 @@ func checkReceiverAccountBalance(t *testing.T, ctx context.Context, builder *Nod
 
 // ensureBatchWasProcessed waits until a particular batch has been processed by the L2 node.
 func ensureBatchWasProcessed(t *testing.T, builder *NodeBuilder, batchNum uint64) {
-	require.Eventuallyf(t, func() bool {
-		_, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchMetadata(batchNum)
-		return err == nil
-	}, 5*time.Second, time.Second, "Batch %d was not processed in time", batchNum)
+	t.Helper()
+	var lastErr error
+	for range 5 {
+		_, lastErr = getBatchMetadata(t, builder.L2.ConsensusNode, batchNum)
+		if lastErr == nil {
+			return
+		}
+		time.Sleep(time.Second)
+	}
+	t.Fatalf("Batch %d was not processed in time, last err: %v", batchNum, lastErr)
 }

--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -132,7 +132,7 @@ func testChallengeProtocolBOLD(t *gotesting.T, useExternalSigner bool, useRedis 
 	ctx, cancelCtx = context.WithCancel(ctx)
 	defer cancelCtx()
 
-	go keepChainMoving(t, 3*time.Second, ctx, l1info, l1client)
+	go keepChainMoving(t, ctx, 3*time.Second, l1info, l1client)
 
 	l2nodeConfig := arbnode.ConfigDefaultL1Test()
 	l2StackB, _, l2nodeB, l2execNodeB, _ := create2ndNodeWithConfigForBoldProtocol(
@@ -174,7 +174,8 @@ func testChallengeProtocolBOLD(t *gotesting.T, useExternalSigner bool, useRedis 
 	blockValidatorConfig.RedisValidationClientConfig.RedisURL = redisURL
 	locator, err := server_common.NewMachineLocator("")
 	Require(t, err)
-	pcdsA := l2nodeA.GetParentChainDataSource()
+	pcdsA, err := l2nodeA.GetParentChainDataSource()
+	Require(t, err)
 	statelessA, err := staker.NewStatelessBlockValidator(
 		pcdsA,
 		pcdsA,
@@ -193,7 +194,8 @@ func testChallengeProtocolBOLD(t *gotesting.T, useExternalSigner bool, useRedis 
 	valCfg.UseJit = false
 	_, valStackB := createTestValidationNode(t, ctx, &valCfg, spawnerOpts...)
 
-	pcdsB := l2nodeB.GetParentChainDataSource()
+	pcdsB, err := l2nodeB.GetParentChainDataSource()
+	Require(t, err)
 	statelessB, err := staker.NewStatelessBlockValidator(
 		pcdsB,
 		pcdsB,
@@ -352,13 +354,13 @@ func testChallengeProtocolBOLD(t *gotesting.T, useExternalSigner bool, useRedis 
 	makeBoldBatch(t, l2nodeB, l2info, l1client, &sequencerTxOpts, evilSeqInboxBinding, evilSeqInbox, numMessagesPerBatch, divergeAt)
 	totalMessagesPosted += numMessagesPerBatch
 
-	bcA, err := l2nodeA.GetParentChainDataSource().GetBatchCount()
+	bcA, err := getBatchCount(t, l2nodeA)
 	Require(t, err)
-	bcB, err := l2nodeB.GetParentChainDataSource().GetBatchCount()
+	bcB, err := getBatchCount(t, l2nodeB)
 	Require(t, err)
-	msgA, err := l2nodeA.GetParentChainDataSource().GetBatchMessageCount(bcA - 1)
+	msgA, err := getBatchMessageCount(t, l2nodeA, bcA-1)
 	Require(t, err)
-	msgB, err := l2nodeB.GetParentChainDataSource().GetBatchMessageCount(bcB - 1)
+	msgB, err := getBatchMessageCount(t, l2nodeB, bcB-1)
 	Require(t, err)
 
 	t.Logf("Node A batch count %d, msgs %d", bcA, msgA)
@@ -713,7 +715,7 @@ func syncBatchToNode(
 	Require(t, err)
 
 	// Optional: log batch metadata
-	batchMetaData, err := l2Node.GetParentChainDataSource().GetBatchMetadata(batches[0].SequenceNumber)
+	batchMetaData, err := getBatchMetadata(t, l2Node, batches[0].SequenceNumber)
 	log.Info("Batch metadata", "md", batchMetaData)
 	Require(t, err, "failed to get batch metadata after adding batch:")
 }

--- a/system_tests/bold_customda_challenge_test.go
+++ b/system_tests/bold_customda_challenge_test.go
@@ -333,7 +333,7 @@ func testChallengeProtocolBOLDCustomDA(t *testing.T, evilStrategy EvilStrategy, 
 	ctx, cancelCtx = context.WithCancel(ctx)
 	defer cancelCtx()
 
-	go keepChainMoving(t, 3*time.Second, ctx, l1info, l1client)
+	go keepChainMoving(t, ctx, 3*time.Second, l1info, l1client)
 
 	// Configure external DA for node B
 	l2nodeConfig := arbnode.ConfigDefaultL1Test()
@@ -398,7 +398,8 @@ func testChallengeProtocolBOLDCustomDA(t *testing.T, evilStrategy EvilStrategy, 
 	err = dapReadersB.SetupDACertificateReader(daClientB, daClientB)
 	Require(t, err)
 
-	pcdsA := l2nodeA.GetParentChainDataSource()
+	pcdsA, err := l2nodeA.GetParentChainDataSource()
+	Require(t, err)
 	statelessA, err := staker.NewStatelessBlockValidator(
 		pcdsA,
 		pcdsA,
@@ -415,7 +416,8 @@ func testChallengeProtocolBOLDCustomDA(t *testing.T, evilStrategy EvilStrategy, 
 	Require(t, err)
 	_, valStackB := createTestValidationNode(t, ctx, &valCfg, spawnerOpts...)
 
-	pcdsB := l2nodeB.GetParentChainDataSource()
+	pcdsB, err := l2nodeB.GetParentChainDataSource()
+	Require(t, err)
 	statelessB, err := staker.NewStatelessBlockValidator(
 		pcdsB,
 		pcdsB,
@@ -586,14 +588,14 @@ func testChallengeProtocolBOLDCustomDA(t *testing.T, evilStrategy EvilStrategy, 
 	time.Sleep(100 * time.Millisecond)
 
 	// Get and log batch 0 from both nodes
-	msgA0, _, err := l2nodeA.GetParentChainDataSource().GetSequencerMessageBytes(ctx, 0)
+	msgA0, _, err := getSequencerMessageBytes(ctx, l2nodeA, 0)
 	if err != nil {
 		t.Logf("Error getting batch 0 from node A: %v", err)
 	} else {
 		PrintSequencerInboxMessage(t, "Node A - Batch 0", msgA0)
 	}
 
-	msgB0, _, err := l2nodeB.GetParentChainDataSource().GetSequencerMessageBytes(ctx, 0)
+	msgB0, _, err := getSequencerMessageBytes(ctx, l2nodeB, 0)
 	if err != nil {
 		t.Logf("Error getting batch 0 from node B: %v", err)
 	}
@@ -680,14 +682,14 @@ func testChallengeProtocolBOLDCustomDA(t *testing.T, evilStrategy EvilStrategy, 
 	time.Sleep(100 * time.Millisecond)
 
 	// Get and log batch 1 from both nodes
-	msgA1, _, err := l2nodeA.GetParentChainDataSource().GetSequencerMessageBytes(ctx, 1)
+	msgA1, _, err := getSequencerMessageBytes(ctx, l2nodeA, 1)
 	if err != nil {
 		t.Logf("Error getting batch 1 from node A: %v", err)
 	} else {
 		PrintSequencerInboxMessage(t, "Node A - Batch 1", msgA1)
 	}
 
-	msgB1, _, err := l2nodeB.GetParentChainDataSource().GetSequencerMessageBytes(ctx, 1)
+	msgB1, _, err := getSequencerMessageBytes(ctx, l2nodeB, 1)
 	if err != nil {
 		t.Logf("Error getting batch 1 from node B: %v", err)
 	}
@@ -704,7 +706,7 @@ func testChallengeProtocolBOLDCustomDA(t *testing.T, evilStrategy EvilStrategy, 
 	// Log third batch messages (batch 2 - second CustomDA batch with divergence)
 	t.Logf("\n======== BATCH 2 (second CustomDA batch - WITH DIVERGENCE) ========")
 	// Get and log batch 2 from both nodes
-	msgA2, _, err := l2nodeA.GetParentChainDataSource().GetSequencerMessageBytes(ctx, 2)
+	msgA2, _, err := getSequencerMessageBytes(ctx, l2nodeA, 2)
 	if err != nil {
 		t.Logf("Error getting batch 2 from node A: %v", err)
 	} else {
@@ -716,7 +718,7 @@ func testChallengeProtocolBOLDCustomDA(t *testing.T, evilStrategy EvilStrategy, 
 		}
 	}
 
-	msgB2, _, err := l2nodeB.GetParentChainDataSource().GetSequencerMessageBytes(ctx, 2)
+	msgB2, _, err := getSequencerMessageBytes(ctx, l2nodeB, 2)
 	if err != nil {
 		t.Logf("Error getting batch 2 from node B: %v", err)
 	} else {
@@ -739,18 +741,18 @@ func testChallengeProtocolBOLDCustomDA(t *testing.T, evilStrategy EvilStrategy, 
 		}
 	}
 
-	bcA, err := l2nodeA.GetParentChainDataSource().GetBatchCount()
+	bcA, err := getBatchCount(t, l2nodeA)
 	Require(t, err)
-	bcB, err := l2nodeB.GetParentChainDataSource().GetBatchCount()
+	bcB, err := getBatchCount(t, l2nodeB)
 	Require(t, err)
 
 	if bcA != bcB {
 		t.Fatalf("FATAL: Expected Node A batch count %d to be equal to Node B batch count %d", bcA, bcB)
 	}
 
-	msgA, err := l2nodeA.GetParentChainDataSource().GetBatchMessageCount(bcA - 1)
+	msgA, err := getBatchMessageCount(t, l2nodeA, bcA-1)
 	Require(t, err)
-	msgB, err := l2nodeB.GetParentChainDataSource().GetBatchMessageCount(bcB - 1)
+	msgB, err := getBatchMessageCount(t, l2nodeB, bcB-1)
 	Require(t, err)
 
 	t.Logf("Node A batch count %d, msgs %d", bcA, msgA)

--- a/system_tests/bold_l3_support_test.go
+++ b/system_tests/bold_l3_support_test.go
@@ -74,8 +74,8 @@ func TestL3ChallengeProtocolBOLD(t *testing.T) {
 	secondNodeTestClient, cleanupL3SecondNode := builder.Build2ndNodeOnL3(t, &SecondNodeParams{nodeConfig: secondNodeNodeConfig})
 	defer cleanupL3SecondNode()
 
-	go keepChainMoving(t, 3*time.Second, ctx, builder.L1Info, builder.L1.Client) // Advance L1.
-	go keepChainMoving(t, 3*time.Second, ctx, builder.L2Info, builder.L2.Client) // Advance L2.
+	go keepChainMoving(t, ctx, 3*time.Second, builder.L1Info, builder.L1.Client) // Advance L1.
+	go keepChainMoving(t, ctx, 3*time.Second, builder.L2Info, builder.L2.Client) // Advance L2.
 
 	builder.L2Info.GenerateAccount("HonestAsserter")
 	fundL3Staker(t, ctx, builder, builder.L2.Client, "HonestAsserter")
@@ -200,8 +200,9 @@ func startL3BoldChallengeManager(t *testing.T, ctx context.Context, builder *Nod
 	}
 
 	var stateManager BoldStateProviderInterface
-	var err error
 	cacheDir := t.TempDir()
+	pcds, err := node.ConsensusNode.GetParentChainDataSource()
+	Require(t, err)
 	stateManager, err = bold.NewBOLDStateProvider(
 		node.ConsensusNode.BlockValidator,
 		node.ConsensusNode.StatelessBlockValidator,
@@ -212,9 +213,9 @@ func startL3BoldChallengeManager(t *testing.T, ctx context.Context, builder *Nod
 			CheckBatchFinality:     false,
 		},
 		cacheDir,
-		node.ConsensusNode.GetParentChainDataSource(),
+		pcds,
 		node.ConsensusNode.TxStreamer,
-		node.ConsensusNode.GetParentChainDataSource(),
+		pcds,
 		nil,
 	)
 	Require(t, err)

--- a/system_tests/bold_new_challenge_test.go
+++ b/system_tests/bold_new_challenge_test.go
@@ -151,7 +151,7 @@ func testChallengeProtocolBOLDVirtualBlocks(t *testing.T, wrongAtFirstVirtual bo
 	})
 	defer cleanupEvilNode()
 
-	go keepChainMoving(t, 3*time.Second, ctx, builder.L1Info, builder.L1.Client)
+	go keepChainMoving(t, ctx, 3*time.Second, builder.L1Info, builder.L1.Client)
 
 	builder.L1Info.GenerateAccount("HonestAsserter")
 	fundBoldStaker(t, ctx, builder, "HonestAsserter")
@@ -281,8 +281,9 @@ func startBoldChallengeManager(t *testing.T, ctx context.Context, builder *NodeB
 	}
 
 	var stateManager BoldStateProviderInterface
-	var err error
 	cacheDir := t.TempDir()
+	pcds, err := node.ConsensusNode.GetParentChainDataSource()
+	Require(t, err)
 	stateManager, err = bold.NewBOLDStateProvider(
 		node.ConsensusNode.BlockValidator,
 		node.ConsensusNode.StatelessBlockValidator,
@@ -293,9 +294,9 @@ func startBoldChallengeManager(t *testing.T, ctx context.Context, builder *NodeB
 			CheckBatchFinality:     false,
 		},
 		cacheDir,
-		node.ConsensusNode.GetParentChainDataSource(),
+		pcds,
 		node.ConsensusNode.TxStreamer,
-		node.ConsensusNode.GetParentChainDataSource(),
+		pcds,
 		nil,
 	)
 	Require(t, err)

--- a/system_tests/bold_state_provider_test.go
+++ b/system_tests/bold_state_provider_test.go
@@ -82,7 +82,7 @@ func TestChallengeProtocolBOLD_Bisections(t *testing.T) {
 	totalBatchesBig, err := bridgeBinding.SequencerMessageCount(&bind.CallOpts{Context: ctx})
 	Require(t, err)
 	totalBatches := totalBatchesBig.Uint64()
-	totalMessageCount, err := l2node.GetParentChainDataSource().GetBatchMessageCount(totalBatches - 1)
+	totalMessageCount, err := getBatchMessageCount(t, l2node, totalBatches-1)
 	Require(t, err)
 	log.Info("Status", "totalBatches", totalBatches, "totalMessageCount", totalMessageCount)
 	t.Logf("totalBatches: %v, totalMessageCount: %v\n", totalBatches, totalMessageCount)
@@ -100,7 +100,7 @@ func TestChallengeProtocolBOLD_Bisections(t *testing.T) {
 		if lastInfo.GlobalState.Batch >= totalBatches {
 			return true
 		}
-		batchMsgCount, err := l2node.GetParentChainDataSource().GetBatchMessageCount(lastInfo.GlobalState.Batch)
+		batchMsgCount, err := getBatchMessageCount(t, l2node, lastInfo.GlobalState.Batch)
 		if err != nil {
 			t.Logf("GetBatchMessageCount error (will retry): %v", err)
 			return false
@@ -199,7 +199,7 @@ func TestChallengeProtocolBOLD_StateProvider(t *testing.T) {
 	totalBatchesBig, err := bridgeBinding.SequencerMessageCount(&bind.CallOpts{Context: ctx})
 	Require(t, err)
 	totalBatches := totalBatchesBig.Uint64()
-	totalMessageCount, err := l2node.GetParentChainDataSource().GetBatchMessageCount(totalBatches - 1)
+	totalMessageCount, err := getBatchMessageCount(t, l2node, totalBatches-1)
 	Require(t, err)
 
 	// Wait until the validator has validated the batches.
@@ -382,7 +382,8 @@ func setupBoldStateProvider(t *testing.T, ctx context.Context, blockChallengeHei
 
 	locator, err := server_common.NewMachineLocator(valnode.TestValidationConfig.Wasm.RootPath)
 	Require(t, err)
-	pcds := l2node.GetParentChainDataSource()
+	pcds, err := l2node.GetParentChainDataSource()
+	Require(t, err)
 	stateless, err := staker.NewStatelessBlockValidator(
 		pcds,
 		pcds,

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/offchainlabs/nitro/arbnode"
+	"github.com/offchainlabs/nitro/arbnode/mel"
 	"github.com/offchainlabs/nitro/arbnode/parent"
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
@@ -2296,6 +2297,129 @@ func Fatal(t *testing.T, printables ...interface{}) {
 	testhelpers.FailImpl(t, printables...)
 }
 
+// Helpers that dispatch to MEL or InboxTracker via Node.BatchDataSource().
+// getDelayedMessage and getSequencerMessageBytes are exceptions because the
+// underlying methods have incompatible signatures across the two backends.
+
+func requireBatchDataSource(t testing.TB, node *arbnode.Node) arbnode.BatchDataReader {
+	t.Helper()
+	r, err := node.BatchDataSource()
+	if err != nil {
+		t.Fatalf("BatchDataSource: %v", err)
+	}
+	return r
+}
+
+func findInboxBatchContainingMessage(t testing.TB, node *arbnode.Node, msgIdx arbutil.MessageIndex) (uint64, bool, error) {
+	t.Helper()
+	return requireBatchDataSource(t, node).FindInboxBatchContainingMessage(msgIdx)
+}
+
+func getDelayedCount(t testing.TB, node *arbnode.Node) (uint64, error) {
+	t.Helper()
+	return requireBatchDataSource(t, node).GetDelayedCount()
+}
+
+func getBatchCount(t testing.TB, node *arbnode.Node) (uint64, error) {
+	t.Helper()
+	return requireBatchDataSource(t, node).GetBatchCount()
+}
+
+func getBatchMetadata(t testing.TB, node *arbnode.Node, seqNum uint64) (mel.BatchMetadata, error) {
+	t.Helper()
+	return requireBatchDataSource(t, node).GetBatchMetadata(seqNum)
+}
+
+func getBatchMessageCount(t testing.TB, node *arbnode.Node, seqNum uint64) (arbutil.MessageIndex, error) {
+	t.Helper()
+	return requireBatchDataSource(t, node).GetBatchMessageCount(seqNum)
+}
+
+func getBatchParentChainBlock(t testing.TB, node *arbnode.Node, seqNum uint64) (uint64, error) {
+	t.Helper()
+	return requireBatchDataSource(t, node).GetBatchParentChainBlock(seqNum)
+}
+
+// getDelayedMessage returns a delayed message by index. MEL and InboxTracker
+// have incompatible signatures (different parameters and return types), so
+// this helper cannot go through BatchDataSource.
+func getDelayedMessage(ctx context.Context, node *arbnode.Node, seqNum uint64) (*arbostypes.L1IncomingMessage, error) {
+	if node.MessageExtractor != nil {
+		delayed, err := node.MessageExtractor.GetDelayedMessage(seqNum)
+		if err != nil {
+			return nil, err
+		}
+		return delayed.Message, nil
+	}
+	if node.InboxTracker != nil {
+		return node.InboxTracker.GetDelayedMessage(ctx, seqNum)
+	}
+	return nil, arbnode.ErrNoBatchDataReader
+}
+
+// getSequencerMessageBytes dispatches to MEL or InboxReader. Unlike the
+// BatchDataReader methods, GetSequencerMessageBytes lives on InboxReader
+// (not InboxTracker), so this helper cannot use BatchDataSource.
+func getSequencerMessageBytes(ctx context.Context, node *arbnode.Node, seqNum uint64) ([]byte, common.Hash, error) {
+	if node.MessageExtractor != nil {
+		return node.MessageExtractor.GetSequencerMessageBytes(ctx, seqNum)
+	}
+	if node.InboxReader != nil {
+		return node.InboxReader.GetSequencerMessageBytes(ctx, seqNum)
+	}
+	return nil, common.Hash{}, fmt.Errorf("GetSequencerMessageBytes: %w", arbnode.ErrNoBatchDataReader)
+}
+
+// waitForBatchContainingMessage polls until the latest batch's message count
+// is at least msgPos. Zero batches is treated as not-yet-ready; errors from
+// batch queries are immediately fatal. Calls t.Fatalf on timeout.
+func waitForBatchContainingMessage(t *testing.T, node *arbnode.Node, msgPos arbutil.MessageIndex, timeout, interval time.Duration) {
+	t.Helper()
+	var lastBatchCount uint64
+	var lastMsgCount arbutil.MessageIndex
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		batches, err := getBatchCount(t, node)
+		if err != nil {
+			t.Fatalf("getBatchCount: %v", err)
+		}
+		lastBatchCount = batches
+		if batches > 0 {
+			haveMessages, err := getBatchMessageCount(t, node, batches-1)
+			if err != nil {
+				t.Fatalf("getBatchMessageCount(%d): %v", batches-1, err)
+			}
+			lastMsgCount = haveMessages
+			if haveMessages >= msgPos {
+				return
+			}
+		}
+		time.Sleep(interval)
+	}
+	t.Fatalf("timed out after %v waiting for inbox position %d (last state: %d batches, %d messages)", timeout, msgPos, lastBatchCount, lastMsgCount)
+}
+
+// waitForFindInboxBatch polls FindInboxBatchContainingMessage until the batch
+// containing msgIdx is found, returning the batch number. The normal "not yet
+// available" case is found=false, so any error is treated as immediately fatal.
+// Calls t.Fatalf on timeout.
+func waitForFindInboxBatch(t *testing.T, node *arbnode.Node, msgIdx arbutil.MessageIndex, timeout, interval time.Duration) uint64 {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		batchNum, found, err := findInboxBatchContainingMessage(t, node, msgIdx)
+		if err != nil {
+			t.Fatalf("findInboxBatchContainingMessage(%d): %v", msgIdx, err)
+		}
+		if found {
+			return batchNum
+		}
+		time.Sleep(interval)
+	}
+	t.Fatalf("timed out after %v waiting for batch containing message %d", timeout, msgIdx)
+	return 0 // unreachable
+}
+
 func CheckEqual[T any](t *testing.T, want T, got T, printables ...interface{}) {
 	t.Helper()
 	if !reflect.DeepEqual(want, got) {
@@ -2823,16 +2947,7 @@ func recordBlock(t *testing.T, block uint64, builder *NodeBuilder, targets ...ra
 	}
 	ctx := builder.ctx
 	inboxPos := arbutil.MessageIndex(block)
-	for {
-		time.Sleep(250 * time.Millisecond)
-		batches, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchCount()
-		Require(t, err)
-		haveMessages, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchMessageCount(batches - 1)
-		Require(t, err)
-		if haveMessages >= inboxPos {
-			break
-		}
-	}
+	waitForBatchContainingMessage(t, builder.L2.ConsensusNode, inboxPos, 60*time.Second, 250*time.Millisecond)
 	var options []inputs.WriterOption
 	options = append(options, inputs.WithTimestampDirEnabled(*testflag.RecordBlockInputsWithTimestampDirEnabled))
 	options = append(options, inputs.WithBlockIdInFileNameEnabled(*testflag.RecordBlockInputsWithBlockIdInFileNameEnabled))
@@ -2912,16 +3027,14 @@ func getFreePort(t testing.TB) int {
 	return tcpAddr.Port
 }
 
-func keepChainMoving(t *testing.T, delay time.Duration, ctx context.Context, l1Info *BlockchainTestInfo, client *ethclient.Client) {
+func keepChainMoving(t *testing.T, ctx context.Context, delay time.Duration, l1Info *BlockchainTestInfo, client *ethclient.Client) {
+	ticker := time.NewTicker(delay)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		default:
-			time.Sleep(delay)
-			if ctx.Err() != nil {
-				return
-			}
+		case <-ticker.C:
 			to := l1Info.GetAddress("Faucet")
 			tx := l1Info.PrepareTxTo("Faucet", &to, l1Info.TransferGas, common.Big0, nil)
 			if err := client.SendTransaction(ctx, tx); err != nil {

--- a/system_tests/consensus_rpc_api_test.go
+++ b/system_tests/consensus_rpc_api_test.go
@@ -226,7 +226,7 @@ func TestFindBatch(t *testing.T) {
 		if expBatchNum != gotBatchNum {
 			Fatal(t, "wrong result from findBatchContainingBlock. blocknum ", blockNum, " expected ", expBatchNum, " got ", gotBatchNum)
 		}
-		batchL1Block, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchParentChainBlock(gotBatchNum)
+		batchL1Block, err := getBatchParentChainBlock(t, builder.L2.ConsensusNode, gotBatchNum)
 		Require(t, err)
 		blockHeader, err := builder.L2.Client.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNum))
 		Require(t, err)

--- a/system_tests/fast_confirm_test.go
+++ b/system_tests/fast_confirm_test.go
@@ -267,7 +267,8 @@ func setupFastConfirmation(ctx context.Context, t *testing.T) (*NodeBuilder, *le
 
 	locator, err := server_common.NewMachineLocator(valnode.TestValidationConfig.Wasm.RootPath)
 	Require(t, err)
-	pcds := l2node.GetParentChainDataSource()
+	pcds, err := l2node.GetParentChainDataSource()
+	Require(t, err)
 	stateless, err := staker.NewStatelessBlockValidator(
 		pcds,
 		pcds,
@@ -464,7 +465,8 @@ func TestFastConfirmationWithSafe(t *testing.T) {
 
 	locator, err := server_common.NewMachineLocator(valnode.TestValidationConfig.Wasm.RootPath)
 	Require(t, err)
-	pcdsA := l2nodeA.GetParentChainDataSource()
+	pcdsA, err := l2nodeA.GetParentChainDataSource()
+	Require(t, err)
 	statelessA, err := staker.NewStatelessBlockValidator(
 		pcdsA,
 		pcdsA,
@@ -522,7 +524,8 @@ func TestFastConfirmationWithSafe(t *testing.T) {
 	valConfigB := legacystaker.TestL1ValidatorConfig
 	valConfigB.EnableFastConfirmation = true
 	valConfigB.Strategy = "watchtower"
-	pcdsB := l2nodeB.GetParentChainDataSource()
+	pcdsB, err := l2nodeB.GetParentChainDataSource()
+	Require(t, err)
 	statelessB, err := staker.NewStatelessBlockValidator(
 		pcdsB,
 		pcdsB,

--- a/system_tests/fees_test.go
+++ b/system_tests/fees_test.go
@@ -168,7 +168,7 @@ func testSequencerPriceAdjustsFrom(t *testing.T, initialEstimate uint64) {
 	Require(t, err)
 	lastEstimate, err := arbGasInfo.GetL1BaseFeeEstimate(&bind.CallOpts{Context: ctx})
 	Require(t, err)
-	lastBatchCount, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchCount()
+	lastBatchCount, err := getBatchCount(t, builder.L2.ConsensusNode)
 	Require(t, err)
 	l1Header, err := builder.L1.Client.HeaderByNumber(ctx, nil)
 	Require(t, err)
@@ -242,7 +242,7 @@ func testSequencerPriceAdjustsFrom(t *testing.T, initialEstimate uint64) {
 			// Wait for the batch poster to post a new batch. Under -race
 			// each poll cycle is significantly slower, so allow more retries.
 			for j := 50; j > 0; j-- {
-				newBatchCount, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchCount()
+				newBatchCount, err := getBatchCount(t, builder.L2.ConsensusNode)
 				Require(t, err)
 				if newBatchCount > lastBatchCount {
 					colors.PrintGrey("posted new batch ", newBatchCount)

--- a/system_tests/full_challenge_impl_test.go
+++ b/system_tests/full_challenge_impl_test.go
@@ -172,7 +172,7 @@ func makeBatch(t *testing.T, l2Node *arbnode.Node, l2Info *BlockchainTestInfo, b
 	}
 	err = l2Node.InboxTracker.AddSequencerBatches(ctx, backend, batches)
 	Require(t, err)
-	_, err = l2Node.GetParentChainDataSource().GetBatchMetadata(0)
+	_, err = getBatchMetadata(t, l2Node, 0)
 	Require(t, err, "failed to get batch metadata after adding batch:")
 }
 
@@ -381,7 +381,8 @@ func RunChallengeTest(t *testing.T, asserterIsCorrect bool, useStubs bool, chall
 
 	locator, err := server_common.NewMachineLocator(builder.valnodeConfig.Wasm.RootPath)
 	Require(t, err)
-	asserterPcds := asserterL2.GetParentChainDataSource()
+	asserterPcds, err := asserterL2.GetParentChainDataSource()
+	Require(t, err)
 	asserterValidator, err := staker.NewStatelessBlockValidator(asserterPcds, asserterPcds, asserterL2.TxStreamer, asserterExec, asserterL2.ConsensusDB, nil, StaticFetcherFrom(t, &conf.BlockValidator), valStack, locator.LatestWasmModuleRoot())
 	if err != nil {
 		Fatal(t, err)
@@ -399,7 +400,8 @@ func RunChallengeTest(t *testing.T, asserterIsCorrect bool, useStubs bool, chall
 	if err != nil {
 		Fatal(t, err)
 	}
-	challengerPcds := challengerL2.GetParentChainDataSource()
+	challengerPcds, err := challengerL2.GetParentChainDataSource()
+	Require(t, err)
 	challengerValidator, err := staker.NewStatelessBlockValidator(challengerPcds, challengerPcds, challengerL2.TxStreamer, challengerExec, challengerL2.ConsensusDB, nil, StaticFetcherFrom(t, &conf.BlockValidator), valStack, locator.LatestWasmModuleRoot())
 	if err != nil {
 		Fatal(t, err)

--- a/system_tests/inbox_blob_failure_test.go
+++ b/system_tests/inbox_blob_failure_test.go
@@ -86,25 +86,16 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	l2Block, err := builder.L2.Client.BlockByHash(ctx, txReceipt.BlockHash)
 	Require(t, err)
 
-	var batchNum uint64
-	for i := 0; i < 30; i++ {
-		var found bool
-		batchNum, found, err = builder.L2.ConsensusNode.GetParentChainDataSource().FindInboxBatchContainingMessage(arbutil.MessageIndex(l2Block.NumberU64()))
-		Require(t, err)
-		if found {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
+	waitForFindInboxBatch(t, builder.L2.ConsensusNode, arbutil.MessageIndex(l2Block.NumberU64()), 3*time.Second, 100*time.Millisecond)
 
 	// Advance L1 more for batch-posting-report finality
 	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 5)
 	time.Sleep(time.Second)
 
 	// Record sequencer state before starting follower
-	seqDelayed, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetDelayedCount()
+	seqDelayed, err := getDelayedCount(t, builder.L2.ConsensusNode)
 	Require(t, err)
-	seqBatch, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchCount()
+	seqBatch, err := getBatchCount(t, builder.L2.ConsensusNode)
 	Require(t, err)
 
 	// Build follower with failing blob reader
@@ -124,9 +115,9 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Check if follower is out of sync
-	follDelayed, err := testClientB.ConsensusNode.GetParentChainDataSource().GetDelayedCount()
+	follDelayed, err := getDelayedCount(t, testClientB.ConsensusNode)
 	Require(t, err)
-	follBatch, err := testClientB.ConsensusNode.GetParentChainDataSource().GetBatchCount()
+	follBatch, err := getBatchCount(t, testClientB.ConsensusNode)
 	Require(t, err)
 
 	if follDelayed == seqDelayed && follBatch < seqBatch {
@@ -140,23 +131,11 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	// Check for database corruption: delayed message should not be readable if its batch doesn't exist
 	// This detects the race condition where AddDelayedMessages succeeds but AddSequencerBatches fails
 	if follDelayed > 0 && follBatch < seqBatch {
-		// Investigate all delayed messages to understand the corruption
+		// Check all delayed messages for corruption
 		for i := uint64(0); i < follDelayed; i++ {
-			var msg *arbostypes.L1IncomingMessage
-			if testClientB.ConsensusNode.MessageExtractor != nil {
-				delayed, err := testClientB.ConsensusNode.MessageExtractor.GetDelayedMessage(i)
-				if err != nil {
-					t.Fatalf("Delayed message %d: Failed to read - %v", i, err)
-					continue
-				}
-				msg = delayed.Message
-			} else {
-				var err error
-				msg, err = testClientB.ConsensusNode.InboxTracker.GetDelayedMessage(ctx, i)
-				if err != nil {
-					t.Fatalf("Delayed message %d: Failed to read - %v", i, err)
-					continue
-				}
+			msg, err := getDelayedMessage(ctx, testClientB.ConsensusNode, i)
+			if err != nil {
+				t.Fatalf("Delayed message %d: Failed to read - %v", i, err)
 			}
 			t.Logf("Delayed message %d: Kind=%v, BlockNumber=%v", i, msg.Header.Kind, msg.Header.BlockNumber)
 
@@ -165,19 +144,17 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 				// Try to parse it to see which batch it references
 				_, _, _, batchNum, _, _, err := arbostypes.ParseBatchPostingReportMessageFields(bytes.NewReader(msg.L2msg))
 				if err != nil {
-					t.Logf("  Failed to parse batch-posting-report: %v", err)
-				} else {
-					t.Logf("  Batch-posting-report for batch %d", batchNum)
+					t.Fatalf("Delayed message %d: batch-posting-report with correct Kind but unparseable body: %v", i, err)
+				}
+				t.Logf("  Batch-posting-report for batch %d", batchNum)
 
-					// Check if this batch exists in our database
-					if _, err := testClientB.ConsensusNode.GetParentChainDataSource().GetBatchMetadata(batchNum); err != nil {
-						// TODO After we have fixed the issue, this can be changed back to log.Fatalf
-						t.Logf("CORRUPTION DETECTED: Delayed message %d is a batch-posting-report for batch %d, but batch %d doesn't exist in database! Error: %v", i, batchNum, batchNum, err)
-					}
+				// Check if this batch exists in our database
+				_, err = getBatchMetadata(t, testClientB.ConsensusNode, batchNum)
+				if err != nil {
+					t.Fatalf("CORRUPTION DETECTED: Delayed message %d is a batch-posting-report for batch %d, but batch %d doesn't exist in database! Error: %v", i, batchNum, batchNum, err)
 				}
 			}
 		}
-		t.Logf("All delayed messages checked - no corruption found")
 	}
 
 	// Re-enable blob fetching
@@ -188,24 +165,16 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	verifyTx := builder.L2Info.PrepareTx("Owner", "Owner", builder.L2Info.TransferGas, big.NewInt(2e12), nil)
 	err = builder.L2.Client.SendTransaction(ctx, verifyTx)
 	Require(t, err)
-	_, err = builder.L2.EnsureTxSucceeded(verifyTx)
+	verifyReceipt, err := builder.L2.EnsureTxSucceeded(verifyTx)
 	Require(t, err)
 
 	// Advance L1 to post batch
 	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 30)
 
-	// Wait for batch and advance for finality
-	for i := 0; i < 30; i++ {
-		verifyReceipt, _ := builder.L2.Client.TransactionReceipt(ctx, verifyTx.Hash())
-		if verifyReceipt != nil {
-			verifyBlock, _ := builder.L2.Client.BlockByHash(ctx, verifyReceipt.BlockHash)
-			_, found, err := builder.L2.ConsensusNode.GetParentChainDataSource().FindInboxBatchContainingMessage(arbutil.MessageIndex(verifyBlock.NumberU64()))
-			if err == nil && found {
-				break
-			}
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
+	// Wait for the verify transaction's batch to be tracked.
+	verifyBlock, err := builder.L2.Client.BlockByHash(ctx, verifyReceipt.BlockHash)
+	Require(t, err)
+	waitForFindInboxBatch(t, builder.L2.ConsensusNode, arbutil.MessageIndex(verifyBlock.NumberU64()), 30*time.Second, 100*time.Millisecond)
 	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 5)
 
 	// Check if follower synced the new transaction
@@ -238,10 +207,7 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	t.Logf("Final block numbers: sequencer=%d follower=%d", seqBlockNum, follBlockNum)
 
 	// Compare the highest common block
-	checkBlockNum := follBlockNum
-	if seqBlockNum < follBlockNum {
-		checkBlockNum = seqBlockNum
-	}
+	checkBlockNum := min(seqBlockNum, follBlockNum)
 
 	// #nosec G115
 	seqBlock, err := builder.L2.Client.BlockByNumber(ctx, big.NewInt(int64(checkBlockNum)))
@@ -263,9 +229,6 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	} else {
 		t.Logf("PASS: Follower is fully synced")
 	}
-
-	// Prevent unused variable warning
-	_ = batchNum
 }
 
 // Build2ndNodeWithBlobReader builds a second node with a custom blob reader.

--- a/system_tests/meaningless_reorg_test.go
+++ b/system_tests/meaningless_reorg_test.go
@@ -46,7 +46,7 @@ func TestMeaninglessBatchReorg(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	metadata, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchMetadata(1)
+	metadata, err := getBatchMetadata(t, builder.L2.ConsensusNode, 1)
 	Require(t, err)
 	originalBatchBlock := batchReceipt.BlockNumber.Uint64()
 	if metadata.ParentChainBlock != originalBatchBlock {
@@ -88,17 +88,17 @@ func TestMeaninglessBatchReorg(t *testing.T) {
 		if i >= 500 {
 			Fatal(t, "Failed to read batch reorg from L1")
 		}
-		metadata, err = builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchMetadata(1)
+		metadata, err = getBatchMetadata(t, builder.L2.ConsensusNode, 1)
 		Require(t, err)
 		if metadata.ParentChainBlock == newBatchBlock {
 			break
 		} else if metadata.ParentChainBlock != originalBatchBlock {
-			Fatal(t, "Batch L1 block changed from", originalBatchBlock, "to", metadata.ParentChainBlock, "instead of expected", metadata.ParentChainBlock)
+			Fatal(t, "Batch L1 block changed from", originalBatchBlock, "to", metadata.ParentChainBlock, "instead of expected", newBatchBlock)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	_, _, err = builder.L2.ConsensusNode.GetParentChainDataSource().GetSequencerMessageBytes(ctx, 1)
+	_, _, err = getSequencerMessageBytes(ctx, builder.L2.ConsensusNode, 1)
 	Require(t, err)
 
 	l2Header, err := builder.L2.Client.HeaderByNumber(ctx, l2Receipt.BlockNumber)

--- a/system_tests/message_extraction_layer_test.go
+++ b/system_tests/message_extraction_layer_test.go
@@ -80,6 +80,7 @@ func TestMessageExtractionLayer_SequencerBatchMessageEquivalence(t *testing.T) {
 		nil, // TODO: SequencerInbox interface needed.
 		l1Reader,
 		reorgEventChan,
+		nil,
 	)
 	Require(t, err)
 	Require(t, extractor.SetMessageConsumer(mockMsgConsumer))
@@ -216,6 +217,7 @@ func TestMessageExtractionLayer_SequencerBatchMessageEquivalence_Blobs(t *testin
 		nil,
 		nil,
 		reorgEventChan,
+		nil,
 	)
 	Require(t, err)
 	Require(t, extractor.SetMessageConsumer(mockMsgConsumer))
@@ -356,6 +358,7 @@ func TestMessageExtractionLayer_DelayedMessageEquivalence_Simple(t *testing.T) {
 		nil,
 		nil,
 		reorgEventChan,
+		nil,
 	)
 	Require(t, err)
 	Require(t, extractor.SetMessageConsumer(mockMsgConsumer))
@@ -422,6 +425,7 @@ func TestMessageExtractionLayer_DelayedMessageEquivalence_Simple(t *testing.T) {
 		nil,
 		nil,
 		reorgEventChan,
+		nil,
 	)
 	Require(t, err)
 	Require(t, newExtractor.SetMessageConsumer(mockMsgConsumer))
@@ -586,7 +590,7 @@ func TestMessageExtractionLayer_TxStreamerHandleReorg(t *testing.T) {
 	// Verify that ethDeposit works as intended on the sequence node's side
 	testDepositETH(t, ctx, builder, delayedInbox, lookupL2Tx, txOpts) // this also checks if balance increment is seen on L2
 
-	// Reorg L1 and advance it so that MEl can pick up the reorg
+	// Reorg L1 and advance it so that MEL can pick up the reorg
 	currHead, err := builder.L1.Client.BlockNumber(ctx)
 	Require(t, err)
 	Require(t, builder.L1.L1Backend.BlockChain().ReorgToOldBlock(reorgToBlock))
@@ -613,7 +617,7 @@ func TestMessageExtractionLayer_TxStreamerHandleReorg(t *testing.T) {
 		}
 	}
 
-	// Post a batch so that mel can send up-to-date L2 messages to txStreamer
+	// Post a batch so that MEL can send up-to-date L2 messages to txStreamer
 	initialBatchCount := GetBatchCount(t, builder)
 	var txs types.Transactions
 	for i := 0; i < 10; i++ {
@@ -630,32 +634,27 @@ func TestMessageExtractionLayer_TxStreamerHandleReorg(t *testing.T) {
 	}
 	CheckBatchCount(t, builder, initialBatchCount+1)
 
-	// Wait until mel can read the posted batch, send correct L2 messages to txStreamer and txStreamer is able to detect the Reorg and handle correct execution of L2 messages
-	{
-		timeout := time.NewTimer(time.Minute)
-		defer timeout.Stop()
-		tick := time.NewTicker(100 * time.Millisecond)
-		defer tick.Stop()
-		for {
-			// Verify that both MEL and TxStreamer detected the reorg
-			if logHandler.WasLogged("MEL detected L1 reorg") && logHandler.WasLogged("TransactionStreamer: Reorg detected!") {
-				break
-			}
-			select {
-			case <-tick.C:
-			case <-timeout.C:
-				t.Fatalf("timed out waiting for MEL and TransactionStreamer to detect reorg")
-			}
+	// Wait for the reorg to complete: MEL and TxStreamer reorg logs, then check balance.
+	var reorgLogsFound bool
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if logHandler.WasLogged("MEL detected L1 reorg") &&
+			logHandler.WasLogged("TransactionStreamer: Reorg detected!") {
+			reorgLogsFound = true
+			break
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
-
-	// Verify that after reorg handling, resulting balance in the account is correct
-	newBalance, err := builder.L2.Client.BalanceAt(ctx, txOpts.From, nil)
+	if !reorgLogsFound {
+		t.Fatal("timed out waiting for reorg logs")
+	}
+	expectedBalance := new(big.Int).Add(oldBalance, txOpts.Value)
+	bal, err := builder.L2.Client.BalanceAt(ctx, txOpts.From, nil)
 	if err != nil {
-		t.Fatalf("BalanceAt(%v) unexpected error: %v", txOpts.From, err)
+		t.Fatalf("BalanceAt: %v", err)
 	}
-	if got := new(big.Int); got.Sub(newBalance, oldBalance).Cmp(txOpts.Value) != 0 {
-		t.Errorf("Got transferred: %v, want: %v", got, txOpts.Value)
+	if bal.Cmp(expectedBalance) != 0 {
+		t.Fatalf("balance=%v, want %v", bal, expectedBalance)
 	}
 }
 
@@ -710,6 +709,7 @@ func TestMessageExtractionLayer_UseArbDBForStoringDelayedMessages(t *testing.T) 
 		nil,
 		nil,
 		reorgEventsChan,
+		nil,
 	)
 	Require(t, err)
 	Require(t, extractor.SetMessageConsumer(mockMsgConsumer))
@@ -1104,7 +1104,7 @@ func sendDelayedMessagesViaL1(
 		Require(t, err)
 	}
 	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 30)
-	waitForDelayedCount(t, ctx, builder, countBefore+uint64(numMsgs))
+	waitForDelayedCount(t, ctx, builder, countBefore+uint64(numMsgs)) // #nosec G115
 }
 
 // waitForDelayedCount polls the inbox tracker until the delayed message count reaches the expected value.

--- a/system_tests/overflow_assertions_test.go
+++ b/system_tests/overflow_assertions_test.go
@@ -84,7 +84,7 @@ func TestOverflowAssertions(t *testing.T) {
 	ctx, cancelCtx = context.WithCancel(ctx)
 	defer cancelCtx()
 
-	go keepChainMoving(t, 3*time.Second, ctx, l1info, l1client)
+	go keepChainMoving(t, ctx, 3*time.Second, l1info, l1client)
 
 	balance := big.NewInt(params.Ether)
 	balance.Mul(balance, big.NewInt(100))
@@ -97,7 +97,8 @@ func TestOverflowAssertions(t *testing.T) {
 
 	locator, err := server_common.NewMachineLocator(valCfg.Wasm.RootPath)
 	Require(t, err)
-	pcds := l2node.GetParentChainDataSource()
+	pcds, err := l2node.GetParentChainDataSource()
+	Require(t, err)
 	stateless, err := staker.NewStatelessBlockValidator(
 		pcds,
 		pcds,
@@ -178,9 +179,9 @@ func TestOverflowAssertions(t *testing.T) {
 	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, honestSeqInboxBinding, honestSeqInbox, numMessagesPerBatch, divergeAt)
 	totalMessagesPosted += numMessagesPerBatch
 
-	bc, err := l2node.GetParentChainDataSource().GetBatchCount()
+	bc, err := getBatchCount(t, l2node)
 	Require(t, err)
-	msgs, err := l2node.GetParentChainDataSource().GetBatchMessageCount(bc - 1)
+	msgs, err := getBatchMessageCount(t, l2node, bc-1)
 	Require(t, err)
 
 	t.Logf("Node batch count %d, msgs %d", bc, msgs)

--- a/system_tests/parent_chain_config_test.go
+++ b/system_tests/parent_chain_config_test.go
@@ -143,7 +143,7 @@ func TestParentChainEthConfigForkTransition(t *testing.T) {
 	}
 
 	// Phase 2: Activate BPO1 by advancing L1
-	go keepChainMoving(t, 100*time.Millisecond, ctx, builder.L1Info, builder.L1.Client)
+	go keepChainMoving(t, ctx, 100*time.Millisecond, builder.L1Info, builder.L1.Client)
 
 	t.Logf("Phase 1: got initial blob config target=%d max=%d (expecting Osaka: target=%d max=%d)",
 		blobConfigPhase1.Target, blobConfigPhase1.Max,

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -1913,9 +1913,12 @@ func waitForSequencer(t *testing.T, builder *NodeBuilder, block uint64) {
 	Require(t, err)
 	msgCount := msgIndex + 1
 	doUntil(t, 20*time.Millisecond, 500, func() bool {
-		batchCount, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchCount()
+		batchCount, err := getBatchCount(t, builder.L2.ConsensusNode)
 		Require(t, err)
-		meta, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchMetadata(batchCount - 1)
+		if batchCount == 0 {
+			return false
+		}
+		meta, err := getBatchMetadata(t, builder.L2.ConsensusNode, batchCount-1)
 		Require(t, err)
 		msgExecuted, err := builder.L2.ExecNode.ExecEngine.HeadMessageIndex()
 		Require(t, err)

--- a/system_tests/revalidation_test.go
+++ b/system_tests/revalidation_test.go
@@ -112,7 +112,7 @@ func createTransactionTillBatchCount(ctx context.Context, t *testing.T, builder 
 		Require(t, err)
 		_, err = builder.L2.EnsureTxSucceeded(tx)
 		Require(t, err)
-		count, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchCount()
+		count, err := getBatchCount(t, builder.L2.ConsensusNode)
 		Require(t, err)
 		if count > finalCount {
 			return

--- a/system_tests/rust_validation_test.go
+++ b/system_tests/rust_validation_test.go
@@ -255,7 +255,7 @@ func waitForMessageIndex(t *testing.T, ctx context.Context, builder *NodeBuilder
 	t.Helper()
 	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 30)
 	doUntil(t, 250*time.Millisecond, 20, func() bool {
-		_, found, err := builder.L2.ConsensusNode.GetParentChainDataSource().FindInboxBatchContainingMessage(pos)
+		_, found, err := findInboxBatchContainingMessage(t, builder.L2.ConsensusNode, pos)
 		Require(t, err)
 		return found
 	})

--- a/system_tests/seqfeed_test.go
+++ b/system_tests/seqfeed_test.go
@@ -519,7 +519,7 @@ func TestRegressionInPopulateFeedBacklog(t *testing.T) {
 	Require(t, err)
 
 	// sub in correct batch hash
-	batchData, _, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetSequencerMessageBytes(ctx, 0)
+	batchData, _, err := getSequencerMessageBytes(ctx, builder.L2.ConsensusNode, 0)
 	Require(t, err)
 	expectedBatchHash := crypto.Keccak256Hash(batchData)
 	copy(data[52:52+32], expectedBatchHash[:])

--- a/system_tests/staker_test.go
+++ b/system_tests/staker_test.go
@@ -196,7 +196,8 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 
 	locator, err := server_common.NewMachineLocator(valnode.TestValidationConfig.Wasm.RootPath)
 	Require(t, err)
-	pcdsA := l2nodeA.GetParentChainDataSource()
+	pcdsA, err := l2nodeA.GetParentChainDataSource()
+	Require(t, err)
 	statelessA, err := staker.NewStatelessBlockValidator(
 		pcdsA,
 		pcdsA,
@@ -256,7 +257,8 @@ func stakerTestImpl(t *testing.T, faultyStaker bool, honestStakerInactive bool) 
 	Require(t, err)
 	valConfigB := legacystaker.TestL1ValidatorConfig
 	valConfigB.Strategy = "MakeNodes"
-	pcdsB := l2nodeB.GetParentChainDataSource()
+	pcdsB, err := l2nodeB.GetParentChainDataSource()
+	Require(t, err)
 	statelessB, err := staker.NewStatelessBlockValidator(
 		pcdsB,
 		pcdsB,

--- a/system_tests/validation_inputs_at_test.go
+++ b/system_tests/validation_inputs_at_test.go
@@ -55,16 +55,7 @@ func TestValidationInputsAtWithWasmTarget(t *testing.T) {
 	Require(t, err)
 
 	inboxPos := arbutil.MessageIndex(receipt.BlockNumber.Uint64())
-	for range 40 {
-		time.Sleep(250 * time.Millisecond)
-		batches, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchCount()
-		Require(t, err)
-		haveMessages, err := builder.L2.ConsensusNode.GetParentChainDataSource().GetBatchMessageCount(batches - 1)
-		Require(t, err)
-		if haveMessages >= inboxPos {
-			break
-		}
-	}
+	waitForBatchContainingMessage(t, builder.L2.ConsensusNode, inboxPos, 10*time.Second, 250*time.Millisecond)
 
 	// Retry ValidationInputsAt because the batch may be tracked locally but
 	// not yet confirmed on L1 ("batch not found on L1 yet").

--- a/validator/proofenhancement/proof_enhancer_test.go
+++ b/validator/proofenhancement/proof_enhancer_test.go
@@ -26,7 +26,7 @@ type mockInboxTracker struct {
 }
 
 // Implement staker.InboxTrackerInterface - only the methods we use
-func (m *mockInboxTracker) SetBlockValidator(v *staker.BlockValidator) {}
+func (m *mockInboxTracker) SetBlockValidator(v *staker.BlockValidator) error { return nil }
 func (m *mockInboxTracker) GetDelayedMessageBytes(ctx context.Context, seqNum uint64) ([]byte, error) {
 	return nil, nil
 }


### PR DESCRIPTION
  Enable nodes to transition from the legacy inbox reader/tracker to the Message Extraction Layer (MEL). This PR builds on the MEL replacement work and adds:
                                                                                                                                                                                
  - Node transition: Detect legacy DB keys at startup and migrate to MEL state via CreateInitialMELStateFromLegacyDB
  - Error handling hardening: Fix nil pointer dereference risks, convert runtime panics to errors, extract prunePrefix helper with iterator leak fix                            
  - Message pruner: Prune all delayed message prefixes (legacy "d", RLP "e", MEL "y", parent chain "p") with legacy boundary capping                                            
  - Crash safety: Delayed message rollback on accumulator mismatch in inbox reader, deleteTrailingEntries extraction for testability                                            
                                                                                                                                                                                
  Commit breakdown                                                                                                                                                              
                                                            
                                                                                                                                                                                 
  1. Core MEL implementation + node integration (61 files) — Architecture, review for correctness                                                                               
  2. Fix nil pointer dereference risks (3 files) — Panic prevention, rubber-stamp
  3. Convert SetDelayedSequencer panics to errors (2 files) — Panic prevention, rubber-stamp                                                                                    
  4. Refactor and harden error handling (6 files) — Code quality, review for logic
  5. Safety tests (6 files) — Test coverage, skim                                                                                                                               


  Key files for review

  - arbnode/mel/runner/mel.go — FSM lifecycle, stall detection, fatal escalation                                                                                                
  - arbnode/mel/runner/database.go — Atomic SaveProcessedBlock, legacy boundary dispatch
  - arbnode/mel/state.go — Two-stack FIFO delayed message queue, accumulator hash chains                                                                                        
  - arbnode/node.go — MEL-or-legacy dispatch, DB migration, computeMigrationStartBlock                                                                                          
  - arbnode/message_pruner.go — Multi-prefix pruning with prunePrefix helper
  - arbnode/transaction_streamer.go — deleteTrailingEntries extraction                                                                                                          
                                                                                                                                                                                
  Schema changes
                                                                                                                                                                                
  Additive only (backwards compatible):                     
  - New keys: _lastPrunedLegacyDelayedMessageKey, _lastPrunedMelDelayedMessageKey, _lastPrunedParentChainBlockNumberKey, _initialMelStateBlockNum
  - No existing keys modified or removed                                                                                                                                        
  - DbSchemaVersion unchanged at 2
                                                                                                                                                                                
  Test plan                                                 

  - Unit tests pass: go test ./arbnode/mel/runner/ ./arbnode/ -count=1                                                                                                          
  - Linters pass: golangci-lint run + go run ./linters ./...
  - System tests: TestMELMigrationFromLegacyNode, TestMessageExtractionLayer_*                                                                                                  
  - Verify nil header guards prevent panics (commits 2 + 5)                                                                                                                     
  - Verify deleteTrailingEntries doesn't corrupt unrelated prefixes (commit 5)
  - Verify pruner handles all delayed message prefix formats (commit 4) 

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>