### PR TITLE
  Add ReportFilteredTransactions RPC endpoint to filtering-report -NIT-4641

### DIFF
--- a/changelog/mnasr-nit-4641.md
+++ b/changelog/mnasr-nit-4641.md
@@ -1,0 +1,2 @@
+### Added
+- Add ReportFilteredTransactions RPC endpoint to cmd/filtering-report with shared FilteredTxReport types and client method

--- a/cmd/filtering-report/api/api_test.go
+++ b/cmd/filtering-report/api/api_test.go
@@ -10,7 +10,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/node"
+
+	"github.com/offchainlabs/nitro/execution/gethexec"
 )
 
 func newTestStack(t *testing.T, filterSetReportingEndpoint string) *node.Node {
@@ -92,5 +95,35 @@ func TestReportCurrentFilterSetId(t *testing.T) {
 	got := <-received
 	if got != expectedId {
 		t.Fatalf("expected filterSetId %q, got %q", expectedId, got)
+	}
+}
+
+func TestReportFilteredTransactions(t *testing.T) {
+	stack := newTestStack(t, "")
+	client := stack.Attach()
+	defer client.Close()
+
+	reports := []gethexec.FilteredTxReport{{
+		Id:          "test-id",
+		TxHash:      common.HexToHash("0x1234"),
+		BlockNumber: 42,
+		ChainId:     "412346",
+		FilteredAddresses: []gethexec.FilteredAddressRecord{{
+			Address:      common.HexToAddress("0xdead"),
+			FilterReason: gethexec.FilterReason{Reason: gethexec.ReasonFrom},
+		}},
+	}}
+	if err := client.Call(nil, "filteringreport_reportFilteredTransactions", reports); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReportFilteredTransactionsEmpty(t *testing.T) {
+	stack := newTestStack(t, "")
+	client := stack.Attach()
+	defer client.Close()
+
+	if err := client.Call(nil, "filteringreport_reportFilteredTransactions", []gethexec.FilteredTxReport{}); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/cmd/filtering-report/api/filtering_report_api.go
+++ b/cmd/filtering-report/api/filtering_report_api.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package api
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/offchainlabs/nitro/execution/gethexec"
+)
+
+// ReportFilteredTransactions logs each filtered transaction report to stdout.
+func (a *FilteringReportAPI) ReportFilteredTransactions(_ context.Context, reports []gethexec.FilteredTxReport) error {
+	for _, report := range reports {
+		log.Info("Filtered transaction report",
+			"id", report.Id,
+			"txHash", report.TxHash,
+			"blockNumber", report.BlockNumber,
+			"positionInBlock", report.PositionInBlock,
+			"isDelayed", report.IsDelayed,
+			"chainId", report.ChainId,
+			"filteredAddressCount", len(report.FilteredAddresses),
+			"filteredAt", report.FilteredAt,
+		)
+		for _, addr := range report.FilteredAddresses {
+			log.Info("Filtered address",
+				"reportId", report.Id,
+				"address", addr.Address,
+				"reason", addr.Reason,
+			)
+		}
+	}
+	return nil
+}

--- a/execution/gethexec/filtered_tx_report.go
+++ b/execution/gethexec/filtered_tx_report.go
@@ -1,0 +1,60 @@
+// Copyright 2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package gethexec
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+type FilterReasonType string
+
+const (
+	ReasonFrom                          FilterReasonType = "from"
+	ReasonTo                            FilterReasonType = "to"
+	ReasonDealiasedFrom                 FilterReasonType = "dealiased_from"
+	ReasonRetryableBeneficiary          FilterReasonType = "retryable_beneficiary"
+	ReasonRetryableFeeRefund            FilterReasonType = "retryable_fee_refund"
+	ReasonRetryableTo                   FilterReasonType = "retryable_to"
+	ReasonDealiasedRetryableBeneficiary FilterReasonType = "dealiased_retryable_beneficiary"
+	ReasonDealiasedRetryableFeeRefund   FilterReasonType = "dealiased_retryable_fee_refund"
+	ReasonEventRule                     FilterReasonType = "event_rule"
+	ReasonContractAddress               FilterReasonType = "contract_address"
+	ReasonContractCaller                FilterReasonType = "contract_caller"
+	ReasonSelfdestructBeneficiary       FilterReasonType = "selfdestruct_beneficiary"
+)
+
+type RawLog struct {
+	Address common.Address `json:"address"`
+	Topics  []common.Hash  `json:"topics"`
+	Data    hexutil.Bytes  `json:"data"`
+}
+
+type FilterReason struct {
+	Reason            FilterReasonType `json:"reason"`
+	MatchedEvent      string           `json:"matchedEvent,omitempty"`
+	MatchedTopicIndex int              `json:"matchedTopicIndex,omitempty"`
+	RawLog            *RawLog          `json:"rawLog,omitempty"`
+}
+
+type FilteredAddressRecord struct {
+	Address common.Address `json:"address"`
+	FilterReason
+}
+
+type FilteredTxReport struct {
+	Id                    string                  `json:"id"`
+	TxHash                common.Hash             `json:"txHash"`
+	TxRLP                 hexutil.Bytes           `json:"txRLP"`
+	FilteredAddresses     []FilteredAddressRecord `json:"filteredAddresses"`
+	BlockNumber           uint64                  `json:"blockNumber"`
+	ParentBlockHash       common.Hash             `json:"parentBlockHash"`
+	PositionInBlock       uint64                  `json:"positionInBlock"`
+	FilteredAt            time.Time               `json:"filteredAt"`
+	IsDelayed             bool                    `json:"isDelayed"`
+	DelayedInboxRequestId string                  `json:"delayedInboxRequestId,omitempty"`
+	ChainId               string                  `json:"chainId"`
+}

--- a/execution/gethexec/filtering_report_client.go
+++ b/execution/gethexec/filtering_report_client.go
@@ -50,3 +50,10 @@ func (c *FilteringReportRPCClient) ReportCurrentFilterSetId(filterSetId string) 
 		return struct{}{}, err
 	})
 }
+
+func (c *FilteringReportRPCClient) ReportFilteredTransactions(reports []FilteredTxReport) containers.PromiseInterface[struct{}] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (struct{}, error) {
+		err := c.client.CallContext(ctx, nil, FilteringReportNamespace+"_reportFilteredTransactions", reports)
+		return struct{}{}, err
+	})
+}


### PR DESCRIPTION
  - Add shared `FilteredTxReport` types (with `FilterReason`, `FilteredAddressRecord`, `RawLog`) 
  - Add `ReportFilteredTransactions` server handler on `FilteringReportAPI` that logs each report to stdout                                                                        
  - Add `ReportFilteredTransactions` client method on `FilteringReportRPCClient` for callers to use in future tasks   