### PR TITLE
preallocate slice capacity across codebase

### DIFF
--- a/arbnode/blockmetadata.go
+++ b/arbnode/blockmetadata.go
@@ -208,7 +208,7 @@ func (b *BlockMetadataFetcher) Update(ctx context.Context) time.Duration {
 	}
 	iter := b.db.NewIterator(schema.MissingBlockMetadataInputFeedPrefix, start)
 	defer iter.Release()
-	var query []uint64
+	query := make([]uint64, 0, b.config.APIBlocksLimit)
 	for iter.Next() {
 		keyBytes := bytes.TrimPrefix(iter.Key(), schema.MissingBlockMetadataInputFeedPrefix)
 		query = append(query, binary.BigEndian.Uint64(keyBytes))

--- a/arbnode/inbox_reader.go
+++ b/arbnode/inbox_reader.go
@@ -689,7 +689,7 @@ func (r *InboxReader) GetSequencerMessageBytesForParentBlock(ctx context.Context
 	if err != nil {
 		return nil, common.Hash{}, err
 	}
-	var seenBatches []uint64
+	seenBatches := make([]uint64, 0, len(seqBatches))
 	for _, batch := range seqBatches {
 		if batch.SequenceNumber == seqNum {
 			data, err := SerializeSequencerInboxBatch(ctx, batch, r.client)

--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -28,6 +28,7 @@ import (
 	"github.com/offchainlabs/nitro/broadcaster/message"
 	"github.com/offchainlabs/nitro/daprovider"
 	"github.com/offchainlabs/nitro/staker"
+	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/containers"
 )
 
@@ -295,7 +296,7 @@ func (t *InboxTracker) PopulateFeedBacklog(broadcastServer *broadcaster.Broadcas
 	if err != nil {
 		return fmt.Errorf("error getting tx streamer message count: %w", err)
 	}
-	var feedMessages []*message.BroadcastFeedMessage
+	feedMessages := make([]*message.BroadcastFeedMessage, 0, arbmath.SaturatingUSub(messageCount, startMessage))
 	for seqNum := startMessage; seqNum < messageCount; seqNum++ {
 		message, err := t.txStreamer.GetMessage(seqNum)
 		if err != nil {

--- a/arbnode/mel/extraction/batch_lookup.go
+++ b/arbnode/mel/extraction/batch_lookup.go
@@ -25,12 +25,12 @@ func ParseBatchesFromBlock(
 	logsFetcher LogsFetcher,
 	eventUnpacker EventUnpacker,
 ) ([]*mel.SequencerInboxBatch, []*types.Transaction, error) {
-	batches := make([]*mel.SequencerInboxBatch, 0)
-	batchTxs := make([]*types.Transaction, 0)
 	logs, err := logsFetcher.LogsForBlockHash(ctx, parentChainHeader.Hash())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch logs from parent chain block %v: %w", parentChainHeader.Hash(), err)
 	}
+	batches := make([]*mel.SequencerInboxBatch, 0, len(logs))
+	batchTxs := make([]*types.Transaction, 0, len(logs))
 	var lastSeqNum *uint64
 	for _, log := range logs {
 		if log == nil || log.Topics[0] != BatchDeliveredID {

--- a/arbnode/mel/extraction/messages_in_batch.go
+++ b/arbnode/mel/extraction/messages_in_batch.go
@@ -30,7 +30,7 @@ func messagesFromBatchSegments(
 	seqMsg *arbstate.SequencerMessage,
 	delayedMsgDB DelayedMessageDatabase,
 ) ([]*arbostypes.MessageWithMetadata, error) {
-	messages := make([]*arbostypes.MessageWithMetadata, 0)
+	messages := make([]*arbostypes.MessageWithMetadata, 0, len(seqMsg.Segments))
 	timestamp := uint64(0)
 	blockNumber := uint64(0)
 	for idx, segment := range seqMsg.Segments {

--- a/arbnode/mel/runner/mel.go
+++ b/arbnode/mel/runner/mel.go
@@ -445,7 +445,7 @@ func (m *MessageExtractor) GetSequencerMessageBytes(ctx context.Context, seqNum 
 	if err != nil {
 		return nil, common.Hash{}, err
 	}
-	var seenBatches []uint64
+	seenBatches := make([]uint64, 0, len(seqBatches))
 	for i, batch := range seqBatches {
 		if batch.SequenceNumber == seqNum {
 			data, err := melextraction.SerializeBatch(ctx, batch, batchTxs[i], logsFetcher)

--- a/arbnode/seq_coordinator.go
+++ b/arbnode/seq_coordinator.go
@@ -622,7 +622,7 @@ func (c *SeqCoordinator) deleteFinalizedMsgsFromRedis(ctx context.Context, final
 	}
 	msgToDelete := min(finalized, remoteMsgCount)
 	if prevFinalized < msgToDelete {
-		var keys []string
+		keys := make([]string, 0, (msgToDelete-prevFinalized)*2) // *2 = one message key + one signature key per message
 		for msg := prevFinalized; msg < msgToDelete; msg++ {
 			keys = append(keys, redisutil.MessageKeyFor(msg), redisutil.MessageSigKeyFor(msg))
 		}
@@ -705,8 +705,9 @@ func (c *SeqCoordinator) update(ctx context.Context) (time.Duration, error) {
 	if c.prevRedisMessageCount != 0 && localMsgCount >= c.prevRedisMessageCount {
 		log.Info("coordinator caught up to prev redis coordinator", "msgcount", localMsgCount, "prevMsgCount", c.prevRedisMessageCount)
 	}
-	var messages []arbostypes.MessageWithMetadata
-	var blockMetadataArr []common.BlockMetadata
+	expectedMsgCount := arbmath.SaturatingUSub(readUntil, localMsgCount)
+	messages := make([]arbostypes.MessageWithMetadata, 0, expectedMsgCount)
+	blockMetadataArr := make([]common.BlockMetadata, 0, expectedMsgCount)
 	msgToRead := localMsgCount
 	var msgReadErr error
 	for msgToRead < readUntil && localMsgCount >= remoteFinalizedMsgCount {

--- a/arbnode/transaction_streamer.go
+++ b/arbnode/transaction_streamer.go
@@ -273,7 +273,7 @@ func deleteFromRange(ctx context.Context, db ethdb.Database, prefix []byte, star
 	batch := db.NewBatch()
 	startIter := db.NewIterator(prefix, uint64ToKey(startMinKey))
 	defer startIter.Release()
-	var prunedKeysRange []uint64
+	prunedKeysRange := make([]uint64, 0, 2) // at most 2 elements: range start and end
 	for startIter.Next() {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
@@ -641,7 +641,7 @@ func (s *TransactionStreamer) AddBroadcastMessages(feedMessages []*message.Broad
 		return nil
 	}
 	broadcastFirstMsgIdx := feedMessages[0].SequenceNumber
-	var messages []arbostypes.MessageWithMetadataAndBlockInfo
+	messages := make([]arbostypes.MessageWithMetadataAndBlockInfo, 0, len(feedMessages))
 	expectedMsgIdx := broadcastFirstMsgIdx
 	for _, feedMessage := range feedMessages {
 		if expectedMsgIdx != feedMessage.SequenceNumber {
@@ -1212,7 +1212,7 @@ func (s *TransactionStreamer) PopulateFeedBacklog(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error getting tx streamer message count: %w", err)
 	}
-	var feedMessages []*message.BroadcastFeedMessage
+	feedMessages := make([]*message.BroadcastFeedMessage, 0, arbmath.SaturatingUSub(messageCount, startMessage))
 	for seqNum := startMessage; seqNum < messageCount; seqNum++ {
 		message, err := s.GetMessage(seqNum)
 		if err != nil {

--- a/bold/commitment/proof/prefix/merkle.go
+++ b/bold/commitment/proof/prefix/merkle.go
@@ -4,6 +4,8 @@
 package prefix
 
 import (
+	"math/bits"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -18,7 +20,7 @@ func (me MerkleExpansion) Clone() MerkleExpansion {
 }
 
 func (me MerkleExpansion) Compact() ([]common.Hash, uint64) {
-	var comp []common.Hash
+	comp := make([]common.Hash, 0, len(me))
 	size := uint64(0)
 	for level, h := range me {
 		if h != (common.Hash{}) {
@@ -30,7 +32,7 @@ func (me MerkleExpansion) Compact() ([]common.Hash, uint64) {
 }
 
 func MerkleExpansionFromCompact(comp []common.Hash, size uint64) (MerkleExpansion, uint64) {
-	var me []common.Hash
+	me := make([]common.Hash, 0, bits.Len64(size))
 	numRead := uint64(0)
 	i := uint64(1)
 	for i <= size {

--- a/changelog/jco-preallocate-slice-capacity.md
+++ b/changelog/jco-preallocate-slice-capacity.md
@@ -1,0 +1,2 @@
+### Changed
+- Preallocate slice capacity across codebase to reduce memory allocations

--- a/daprovider/anytrust/reader_aggregator.go
+++ b/daprovider/anytrust/reader_aggregator.go
@@ -230,7 +230,7 @@ func (a *SimpleReaderAggregator) GetByHash(ctx context.Context, hash common.Hash
 		}
 	}()
 
-	var errorCollection []error
+	errorCollection := make([]error, 0, len(a.readers))
 	for i := 0; i < len(a.readers); i++ {
 		select {
 		case <-ctx.Done():

--- a/staker/block_validator.go
+++ b/staker/block_validator.go
@@ -993,7 +993,7 @@ func (v *BlockValidator) sendValidations(ctx context.Context) (*arbutil.MessageI
 		for _, moduleRoot := range wasmRoots {
 			v.chosenValidator[moduleRoot].Throttler.Acquire()
 		}
-		var runs []validator.ValidationRun
+		runs := make([]validator.ValidationRun, 0, len(wasmRoots))
 		for _, moduleRoot := range wasmRoots {
 			throttledSpawner := v.chosenValidator[moduleRoot]
 			input, err := validationStatus.Entry.ToInput(throttledSpawner.Spawner.StylusArchs())

--- a/staker/challenge-cache/cache.go
+++ b/staker/challenge-cache/cache.go
@@ -263,7 +263,7 @@ for a given filesystem challenge cache will look as follows:
 				hashes.bin
 */
 func determineFilePath(baseDir string, lookup *Key) (string, error) {
-	key := make([]string, 0)
+	key := make([]string, 0, 3+len(lookup.StepHeights)) // 3 = wavmModuleRoot + messageNumAndRollupBlockHash + hashesFileName
 	key = append(key, fmt.Sprintf("%s-%s", wavmModuleRootPrefix, lookup.WavmModuleRoot.Hex()))
 	key = append(key, fmt.Sprintf("%s-%d-%s-%s", messageNumberPrefix, lookup.MessageHeight, rollupBlockHashPrefix, lookup.RollupBlockHash.Hex()))
 	for challengeLevel, height := range lookup.StepHeights {

--- a/staker/legacy/challenge_manager.go
+++ b/staker/legacy/challenge_manager.go
@@ -476,7 +476,7 @@ func (m *ChallengeManager) createExecutionBackend(ctx context.Context, step uint
 	if err != nil {
 		return fmt.Errorf("error getting validation entry input of challenge %v msg %v: %w", m.challengeIndex, initialCount, err)
 	}
-	var prunedBatches []validator.BatchInfo
+	prunedBatches := make([]validator.BatchInfo, 0, len(input.BatchInfo))
 	for _, batch := range input.BatchInfo {
 		if batch.Number < m.maxBatchesRead {
 			prunedBatches = append(prunedBatches, batch)


### PR DESCRIPTION
Use make() with capacity hints derived from known bounds (input lengths,
config limits, saturating subtraction) to reduce unnecessary slice growth
and GC pressure. No logic changes.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
