### PR TITLE
Move ErrResultNotFound sentinel from gethexec to execution package

### DIFF
--- a/arbnode/consensus_execution_syncer.go
+++ b/arbnode/consensus_execution_syncer.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/execution"
-	"github.com/offchainlabs/nitro/execution/gethexec"
 	"github.com/offchainlabs/nitro/staker"
 	"github.com/offchainlabs/nitro/util"
 	"github.com/offchainlabs/nitro/util/headerreader"
@@ -32,9 +31,6 @@ var DefaultConsensusExecutionSyncerConfig = ConsensusExecutionSyncerConfig{
 var TestConsensusExecutionSyncerConfig = ConsensusExecutionSyncerConfig{
 	SyncInterval: TestSyncMonitorConfig.MsgLag / 2,
 }
-
-// We don't define a Test config. For most tests we want the Syncer to behave
-// the same as in production.
 
 func ConsensusExecutionSyncerConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Duration(prefix+".sync-interval", DefaultConsensusExecutionSyncerConfig.SyncInterval, "Interval in which finality and sync data is pushed from consensus to execution")
@@ -108,7 +104,7 @@ func (c *ConsensusExecutionSyncer) getFinalityData(
 	}
 	msgIdx := msgCount - 1
 	msgResult, err := c.txStreamer.ResultAtMessageIndex(msgIdx)
-	if errors.Is(err, gethexec.ResultNotFound) {
+	if errors.Is(err, execution.ErrResultNotFound) {
 		log.Debug("Message result not found, node out of sync", "msgIdx", msgIdx, "err", err)
 		return nil, nil
 	} else if err != nil {

--- a/changelog/jco-move-err-result-not-found.md
+++ b/changelog/jco-move-err-result-not-found.md
@@ -1,0 +1,2 @@
+### Changed
+- Move `ResultNotFound` sentinel from `gethexec` to `execution.ErrResultNotFound` to break unnecessary import dependency

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -71,7 +71,6 @@ var (
 
 var (
 	ExecutionEngineBlockCreationStopped = errors.New("block creation stopped in execution engine")
-	ResultNotFound                      = errors.New("result not found")
 	BlockNumBeforeGenesis               = errors.New("block number is before genesis")
 )
 
@@ -1024,7 +1023,7 @@ func (s *ExecutionEngine) appendBlock(block *types.Block, statedb *state.StateDB
 
 func (s *ExecutionEngine) resultFromHeader(header *types.Header) (*execution.MessageResult, error) {
 	if header == nil {
-		return nil, ResultNotFound
+		return nil, execution.ErrResultNotFound
 	}
 	info := types.DeserializeHeaderExtraInformation(header)
 	return &execution.MessageResult{

--- a/execution/interface.go
+++ b/execution/interface.go
@@ -44,6 +44,7 @@ type ConsensusSyncData struct {
 
 var ErrRetrySequencer = errors.New("please retry transaction")
 var ErrSequencerInsertLockTaken = errors.New("insert lock taken")
+var ErrResultNotFound = errors.New("result not found")
 
 // always needed
 type ExecutionClient interface {

--- a/execution/rpcclient/client.go
+++ b/execution/rpcclient/client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/execution"
-	"github.com/offchainlabs/nitro/execution/gethexec"
 	"github.com/offchainlabs/nitro/util/containers"
 	"github.com/offchainlabs/nitro/util/rpcclient"
 	"github.com/offchainlabs/nitro/util/stopwaiter"
@@ -48,8 +47,8 @@ func convertError(err error) error {
 	errStr := err.Error()
 	if strings.Contains(errStr, execution.ErrRetrySequencer.Error()) {
 		return execution.ErrRetrySequencer
-	} else if strings.Contains(errStr, gethexec.ResultNotFound.Error()) {
-		return gethexec.ResultNotFound
+	} else if strings.Contains(errStr, execution.ErrResultNotFound.Error()) {
+		return execution.ErrResultNotFound
 	}
 	return err
 }

--- a/execution/rpcclient/client_test.go
+++ b/execution/rpcclient/client_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/offchainlabs/nitro/arbutil"
 	"github.com/offchainlabs/nitro/execution"
-	"github.com/offchainlabs/nitro/execution/gethexec"
 	utilrpc "github.com/offchainlabs/nitro/util/rpcclient"
 	"github.com/offchainlabs/nitro/util/testhelpers"
 )
@@ -66,13 +65,13 @@ func TestClientErrorHandling(t *testing.T) {
 	}{
 		{
 			name:        "ResultNotFound mapped to sentinel",
-			serverErr:   gethexec.ResultNotFound,
-			expectedErr: gethexec.ResultNotFound,
+			serverErr:   execution.ErrResultNotFound,
+			expectedErr: execution.ErrResultNotFound,
 		},
 		{
 			name:        "ResultNotFound wrapped in longer message mapped to sentinel",
-			serverErr:   fmt.Errorf("execution context: %w", gethexec.ResultNotFound),
-			expectedErr: gethexec.ResultNotFound,
+			serverErr:   fmt.Errorf("execution context: %w", execution.ErrResultNotFound),
+			expectedErr: execution.ErrResultNotFound,
 		},
 		{
 			name:        "ErrRetrySequencer mapped to sentinel",
@@ -111,7 +110,7 @@ func TestClientErrorHandling(t *testing.T) {
 				t.Fatal("expected an error from server, got nil")
 			}
 			switch {
-			case errors.Is(tc.expectedErr, gethexec.ResultNotFound), errors.Is(tc.expectedErr, execution.ErrRetrySequencer):
+			case errors.Is(tc.expectedErr, execution.ErrResultNotFound), errors.Is(tc.expectedErr, execution.ErrRetrySequencer):
 				if !errors.Is(err, tc.expectedErr) {
 					t.Errorf("expected sentinel error %v, got %v", tc.expectedErr, err)
 				}


### PR DESCRIPTION
Move ResultNotFound from execution/gethexec to execution.ErrResultNotFound
so that arbnode (consensus_execution_syncer) can reference the sentinel
without importing the lower-level gethexec package. This breaks the
unnecessary arbnode → gethexec dependency for this error check.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
