### PR TITLE
Stylus V3 - disable multiValue

### DIFF
--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -489,6 +489,7 @@ func (state *ArbosState) UpgradeArbosVersion(
 			p, err := state.Programs().Params()
 			ensure(err)
 			ensure(p.UpgradeToArbosVersion(nextArbosVersion))
+			ensure(p.UpgradeToVersion(3))
 			ensure(p.Save())
 			// Changes for ArbosVersion_TransactionFiltering
 			ensure(addressSet.Initialize(state.backingStorage.OpenSubStorage(transactionFiltererSubspace)))

--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -481,15 +481,20 @@ func (state *ArbosState) UpgradeArbosVersion(
 		case params.ArbosVersion_51:
 			// nothing
 
-		case 52, 53, 54, 55, 56, 57, 58, 59:
+		case 52, 53, 54, 55, 56, 57, 58:
 			// these versions are left to Orbit chains for custom upgrades.
+
+		case params.ArbosVersion_59:
+			p, err := state.Programs().Params()
+			ensure(err)
+			ensure(p.UpgradeToVersion(3))
+			ensure(p.Save())
 
 		case params.ArbosVersion_60:
 			// Changes for ArbosVersion_StylusContractLimit
 			p, err := state.Programs().Params()
 			ensure(err)
 			ensure(p.UpgradeToArbosVersion(nextArbosVersion))
-			ensure(p.UpgradeToVersion(3))
 			ensure(p.Save())
 			// Changes for ArbosVersion_TransactionFiltering
 			ensure(addressSet.Initialize(state.backingStorage.OpenSubStorage(transactionFiltererSubspace)))

--- a/arbos/programs/params.go
+++ b/arbos/programs/params.go
@@ -207,6 +207,9 @@ func (p *StylusParams) UpgradeToArbosVersion(newArbosVersion uint64) error {
 		}
 		p.MaxWasmSize = initialMaxWasmSize
 	case params.ArbosVersion_StylusContractLimit:
+		if p.Version != 2 {
+			return fmt.Errorf("unexpected arbosVersion upgrade to %d while stylus version %d", newArbosVersion, p.Version)
+		}
 		p.MaxFragmentCount = initialMaxFragmentCount
 	}
 

--- a/arbos/programs/params.go
+++ b/arbos/programs/params.go
@@ -180,8 +180,14 @@ func (p *StylusParams) UpgradeToVersion(version uint16) error {
 		p.Version = 2
 		p.MinInitGas = v2MinInitGas
 		return nil
+	case 3:
+		if p.Version != 2 {
+			return fmt.Errorf("unexpected upgrade from %d to %d", p.Version, version)
+		}
+		p.Version = 3
+		return nil
 	default:
-		return fmt.Errorf("unsupported upgrade to %d. Only 2 is supported", version)
+		return fmt.Errorf("unsupported upgrade to %d. Only 2 and 3 are supported", version)
 	}
 }
 

--- a/arbos/programs/params.go
+++ b/arbos/programs/params.go
@@ -207,9 +207,6 @@ func (p *StylusParams) UpgradeToArbosVersion(newArbosVersion uint64) error {
 		}
 		p.MaxWasmSize = initialMaxWasmSize
 	case params.ArbosVersion_StylusContractLimit:
-		if p.Version != 2 {
-			return fmt.Errorf("unexpected arbosVersion upgrade to %d while stylus version %d", newArbosVersion, p.Version)
-		}
 		p.MaxFragmentCount = initialMaxFragmentCount
 	}
 

--- a/arbos/programs/params_test.go
+++ b/arbos/programs/params_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package programs
+
+import (
+	"testing"
+)
+
+func TestUpgradeToVersion(t *testing.T) {
+	// Happy path: sequential 1 -> 2 -> 3 upgrade.
+	p := &StylusParams{Version: 1}
+	if err := p.UpgradeToVersion(2); err != nil {
+		Fail(t, "expected version 1->2 upgrade to succeed:", err)
+	}
+	AssertEq(t, p.Version, uint16(2))
+	AssertEq(t, p.MinInitGas, uint8(v2MinInitGas))
+
+	if err := p.UpgradeToVersion(3); err != nil {
+		Fail(t, "expected version 2->3 upgrade to succeed:", err)
+	}
+	AssertEq(t, p.Version, uint16(3))
+
+	// Re-applying version 3 must fail.
+	if err := p.UpgradeToVersion(3); err == nil {
+		Fail(t, "expected version 3->3 re-application to fail")
+	}
+
+	// Skipping from 1 directly to 3 must fail; Version must be unchanged.
+	p2 := &StylusParams{Version: 1}
+	if err := p2.UpgradeToVersion(3); err == nil {
+		Fail(t, "expected version 1->3 skip to fail")
+	}
+	AssertEq(t, p2.Version, uint16(1))
+
+	// Re-applying version 2 must fail (p.Version != 1).
+	p3 := &StylusParams{Version: 2}
+	if err := p3.UpgradeToVersion(2); err == nil {
+		Fail(t, "expected version 2->2 re-application to fail")
+	}
+
+	// Upgrading to an unsupported version must fail.
+	p4 := &StylusParams{Version: 3}
+	if err := p4.UpgradeToVersion(4); err == nil {
+		Fail(t, "expected upgrade to unsupported version 4 to fail")
+	}
+}

--- a/changelog/pmikolajczyk-nit-4791.md
+++ b/changelog/pmikolajczyk-nit-4791.md
@@ -1,0 +1,2 @@
+### Changed
+- Disable multi-value WASM for Stylus V3 contracts: upon activation at ArbOS version 60, the Stylus runtime version is upgraded to V3, and any new activation of a WASM containing multi-value blocks or functions is rejected. This replaces the previous ArbOS-version-specific gate.

--- a/crates/arbutil/src/evm/mod.rs
+++ b/crates/arbutil/src/evm/mod.rs
@@ -78,7 +78,6 @@ pub const ORIGIN_GAS: Gas = GAS_QUICK_STEP;
 
 pub const ARBOS_VERSION_STYLUS_CHARGING_FIXES: u64 = 32;
 pub const ARBOS_VERSION_STYLUS_LAST_CODE_CACHE_FIX: u64 = 40;
-pub const ARBOS_VERSION_STYLUS_NO_MULTI_VALUE: u64 = 60;
 
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]

--- a/crates/prover/src/binary.rs
+++ b/crates/prover/src/binary.rs
@@ -5,7 +5,7 @@ use std::{convert::TryInto, fmt::Debug, hash::Hash, mem, path::Path, str::FromSt
 
 use arbutil::{
     Bytes32, Color, DebugColor,
-    evm::{ARBOS_VERSION_STYLUS_CHARGING_FIXES, ARBOS_VERSION_STYLUS_NO_MULTI_VALUE},
+    evm::ARBOS_VERSION_STYLUS_CHARGING_FIXES,
     math::SaturatingSum,
 };
 use eyre::{Result, WrapErr, bail, ensure, eyre};
@@ -314,17 +314,14 @@ pub fn parse<'a>(input: &'a [u8], path: &'_ Path) -> Result<WasmBinary<'a>> {
 pub fn parse_with_version<'a>(
     input: &'a [u8],
     path: &'_ Path,
-    arbos_version: u64,
+    stylus_version: u16,
 ) -> Result<WasmBinary<'a>> {
     let mut features = WasmFeatures::empty();
     features.set(WasmFeatures::MUTABLE_GLOBAL, true);
     features.set(WasmFeatures::SATURATING_FLOAT_TO_INT, true);
     features.set(WasmFeatures::SIGN_EXTENSION, true);
     features.set(WasmFeatures::REFERENCE_TYPES, false);
-    features.set(
-        WasmFeatures::MULTI_VALUE,
-        arbos_version < ARBOS_VERSION_STYLUS_NO_MULTI_VALUE,
-    );
+    features.set(WasmFeatures::MULTI_VALUE, stylus_version < 3);
     features.set(WasmFeatures::BULK_MEMORY, true); // not all ops supported yet
     features.set(WasmFeatures::SIMD, false);
     features.set(WasmFeatures::RELAXED_SIMD, false);
@@ -664,12 +661,13 @@ impl<'a> WasmBinary<'a> {
     /// Parses and instruments a user wasm
     pub fn parse_user(
         wasm: &'a [u8],
+        stylus_version: u16,
         arbos_version_for_activation: u64,
         page_limit: u16,
         compile: &CompileConfig,
         codehash: &Bytes32,
     ) -> Result<(WasmBinary<'a>, StylusData)> {
-        let mut bin = parse_with_version(wasm, Path::new("user"), arbos_version_for_activation)?;
+        let mut bin = parse_with_version(wasm, Path::new("user"), stylus_version)?;
 
         let stylus_data = bin.instrument(compile, codehash)?;
 

--- a/crates/prover/src/binary.rs
+++ b/crates/prover/src/binary.rs
@@ -667,7 +667,11 @@ impl<'a> WasmBinary<'a> {
         compile: &CompileConfig,
         codehash: &Bytes32,
     ) -> Result<(WasmBinary<'a>, StylusData)> {
-        let mut bin = parse_with_version(wasm, Path::new("user"), stylus_version)?;
+        // When recompiling an already-active contract (arbos_version_for_activation == 0) the
+        // original activation version is unknown, so we cannot apply version-gated restrictions.
+        // Pass 0 so that pre-V3 contracts with multi-value WASM can still be recompiled.
+        let validation_version = if arbos_version_for_activation == 0 { 0 } else { stylus_version };
+        let mut bin = parse_with_version(wasm, Path::new("user"), validation_version)?;
 
         let stylus_data = bin.instrument(compile, codehash)?;
 

--- a/crates/prover/src/programs/config.rs
+++ b/crates/prover/src/programs/config.rs
@@ -165,7 +165,7 @@ impl CompileConfig {
 
         match version {
             0 => {}
-            1 | 2 => {
+            1 | 2 | 3 => {
                 config.bounds.heap_bound = Pages(128); // 8 mb
                 config.bounds.max_frame_size = 10 * 1024;
                 config.bounds.max_frame_contention = 4096;

--- a/crates/prover/src/programs/mod.rs
+++ b/crates/prover/src/programs/mod.rs
@@ -430,6 +430,7 @@ impl Module {
         let compile = CompileConfig::version(stylus_version, debug);
         let (bin, stylus_data) = WasmBinary::parse_user(
             wasm,
+            stylus_version,
             arbos_version_for_activation,
             page_limit,
             &compile,
@@ -496,15 +497,13 @@ impl Module {
 mod test {
     use std::path::Path;
 
-    use arbutil::evm::ARBOS_VERSION_STYLUS_NO_MULTI_VALUE;
-
     use super::*;
     use crate::binary;
 
-    // Parse at the threshold version so multi-value is rejected by the validator.
+    // Parse at the Stylus V3 version so multi-value is rejected by the validator.
     fn parse_at_threshold(wat: &str) -> Result<WasmBinary<'static>> {
         let wasm: &'static [u8] = Box::leak(wat::parse_str(wat).unwrap().into_boxed_slice());
-        binary::parse_with_version(wasm, Path::new("test"), ARBOS_VERSION_STYLUS_NO_MULTI_VALUE)
+        binary::parse_with_version(wasm, Path::new("test"), 3)
     }
 
     #[test]
@@ -612,14 +611,14 @@ mod test {
         .unwrap()
     }
 
-    fn activate_with_version(arbos_version: u64) -> Result<(Module, StylusData)> {
+    fn activate_with_stylus_version(stylus_version: u16) -> Result<(Module, StylusData)> {
         let wasm = multi_value_stylus_wasm();
         let mut gas = u64::MAX;
         Module::activate(
             &wasm[..],
             &Bytes32([0u8; 32]),
-            1,
-            arbos_version,
+            stylus_version,
+            1, // non-zero arbos_version (new activation, not recompilation)
             128,
             false,
             &mut gas,
@@ -627,21 +626,15 @@ mod test {
     }
 
     #[test]
-    fn test_activate_rejects_multi_value_at_threshold() {
-        // At the threshold version the validator rejects multi-value wasm.
-        assert!(activate_with_version(ARBOS_VERSION_STYLUS_NO_MULTI_VALUE).is_err());
+    fn test_activate_rejects_multi_value_at_stylus_v3() {
+        // Stylus V3 and above must reject multi-value wasm.
+        assert!(activate_with_stylus_version(3).is_err());
     }
 
     #[test]
-    fn test_activate_allows_multi_value_below_threshold() {
-        // One version below the threshold: gate must not fire, activation succeeds.
-        assert!(activate_with_version(ARBOS_VERSION_STYLUS_NO_MULTI_VALUE - 1).is_ok());
-    }
-
-    #[test]
-    fn test_activate_allows_multi_value_at_zero() {
-        // Version 0 is the recompilation path for already-active contracts.
-        // Multi-value must be accepted and activation must succeed.
-        assert!(activate_with_version(0).is_ok());
+    fn test_activate_allows_multi_value_below_stylus_v3() {
+        // Stylus V1 and V2 must still accept multi-value wasm.
+        assert!(activate_with_stylus_version(2).is_ok());
+        assert!(activate_with_stylus_version(1).is_ok());
     }
 }

--- a/crates/prover/src/programs/mod.rs
+++ b/crates/prover/src/programs/mod.rs
@@ -637,4 +637,25 @@ mod test {
         assert!(activate_with_stylus_version(2).is_ok());
         assert!(activate_with_stylus_version(1).is_ok());
     }
+
+    #[test]
+    fn test_recompile_allows_multi_value_at_stylus_v3() {
+        // Recompilation of an already-active contract (arbos_version == 0) must accept
+        // multi-value even when the chain is at Stylus V3, because the contract was
+        // legitimately activated pre-V3 and its wasm cannot change.
+        let wasm = multi_value_stylus_wasm();
+        let mut gas = u64::MAX;
+        assert!(
+            Module::activate(
+                &wasm[..],
+                &Bytes32([0u8; 32]),
+                3,
+                0, // arbos_version == 0 signals recompilation
+                128,
+                false,
+                &mut gas,
+            )
+            .is_ok()
+        );
+    }
 }


### PR DESCRIPTION
Multi-value WASM is now gated on the Stylus runtime version rather than the ArbOS version. Previously the gate was `arbos_version < 60` (a named constant). Now it is `stylus_version < 3`, evaluated at parse time.

Upon activation at ArbOS v59, `StylusParams` is upgraded to Stylus V3. Any new activation of a WASM containing multi-value blocks or functions at V3 is rejected by the WASM validator.

---

closes NIT-4791
pulls in https://github.com/OffchainLabs/go-ethereum/pull/650