### PR TITLE
Force net.Dialer to use tcp4 instead of falling back to tcp6

### DIFF
--- a/broadcastclient/broadcastclient.go
+++ b/broadcastclient/broadcastclient.go
@@ -291,13 +291,8 @@ func (bc *BroadcastClient) connect(ctx context.Context, nextSeqNum arbutil.Messa
 		Extensions: extensions,
 		NetDial: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			var netDialer net.Dialer
-			// For tcp connections, prefer IPv4 over IPv6 to avoid rate limiting issues
 			if network == "tcp" {
-				conn, err := netDialer.DialContext(ctx, "tcp4", addr)
-				if err == nil {
-					return conn, nil
-				}
-				return netDialer.DialContext(ctx, "tcp6", addr)
+				return netDialer.DialContext(ctx, "tcp4", addr)
 			}
 			return netDialer.DialContext(ctx, network, addr)
 		},

--- a/changelog/jcolvin-force-tcp4-dialer.md
+++ b/changelog/jcolvin-force-tcp4-dialer.md
@@ -1,0 +1,2 @@
+### Changed
+- Force net.Dialer to use "tcp4" instead of falling back to "tcp6"

--- a/execution/gethexec/forwarder.go
+++ b/execution/gethexec/forwarder.go
@@ -97,13 +97,8 @@ func NewForwarder(targets []string, config *ForwarderConfig) *TxForwarder {
 
 	transport := &http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			// For tcp connections, prefer IPv4 over IPv6
 			if network == "tcp" {
-				conn, err := dialer.DialContext(ctx, "tcp4", addr)
-				if err == nil {
-					return conn, nil
-				}
-				return dialer.DialContext(ctx, "tcp6", addr)
+				return dialer.DialContext(ctx, "tcp4", addr)
 			}
 			return dialer.DialContext(ctx, network, addr)
 		},


### PR DESCRIPTION
Our datacenter doesn't support IPv6, and any momentary glitch with IPv4 causes fallback to IPv6 and ensuing error messages stating that IPv6 cannot connect

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
