### PR TITLE
Add a Linter to Detect Defer Calls in For Loop

### DIFF
--- a/arbnode/simple_redis_lock_test.go
+++ b/arbnode/simple_redis_lock_test.go
@@ -71,7 +71,7 @@ func simpleRedisLockTest(t *testing.T, redisKeySuffix string, chosen int, backgr
 			t.Fatal(err)
 		}
 		lock.Start(ctx)
-		defer lock.StopAndWait()
+		t.Cleanup(lock.StopAndWait)
 		locks = append(locks, lock)
 	}
 	if background {

--- a/changelog/rauljordan-nit-4439.md
+++ b/changelog/rauljordan-nit-4439.md
@@ -1,0 +1,2 @@
+### Added
+- Linter for checking defer usage inside for loops

--- a/cmd/nitro/init/init.go
+++ b/cmd/nitro/init/init.go
@@ -472,31 +472,36 @@ func deleteWasmEntries(db ethdb.Database, prefixes [][]byte, checkKeyLength bool
 	batch := db.NewBatch()
 	notMatchingLengthKeyLogged := false
 	for _, prefix := range prefixes {
-		it := db.NewIterator(prefix, nil)
-		defer it.Release()
-		for it.Next() {
-			key := it.Key()
-			if checkKeyLength && len(key) != expectedKeyLength {
-				if !notMatchingLengthKeyLogged {
-					log.Warn("Found key with deprecated prefix but not matching length, skipping removal. (this warning is logged only once)", "key", key)
-					notMatchingLengthKeyLogged = true
+		if err := func() error {
+			it := db.NewIterator(prefix, nil)
+			defer it.Release()
+			for it.Next() {
+				key := it.Key()
+				if checkKeyLength && len(key) != expectedKeyLength {
+					if !notMatchingLengthKeyLogged {
+						log.Warn("Found key with deprecated prefix but not matching length, skipping removal. (this warning is logged only once)", "key", key)
+						notMatchingLengthKeyLogged = true
+					}
+					continue
 				}
-				continue
-			}
-			if err := batch.Delete(key); err != nil {
-				return fmt.Errorf("failed to remove key %v : %w", key, err)
-			}
+				if err := batch.Delete(key); err != nil {
+					return fmt.Errorf("failed to remove key %v : %w", key, err)
+				}
 
-			// Recreate the iterator after every batch commit in order
-			// to allow the underlying compactor to delete the entries.
-			if batch.ValueSize() >= ethdb.IdealBatchSize {
-				if err := batch.Write(); err != nil {
-					return fmt.Errorf("failed to write batch: %w", err)
+				// Recreate the iterator after every batch commit in order
+				// to allow the underlying compactor to delete the entries.
+				if batch.ValueSize() >= ethdb.IdealBatchSize {
+					if err := batch.Write(); err != nil {
+						return fmt.Errorf("failed to write batch: %w", err)
+					}
+					batch.Reset()
+					it.Release()
+					it = db.NewIterator(prefix, key)
 				}
-				batch.Reset()
-				it.Release()
-				it = db.NewIterator(prefix, key)
 			}
+			return nil
+		}(); err != nil {
+			return err
 		}
 	}
 	if batch.ValueSize() > 0 {

--- a/linters/deferinloop/deferinloop.go
+++ b/linters/deferinloop/deferinloop.go
@@ -1,0 +1,78 @@
+// Copyright 2024-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package deferinloop
+
+import (
+	"go/ast"
+	"go/token"
+	"reflect"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:       "deferinloop",
+	Doc:        "check for defer statements directly inside loop bodies",
+	Run:        run,
+	ResultType: reflect.TypeOf(Result{}),
+}
+
+type deferInLoopError struct {
+	Pos     token.Position
+	Message string
+}
+
+type Result struct {
+	Errors []deferInLoopError
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	var ret Result
+	for _, f := range pass.Files {
+		ast.Inspect(f, func(node ast.Node) bool {
+			switch node.(type) {
+			case *ast.ForStmt, *ast.RangeStmt:
+				findDirectDefers(pass, f, node, &ret)
+				return false // we handle children ourselves
+			}
+			return true
+		})
+	}
+	return ret, nil
+}
+
+// findDirectDefers walks the body of a loop looking for defer statements
+// that are not nested inside a function literal.
+func findDirectDefers(pass *analysis.Pass, file *ast.File, loop ast.Node, ret *Result) {
+	var body *ast.BlockStmt
+	switch l := loop.(type) {
+	case *ast.ForStmt:
+		body = l.Body
+	case *ast.RangeStmt:
+		body = l.Body
+	}
+	if body == nil {
+		return
+	}
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch node.(type) {
+		case *ast.FuncLit:
+			// Don't descend into anonymous functions — defer inside
+			// func literals is fine since the function scope ends each iteration.
+			return false
+		case *ast.DeferStmt:
+			err := deferInLoopError{
+				Pos:     pass.Fset.Position(node.Pos()),
+				Message: "defer called directly in loop body, consider wrapping in an immediately-invoked function literal",
+			}
+			ret.Errors = append(ret.Errors, err)
+			pass.Report(analysis.Diagnostic{
+				Pos:      pass.Fset.File(file.Pos()).Pos(err.Pos.Offset),
+				Message:  err.Message,
+				Category: "deferinloop",
+			})
+		}
+		return true
+	})
+}

--- a/linters/deferinloop/deferinloop_test.go
+++ b/linters/deferinloop/deferinloop_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package deferinloop
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAll(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	testdata := filepath.Join(filepath.Dir(wd), "testdata")
+	res := analysistest.Run(t, testdata, Analyzer, "deferinloop")
+	want := []int{12, 19, 43, 64}
+	got := errorLines(res)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("analysistest.Run() unexpected diff in error lines:\n%s\n", diff)
+	}
+}
+
+func errorLines(errs []*analysistest.Result) []int {
+	var ret []int
+	for _, e := range errs {
+		if r, ok := e.Result.(Result); ok {
+			for _, err := range r.Errors {
+				ret = append(ret, err.Pos.Line)
+			}
+		}
+	}
+	return ret
+}

--- a/linters/linters.go
+++ b/linters/linters.go
@@ -6,6 +6,7 @@ package main
 import (
 	"golang.org/x/tools/go/analysis/multichecker"
 
+	"github.com/offchainlabs/nitro/linters/deferinloop"
 	"github.com/offchainlabs/nitro/linters/jsonneverempty"
 	"github.com/offchainlabs/nitro/linters/koanf"
 	"github.com/offchainlabs/nitro/linters/namedfieldsinit"
@@ -16,6 +17,7 @@ import (
 
 func main() {
 	multichecker.Main(
+		deferinloop.Analyzer,
 		koanf.Analyzer,
 		namedfieldsinit.Analyzer,
 		pointercheck.Analyzer,

--- a/linters/testdata/src/deferinloop/deferinloop.go
+++ b/linters/testdata/src/deferinloop/deferinloop.go
@@ -1,0 +1,73 @@
+// Copyright 2024-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package deferinloop
+
+import "os"
+
+// Bad: defer directly in for loop.
+func forLoop() {
+	for i := 0; i < 10; i++ {
+		f, _ := os.Open("file")
+		defer f.Close() // want `defer called directly in loop body, consider wrapping in an immediately-invoked function literal`
+	}
+}
+
+// Bad: defer directly in range loop.
+func rangeLoop() {
+	for _, name := range []string{"a", "b"} {
+		defer func() { _ = name }() // want `defer called directly in loop body, consider wrapping in an immediately-invoked function literal`
+	}
+}
+
+// Good: defer inside anonymous function within loop.
+func funcLitInLoop() {
+	for i := 0; i < 10; i++ {
+		func() {
+			f, _ := os.Open("file")
+			defer f.Close()
+		}()
+	}
+}
+
+// Good: defer outside of any loop.
+func noLoop() {
+	f, _ := os.Open("file")
+	defer f.Close()
+}
+
+// Bad: defer in nested for loop.
+func nestedLoops() {
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 5; j++ {
+			defer func() { _, _ = i, j }() // want `defer called directly in loop body, consider wrapping in an immediately-invoked function literal`
+		}
+	}
+}
+
+// Good: defer inside func lit in nested loop.
+func nestedLoopWithFunc() {
+	for i := 0; i < 5; i++ {
+		func() {
+			for j := 0; j < 5; j++ {
+				func() {
+					defer func() { _, _ = i, j }()
+				}()
+			}
+		}()
+	}
+}
+
+// Bad: defer in range with nested func lit that also contains a loop.
+func complexNesting() {
+	for range []int{1, 2, 3} {
+		defer os.Getenv("HOME") // want `defer called directly in loop body, consider wrapping in an immediately-invoked function literal`
+		func() {
+			for i := 0; i < 3; i++ {
+				func() {
+					defer func() { _ = i }()
+				}()
+			}
+		}()
+	}
+}

--- a/relay/relay_stress_test.go
+++ b/relay/relay_stress_test.go
@@ -149,7 +149,7 @@ func largeBacklogRelayTestImpl(t *testing.T, numClients, backlogSize, l2MsgSize 
 			t.FailNow()
 		}
 		client.Start(ctx)
-		defer client.StopOnly()
+		t.Cleanup(client.StopOnly)
 	}
 
 	// wait for all clients to atleast connect once

--- a/system_tests/archive_redirect_test.go
+++ b/system_tests/archive_redirect_test.go
@@ -59,8 +59,10 @@ func TestRequestForwardingToArchiveNodes(t *testing.T) {
 		})
 		listener, srv, err := rpc.StartIPCEndpoint(ipcPath, apis)
 		Require(t, err)
-		defer srv.Stop()
-		defer listener.Close()
+		t.Cleanup(func() {
+			srv.Stop()
+			listener.Close()
+		})
 		archiveConfigs = append(archiveConfigs, arbitrum.BlockRedirectConfig{
 			URL:       ipcPath,
 			Timeout:   time.Second,

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -172,7 +172,7 @@ func testBatchPosterParallel(t *testing.T, useRedis bool, useRedisLock bool) {
 		)
 		Require(t, err)
 		batchPoster.Start(ctx)
-		defer batchPoster.StopAndWait()
+		t.Cleanup(batchPoster.StopAndWait)
 	}
 
 	lastTxHash := txs[len(txs)-1].Hash()

--- a/system_tests/forwarder_test.go
+++ b/system_tests/forwarder_test.go
@@ -225,7 +225,7 @@ func TestRedisForwarder(t *testing.T) {
 	var seqClients []*ethclient.Client
 	for _, path := range nodePaths {
 		testClientSeq, cleanupTestSeq := createSequencer(t, builder, path, redisUrl)
-		defer cleanupTestSeq()
+		t.Cleanup(cleanupTestSeq)
 		seqNodes = append(seqNodes, testClientSeq.ConsensusNode)
 		seqClients = append(seqClients, testClientSeq.Client)
 	}


### PR DESCRIPTION
Resolves NIT-4439

A common pitfall in Go development are bugs arising from defer invocations in for loops, which we are best avoiding. This adds a linter with tests