### PR TITLE
fix arbos precompile version gating for ArbOS60 (Elara) 

### DIFF
--- a/changelog/mkulawik-nit-4785.md
+++ b/changelog/mkulawik-nit-4785.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fix version gating of active ArbOS precompiles

--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -173,7 +173,7 @@
         "EnableArbOS": true,
         "AllowDebugPrecompiles": true,
         "DataAvailabilityCommittee": false,
-        "InitialArbOSVersion": 51,
+        "InitialArbOSVersion": 60,
         "InitialChainOwner": "0x0000000000000000000000000000000000000000",
         "GenesisBlockNum": 0
       }

--- a/gethhook/geth-hook.go
+++ b/gethhook/geth-hook.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/precompiles"
@@ -79,11 +80,17 @@ func init() {
 			precompileErrors[[4]byte(errABI.ID.Bytes())] = errABI
 		}
 
-		// Arbos is a special case, Arbos handles versioning of precompiles internally, versioning of Ethereum/non-Arbos precompiles must be handled externally
 		var wrapped vm.AdvancedPrecompile = ArbosPrecompileWrapper{precompile}
 		vm.PrecompiledContractsBeforeArbOS30[addr] = wrapped
-		vm.PrecompiledContractsStartingFromArbOS30[addr] = wrapped
-		vm.PrecompiledContractsStartingFromArbOS50[addr] = wrapped
+		if precompile.Precompile().ArbosVersion() >= params.ArbosVersion_30 {
+			vm.PrecompiledContractsStartingFromArbOS30[addr] = wrapped
+		}
+		if precompile.Precompile().ArbosVersion() >= params.ArbosVerison_50 {
+			vm.PrecompiledContractsStartingFromArbOS50[addr] = wrapped
+		}
+		if precompile.Precompile().ArbosVersion() >= params.ArbosVerison_60 {
+			vm.PrecompiledContractsStartingFromArbOS60[addr] = wrapped
+		}
 	}
 
 	// process Ethereum precompiles for respective arbos versions

--- a/gethhook/geth-hook.go
+++ b/gethhook/geth-hook.go
@@ -85,10 +85,10 @@ func init() {
 		if precompile.Precompile().ArbosVersion() >= params.ArbosVersion_30 {
 			vm.PrecompiledContractsStartingFromArbOS30[addr] = wrapped
 		}
-		if precompile.Precompile().ArbosVersion() >= params.ArbosVerison_50 {
+		if precompile.Precompile().ArbosVersion() >= params.ArbosVersion_50 {
 			vm.PrecompiledContractsStartingFromArbOS50[addr] = wrapped
 		}
-		if precompile.Precompile().ArbosVersion() >= params.ArbosVerison_60 {
+		if precompile.Precompile().ArbosVersion() >= params.ArbosVersion_60 {
 			vm.PrecompiledContractsStartingFromArbOS60[addr] = wrapped
 		}
 	}

--- a/gethhook/geth-hook.go
+++ b/gethhook/geth-hook.go
@@ -98,11 +98,13 @@ func init() {
 	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS30, vm.PrecompiledContractsCancun)
 	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS30, vm.PrecompiledContractsP256Verify)
 	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS50, vm.PrecompiledContractsOsaka)
+	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS60, vm.PrecompiledContractsOsaka)
 
 	// process addresses for respective arbos version precompile maps
 	addAddresses(&vm.PrecompiledAddressesBeforeArbOS30, vm.PrecompiledContractsBeforeArbOS30)
 	addAddresses(&vm.PrecompiledAddressesStartingFromArbOS30, vm.PrecompiledContractsStartingFromArbOS30)
 	addAddresses(&vm.PrecompiledAddressesStartingFromArbOS50, vm.PrecompiledContractsStartingFromArbOS50)
+	addAddresses(&vm.PrecompiledAddressesStartingFromArbOS60, vm.PrecompiledContractsStartingFromArbOS60)
 
 	core.RenderRPCError = func(data []byte) error {
 		if len(data) < 4 {

--- a/gethhook/geth-hook.go
+++ b/gethhook/geth-hook.go
@@ -81,16 +81,16 @@ func init() {
 		}
 
 		var wrapped vm.AdvancedPrecompile = ArbosPrecompileWrapper{precompile}
-		vm.PrecompiledContractsBeforeArbOS30[addr] = wrapped
-		if precompile.Precompile().ArbosVersion() >= params.ArbosVersion_30 {
+		if precompile.Precompile().ArbosVersion() < params.ArbosVersion_30 {
+			vm.PrecompiledContractsBeforeArbOS30[addr] = wrapped
+		}
+		if precompile.Precompile().ArbosVersion() < params.ArbosVersion_50 {
 			vm.PrecompiledContractsStartingFromArbOS30[addr] = wrapped
 		}
-		if precompile.Precompile().ArbosVersion() >= params.ArbosVersion_50 {
+		if precompile.Precompile().ArbosVersion() < params.ArbosVersion_60 {
 			vm.PrecompiledContractsStartingFromArbOS50[addr] = wrapped
 		}
-		if precompile.Precompile().ArbosVersion() >= params.ArbosVersion_60 {
-			vm.PrecompiledContractsStartingFromArbOS60[addr] = wrapped
-		}
+		vm.PrecompiledContractsStartingFromArbOS60[addr] = wrapped
 	}
 
 	// process Ethereum precompiles for respective arbos versions

--- a/gethhook/geth-hook.go
+++ b/gethhook/geth-hook.go
@@ -84,8 +84,11 @@ func init() {
 		if precompile.Precompile().ArbosVersion() < params.ArbosVersion_30 {
 			vm.PrecompiledContractsBeforeArbOS30[addr] = wrapped
 		}
-		if precompile.Precompile().ArbosVersion() < params.ArbosVersion_50 {
+		if precompile.Precompile().ArbosVersion() < params.ArbosVersion_41 {
 			vm.PrecompiledContractsStartingFromArbOS30[addr] = wrapped
+		}
+		if precompile.Precompile().ArbosVersion() < params.ArbosVersion_50 {
+			vm.PrecompiledContractsStartingFromArbOS41[addr] = wrapped
 		}
 		if precompile.Precompile().ArbosVersion() < params.ArbosVersion_60 {
 			vm.PrecompiledContractsStartingFromArbOS50[addr] = wrapped
@@ -97,12 +100,15 @@ func init() {
 	addPrecompiles(vm.PrecompiledContractsBeforeArbOS30, vm.PrecompiledContractsBerlin)
 	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS30, vm.PrecompiledContractsCancun)
 	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS30, vm.PrecompiledContractsP256Verify)
+	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS41, vm.PrecompiledContractsCancun)
+	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS41, vm.PrecompiledContractsP256Verify)
 	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS50, vm.PrecompiledContractsOsaka)
 	addPrecompiles(vm.PrecompiledContractsStartingFromArbOS60, vm.PrecompiledContractsOsaka)
 
 	// process addresses for respective arbos version precompile maps
 	addAddresses(&vm.PrecompiledAddressesBeforeArbOS30, vm.PrecompiledContractsBeforeArbOS30)
 	addAddresses(&vm.PrecompiledAddressesStartingFromArbOS30, vm.PrecompiledContractsStartingFromArbOS30)
+	addAddresses(&vm.PrecompiledAddressesStartingFromArbOS41, vm.PrecompiledContractsStartingFromArbOS41)
 	addAddresses(&vm.PrecompiledAddressesStartingFromArbOS50, vm.PrecompiledContractsStartingFromArbOS50)
 	addAddresses(&vm.PrecompiledAddressesStartingFromArbOS60, vm.PrecompiledContractsStartingFromArbOS60)
 

--- a/gethhook/geth_test.go
+++ b/gethhook/geth_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbos/util"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
+	"github.com/offchainlabs/nitro/precompiles"
 	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 
@@ -170,4 +171,103 @@ func Require(t *testing.T, err error, printables ...interface{}) {
 func Fail(t *testing.T, printables ...interface{}) {
 	t.Helper()
 	testhelpers.FailImpl(t, printables...)
+}
+
+func TestPrecompileBucketMembership(t *testing.T) {
+	// Each PrecompiledContractsStartingFromArbOS<N> map is the active-precompile
+	// set for the ArbOS version range [N, nextN). A precompile with ArbosVersion()
+	// V is registered in a bucket iff V < nextN — i.e. the precompile has at
+	// least one active method during the range.
+	//
+	// If a new ArbOS version is introduced, add a new bucket entry below and bump
+	// maxKnownArbosVersion.
+	const maxKnownArbosVersion = params.ArbosVersion_60
+
+	if params.MaxDebugArbosVersionSupported > maxKnownArbosVersion {
+		t.Errorf("MaxDebugArbosVersionSupported (%d) > maxKnownArbosVersion (%d); add a new bucket and bump the constant",
+			params.MaxDebugArbosVersionSupported, maxKnownArbosVersion)
+	}
+
+	buckets := []struct {
+		name       string
+		contracts  map[common.Address]vm.PrecompiledContract
+		addrs      []common.Address
+		upperBound uint64 // exclusive
+	}{
+		{"BeforeArbOS30", vm.PrecompiledContractsBeforeArbOS30, vm.PrecompiledAddressesBeforeArbOS30, params.ArbosVersion_30},
+		{"StartingFromArbOS30", vm.PrecompiledContractsStartingFromArbOS30, vm.PrecompiledAddressesStartingFromArbOS30, params.ArbosVersion_50},
+		{"StartingFromArbOS50", vm.PrecompiledContractsStartingFromArbOS50, vm.PrecompiledAddressesStartingFromArbOS50, params.ArbosVersion_60},
+		{"StartingFromArbOS60", vm.PrecompiledContractsStartingFromArbOS60, vm.PrecompiledAddressesStartingFromArbOS60, maxKnownArbosVersion + 1},
+	}
+
+	for addr, p := range precompiles.Precompiles() {
+		name := p.Precompile().Name()
+		v := p.Precompile().ArbosVersion()
+		if v > maxKnownArbosVersion {
+			t.Errorf("precompile %s has ArbosVersion %d > maxKnownArbosVersion %d; add a new bucket and bump the constant",
+				name, v, maxKnownArbosVersion)
+			continue
+		}
+		for _, b := range buckets {
+			_, present := b.contracts[addr]
+			want := v < b.upperBound
+			if present != want {
+				t.Errorf("precompile %s (v=%d) in bucket %s: got present=%v, want=%v",
+					name, v, b.name, present, want)
+			}
+		}
+	}
+
+	// Ethereum precompile subsets init() explicitly merges into each bucket
+	// (see geth-hook.go). Keys must match the bucket names declared above.
+	ethSubsets := map[string][]map[common.Address]vm.PrecompiledContract{
+		"BeforeArbOS30":       {vm.PrecompiledContractsBerlin},
+		"StartingFromArbOS30": {vm.PrecompiledContractsCancun, vm.PrecompiledContractsP256Verify},
+		"StartingFromArbOS50": {vm.PrecompiledContractsOsaka},
+		"StartingFromArbOS60": {vm.PrecompiledContractsOsaka},
+	}
+
+	for _, b := range buckets {
+		// Every address from each assigned Ethereum subset must be present.
+		ethUnion := make(map[common.Address]struct{})
+		for _, subset := range ethSubsets[b.name] {
+			for addr := range subset {
+				ethUnion[addr] = struct{}{}
+				if _, ok := b.contracts[addr]; !ok {
+					t.Errorf("bucket %s missing Ethereum precompile %s", b.name, addr.Hex())
+				}
+			}
+		}
+
+		// Total-size closure: bucket = arbos-in-bucket + eth-subsets-union.
+		// Catches accidental extras (e.g. a stray addPrecompiles line).
+		arbosInBucket := 0
+		for _, p := range precompiles.Precompiles() {
+			if p.Precompile().ArbosVersion() < b.upperBound {
+				arbosInBucket++
+			}
+		}
+		if got, want := len(b.contracts), arbosInBucket+len(ethUnion); got != want {
+			t.Errorf("bucket %s has %d entries, expected %d (%d arbos + %d ethereum)",
+				b.name, got, want, arbosInBucket, len(ethUnion))
+		}
+	}
+
+	// Address slice must match its contracts map (catches addAddresses drift).
+	for _, b := range buckets {
+		if len(b.addrs) != len(b.contracts) {
+			t.Errorf("bucket %s: addresses slice has %d entries but contracts map has %d",
+				b.name, len(b.addrs), len(b.contracts))
+		}
+		seen := make(map[common.Address]bool, len(b.addrs))
+		for _, a := range b.addrs {
+			if seen[a] {
+				t.Errorf("bucket %s: address %s appears twice in addresses slice", b.name, a.Hex())
+			}
+			seen[a] = true
+			if _, ok := b.contracts[a]; !ok {
+				t.Errorf("bucket %s: address %s in slice but not in contracts map", b.name, a.Hex())
+			}
+		}
+	}
 }

--- a/gethhook/geth_test.go
+++ b/gethhook/geth_test.go
@@ -193,11 +193,36 @@ func TestPrecompileBucketMembership(t *testing.T) {
 		contracts  map[common.Address]vm.PrecompiledContract
 		addrs      []common.Address
 		upperBound uint64 // exclusive
+		ethSubsets []map[common.Address]vm.PrecompiledContract
 	}{
-		{"BeforeArbOS30", vm.PrecompiledContractsBeforeArbOS30, vm.PrecompiledAddressesBeforeArbOS30, params.ArbosVersion_30},
-		{"StartingFromArbOS30", vm.PrecompiledContractsStartingFromArbOS30, vm.PrecompiledAddressesStartingFromArbOS30, params.ArbosVersion_50},
-		{"StartingFromArbOS50", vm.PrecompiledContractsStartingFromArbOS50, vm.PrecompiledAddressesStartingFromArbOS50, params.ArbosVersion_60},
-		{"StartingFromArbOS60", vm.PrecompiledContractsStartingFromArbOS60, vm.PrecompiledAddressesStartingFromArbOS60, maxKnownArbosVersion + 1},
+		{
+			name:       "BeforeArbOS30",
+			contracts:  vm.PrecompiledContractsBeforeArbOS30,
+			addrs:      vm.PrecompiledAddressesBeforeArbOS30,
+			upperBound: params.ArbosVersion_30,
+			ethSubsets: []map[common.Address]vm.PrecompiledContract{vm.PrecompiledContractsBerlin},
+		},
+		{
+			name:       "StartingFromArbOS30",
+			contracts:  vm.PrecompiledContractsStartingFromArbOS30,
+			addrs:      vm.PrecompiledAddressesStartingFromArbOS30,
+			upperBound: params.ArbosVersion_50,
+			ethSubsets: []map[common.Address]vm.PrecompiledContract{vm.PrecompiledContractsCancun, vm.PrecompiledContractsP256Verify},
+		},
+		{
+			name:       "StartingFromArbOS50",
+			contracts:  vm.PrecompiledContractsStartingFromArbOS50,
+			addrs:      vm.PrecompiledAddressesStartingFromArbOS50,
+			upperBound: params.ArbosVersion_60,
+			ethSubsets: []map[common.Address]vm.PrecompiledContract{vm.PrecompiledContractsOsaka},
+		},
+		{
+			name:       "StartingFromArbOS60",
+			contracts:  vm.PrecompiledContractsStartingFromArbOS60,
+			addrs:      vm.PrecompiledAddressesStartingFromArbOS60,
+			upperBound: maxKnownArbosVersion + 1,
+			ethSubsets: []map[common.Address]vm.PrecompiledContract{vm.PrecompiledContractsOsaka},
+		},
 	}
 
 	for addr, p := range precompiles.Precompiles() {
@@ -218,19 +243,10 @@ func TestPrecompileBucketMembership(t *testing.T) {
 		}
 	}
 
-	// Ethereum precompile subsets init() explicitly merges into each bucket
-	// (see geth-hook.go). Keys must match the bucket names declared above.
-	ethSubsets := map[string][]map[common.Address]vm.PrecompiledContract{
-		"BeforeArbOS30":       {vm.PrecompiledContractsBerlin},
-		"StartingFromArbOS30": {vm.PrecompiledContractsCancun, vm.PrecompiledContractsP256Verify},
-		"StartingFromArbOS50": {vm.PrecompiledContractsOsaka},
-		"StartingFromArbOS60": {vm.PrecompiledContractsOsaka},
-	}
-
 	for _, b := range buckets {
 		// Every address from each assigned Ethereum subset must be present.
 		ethUnion := make(map[common.Address]struct{})
-		for _, subset := range ethSubsets[b.name] {
+		for _, subset := range b.ethSubsets {
 			for addr := range subset {
 				ethUnion[addr] = struct{}{}
 				if _, ok := b.contracts[addr]; !ok {

--- a/gethhook/geth_test.go
+++ b/gethhook/geth_test.go
@@ -206,6 +206,13 @@ func TestPrecompileBucketMembership(t *testing.T) {
 			name:       "StartingFromArbOS30",
 			contracts:  vm.PrecompiledContractsStartingFromArbOS30,
 			addrs:      vm.PrecompiledAddressesStartingFromArbOS30,
+			upperBound: params.ArbosVersion_41,
+			ethSubsets: []map[common.Address]vm.PrecompiledContract{vm.PrecompiledContractsCancun, vm.PrecompiledContractsP256Verify},
+		},
+		{
+			name:       "StartingFromArbOS41",
+			contracts:  vm.PrecompiledContractsStartingFromArbOS41,
+			addrs:      vm.PrecompiledAddressesStartingFromArbOS41,
 			upperBound: params.ArbosVersion_50,
 			ethSubsets: []map[common.Address]vm.PrecompiledContract{vm.PrecompiledContractsCancun, vm.PrecompiledContractsP256Verify},
 		},

--- a/precompiles/ArbOwner_test.go
+++ b/precompiles/ArbOwner_test.go
@@ -37,7 +37,10 @@ func TestArbOwner(t *testing.T) {
 	addr2 := common.BytesToAddress(crypto.Keccak256([]byte{2})[:20])
 	addr3 := common.BytesToAddress(crypto.Keccak256([]byte{3})[:20])
 
-	prec := &ArbOwner{}
+	prec := &ArbOwner{
+		ChainOwnerAdded:   func(ctx, mech, common.Address) error { return nil },
+		ChainOwnerRemoved: func(ctx, mech, common.Address) error { return nil },
+	}
 	gasInfo := &ArbGasInfo{}
 	callCtx := testContext(caller, evm)
 

--- a/precompiles/ArbOwner_test.go
+++ b/precompiles/ArbOwner_test.go
@@ -37,9 +37,32 @@ func TestArbOwner(t *testing.T) {
 	addr2 := common.BytesToAddress(crypto.Keccak256([]byte{2})[:20])
 	addr3 := common.BytesToAddress(crypto.Keccak256([]byte{3})[:20])
 
+	type eventNameAndEmits struct {
+		eventName string
+		emitted   []common.Address
+	}
+	ownerAddedEvents := eventNameAndEmits{}
+
+	eventEmmitterMock := func(event *eventNameAndEmits) func(ctx, mech, common.Address) error {
+		return func(ctx, mech, address common.Address) error {
+			events = append(event.emitted, address)
+			return nil
+		}
+	}
+	checkAndClear := func(event *eventNameAndEmits, expectedAddress common.Address) {
+		t.Helper()
+		if len(expectedAddress) == 0 && len(event.emitted) > 0 {
+			Fail(t, event.name, "shouldn't have been emitted, got:", events)
+		}
+		expected := []common.Address{expectedAddress}
+		if event.emmited != expected {
+			Fail(t, "Unexpected ", event.name, "events emitted, got:", events, "want:", expected)
+		}
+		event.emitted = nil
+	}
 	prec := &ArbOwner{
-		ChainOwnerAdded:   func(ctx, mech, common.Address) error { return nil },
-		ChainOwnerRemoved: func(ctx, mech, common.Address) error { return nil },
+		ChainOwnerAdded:   eventEmmitterMock(&ownerAddedEvents),
+		ChainOwnerRemoved: eventEmmitterMock(&ownerRemovedEvents),
 	}
 	gasInfo := &ArbGasInfo{}
 	callCtx := testContext(caller, evm)
@@ -48,8 +71,14 @@ func TestArbOwner(t *testing.T) {
 	Require(t, prec.RemoveChainOwner(callCtx, evm, common.Address{}))
 
 	Require(t, prec.AddChainOwner(callCtx, evm, addr1))
+	checkAndClear(ownerAddedEvents, addr1)
+	checkAndClear(ownerRemovedEvents, nil)
 	Require(t, prec.AddChainOwner(callCtx, evm, addr2))
+	checkAndClear(ownerAddedEvents, addr2)
+	checkAndClear(ownerRemovedEvents, nil)
 	Require(t, prec.AddChainOwner(callCtx, evm, addr1))
+	checkAndClear(ownerAddedEvents, nil)
+	checkAndClear(ownerRemovedEvents, nil)
 
 	member, err := prec.IsChainOwner(callCtx, evm, addr1)
 	Require(t, err)
@@ -70,6 +99,8 @@ func TestArbOwner(t *testing.T) {
 	}
 
 	Require(t, prec.RemoveChainOwner(callCtx, evm, addr1))
+	checkAndClear(ownerAddedEvents, nil)
+	checkAndClear(ownerRemovedEvents, addr1)
 	member, err = prec.IsChainOwner(callCtx, evm, addr1)
 	Require(t, err)
 	if member {
@@ -82,6 +113,8 @@ func TestArbOwner(t *testing.T) {
 	}
 
 	Require(t, prec.AddChainOwner(callCtx, evm, addr1))
+	checkAndClear(ownerAddedEvents, addr1)
+	checkAndClear(ownerRemovedEvents, nil)
 	all, err := prec.GetAllChainOwners(callCtx, evm)
 	Require(t, err)
 	if len(all) != 3 {

--- a/precompiles/ArbOwner_test.go
+++ b/precompiles/ArbOwner_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"math/big"
+	"slices"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -38,25 +39,22 @@ func TestArbOwner(t *testing.T) {
 	addr3 := common.BytesToAddress(crypto.Keccak256([]byte{3})[:20])
 
 	type eventNameAndEmits struct {
-		eventName string
-		emitted   []common.Address
+		name    string
+		emitted []common.Address
 	}
-	ownerAddedEvents := eventNameAndEmits{}
+	ownerAddedEvents := eventNameAndEmits{name: "OwnerAdded"}
+	ownerRemovedEvents := eventNameAndEmits{name: "OwnerRemoved"}
 
 	eventEmmitterMock := func(event *eventNameAndEmits) func(ctx, mech, common.Address) error {
-		return func(ctx, mech, address common.Address) error {
-			events = append(event.emitted, address)
+		return func(_ ctx, _ mech, address common.Address) error {
+			event.emitted = append(event.emitted, address)
 			return nil
 		}
 	}
-	checkAndClear := func(event *eventNameAndEmits, expectedAddress common.Address) {
+	checkAndClear := func(event *eventNameAndEmits, expected ...common.Address) {
 		t.Helper()
-		if len(expectedAddress) == 0 && len(event.emitted) > 0 {
-			Fail(t, event.name, "shouldn't have been emitted, got:", events)
-		}
-		expected := []common.Address{expectedAddress}
-		if event.emmited != expected {
-			Fail(t, "Unexpected ", event.name, "events emitted, got:", events, "want:", expected)
+		if !slices.Equal(event.emitted, expected) {
+			Fail(t, event.name, "got:", event.emitted, "want:", expected)
 		}
 		event.emitted = nil
 	}
@@ -69,16 +67,18 @@ func TestArbOwner(t *testing.T) {
 
 	// the zero address is an owner by default
 	Require(t, prec.RemoveChainOwner(callCtx, evm, common.Address{}))
+	checkAndClear(&ownerAddedEvents)
+	checkAndClear(&ownerRemovedEvents, common.Address{})
 
 	Require(t, prec.AddChainOwner(callCtx, evm, addr1))
-	checkAndClear(ownerAddedEvents, addr1)
-	checkAndClear(ownerRemovedEvents, nil)
+	checkAndClear(&ownerAddedEvents, addr1)
+	checkAndClear(&ownerRemovedEvents)
 	Require(t, prec.AddChainOwner(callCtx, evm, addr2))
-	checkAndClear(ownerAddedEvents, addr2)
-	checkAndClear(ownerRemovedEvents, nil)
+	checkAndClear(&ownerAddedEvents, addr2)
+	checkAndClear(&ownerRemovedEvents)
 	Require(t, prec.AddChainOwner(callCtx, evm, addr1))
-	checkAndClear(ownerAddedEvents, nil)
-	checkAndClear(ownerRemovedEvents, nil)
+	checkAndClear(&ownerAddedEvents, addr1)
+	checkAndClear(&ownerRemovedEvents)
 
 	member, err := prec.IsChainOwner(callCtx, evm, addr1)
 	Require(t, err)
@@ -99,8 +99,8 @@ func TestArbOwner(t *testing.T) {
 	}
 
 	Require(t, prec.RemoveChainOwner(callCtx, evm, addr1))
-	checkAndClear(ownerAddedEvents, nil)
-	checkAndClear(ownerRemovedEvents, addr1)
+	checkAndClear(&ownerAddedEvents)
+	checkAndClear(&ownerRemovedEvents, addr1)
 	member, err = prec.IsChainOwner(callCtx, evm, addr1)
 	Require(t, err)
 	if member {
@@ -113,8 +113,8 @@ func TestArbOwner(t *testing.T) {
 	}
 
 	Require(t, prec.AddChainOwner(callCtx, evm, addr1))
-	checkAndClear(ownerAddedEvents, addr1)
-	checkAndClear(ownerRemovedEvents, nil)
+	checkAndClear(&ownerAddedEvents, addr1)
+	checkAndClear(&ownerRemovedEvents)
 	all, err := prec.GetAllChainOwners(callCtx, evm)
 	Require(t, err)
 	if len(all) != 3 {

--- a/system_tests/eth_config_test.go
+++ b/system_tests/eth_config_test.go
@@ -49,7 +49,7 @@ func TestEthConfig(t *testing.T) {
 			ActivationTime: 0,
 			BlobSchedule:   nil,
 			ChainId:        (*hexutil.Big)(hexutil.MustDecodeBig("0x64aba")),
-			ForkId:         (hexutil.Bytes)(hexutil.MustDecode("0x9aa9b1b0")),
+			ForkId:         (hexutil.Bytes)(hexutil.MustDecode("0xa2965b4a")),
 			Precompiles: map[string]common.Address{
 				"ArbAddressTable":                common.HexToAddress("0x0000000000000000000000000000000000000066"),
 				"ArbAggregator":                  common.HexToAddress("0x000000000000000000000000000000000000006d"),

--- a/system_tests/precompile_inclusion_test.go
+++ b/system_tests/precompile_inclusion_test.go
@@ -119,7 +119,7 @@ func testPrecompiles(t *testing.T, arbosVersion uint64, cases ...precompileCase)
 		// would fail against the expected cold-access range.
 		gas, err := simple.CheckGasUsed(&bind.CallOpts{Context: ctx}, c.addr, c.in)
 		Require(t, err, "Simple.CheckGasUsed failed for", c.addr)
-		if gas.Cmp(big.NewInt(int64(c.gasMin))) < 0 || gas.Cmp(big.NewInt(int64(c.gasMax))) > 0 {
+		if gas.Cmp(new(big.Int).SetUint64(c.gasMin)) < 0 || gas.Cmp(new(big.Int).SetUint64(c.gasMax)) > 0 {
 			t.Errorf("Precompile %v: gas used %v, expected in [%d, %d]",
 				c.addr, gas, c.gasMin, c.gasMax)
 		}

--- a/system_tests/precompile_inclusion_test.go
+++ b/system_tests/precompile_inclusion_test.go
@@ -6,10 +6,12 @@ package arbtest
 import (
 	"bytes"
 	"context"
+	"math/big"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 
@@ -58,26 +60,33 @@ var (
 		input:    bytes.Repeat([]byte{0}, 320),
 		expected: bytes.Repeat([]byte{0}, 128),
 	}
+	// ArbFilteredTransactionsManager.isTransactionFiltered(bytes32) — gated at ArbOS 60.
+	// Selector 0x85c733a4; passing zero hash returns bool false = 32 zero bytes.
+	arbFilteredTransactionsManagerIsTransactionFiltered = precompileCaseProvider{
+		addr:     common.HexToAddress("0x74"),
+		input:    common.Hex2Bytes("85c733a40000000000000000000000000000000000000000000000000000000000000000"),
+		expected: bytes.Repeat([]byte{0}, 32),
+	}
 )
 
 func TestVersion11(t *testing.T) {
-	testPrecompiles(t, params.ArbosVersion_11, ecrecover.Included(), bn256AddByzantium.Included(), blake2F.Included(), kzgPointEvaluation.NotIncluded(), p256Verify.NotIncluded(), bls12381G1Add.NotIncluded(), bls12381G1MultiExp.NotIncluded())
+	testPrecompiles(t, params.ArbosVersion_11, ecrecover.Included(), bn256AddByzantium.Included(), blake2F.Included(), kzgPointEvaluation.NotIncluded(), p256Verify.NotIncluded(), bls12381G1Add.NotIncluded(), bls12381G1MultiExp.NotIncluded(), arbFilteredTransactionsManagerIsTransactionFiltered.NotIncluded())
 }
 
 func TestVersion30(t *testing.T) {
-	testPrecompiles(t, params.ArbosVersion_30, ecrecover.Included(), bn256AddByzantium.Included(), kzgPointEvaluation.Included(), p256Verify.Included(), bls12381G1Add.NotIncluded(), bls12381G1MultiExp.NotIncluded())
+	testPrecompiles(t, params.ArbosVersion_30, ecrecover.Included(), bn256AddByzantium.Included(), kzgPointEvaluation.Included(), p256Verify.Included(), bls12381G1Add.NotIncluded(), bls12381G1MultiExp.NotIncluded(), arbFilteredTransactionsManagerIsTransactionFiltered.NotIncluded())
 }
 
 func TestVersion40(t *testing.T) {
-	testPrecompiles(t, params.ArbosVersion_40, bn256AddByzantium.Included(), kzgPointEvaluation.Included(), p256Verify.Included(), bls12381G1Add.NotIncluded(), bls12381G1MultiExp.NotIncluded())
+	testPrecompiles(t, params.ArbosVersion_40, bn256AddByzantium.Included(), kzgPointEvaluation.Included(), p256Verify.Included(), bls12381G1Add.NotIncluded(), bls12381G1MultiExp.NotIncluded(), arbFilteredTransactionsManagerIsTransactionFiltered.NotIncluded())
 }
 
 func TestArbOSVersion50(t *testing.T) {
-	testPrecompiles(t, params.ArbosVersion_50, kzgPointEvaluation.Included(), bls12381G1Add.Included(), bls12381G1MultiExp.Included())
+	testPrecompiles(t, params.ArbosVersion_50, kzgPointEvaluation.Included(), bls12381G1Add.Included(), bls12381G1MultiExp.Included(), arbFilteredTransactionsManagerIsTransactionFiltered.NotIncluded())
 }
 
 func TestArbOSVersion60(t *testing.T) {
-	testPrecompiles(t, params.ArbosVersion_60, kzgPointEvaluation.Included(), bls12381G1Add.Included(), bls12381G1MultiExp.Included())
+	testPrecompiles(t, params.ArbosVersion_60, kzgPointEvaluation.Included(), bls12381G1Add.Included(), bls12381G1MultiExp.Included(), arbFilteredTransactionsManagerIsTransactionFiltered.Included())
 }
 
 func testPrecompiles(t *testing.T, arbosVersion uint64, cases ...precompileCase) {
@@ -91,20 +100,36 @@ func testPrecompiles(t *testing.T, arbosVersion uint64, cases ...precompileCase)
 	builder.execConfig.RPC.RPCEVMTimeout = 30 * time.Second
 	cleanup := builder.Build(t)
 	defer cleanup()
+
+	auth := builder.L2Info.GetDefaultTransactOpts("Faucet", ctx)
+	_, simple := builder.L2.DeploySimple(t, auth)
+
 	for _, c := range cases {
-		res, err := builder.L2.Client.CallContract(context.Background(), ethereum.CallMsg{To: &c.addr, Data: c.in}, nil)
+		res, err := builder.L2.Client.CallContract(ctx, ethereum.CallMsg{To: &c.addr, Data: c.in}, nil)
 		Require(t, err)
 		if !bytes.Equal(res, c.out) {
 			t.Errorf("Expected %v [%d], got %v [%d]", c.out, len(c.out), res, len(res))
 		}
-	}
 
+		// Charge check: a staticcall to a not-yet-active precompile must pay
+		// COLD account access (~2600), not WARM (~100). If the address were
+		// wrongly pre-registered as a precompile it would be pre-warmed via
+		// state.Prepare(..., ActivePrecompiles(rules), ...) and this check
+		// would fail against the expected cold-access range.
+		gas, err := simple.CheckGasUsed(&bind.CallOpts{Context: ctx}, c.addr, c.in)
+		Require(t, err, "Simple.CheckGasUsed failed for", c.addr)
+		if gas.Cmp(big.NewInt(int64(c.gasMin))) < 0 || gas.Cmp(big.NewInt(int64(c.gasMax))) > 0 {
+			t.Errorf("Precompile %v: gas used %v, expected in [%d, %d]",
+				c.addr, gas, c.gasMin, c.gasMax)
+		}
+	}
 }
 
 type precompileCase struct {
-	addr common.Address
-	in   []byte
-	out  []byte
+	addr           common.Address
+	in             []byte
+	out            []byte
+	gasMin, gasMax uint64
 }
 
 type precompileCaseProvider struct {
@@ -118,6 +143,11 @@ func (c precompileCaseProvider) Included() precompileCase {
 		addr: c.addr,
 		in:   c.input,
 		out:  c.expected,
+		// Warm access (100) + precompile.RequiredGas + staticcall/solidity
+		// overhead. Lower bound rules out warm-and-no-op (~100) — the cheapest
+		// precompile here is bls12381G1Add at 375 gas.
+		gasMin: 400,
+		gasMax: 100_000,
 	}
 }
 
@@ -126,5 +156,8 @@ func (c precompileCaseProvider) NotIncluded() precompileCase {
 		addr: c.addr,
 		in:   c.input,
 		out:  []byte{},
+		// COLD account access (2600) + empty-account no-op + minor overhead.
+		gasMin: 2500,
+		gasMax: 3000,
 	}
 }

--- a/system_tests/precompile_inclusion_test.go
+++ b/system_tests/precompile_inclusion_test.go
@@ -111,6 +111,7 @@ func testPrecompiles(t *testing.T, arbosVersion uint64, cases ...precompileCase)
 			t.Errorf("Expected %v [%d], got %v [%d]", c.out, len(c.out), res, len(res))
 		}
 
+		// TODO the range was claude suggested, need to validate if we can't just have exact value
 		// Charge check: a staticcall to a not-yet-active precompile must pay
 		// COLD account access (~2600), not WARM (~100). If the address were
 		// wrongly pre-registered as a precompile it would be pre-warmed via


### PR DESCRIPTION
Pulls in https://github.com/OffchainLabs/go-ethereum/pull/655
Resolves NIT-4785

Before this PR, all ArbOS precompiles were considered active in all ArbOS versions. https://github.com/OffchainLabs/nitro/pull/3807 that added this behaviour was based on assumption that it's enough for each precompile to be version gated internally.
It turned out that it is not the case and this could have caused divergence when executing old blocks.

Before execution of each transaction `AccessList` is prepared and ia. all active precompile addresses are added to this list.
https://github.com/OffchainLabs/go-ethereum/blob/49b38a638a91f91f0fdb8be5f740c69f8d6abefc/core/state/statedb.go#L1593

This means that:
- a call to a inactive contract (not existent in specific version) will cost COLD access gas
- a call to an active contract that immediately exits because of too low current ArbOS version, will cost the WARM access
And that's the source of the possible divergence when address of not yet existing contract was called in older ArbOS version, and depending on nitro version it was charged different amount of gas.

This PR brings back the ArbOS precompile buckets logic and adds a simple sanity test for them.