### PR TITLE
precompiles: gate Arbitrum precompiles on ArbOS activation version

### DIFF
--- a/changelog/jco-free-access-precompile-version-check.md
+++ b/changelog/jco-free-access-precompile-version-check.md
@@ -1,0 +1,2 @@
+### Fixed
+- Check ArbOS version in `FreeAccessPrecompile.Call` before reading state, matching the gate in `Precompile.Call`. Fixes consensus divergence on blocks that CALLed 0x74 prior to the activation of ArbFilteredTransactionsManager, where the wrapper's filterer lookup burned gas that the canonical chain did not charge.

--- a/gethhook/arbos_precompile_snapshots.go
+++ b/gethhook/arbos_precompile_snapshots.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2026, Offchain Labs, Inc.
+// Copyright 2026, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
 
 package gethhook

--- a/gethhook/arbos_precompile_snapshots.go
+++ b/gethhook/arbos_precompile_snapshots.go
@@ -1,0 +1,148 @@
+// Copyright 2021-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package gethhook
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+// Arbitrum precompiles are registered per ArbOS activation version
+// through registerArbOSPrecompile. Dispatch picks the snapshot with
+// the largest activationVersion <= rules.ArbOSVersion, so a
+// precompile introduced at version V is hidden on blocks < V —
+// matching consensus, which treats the address as a regular account
+// on pre-activation blocks (cold CALL 2600 gas, not warm precompile
+// 100 gas). Without this gate, historical replay diverges on state
+// root.
+//
+// Registrations are init-only and materialized lazily under
+// sync.Once. All ArbOS-versioning semantics live here rather than
+// in core/vm to keep the fork's delta vs upstream ethereum/go-ethereum
+// minimal.
+
+type arbOSPrecompileRegistration struct {
+	minVersion uint64
+	addr       common.Address
+	contract   vm.PrecompiledContract
+}
+
+// arbOSPrecompileSnapshot holds the contracts and addresses active
+// at a specific ArbOS version. Every mutation goes through
+// addPrecompile so the two views never drift.
+type arbOSPrecompileSnapshot struct {
+	activationVersion uint64
+	contracts         vm.PrecompiledContracts
+	addresses         []common.Address
+}
+
+// addPrecompile permits re-registration at the same address so
+// layering (higher-minVersion registration overwrites lower) works:
+// the later contract replaces the earlier in the map, and the
+// existing address slot is left in place so the slice never grows
+// duplicates. Called only from materializeArbOSPrecompileSnapshots;
+// snapshots are immutable after that.
+func (s *arbOSPrecompileSnapshot) addPrecompile(addr common.Address, c vm.PrecompiledContract) {
+	if _, exists := s.contracts[addr]; !exists {
+		s.addresses = append(s.addresses, addr)
+	}
+	s.contracts[addr] = c
+}
+
+var (
+	arbOSPrecompileRegistrations []arbOSPrecompileRegistration
+	// Sorted descending so dispatch returns on the first match.
+	// Non-nil after materialization (even on the empty-registrations
+	// sentinel path), which keeps the post-materialize guard in
+	// registerArbOSPrecompile armed.
+	arbOSPrecompileSnapshots []arbOSPrecompileSnapshot
+	arbOSPrecompileOnce      sync.Once
+)
+
+// registerArbOSPrecompile must be called from init(). Multiple
+// registrations at the same address with different minVersions are
+// allowed: the highest-minVersion entry <= each snapshot's
+// activationVersion wins, so e.g. Berlin's ecrecover can be
+// registered at 0 and replaced by Cancun's at
+// params.ArbosVersion_Stylus.
+func registerArbOSPrecompile(minVersion uint64, addr common.Address, c vm.PrecompiledContract) {
+	if c == nil {
+		panic(fmt.Sprintf("registerArbOSPrecompile: nil contract for %s at version %d", addr, minVersion))
+	}
+	if arbOSPrecompileSnapshots != nil {
+		panic(fmt.Sprintf("registerArbOSPrecompile: %s registered at version %d after snapshots were materialized; must be called from init()", addr, minVersion))
+	}
+	arbOSPrecompileRegistrations = append(arbOSPrecompileRegistrations, arbOSPrecompileRegistration{
+		minVersion: minVersion,
+		addr:       addr,
+		contract:   c,
+	})
+}
+
+// arbOSPrecompilesFor is installed into core/vm via
+// vm.SetArbOSPrecompileResolver. Returns (nil, nil) when no
+// registration sits at or below v so Arbitrum dispatch falls
+// through to account handling. The views are shared read-only.
+func arbOSPrecompilesFor(v uint64) (vm.PrecompiledContracts, []common.Address) {
+	arbOSPrecompileOnce.Do(materializeArbOSPrecompileSnapshots)
+	for _, s := range arbOSPrecompileSnapshots {
+		if s.activationVersion <= v {
+			return s.contracts, s.addresses
+		}
+	}
+	return nil, nil
+}
+
+// materializeArbOSPrecompileSnapshots builds one snapshot per
+// distinct activation version. Snapshot count and registration
+// count are both tiny in practice, so we rebuild from scratch
+// rather than maintain snapshots incrementally.
+func materializeArbOSPrecompileSnapshots() {
+	if len(arbOSPrecompileRegistrations) == 0 {
+		// Non-nil zero-length sentinel: keeps the
+		// post-materialize guard in registerArbOSPrecompile armed.
+		arbOSPrecompileSnapshots = []arbOSPrecompileSnapshot{}
+		return
+	}
+
+	versionSet := make(map[uint64]struct{}, 8)
+	for _, r := range arbOSPrecompileRegistrations {
+		versionSet[r.minVersion] = struct{}{}
+	}
+	versions := make([]uint64, 0, len(versionSet))
+	for v := range versionSet {
+		versions = append(versions, v)
+	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
+
+	// Replay in ascending minVersion order so higher-minVersion
+	// entries overwrite lower ones at the same address. Stable sort
+	// keeps the address slice deterministic across runs.
+	regs := make([]arbOSPrecompileRegistration, len(arbOSPrecompileRegistrations))
+	copy(regs, arbOSPrecompileRegistrations)
+	sort.SliceStable(regs, func(i, j int) bool { return regs[i].minVersion < regs[j].minVersion })
+
+	snapshots := make([]arbOSPrecompileSnapshot, len(versions))
+	for i, v := range versions {
+		snap := arbOSPrecompileSnapshot{
+			activationVersion: v,
+			contracts:         make(vm.PrecompiledContracts),
+		}
+		for _, r := range regs {
+			if r.minVersion > v {
+				break // regs is ascending; remainder is all > v.
+			}
+			snap.addPrecompile(r.addr, r.contract)
+		}
+		snapshots[i] = snap
+	}
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].activationVersion > snapshots[j].activationVersion
+	})
+	arbOSPrecompileSnapshots = snapshots
+}

--- a/gethhook/arbos_precompile_snapshots_test.go
+++ b/gethhook/arbos_precompile_snapshots_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2026, Offchain Labs, Inc.
+// Copyright 2026, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
 
 package gethhook

--- a/gethhook/arbos_precompile_snapshots_test.go
+++ b/gethhook/arbos_precompile_snapshots_test.go
@@ -1,0 +1,304 @@
+// Copyright 2021-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package gethhook
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/offchainlabs/nitro/precompiles"
+)
+
+// withIsolatedArbOSRegistry lets a test register its own precompiles
+// without bleeding into the real init-registered state used by
+// TestAllRealPrecompilesReachableAtDeclaredVersion and the existing
+// geth_test.go chain tests. Tests share package state and must not
+// use t.Parallel().
+func withIsolatedArbOSRegistry(t *testing.T) {
+	t.Helper()
+	savedRegs := make([]arbOSPrecompileRegistration, len(arbOSPrecompileRegistrations))
+	copy(savedRegs, arbOSPrecompileRegistrations)
+	arbOSPrecompileRegistrations = nil
+	arbOSPrecompileSnapshots = nil
+	arbOSPrecompileOnce = sync.Once{}
+	t.Cleanup(func() {
+		arbOSPrecompileRegistrations = savedRegs
+		arbOSPrecompileSnapshots = nil
+		arbOSPrecompileOnce = sync.Once{}
+	})
+}
+
+type stubPrecompile struct{ tag string }
+
+func (s *stubPrecompile) RequiredGas(input []byte) uint64  { return 0 }
+func (s *stubPrecompile) Run(input []byte) ([]byte, error) { return []byte(s.tag), nil }
+func (s *stubPrecompile) Name() string                     { return "stub:" + s.tag }
+
+func addrOf(hex string) common.Address { return common.HexToAddress(hex) }
+
+// Empty registry must return (nil, nil) and hit the non-nil empty
+// sentinel without panicking.
+func TestArbOSPrecompilesForEmptyRegistry(t *testing.T) {
+	withIsolatedArbOSRegistry(t)
+
+	for _, v := range []uint64{0, 1, 30, 50, 60, 1 << 40} {
+		m, a := arbOSPrecompilesFor(v)
+		if m != nil || a != nil {
+			t.Errorf("ArbOS %d: expected (nil, nil), got map=%v addrs=%v", v, m, a)
+		}
+	}
+}
+
+// Pins the core consensus fix: a pre-activation CALL must charge
+// 2600 gas (cold account) not 100 (warm precompile). An earlier
+// gethhook change unconditionally registered precompiles into every
+// bucket and shifted state roots during historical replay.
+func TestArbOSPrecompileActivationVersionGating(t *testing.T) {
+	withIsolatedArbOSRegistry(t)
+
+	a := addrOf("0xfeed")
+	registerArbOSPrecompile(60, a, &stubPrecompile{tag: "v60"})
+
+	for _, v := range []uint64{0, 30, 50, 59} {
+		m, addrs := arbOSPrecompilesFor(v)
+		if _, ok := m[a]; ok {
+			t.Errorf("ArbOS %d: precompile %s should be hidden (activation 60)", v, a)
+		}
+		if containsAddr(addrs, a) {
+			t.Errorf("ArbOS %d: address %s leaked into active list", v, a)
+		}
+	}
+	for _, v := range []uint64{60, 61, 100, 1 << 40} {
+		m, addrs := arbOSPrecompilesFor(v)
+		if _, ok := m[a]; !ok {
+			t.Errorf("ArbOS %d: precompile %s should be active", v, a)
+		}
+		if !containsAddr(addrs, a) {
+			t.Errorf("ArbOS %d: address %s missing from active list", v, a)
+		}
+	}
+}
+
+// Non-fork-boundary activation: the previous fork-name bucket
+// scheme (IsDia / IsStylus / IsArbitrum) silently widened any
+// between-fork registration to the lower bucket's whole window.
+func TestArbOSPrecompileIntermediateVersion(t *testing.T) {
+	withIsolatedArbOSRegistry(t)
+
+	a := addrOf("0xa1")
+	registerArbOSPrecompile(41, a, &stubPrecompile{tag: "v41"})
+
+	cases := []struct {
+		v    uint64
+		want bool
+	}{
+		{0, false}, {30, false}, {40, false},
+		{41, true}, {45, true}, {50, true}, {60, true},
+	}
+	for _, c := range cases {
+		m, _ := arbOSPrecompilesFor(c.v)
+		_, got := m[a]
+		if got != c.want {
+			t.Errorf("ArbOS %d: present=%v want %v", c.v, got, c.want)
+		}
+	}
+}
+
+// Berlin's ecrecover at minVersion 0 overwritten by Cancun's at
+// ArbosVersion_Stylus. The address must appear exactly once in
+// each snapshot's slice so iteration doesn't double-count.
+func TestArbOSPrecompileLayeringOverwrites(t *testing.T) {
+	withIsolatedArbOSRegistry(t)
+
+	a := addrOf("0xec")
+	early := &stubPrecompile{tag: "berlin"}
+	late := &stubPrecompile{tag: "cancun"}
+	registerArbOSPrecompile(0, a, early)
+	registerArbOSPrecompile(params.ArbosVersion_Stylus, a, late)
+
+	m0, addrs0 := arbOSPrecompilesFor(0)
+	if m0[a] != early {
+		t.Errorf("ArbOS 0: expected early contract, got %+v", m0[a])
+	}
+	if n := countAddr(addrs0, a); n != 1 {
+		t.Errorf("ArbOS 0: address %s appears %d times, want 1", a, n)
+	}
+
+	mStylus, addrsStylus := arbOSPrecompilesFor(params.ArbosVersion_Stylus)
+	if mStylus[a] != late {
+		t.Errorf("ArbOS Stylus: expected late contract, got %+v", mStylus[a])
+	}
+	if n := countAddr(addrsStylus, a); n != 1 {
+		t.Errorf("ArbOS Stylus: address %s appears %d times, want 1", a, n)
+	}
+}
+
+// End-to-end through the real vm.ActivePrecompiledContracts /
+// ActivePrecompiles path, plus a pointer-equality pin on
+// arbOSPrecompilesFor so a refactor that allocates a fresh snapshot
+// per call fails here.
+func TestArbOSPrecompileDispatchEndToEnd(t *testing.T) {
+	withIsolatedArbOSRegistry(t)
+
+	active := addrOf("0xabcd01")
+	future := addrOf("0xabcd02")
+	registerArbOSPrecompile(0, active, &stubPrecompile{tag: "active"})
+	registerArbOSPrecompile(60, future, &stubPrecompile{tag: "future"})
+
+	rules50 := params.Rules{IsArbitrum: true, ArbOSVersion: 50}
+	cloned := vm.ActivePrecompiledContracts(rules50)
+	if _, ok := cloned[active]; !ok {
+		t.Error("ArbOS 50: expected active precompile present via ActivePrecompiledContracts")
+	}
+	if _, ok := cloned[future]; ok {
+		t.Error("ArbOS 50: future precompile leaked through ActivePrecompiledContracts")
+	}
+
+	rawMap1, _ := arbOSPrecompilesFor(50)
+	rawMap2, _ := arbOSPrecompilesFor(50)
+	if reflect.ValueOf(rawMap1).Pointer() != reflect.ValueOf(rawMap2).Pointer() {
+		t.Error("arbOSPrecompilesFor returned a fresh map on repeat call -- cache broken")
+	}
+
+	rules60 := params.Rules{IsArbitrum: true, ArbOSVersion: 60}
+	if _, ok := vm.ActivePrecompiledContracts(rules60)[future]; !ok {
+		t.Error("ArbOS 60: future precompile should be active")
+	}
+	if !containsAddr(vm.ActivePrecompiles(rules60), future) {
+		t.Error("ArbOS 60: ActivePrecompiles missing future address")
+	}
+}
+
+// Pins the !rules.IsArbitrum gate in arbOSActivePrecompiles: a
+// non-Arbitrum chain must never observe the Arbitrum snapshot, and
+// a regression that dropped the gate would fail here.
+func TestArbOSPrecompileDispatchFallsThroughForNonArbitrum(t *testing.T) {
+	withIsolatedArbOSRegistry(t)
+
+	a := addrOf("0xfeed")
+	registerArbOSPrecompile(60, a, &stubPrecompile{tag: "v60"})
+
+	rules := params.Rules{IsArbitrum: false, IsCancun: true, ArbOSVersion: 60}
+	m := vm.ActivePrecompiledContracts(rules)
+	if _, ok := m[a]; ok {
+		t.Error("non-Arbitrum dispatch leaked the Arbitrum snapshot precompile")
+	}
+	// Also assert we landed in the Ethereum switch and didn't
+	// just return empty.
+	if _, ok := m[common.BytesToAddress([]byte{0x01})]; !ok {
+		t.Error("non-Arbitrum Cancun dispatch missing ecrecover -- fall-through broken")
+	}
+	addrs := vm.ActivePrecompiles(rules)
+	if containsAddr(addrs, a) {
+		t.Error("non-Arbitrum ActivePrecompiles leaked the Arbitrum snapshot address")
+	}
+}
+
+// Pins the maps.Clone wrapper: a refactor that aliased the cached
+// snapshot would silently let one caller poison every subsequent
+// lookup.
+func TestActivePrecompiledContractsReturnsDistinctClone(t *testing.T) {
+	withIsolatedArbOSRegistry(t)
+
+	a := addrOf("0xcace01")
+	registerArbOSPrecompile(0, a, &stubPrecompile{tag: "active"})
+
+	rules := params.Rules{IsArbitrum: true, ArbOSVersion: 50}
+	cloned := vm.ActivePrecompiledContracts(rules)
+	if _, ok := cloned[a]; !ok {
+		t.Fatalf("clone missing registered address %s", a)
+	}
+	cached, _ := arbOSPrecompilesFor(50)
+	if reflect.ValueOf(cloned).Pointer() == reflect.ValueOf(cached).Pointer() {
+		t.Fatal("ActivePrecompiledContracts returned the cached snapshot; must be a clone")
+	}
+
+	mut := addrOf("0xcace02")
+	cloned[mut] = &stubPrecompile{tag: "mut"}
+	again, _ := arbOSPrecompilesFor(50)
+	if _, poisoned := again[mut]; poisoned {
+		t.Error("mutation of the clone leaked into the cached snapshot")
+	}
+}
+
+func TestRegisterArbOSPrecompileNilPanics(t *testing.T) {
+	withIsolatedArbOSRegistry(t)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil contract")
+		}
+	}()
+	registerArbOSPrecompile(0, addrOf("0x1"), nil)
+}
+
+// A post-materialize registration would be silently ignored and
+// consensus would diverge, so the panic must fire.
+func TestRegisterArbOSPrecompileAfterMaterializePanics(t *testing.T) {
+	withIsolatedArbOSRegistry(t)
+
+	registerArbOSPrecompile(0, addrOf("0x1"), &stubPrecompile{tag: "early"})
+	_, _ = arbOSPrecompilesFor(0) // materialize
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on registration after materialization")
+		}
+	}()
+	registerArbOSPrecompile(0, addrOf("0x2"), &stubPrecompile{tag: "late"})
+}
+
+// Against the real init-registered state (not isolated): every
+// Nitro precompile must be reachable at its declared ArbosVersion,
+// wrapped in ArbosPrecompileWrapper, and absent at declared-1.
+// Layering further back is covered by
+// TestArbOSPrecompileActivationVersionGating.
+func TestAllRealPrecompilesReachableAtDeclaredVersion(t *testing.T) {
+	for addr, p := range precompiles.Precompiles() {
+		name := p.Precompile().Name()
+		declared := p.Precompile().ArbosVersion()
+
+		m, _ := arbOSPrecompilesFor(declared)
+		got, ok := m[addr]
+		if !ok {
+			t.Errorf("precompile %s (%s) not registered at its declared ArbosVersion %d", addr, name, declared)
+			continue
+		}
+		if _, isWrapper := got.(ArbosPrecompileWrapper); !isWrapper {
+			t.Errorf("precompile %s (%s) at version %d is registered but not wrapped in ArbosPrecompileWrapper", addr, name, declared)
+		}
+
+		if declared == 0 {
+			continue
+		}
+		mPrev, _ := arbOSPrecompilesFor(declared - 1)
+		if _, stillThere := mPrev[addr]; stillThere {
+			t.Errorf("precompile %s (%s) declared at version %d is also present at version %d — off-by-one regression", addr, name, declared, declared-1)
+		}
+	}
+}
+
+func containsAddr(addrs []common.Address, want common.Address) bool {
+	for _, a := range addrs {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func countAddr(addrs []common.Address, want common.Address) int {
+	n := 0
+	for _, a := range addrs {
+		if a == want {
+			n++
+		}
+	}
+	return n
+}

--- a/gethhook/ethereum_precompile_sets.go
+++ b/gethhook/ethereum_precompile_sets.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2026, Offchain Labs, Inc.
+// Copyright 2026, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
 
 package gethhook

--- a/gethhook/ethereum_precompile_sets.go
+++ b/gethhook/ethereum_precompile_sets.go
@@ -1,0 +1,87 @@
+// Copyright 2021-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package gethhook
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// upstreamSymbol pins the upstream var name as a string so
+// TestAllUpstreamPrecompileSetsCataloged can cross-check this list
+// against a go/parser walk of core/vm/contracts.go.
+type ethereumPrecompileSet struct {
+	upstreamSymbol string
+	contracts      vm.PrecompiledContracts
+	minVersion     uint64
+}
+
+// Each entry references an upstream vm.PrecompiledContractsXxx var
+// directly, so a rename or removal upstream fails to compile.
+// Upstream ADDITIONS are caught by knownUpstreamPrecompileSetSymbols
+// + TestAllUpstreamPrecompileSetsCataloged.
+var ethereumPrecompileSets = []ethereumPrecompileSet{
+	{
+		upstreamSymbol: "PrecompiledContractsBerlin",
+		contracts:      vm.PrecompiledContractsBerlin,
+		minVersion:     0,
+	},
+	{
+		upstreamSymbol: "PrecompiledContractsCancun",
+		contracts:      vm.PrecompiledContractsCancun,
+		minVersion:     params.ArbosVersion_Stylus,
+	},
+	{
+		upstreamSymbol: "PrecompiledContractsOsaka",
+		contracts:      vm.PrecompiledContractsOsaka,
+		minVersion:     params.ArbosVersion_Dia,
+	},
+	{
+		upstreamSymbol: "PrecompiledContractsP256Verify",
+		contracts:      vm.PrecompiledContractsP256Verify,
+		minVersion:     params.ArbosVersion_Stylus,
+	},
+}
+
+// Exhaustive catalog of upstream PrecompiledContractsXxx symbols.
+// TestAllUpstreamPrecompileSetsCataloged fails when this map drifts
+// from the real contracts.go, so a geth rebase that adds a new set
+// surfaces the decision loudly.
+//
+// Each rationale must take one of three forms, enforced by
+// TestEthereumPrecompileSetRelationships:
+//
+//   - "registered": has an entry in ethereumPrecompileSets above.
+//   - "covered by <Set>": a registered entry that contains every
+//     address this symbol exposes (superset check).
+//   - "alias of <Set>": a Go-level `var X = Y` alias (pointer
+//     equality check).
+var knownUpstreamPrecompileSetSymbols = map[string]string{
+	"PrecompiledContractsHomestead":  "covered by Berlin",
+	"PrecompiledContractsByzantium":  "covered by Berlin",
+	"PrecompiledContractsIstanbul":   "covered by Berlin",
+	"PrecompiledContractsBerlin":     "registered",
+	"PrecompiledContractsCancun":     "registered",
+	"PrecompiledContractsPrague":     "covered by Osaka",
+	"PrecompiledContractsBLS":        "alias of Prague",
+	"PrecompiledContractsVerkle":     "alias of Berlin",
+	"PrecompiledContractsOsaka":      "registered",
+	"PrecompiledContractsP256Verify": "registered",
+}
+
+// registerAllEthereumPrecompileSets panics on an empty/nil
+// contracts field so `range nil_map → zero iterations` can't
+// silently drop a set from every snapshot.
+func registerAllEthereumPrecompileSets() {
+	for _, set := range ethereumPrecompileSets {
+		if len(set.contracts) == 0 {
+			panic(fmt.Sprintf("gethhook: Ethereum precompile set %s has empty/nil contracts — check the entry in ethereumPrecompileSets", set.upstreamSymbol))
+		}
+		for addr, precompile := range set.contracts {
+			registerArbOSPrecompile(set.minVersion, addr, precompile)
+		}
+	}
+}

--- a/gethhook/ethereum_precompile_sets_test.go
+++ b/gethhook/ethereum_precompile_sets_test.go
@@ -1,0 +1,185 @@
+// Copyright 2021-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package gethhook
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+// Hand-maintained string → var map; Go can't reflect on
+// package-level names. Drift from knownUpstreamPrecompileSetSymbols
+// is caught by TestEthereumPrecompileSetRelationships.
+var upstreamPrecompileContractsBySymbol = map[string]vm.PrecompiledContracts{
+	"PrecompiledContractsHomestead":  vm.PrecompiledContractsHomestead,
+	"PrecompiledContractsByzantium":  vm.PrecompiledContractsByzantium,
+	"PrecompiledContractsIstanbul":   vm.PrecompiledContractsIstanbul,
+	"PrecompiledContractsBerlin":     vm.PrecompiledContractsBerlin,
+	"PrecompiledContractsCancun":     vm.PrecompiledContractsCancun,
+	"PrecompiledContractsPrague":     vm.PrecompiledContractsPrague,
+	"PrecompiledContractsBLS":        vm.PrecompiledContractsBLS,
+	"PrecompiledContractsVerkle":     vm.PrecompiledContractsVerkle,
+	"PrecompiledContractsOsaka":      vm.PrecompiledContractsOsaka,
+	"PrecompiledContractsP256Verify": vm.PrecompiledContractsP256Verify,
+}
+
+// Relative to the gethhook package dir, which is the cwd under
+// `go test`.
+const upstreamContractsPath = "../go-ethereum/core/vm/contracts.go"
+
+// Primary safety net against silently dropping a newly-added
+// upstream precompile set. Uses go/parser (not a regex) so
+// block-form `var (...)` declarations can't slip past.
+func TestAllUpstreamPrecompileSetsCataloged(t *testing.T) {
+	seen := parseUpstreamPrecompileSymbols(t)
+	if len(seen) == 0 {
+		t.Fatalf("found no PrecompiledContracts* vars in %s — parser or submodule layout regressed", upstreamContractsPath)
+	}
+
+	for name := range seen {
+		if _, ok := knownUpstreamPrecompileSetSymbols[name]; !ok {
+			t.Errorf("upstream symbol %s is not cataloged in knownUpstreamPrecompileSetSymbols — decide how Arbitrum gates it, then add a rationale entry", name)
+		}
+	}
+	// Inverse direction catches stale catalog entries that a
+	// compile-time rename would miss.
+	for name := range knownUpstreamPrecompileSetSymbols {
+		if _, ok := seen[name]; !ok {
+			t.Errorf("catalog entry %s no longer exists upstream — remove it from knownUpstreamPrecompileSetSymbols", name)
+		}
+	}
+}
+
+func parseUpstreamPrecompileSymbols(t *testing.T) map[string]struct{} {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, upstreamContractsPath, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", upstreamContractsPath, err)
+	}
+	seen := make(map[string]struct{})
+	ast.Inspect(file, func(n ast.Node) bool {
+		decl, ok := n.(*ast.GenDecl)
+		if !ok || decl.Tok != token.VAR {
+			return true
+		}
+		for _, spec := range decl.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, name := range vs.Names {
+				if strings.HasPrefix(name.Name, "PrecompiledContracts") {
+					seen[name.Name] = struct{}{}
+				}
+			}
+		}
+		return true
+	})
+	return seen
+}
+
+// Pins consistency between the catalog and the registration list.
+func TestEveryRegisteredSetIsCataloged(t *testing.T) {
+	for _, set := range ethereumPrecompileSets {
+		rationale, ok := knownUpstreamPrecompileSetSymbols[set.upstreamSymbol]
+		if !ok {
+			t.Errorf("ethereumPrecompileSets entry %s missing from knownUpstreamPrecompileSetSymbols", set.upstreamSymbol)
+			continue
+		}
+		if rationale != "registered" {
+			t.Errorf("ethereumPrecompileSets entry %s is catalogued as %q, expected \"registered\"", set.upstreamSymbol, rationale)
+		}
+	}
+}
+
+// Backs the "covered by X" and "alias of X" rationales with real
+// assertions — without this, a future upstream change that breaks
+// the superset relationship (e.g. Prague adds a precompile Osaka
+// doesn't carry) would silently drop the covered set. Iterates the
+// catalog directly so unknown rationale forms and unknown targets
+// fail loudly.
+func TestEthereumPrecompileSetRelationships(t *testing.T) {
+	for name := range knownUpstreamPrecompileSetSymbols {
+		if _, ok := upstreamPrecompileContractsBySymbol[name]; !ok {
+			t.Errorf("upstreamPrecompileContractsBySymbol is missing %s — add the var reference alongside the catalog entry", name)
+		}
+	}
+
+	for name, rationale := range knownUpstreamPrecompileSetSymbols {
+		covered, ok := upstreamPrecompileContractsBySymbol[name]
+		if !ok {
+			continue // already reported above
+		}
+		switch {
+		case rationale == "registered":
+			// Covered by TestEveryRegisteredSetIsCataloged +
+			// TestEveryEthereumPrecompileAddressRegistered.
+		case strings.HasPrefix(rationale, "covered by "):
+			targetName := "PrecompiledContracts" + strings.TrimPrefix(rationale, "covered by ")
+			target, ok := upstreamPrecompileContractsBySymbol[targetName]
+			if !ok {
+				t.Errorf("%s rationale %q points at unknown target %s", name, rationale, targetName)
+				continue
+			}
+			for a := range covered {
+				if _, ok := target[a]; !ok {
+					t.Errorf("%s (%s): address %s missing from %s — catalog rationale is stale", name, rationale, a, targetName)
+				}
+			}
+		case strings.HasPrefix(rationale, "alias of "):
+			targetName := "PrecompiledContracts" + strings.TrimPrefix(rationale, "alias of ")
+			target, ok := upstreamPrecompileContractsBySymbol[targetName]
+			if !ok {
+				t.Errorf("%s rationale %q points at unknown target %s", name, rationale, targetName)
+				continue
+			}
+			if reflect.ValueOf(covered).Pointer() != reflect.ValueOf(target).Pointer() {
+				t.Errorf("%s (%s): no longer shares a backing map with %s — catalog rationale is stale", name, rationale, targetName)
+			}
+		default:
+			t.Errorf("%s has unknown rationale form %q — expected \"registered\", \"covered by <Set>\", or \"alias of <Set>\"", name, rationale)
+		}
+	}
+}
+
+// The nil-contracts guard exists specifically to prevent a silent
+// `range nil_map → zero iterations` drop, so exercise the panic
+// path directly — a regression that removed the guard would otherwise
+// re-open the exact bug it was added to prevent.
+func TestRegisterAllEthereumPrecompileSetsPanicsOnNilContracts(t *testing.T) {
+	withIsolatedArbOSRegistry(t)
+	saved := ethereumPrecompileSets
+	t.Cleanup(func() { ethereumPrecompileSets = saved })
+
+	ethereumPrecompileSets = []ethereumPrecompileSet{
+		{upstreamSymbol: "PrecompiledContractsFake", contracts: nil, minVersion: 0},
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("registerAllEthereumPrecompileSets should panic on nil contracts")
+		}
+	}()
+	registerAllEthereumPrecompileSets()
+}
+
+// Catches a registration-loop typo that silently drops addresses
+// from dispatch.
+func TestEveryEthereumPrecompileAddressRegistered(t *testing.T) {
+	for _, set := range ethereumPrecompileSets {
+		m, _ := arbOSPrecompilesFor(set.minVersion)
+		for a := range set.contracts {
+			if _, ok := m[a]; !ok {
+				t.Errorf("Ethereum precompile %s from set %s not registered at activation version %d", a, set.upstreamSymbol, set.minVersion)
+			}
+		}
+	}
+}

--- a/gethhook/ethereum_precompile_sets_test.go
+++ b/gethhook/ethereum_precompile_sets_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2026, Offchain Labs, Inc.
+// Copyright 2026, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
 
 package gethhook

--- a/gethhook/geth-hook.go
+++ b/gethhook/geth-hook.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/arbitrum/multigas"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -66,7 +65,9 @@ func init() {
 		}
 	}
 
-	// process arbos precompiles
+	// Register each Arbitrum precompile at its declared ArbosVersion
+	// so CALLs on pre-activation blocks fall through to account
+	// dispatch, matching consensus.
 	precompileErrors := make(map[[4]byte]abi.Error)
 	arbosPrecompiles := precompiles.Precompiles()
 	if ownerPC, ok := arbosPrecompiles[types.ArbOwnerAddress].(*precompiles.OwnerPrecompile); ok {
@@ -78,24 +79,18 @@ func init() {
 		for _, errABI := range precompile.Precompile().GetErrorABIs() {
 			precompileErrors[[4]byte(errABI.ID.Bytes())] = errABI
 		}
-
-		// Arbos is a special case, Arbos handles versioning of precompiles internally, versioning of Ethereum/non-Arbos precompiles must be handled externally
-		var wrapped vm.AdvancedPrecompile = ArbosPrecompileWrapper{precompile}
-		vm.PrecompiledContractsBeforeArbOS30[addr] = wrapped
-		vm.PrecompiledContractsStartingFromArbOS30[addr] = wrapped
-		vm.PrecompiledContractsStartingFromArbOS50[addr] = wrapped
+		wrapped := ArbosPrecompileWrapper{inner: precompile}
+		registerArbOSPrecompile(precompile.Precompile().ArbosVersion(), addr, wrapped)
 	}
 
-	// process Ethereum precompiles for respective arbos versions
-	addPrecompiles(vm.PrecompiledContractsBeforeArbOS30, vm.PrecompiledContractsBerlin)
-	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS30, vm.PrecompiledContractsCancun)
-	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS30, vm.PrecompiledContractsP256Verify)
-	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS50, vm.PrecompiledContractsOsaka)
+	// List + activation versions live in ethereum_precompile_sets.go;
+	// TestAllUpstreamPrecompileSetsCataloged catches any upstream set
+	// we forgot to catalog.
+	registerAllEthereumPrecompileSets()
 
-	// process addresses for respective arbos version precompile maps
-	addAddresses(&vm.PrecompiledAddressesBeforeArbOS30, vm.PrecompiledContractsBeforeArbOS30)
-	addAddresses(&vm.PrecompiledAddressesStartingFromArbOS30, vm.PrecompiledContractsStartingFromArbOS30)
-	addAddresses(&vm.PrecompiledAddressesStartingFromArbOS50, vm.PrecompiledContractsStartingFromArbOS50)
+	// Single authoritative install site; vm.SetArbOSPrecompileResolver
+	// panics on a second call.
+	vm.SetArbOSPrecompileResolver(arbOSPrecompilesFor)
 
 	core.RenderRPCError = func(data []byte) error {
 		if len(data) < 4 {
@@ -113,18 +108,6 @@ func init() {
 			return nil
 		}
 		return errors.New(rendered)
-	}
-}
-
-func addPrecompiles(contracts map[common.Address]vm.PrecompiledContract, toAdd map[common.Address]vm.PrecompiledContract) {
-	for addr, precompile := range toAdd {
-		contracts[addr] = precompile
-	}
-}
-
-func addAddresses(addresses *[]common.Address, toAdd map[common.Address]vm.PrecompiledContract) {
-	for addr := range toAdd {
-		*addresses = append(*addresses, addr)
 	}
 }
 

--- a/precompiles/wrapper.go
+++ b/precompiles/wrapper.go
@@ -168,6 +168,17 @@ func (wrapper *FreeAccessPrecompile) Call(
 ) ([]byte, uint64, multigas.MultiGas, error) {
 	con := wrapper.precompile
 
+	// Short-circuit before the precompile is active. Mirrors the version check
+	// in Precompile.Call so that on historical blocks (where this address was
+	// not yet a precompile) we don't burn gas on the filterer lookup below.
+	// Without this, the state reads that determine whether the caller is a
+	// filterer charge gas and cause total CALL cost to diverge from the
+	// canonical chain, which at those blocks treated the address as an
+	// empty account with a cold access cost.
+	if arbosState.ArbOSVersion(evm.StateDB) < wrapper.precompile.Precompile().ArbosVersion() {
+		return []byte{}, gasSupplied, multigas.ZeroGas(), nil
+	}
+
 	burner := &Context{
 		gasSupplied: gasSupplied,
 		gasUsed:     multigas.ZeroGas(),


### PR DESCRIPTION
pulls in https://github.com/OffchainLabs/go-ethereum/pull/653

Three related fixes for silent state-root divergence on historical
replay caused by Arbitrum precompiles being visible or doing work on
blocks before their declared activation version.

FreeAccessPrecompile.Call version gate (precompiles/wrapper.go)
---------------------------------------------------------------
FreeAccessPrecompile.Call read state (OpenArbosState,
TransactionFilterers, IsMember) before delegating to the inner
Precompile.Call where the ArbOS version gate lives. On blocks before
the ArbFilteredTransactionsManager precompile at 0x74 was activated
at ArbosVersion_TransactionFiltering, a CALL from a contract to 0x74
charged ~900 gas the canonical chain did not — diverging block
gasUsed, receipts root, and state root for nodes replaying those
blocks with the precompile registered.

Short-circuit before the filterer lookup when currentArbosVersion <
precompile.arbosVersion, matching Precompile.Call's gate. The check
reads ArbOSVersion through a system burner (no gas charged, no
consensus-visible work).

Per-ArbOS-version snapshot model (gethhook/)
--------------------------------------------
Replaces the prior per-fork bucket dispatch (Before30 / From30 /
From50) where every precompile was unconditionally registered into
every bucket, making future-activation precompiles look always-active
on pre-activation blocks — a CALL to such an address charged 100 gas
(warm precompile) instead of 2600 (cold account).

gethhook/arbos_precompile_snapshots.go builds one snapshot per
distinct activation version under sync.Once. Dispatch scans a
sorted-descending slice and returns the snapshot with the largest
activationVersion <= rules.ArbOSVersion, so a precompile introduced
at V is hidden on blocks with ArbOSVersion < V — matching consensus
exactly. addPrecompile keeps the map and address slice in sync on
re-registration (Berlin → Cancun → Osaka layering for upstream sets).

gethhook/ethereum_precompile_sets.go registers every upstream
Ethereum precompile set through a single driver that pairs each
symbol name with its activation version. A rename or removal
upstream fails to compile; a nil contracts field panics at init.

knownUpstreamPrecompileSetSymbols exhaustively catalogs every
`PrecompiledContractsXxx` in upstream core/vm/contracts.go with one
of three rationales (registered / covered by / alias of).
TestAllUpstreamPrecompileSetsCataloged parses the upstream file with
go/parser and fails CI if any symbol is uncataloged, forcing a
rebaser to decide how Arbitrum gates each new set before the build
succeeds. TestEthereumPrecompileSetRelationships backs every
"covered by" and "alias of" rationale with a real superset or
pointer-equality assertion.

Test coverage includes pre-activation gating (the consensus
regression guard), non-fork-boundary activation, Berlin → Cancun
layering, end-to-end dispatch through vm.ActivePrecompiledContracts /
vm.ActivePrecompiles, maps.Clone isolation, nil-contract and
post-materialize registration panics, and a walk over
precompiles.Precompiles() asserting every precompile is reachable at
its declared ArbosVersion and absent at declared-1.

go-ethereum pin bump
--------------------
Bumps the go-ethereum submodule to the squashed resolver-hook branch.
The companion go-ethereum commit removes the hardcoded
IsDia/IsStylus/IsArbitrum dispatch from activePrecompiledContracts /
ActivePrecompiles and installs arbOSPrecompilesFor via
vm.SetArbOSPrecompileResolver at gethhook init. ArbOS
activation-version semantics now live entirely in gethhook, keeping
the delta vs upstream ethereum/go-ethereum minimal and rebases cheap.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
