### PR TITLE
Fix CI for 3.9.x-release branch

### DIFF
--- a/.github/workflows/_bold-legacy.yml
+++ b/.github/workflows/_bold-legacy.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Setup CI
         uses: ./.github/actions/ci-setup
 
+      - name: Build
+        run: make -j8 build test-go-deps
+
       - name: run challenge tests
         run: >-
           ${{ github.workspace }}/.github/workflows/gotestsum.sh --tags legacychallengetest

--- a/.github/workflows/_codecov.yml
+++ b/.github/workflows/_codecov.yml
@@ -26,6 +26,7 @@ jobs:
     name: Aggregate test results
     runs-on: ubuntu-4
     permissions:
+      contents: read
       pull-requests: write
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
     uses: ./.github/workflows/_codecov.yml
     secrets: inherit
     permissions:
+      contents: read
       pull-requests: write
     with:
       post_comment: true

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -42,6 +42,7 @@ jobs:
     uses: ./.github/workflows/_codecov.yml
     secrets: inherit
     permissions:
+      contents: read
       pull-requests: write
     with:
       post_comment: false

--- a/changelog/bragaigor-fix-ci-3.9.x.md
+++ b/changelog/bragaigor-fix-ci-3.9.x.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fix CI in v3.9.x branch

--- a/system_tests/batch_poster_test.go
+++ b/system_tests/batch_poster_test.go
@@ -876,11 +876,28 @@ func TestBatchPosterActuallyPostsBlobsToL1(t *testing.T) {
 	tx := builder.L2Info.PrepareTx("Faucet", "Owner", builder.L2Info.TransferGas, common.Big1, nil)
 	_ = builder.L2.SendWaitTestTransactions(t, []*types.Transaction{tx})[0]
 
-	// Advance L1 enough to ensure everything is synced
-	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 30)
+	// Brief pause for batch poster to detect the new L2 message
+	time.Sleep(100 * time.Millisecond)
 
-	// Wait for the batch to be posted and processed by node B
-	_, err = WaitForTx(ctx, testClientB.Client, tx.Hash(), 5*time.Second)
+	// Advance L1 one block at a time until the batch is posted, so that
+	// subsequent blocks remain for node B's inbox reader to pick it up.
+	initialBatchCount := GetBatchCount(t, builder)
+	batchPosted := false
+	for i := 0; i < 30; i++ {
+		AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 1)
+		time.Sleep(100 * time.Millisecond)
+		if GetBatchCount(t, builder) > initialBatchCount {
+			batchPosted = true
+			break
+		}
+	}
+	require.True(t, batchPosted, "batch was not posted to L1 after 30 blocks")
+
+	// Advance a few more L1 blocks so node B's inbox reader picks up the batch
+	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 10)
+
+	// Wait for node B to process the batch
+	_, err = WaitForTx(ctx, testClientB.Client, tx.Hash(), 30*time.Second)
 	Require(t, err)
 
 	// We assume that `builder.L1.Client` has the L1 block that made `testClientB.Client` notice `tx`.

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -1530,6 +1530,7 @@ func createTestL1BlockChain(t *testing.T, l1info info, withClientWrapper bool) (
 
 	simBeacon, err := catalyst.NewSimulatedBeacon(0, common.Address{}, l1backend)
 	Require(t, err)
+	Require(t, simBeacon.Initialize(context.Background()))
 	catalyst.RegisterSimulatedBeaconAPIs(stack, simBeacon)
 	stack.RegisterLifecycle(simBeacon)
 

--- a/util/blobs/blobs.go
+++ b/util/blobs/blobs.go
@@ -128,21 +128,20 @@ func ComputeCommitmentsAndHashes(blobs []kzg4844.Blob) ([]kzg4844.Commitment, []
 	return commitments, versionedHashes, nil
 }
 
-// ComputeProofs computes cell proofs for the given blobs.
-// Each blob generates CellProofsPerBlob (128) proofs.
-// Returns proofs, version byte (always 1), and error.
+// ComputeProofs computes legacy KZG proofs (version 0) for the given blobs.
+// Returns one proof per blob, version byte 0, and error.
 func ComputeProofs(blobs []kzg4844.Blob, commitments []kzg4844.Commitment) ([]kzg4844.Proof, byte, error) {
 	if len(blobs) != len(commitments) {
 		return nil, 0, fmt.Errorf("ComputeProofs got %v blobs but %v commitments", len(blobs), len(commitments))
 	}
 
-	proofs := make([]kzg4844.Proof, 0, len(blobs)*kzg4844.CellProofsPerBlob)
+	proofs := make([]kzg4844.Proof, len(blobs))
 	for i := range blobs {
-		cellProofs, err := kzg4844.ComputeCellProofs(&blobs[i])
+		proof, err := kzg4844.ComputeBlobProof(&blobs[i], commitments[i])
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to compute cell proofs for blob %d: %w", i, err)
+			return nil, 0, fmt.Errorf("failed to compute KZG proof for blob %d: %w", i, err)
 		}
-		proofs = append(proofs, cellProofs...)
+		proofs[i] = proof
 	}
-	return proofs, 1, nil
+	return proofs, 0, nil
 }

--- a/util/blobs/blobs_test.go
+++ b/util/blobs/blobs_test.go
@@ -52,8 +52,8 @@ outer:
 	}
 }
 
-func TestComputeProofsVersion1(t *testing.T) {
-	testData := []byte("test data for blob proof version 1 with cell proofs")
+func TestComputeProofsVersion0(t *testing.T) {
+	testData := []byte("test data for blob proof version 0 with legacy KZG proofs")
 	blobs, err := EncodeBlobs(testData)
 	if err != nil {
 		t.Fatalf("failed to encode blobs: %v", err)
@@ -68,24 +68,23 @@ func TestComputeProofsVersion1(t *testing.T) {
 
 	proofs, version, err := ComputeProofs(blobs, commitments)
 	if err != nil {
-		t.Fatalf("failed to compute version 1 proofs: %v", err)
+		t.Fatalf("failed to compute version 0 proofs: %v", err)
 	}
 
-	// Check version
-	if version != 1 {
-		t.Errorf("expected version 1, got %d", version)
+	if version != 0 {
+		t.Errorf("expected version 0, got %d", version)
 	}
 
-	// Check proof count: should be CellProofsPerBlob (128) proofs per blob
-	expectedProofCount := len(blobs) * kzg4844.CellProofsPerBlob
-	if len(proofs) != expectedProofCount {
-		t.Errorf("expected %d proofs, got %d", expectedProofCount, len(proofs))
+	// One proof per blob
+	if len(proofs) != len(blobs) {
+		t.Errorf("expected %d proofs, got %d", len(blobs), len(proofs))
 	}
 
-	// Verify the cell proofs are valid
-	err = kzg4844.VerifyCellProofs(blobs, commitments, proofs)
-	if err != nil {
-		t.Errorf("cell proof verification failed: %v", err)
+	// Verify each blob proof
+	for i := range blobs {
+		if err := kzg4844.VerifyBlobProof(&blobs[i], commitments[i], proofs[i]); err != nil {
+			t.Errorf("blob proof verification failed for blob %d: %v", i, err)
+		}
 	}
 }
 
@@ -102,7 +101,7 @@ func TestComputeProofsMismatchedInputs(t *testing.T) {
 	}
 }
 
-func TestComputeProofsMultipleBlobsVersion1(t *testing.T) {
+func TestComputeProofsMultipleBlobsVersion0(t *testing.T) {
 	// Create test data large enough to span multiple blobs
 	testData := make([]byte, bytesEncodedPerBlob*2)
 	for i := range testData {
@@ -126,19 +125,19 @@ func TestComputeProofsMultipleBlobsVersion1(t *testing.T) {
 		t.Fatalf("failed to compute proofs: %v", err)
 	}
 
-	if version != 1 {
-		t.Errorf("expected version 1, got %d", version)
+	if version != 0 {
+		t.Errorf("expected version 0, got %d", version)
 	}
 
-	// Should be CellProofsPerBlob proofs per blob
-	expectedCount := len(multiBlobs) * kzg4844.CellProofsPerBlob
-	if len(proofs) != expectedCount {
-		t.Errorf("expected %d proofs, got %d", expectedCount, len(proofs))
+	// One proof per blob
+	if len(proofs) != len(multiBlobs) {
+		t.Errorf("expected %d proofs, got %d", len(multiBlobs), len(proofs))
 	}
 
-	// Verify all cell proofs
-	err = kzg4844.VerifyCellProofs(multiBlobs, multiCommitments, proofs)
-	if err != nil {
-		t.Errorf("cell proof verification failed: %v", err)
+	// Verify each blob proof
+	for i := range multiBlobs {
+		if err := kzg4844.VerifyBlobProof(&multiBlobs[i], multiCommitments[i], proofs[i]); err != nil {
+			t.Errorf("blob proof verification failed for blob %d: %v", i, err)
+		}
 	}
 }


### PR DESCRIPTION
go-ethereum on this branch lacks Osaka support, so the blob pool rejects Version1 cell-proof sidecars. Revert ComputeProofs to produce Version0 legacy KZG proofs, update blob proof unit tests accordingly, initialize simulated beacon blob storage, stabilize the batch poster test with per-block polling, and fix the bold CI workflow.

pulls in https://github.com/OffchainLabs/go-ethereum/pull/652