### PR TITLE
TxPreChecker: report filtered txs to filtering-report service

### DIFF
--- a/changelog/mrogachev-nit-4645.md
+++ b/changelog/mrogachev-nit-4645.md
@@ -1,0 +1,2 @@
+### Added
+- TxPreChecker reports filtered transactions to the filtering-report service via FilteringReportRPCClient

--- a/execution/gethexec/node.go
+++ b/execution/gethexec/node.go
@@ -420,7 +420,7 @@ func CreateExecutionNode(
 
 	txprecheckConfigFetcher := func() *TxPreCheckerConfig { return &configFetcher.Get().TxPreChecker }
 
-	txPreChecker := NewTxPreChecker(txPublisher, l2BlockChain, txprecheckConfigFetcher)
+	txPreChecker := NewTxPreChecker(txPublisher, l2BlockChain, txprecheckConfigFetcher, filteringReportRPCClient)
 	txPublisher = txPreChecker
 	arbInterface, err := NewArbInterface(l2BlockChain, txPublisher)
 	if err != nil {

--- a/execution/gethexec/tx_filterer.go
+++ b/execution/gethexec/tx_filterer.go
@@ -4,6 +4,7 @@
 package gethexec
 
 import (
+	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -28,10 +29,10 @@ func (f *txFilterer) TouchAddresses(statedb *state.StateDB, tx *types.Transactio
 	touchAddresses(statedb, tx, sender)
 }
 
-func (f *txFilterer) CheckFiltered(statedb *state.StateDB) error {
+func (f *txFilterer) CheckFiltered(statedb *state.StateDB) ([]filter.FilteredAddressRecord, error) {
 	applyEventFilter(f.eventFilter, statedb)
-	if filtered, _ := statedb.IsAddressFiltered(); filtered {
-		return state.ErrArbTxFilter
+	if filtered, records := statedb.IsAddressFiltered(); filtered {
+		return records, state.ErrArbTxFilter
 	}
-	return nil
+	return nil, nil
 }

--- a/execution/gethexec/tx_pre_checker.go
+++ b/execution/gethexec/tx_pre_checker.go
@@ -44,8 +44,6 @@ const TxPreCheckerStrictnessAlwaysCompatible uint = 10
 const TxPreCheckerStrictnessLikelyCompatible uint = 20
 const TxPreCheckerStrictnessFullValidation uint = 30
 
-const filteredTxReportDeliveryTimeout = 5 * time.Second
-
 type TxPreCheckerConfig struct {
 	Strictness             uint  `koanf:"strictness" reload:"hot"`
 	RequiredStateAge       int64 `koanf:"required-state-age" reload:"hot"`
@@ -331,9 +329,7 @@ func (c *TxPreChecker) checkFilteredAddresses(ctx context.Context, tx *types.Tra
 		Backend:          c.backend,
 		RunScheduledTxes: retryables.RunScheduledTxes,
 		ReportFilteredTx: func(_ context.Context, records []filter.FilteredAddressRecord) {
-			if reportErr := c.reportFilteredTx(tx, header, records); reportErr != nil {
-				log.Error("failed to build filtered tx report", "txHash", tx.Hash(), "err", reportErr)
-			}
+			c.reportFilteredTx(tx, header, records)
 		},
 	})
 	if errors.Is(err, state.ErrArbTxFilter) {
@@ -344,17 +340,19 @@ func (c *TxPreChecker) checkFilteredAddresses(ctx context.Context, tx *types.Tra
 	return nil
 }
 
-func (c *TxPreChecker) reportFilteredTx(tx *types.Transaction, header *types.Header, filteredAddresses []filter.FilteredAddressRecord) error {
+func (c *TxPreChecker) reportFilteredTx(tx *types.Transaction, header *types.Header, filteredAddresses []filter.FilteredAddressRecord) {
 	if c.filteringReportRPCClient == nil {
-		return nil
+		return
 	}
+	txHash := tx.Hash()
 	txRLP, err := tx.MarshalBinary()
 	if err != nil {
-		return fmt.Errorf("failed to marshal filtered tx: %w", err)
+		log.Error("failed to marshal filtered tx", "txHash", txHash, "err", err)
+		return
 	}
 	report := addressfilter.FilteredTxReport{
 		ID:                uuid.Must(uuid.NewV7()).String(),
-		TxHash:            tx.Hash(),
+		TxHash:            txHash,
 		TxRLP:             txRLP,
 		FilteredAddresses: filteredAddresses,
 		BlockNumber:       header.Number.Uint64(),
@@ -365,13 +363,9 @@ func (c *TxPreChecker) reportFilteredTx(tx *types.Transaction, header *types.Hea
 		DelayedReportData: nil,
 	}
 	promise := c.filteringReportRPCClient.ReportFilteredTransactions([]addressfilter.FilteredTxReport{report})
-	txHash := tx.Hash()
 	c.filteringReportRPCClient.LaunchThread(func(ctx context.Context) {
-		awaitCtx, cancel := context.WithTimeout(ctx, filteredTxReportDeliveryTimeout)
-		defer cancel()
-		if _, err := promise.Await(awaitCtx); err != nil {
+		if _, err := promise.Await(ctx); err != nil {
 			log.Error("failed to deliver filtered tx report", "txHash", txHash, "err", err)
 		}
 	})
-	return nil
 }

--- a/execution/gethexec/tx_pre_checker.go
+++ b/execution/gethexec/tx_pre_checker.go
@@ -44,6 +44,8 @@ const TxPreCheckerStrictnessAlwaysCompatible uint = 10
 const TxPreCheckerStrictnessLikelyCompatible uint = 20
 const TxPreCheckerStrictnessFullValidation uint = 30
 
+const filteredTxReportDeliveryTimeout = 5 * time.Second
+
 type TxPreCheckerConfig struct {
 	Strictness             uint  `koanf:"strictness" reload:"hot"`
 	RequiredStateAge       int64 `koanf:"required-state-age" reload:"hot"`
@@ -366,7 +368,9 @@ func (c *TxPreChecker) reportFilteredTx(tx *types.Transaction, header *types.Hea
 	}
 	promise := c.filteringReportRPCClient.ReportFilteredTransactions([]addressfilter.FilteredTxReport{report})
 	go func(txHash common.Hash) {
-		if _, err := promise.Await(context.Background()); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), filteredTxReportDeliveryTimeout)
+		defer cancel()
+		if _, err := promise.Await(ctx); err != nil {
 			log.Error("failed to deliver filtered tx report", "txHash", txHash, "err", err)
 		}
 	}(tx.Hash())

--- a/execution/gethexec/tx_pre_checker.go
+++ b/execution/gethexec/tx_pre_checker.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/spf13/pflag"
 
+	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/arbitrum/retryables"
 	"github.com/ethereum/go-ethereum/arbitrum_types"
 	"github.com/ethereum/go-ethereum/common"
@@ -24,6 +26,7 @@ import (
 
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/l1pricing"
+	"github.com/offchainlabs/nitro/execution/gethexec/addressfilter"
 	"github.com/offchainlabs/nitro/timeboost"
 	"github.com/offchainlabs/nitro/util/arbmath"
 	"github.com/offchainlabs/nitro/util/headerreader"
@@ -65,25 +68,32 @@ func TxPreCheckerConfigAddOptions(prefix string, f *pflag.FlagSet) {
 
 type TxPreChecker struct {
 	TransactionPublisher
-	bc                 *core.BlockChain
-	config             TxPreCheckerConfigFetcher
-	expressLaneTracker *timeboost.ExpressLaneTracker
-	backend            core.NodeInterfaceBackendAPI
+	bc                       *core.BlockChain
+	config                   TxPreCheckerConfigFetcher
+	expressLaneTracker       *timeboost.ExpressLaneTracker
+	backend                  core.NodeInterfaceBackendAPI
+	filteringReportRPCClient *FilteringReportRPCClient
 }
 
 func NewTxPreChecker(
 	publisher TransactionPublisher,
 	bc *core.BlockChain,
-	config TxPreCheckerConfigFetcher) *TxPreChecker {
+	config TxPreCheckerConfigFetcher,
+	filteringReportRPCClient *FilteringReportRPCClient) *TxPreChecker {
 	return &TxPreChecker{
-		TransactionPublisher: publisher,
-		bc:                   bc,
-		config:               config,
+		TransactionPublisher:     publisher,
+		bc:                       bc,
+		config:                   config,
+		filteringReportRPCClient: filteringReportRPCClient,
 	}
 }
 
 func (c *TxPreChecker) SetAPIBackend(backend core.NodeInterfaceBackendAPI) {
 	c.backend = backend
+}
+
+func (c *TxPreChecker) SetFilteringReportRPCClient(client *FilteringReportRPCClient) {
+	c.filteringReportRPCClient = client
 }
 
 type NonceError struct {
@@ -315,7 +325,7 @@ func (c *TxPreChecker) checkFilteredAddresses(ctx context.Context, tx *types.Tra
 	}
 	msg.SkipNonceChecks = true
 
-	_, err = gasestimator.Run(ctx, msg, &gasestimator.Options{
+	_, filteredAddresses, err := gasestimator.Run(ctx, msg, &gasestimator.Options{
 		Config:           c.bc.Config(),
 		Chain:            c.bc,
 		Header:           header,
@@ -324,9 +334,41 @@ func (c *TxPreChecker) checkFilteredAddresses(ctx context.Context, tx *types.Tra
 		RunScheduledTxes: retryables.RunScheduledTxes,
 	})
 	if errors.Is(err, state.ErrArbTxFilter) {
+		if reportErr := c.reportFilteredTx(tx, header, filteredAddresses); reportErr != nil {
+			log.Error("failed to build filtered tx report", "txHash", tx.Hash(), "err", reportErr)
+		}
 		return err
 	}
 	// Other execution errors are ignored since the pre-check is only concerned
 	// with address filtering results, not with exact execution results.
+	return nil
+}
+
+func (c *TxPreChecker) reportFilteredTx(tx *types.Transaction, header *types.Header, filteredAddresses []filter.FilteredAddressRecord) error {
+	if c.filteringReportRPCClient == nil {
+		return nil
+	}
+	txRLP, err := tx.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("failed to marshal filtered tx: %w", err)
+	}
+	report := addressfilter.FilteredTxReport{
+		ID:                uuid.Must(uuid.NewV7()).String(),
+		TxHash:            tx.Hash(),
+		TxRLP:             txRLP,
+		FilteredAddresses: filteredAddresses,
+		BlockNumber:       header.Number.Uint64(),
+		ParentBlockHash:   header.ParentHash,
+		PositionInBlock:   0,
+		FilteredAt:        time.Now().UTC(),
+		IsDelayed:         false,
+		DelayedReportData: nil,
+	}
+	promise := c.filteringReportRPCClient.ReportFilteredTransactions([]addressfilter.FilteredTxReport{report})
+	go func(txHash common.Hash) {
+		if _, err := promise.Await(context.Background()); err != nil {
+			log.Error("failed to deliver filtered tx report", "txHash", txHash, "err", err)
+		}
+	}(tx.Hash())
 	return nil
 }

--- a/execution/gethexec/tx_pre_checker.go
+++ b/execution/gethexec/tx_pre_checker.go
@@ -94,10 +94,6 @@ func (c *TxPreChecker) SetAPIBackend(backend core.NodeInterfaceBackendAPI) {
 	c.backend = backend
 }
 
-func (c *TxPreChecker) SetFilteringReportRPCClient(client *FilteringReportRPCClient) {
-	c.filteringReportRPCClient = client
-}
-
 type NonceError struct {
 	sender     common.Address
 	txNonce    uint64
@@ -327,18 +323,20 @@ func (c *TxPreChecker) checkFilteredAddresses(ctx context.Context, tx *types.Tra
 	}
 	msg.SkipNonceChecks = true
 
-	_, filteredAddresses, err := gasestimator.Run(ctx, msg, &gasestimator.Options{
+	_, err = gasestimator.Run(ctx, msg, &gasestimator.Options{
 		Config:           c.bc.Config(),
 		Chain:            c.bc,
 		Header:           header,
 		State:            statedb,
 		Backend:          c.backend,
 		RunScheduledTxes: retryables.RunScheduledTxes,
+		ReportFilteredTx: func(_ context.Context, records []filter.FilteredAddressRecord) {
+			if reportErr := c.reportFilteredTx(tx, header, records); reportErr != nil {
+				log.Error("failed to build filtered tx report", "txHash", tx.Hash(), "err", reportErr)
+			}
+		},
 	})
 	if errors.Is(err, state.ErrArbTxFilter) {
-		if reportErr := c.reportFilteredTx(tx, header, filteredAddresses); reportErr != nil {
-			log.Error("failed to build filtered tx report", "txHash", tx.Hash(), "err", reportErr)
-		}
 		return err
 	}
 	// Other execution errors are ignored since the pre-check is only concerned
@@ -367,12 +365,13 @@ func (c *TxPreChecker) reportFilteredTx(tx *types.Transaction, header *types.Hea
 		DelayedReportData: nil,
 	}
 	promise := c.filteringReportRPCClient.ReportFilteredTransactions([]addressfilter.FilteredTxReport{report})
-	go func(txHash common.Hash) {
-		ctx, cancel := context.WithTimeout(context.Background(), filteredTxReportDeliveryTimeout)
+	txHash := tx.Hash()
+	c.filteringReportRPCClient.LaunchThread(func(ctx context.Context) {
+		awaitCtx, cancel := context.WithTimeout(ctx, filteredTxReportDeliveryTimeout)
 		defer cancel()
-		if _, err := promise.Await(ctx); err != nil {
+		if _, err := promise.Await(awaitCtx); err != nil {
 			log.Error("failed to deliver filtered tx report", "txHash", txHash, "err", err)
 		}
-	}(tx.Hash())
+	})
 	return nil
 }

--- a/system_tests/prechecker_filter_test.go
+++ b/system_tests/prechecker_filter_test.go
@@ -6,15 +6,19 @@ package arbtest
 import (
 	"context"
 	"math/big"
+	"net"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbos"
@@ -22,11 +26,13 @@ import (
 	"github.com/offchainlabs/nitro/arbos/l2pricing"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
 	"github.com/offchainlabs/nitro/execution/gethexec"
+	"github.com/offchainlabs/nitro/execution/gethexec/addressfilter"
 	"github.com/offchainlabs/nitro/execution/gethexec/eventfilter"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/solgen/go/localgen"
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/util/arbmath"
+	"github.com/offchainlabs/nitro/util/rpcclient"
 	"github.com/offchainlabs/nitro/util/testhelpers"
 	"github.com/offchainlabs/nitro/util/testhelpers/env"
 )
@@ -482,6 +488,104 @@ func TestPrecheckerFilterCascadingRedeemDepth3(t *testing.T) {
 // TestPrecheckerFilterCascadingRedeemDepth4 tests A -> B -> C -> D -> wrapper.callTarget(filtered).
 func TestPrecheckerFilterCascadingRedeemDepth4(t *testing.T) {
 	testPrecheckerFilterCascadingRedeem(t, 4)
+}
+
+// testReportCollector implements the filteringreport RPC namespace for testing.
+// Reports sent via FilteringReportRPCClient are captured in the Reports channel.
+type testReportCollector struct {
+	Reports chan []addressfilter.FilteredTxReport
+}
+
+func (c *testReportCollector) ReportFilteredTransactions(_ context.Context, reports []addressfilter.FilteredTxReport) error {
+	c.Reports <- reports
+	return nil
+}
+
+// startTestReportServer starts an HTTP-JSON-RPC server that captures
+// filteringreport_reportFilteredTransactions calls. Returns the server URL
+// and the collector. The server shuts down when ctx is cancelled.
+func startTestReportServer(t *testing.T, ctx context.Context) (string, *testReportCollector) {
+	t.Helper()
+	collector := &testReportCollector{
+		Reports: make(chan []addressfilter.FilteredTxReport, 16),
+	}
+	rpcServer := rpc.NewServer()
+	err := rpcServer.RegisterName(gethexec.FilteringReportNamespace, collector)
+	require.NoError(t, err)
+
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	httpServer := &http.Server{Handler: rpcServer, ReadHeaderTimeout: 5 * time.Second}
+	go httpServer.Serve(listener) //nolint:errcheck
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		httpServer.Shutdown(shutdownCtx) //nolint:errcheck
+	}()
+
+	return "http://" + listener.Addr().String(), collector
+}
+
+// TestPrecheckerFilterReport verifies that the prechecker sends a
+// FilteredTxReport to the filtering-report service when a tx is filtered.
+func TestPrecheckerFilterReport(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reportURL, collector := startTestReportServer(t, ctx)
+
+	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, false)
+	defer cleanup()
+
+	// Wire report client into forwarder's prechecker
+	reportConfig := gethexec.DefaultFilteringReportRPCClientConfig
+	reportConfig.URL = reportURL
+	reportClient := gethexec.NewFilteringReportRPCClient(func() *rpcclient.ClientConfig {
+		return &reportConfig
+	})
+	Require(t, reportClient.Start(ctx))
+	defer reportClient.StopAndWait()
+	forwarder.ExecNode.TxPreChecker.SetFilteringReportRPCClient(reportClient)
+
+	builder.L2Info.GenerateAccount("FilteredUser")
+	builder.L2Info.GenerateAccount("NormalUser")
+	builder.L2.TransferBalance(t, "Owner", "NormalUser", big.NewInt(1e18), builder.L2Info)
+	_, fundReceipt := builder.L2.TransferBalance(t, "Owner", "FilteredUser", big.NewInt(1e18), builder.L2Info)
+	waitForForwarderSync(t, ctx, forwarder, fundReceipt.BlockNumber.Uint64())
+
+	filteredAddr := builder.L2Info.GetAddress("FilteredUser")
+	forwarder.ExecNode.ExecEngine.SetAddressChecker(t, newHashedChecker([]common.Address{filteredAddr}))
+
+	// Filtered tx should be rejected and generate a report
+	tx := builder.L2Info.PrepareTx("NormalUser", "FilteredUser", builder.L2Info.TransferGas, big.NewInt(1e12), nil)
+	err := forwarder.Client.SendTransaction(ctx, tx)
+	require.True(t, isFilteredError(err), "expected filtered error, got: %v", err)
+
+	select {
+	case reports := <-collector.Reports:
+		require.Len(t, reports, 1)
+		report := reports[0]
+		require.Equal(t, tx.Hash(), report.TxHash)
+		require.NotEmpty(t, report.ID)
+		require.NotEmpty(t, report.TxRLP)
+		require.NotZero(t, report.BlockNumber)
+		require.False(t, report.IsDelayed)
+		require.False(t, report.FilteredAt.IsZero())
+
+		var found bool
+		for _, rec := range report.FilteredAddresses {
+			if rec.Address == filteredAddr {
+				found = true
+				require.Equal(t, filter.ReasonTo, rec.Reason)
+				break
+			}
+		}
+		require.True(t, found, "report should contain filtered address %s", filteredAddr.Hex())
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for filtered tx report")
+	}
 }
 
 // lookupSubmissionTxHash finds the ArbitrumSubmitRetryableTx hash from an L1 receipt

--- a/system_tests/prechecker_filter_test.go
+++ b/system_tests/prechecker_filter_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/offchainlabs/nitro/solgen/go/localgen"
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/util/arbmath"
-	"github.com/offchainlabs/nitro/util/rpcclient"
 	"github.com/offchainlabs/nitro/util/testhelpers"
 	"github.com/offchainlabs/nitro/util/testhelpers/env"
 )
@@ -64,8 +63,10 @@ func waitForForwarderSync(t *testing.T, ctx context.Context, forwarder *TestClie
 }
 
 // buildPrecheckerFilterNodes creates a sequencer node A and a forwarder node B
-// for prechecker filter testing. Node B forwards to A via IPC.
-func buildPrecheckerFilterNodes(t *testing.T, ctx context.Context, withDelayedSeq bool, eventRules ...eventfilter.EventRule) (builder *NodeBuilder, forwarder *TestClient, cleanup func()) {
+// for prechecker filter testing. Node B forwards to A via IPC. If reportURL is
+// non-empty, the forwarder's TxPreChecker is wired to send filtered tx reports
+// to that URL.
+func buildPrecheckerFilterNodes(t *testing.T, ctx context.Context, withDelayedSeq bool, reportURL string, eventRules ...eventfilter.EventRule) (builder *NodeBuilder, forwarder *TestClient, cleanup func()) {
 	t.Helper()
 	ipcPath := tmpPath(t, "test.ipc")
 
@@ -97,6 +98,9 @@ func buildPrecheckerFilterNodes(t *testing.T, ctx context.Context, withDelayedSe
 	if len(eventRules) > 0 {
 		execConfigB.TransactionFiltering.EventFilter.Rules = eventRules
 	}
+	if reportURL != "" {
+		execConfigB.TransactionFiltering.FilteringReportRPCClient.URL = reportURL
+	}
 
 	forwarder, cleanupB := builder.Build2ndNode(t, &SecondNodeParams{
 		nodeConfig: nodeConfigB,
@@ -116,7 +120,7 @@ func TestPrecheckerFilterDirectAddress(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, false)
+	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, false, "")
 	defer cleanup()
 
 	builder.L2Info.GenerateAccount("FilteredUser")
@@ -162,7 +166,7 @@ func TestPrecheckerFilterCleanTxPasses(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, false)
+	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, false, "")
 	defer cleanup()
 
 	builder.L2Info.GenerateAccount("User1")
@@ -188,7 +192,7 @@ func TestPrecheckerFilterDisabled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, false)
+	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, false, "")
 	defer cleanup()
 
 	builder.L2Info.GenerateAccount("User1")
@@ -221,7 +225,7 @@ func TestPrecheckerFilterEvents(t *testing.T) {
 		},
 	}
 
-	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, false, rules...)
+	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, false, "", rules...)
 	defer cleanup()
 
 	// Deploy contract through sequencer and wait for forwarder to sync
@@ -268,7 +272,7 @@ func TestPrecheckerFilterManualRedeem(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, true)
+	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, true, "")
 	defer cleanup()
 
 	// Deploy contract through sequencer as retryable destination
@@ -314,7 +318,7 @@ func TestPrecheckerFilterContractTriggeredRedeem(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, true)
+	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, true, "")
 	defer cleanup()
 
 	// Contract A: the retryable destination (will be filtered)
@@ -406,7 +410,7 @@ func testPrecheckerFilterCascadingRedeem(t *testing.T, depth int) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, true)
+	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, true, "")
 	defer cleanup()
 
 	// Deploy wrapper (neutral) and filteredTarget contracts
@@ -536,18 +540,8 @@ func TestPrecheckerFilterReport(t *testing.T) {
 
 	reportURL, collector := startTestReportServer(t, ctx)
 
-	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, false)
+	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, false, reportURL)
 	defer cleanup()
-
-	// Wire report client into forwarder's prechecker
-	reportConfig := gethexec.DefaultFilteringReportRPCClientConfig
-	reportConfig.URL = reportURL
-	reportClient := gethexec.NewFilteringReportRPCClient(func() *rpcclient.ClientConfig {
-		return &reportConfig
-	})
-	Require(t, reportClient.Start(ctx))
-	defer reportClient.StopAndWait()
-	forwarder.ExecNode.TxPreChecker.SetFilteringReportRPCClient(reportClient)
 
 	builder.L2Info.GenerateAccount("FilteredUser")
 	builder.L2Info.GenerateAccount("NormalUser")

--- a/system_tests/prechecker_filter_test.go
+++ b/system_tests/prechecker_filter_test.go
@@ -532,6 +532,34 @@ func startTestReportServer(t *testing.T, ctx context.Context) (string, *testRepo
 	return "http://" + listener.Addr().String(), collector
 }
 
+// lookupSubmissionTxHash finds the ArbitrumSubmitRetryableTx hash from an L1 receipt
+// by parsing the delayed message.
+func lookupSubmissionTxHash(t *testing.T, ctx context.Context, builder *NodeBuilder, l1Receipt *types.Receipt) common.Hash {
+	t.Helper()
+
+	delayedBridge, err := arbnode.NewDelayedBridge(builder.L1.Client, builder.L1Info.GetAddress("Bridge"), 0)
+	require.NoError(t, err)
+
+	messages, err := delayedBridge.LookupMessagesInRange(ctx, l1Receipt.BlockNumber, l1Receipt.BlockNumber, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, messages, "no delayed messages found")
+
+	for _, message := range messages {
+		if message.Message.Header.Kind != arbostypes.L1MessageType_SubmitRetryable {
+			continue
+		}
+		txs, err := arbos.ParseL2Transactions(message.Message, chaininfo.ArbitrumDevTestChainConfig().ChainID, params.MaxDebugArbosVersionSupported)
+		require.NoError(t, err)
+		for _, tx := range txs {
+			if tx.Type() == types.ArbitrumSubmitRetryableTxType {
+				return tx.Hash()
+			}
+		}
+	}
+	t.Fatal("no retryable submission tx found in delayed messages")
+	return common.Hash{}
+}
+
 // TestPrecheckerFilterReport verifies that the prechecker sends a
 // FilteredTxReport to the filtering-report service when a tx is filtered.
 func TestPrecheckerFilterReport(t *testing.T) {
@@ -582,30 +610,37 @@ func TestPrecheckerFilterReport(t *testing.T) {
 	}
 }
 
-// lookupSubmissionTxHash finds the ArbitrumSubmitRetryableTx hash from an L1 receipt
-// by parsing the delayed message.
-func lookupSubmissionTxHash(t *testing.T, ctx context.Context, builder *NodeBuilder, l1Receipt *types.Receipt) common.Hash {
-	t.Helper()
+// TestPrecheckerFilterNoReportWhenClean verifies that no FilteredTxReport is
+// sent to the filtering-report service when a tx is not filtered.
+func TestPrecheckerFilterNoReportWhenClean(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	delayedBridge, err := arbnode.NewDelayedBridge(builder.L1.Client, builder.L1Info.GetAddress("Bridge"), 0)
-	require.NoError(t, err)
+	reportURL, collector := startTestReportServer(t, ctx)
 
-	messages, err := delayedBridge.LookupMessagesInRange(ctx, l1Receipt.BlockNumber, l1Receipt.BlockNumber, nil)
-	require.NoError(t, err)
-	require.NotEmpty(t, messages, "no delayed messages found")
+	builder, forwarder, cleanup := buildPrecheckerFilterNodes(t, ctx, false, reportURL)
+	defer cleanup()
 
-	for _, message := range messages {
-		if message.Message.Header.Kind != arbostypes.L1MessageType_SubmitRetryable {
-			continue
-		}
-		txs, err := arbos.ParseL2Transactions(message.Message, chaininfo.ArbitrumDevTestChainConfig().ChainID, params.MaxDebugArbosVersionSupported)
-		require.NoError(t, err)
-		for _, tx := range txs {
-			if tx.Type() == types.ArbitrumSubmitRetryableTxType {
-				return tx.Hash()
-			}
-		}
+	builder.L2Info.GenerateAccount("FilteredUser")
+	builder.L2Info.GenerateAccount("NormalUser")
+	builder.L2.TransferBalance(t, "Owner", "NormalUser", big.NewInt(1e18), builder.L2Info)
+	builder.L2Info.GenerateAccount("AnotherUser")
+	_, fundReceipt := builder.L2.TransferBalance(t, "Owner", "AnotherUser", big.NewInt(1e18), builder.L2Info)
+	waitForForwarderSync(t, ctx, forwarder, fundReceipt.BlockNumber.Uint64())
+
+	filteredAddr := builder.L2Info.GetAddress("FilteredUser")
+	forwarder.ExecNode.ExecEngine.SetAddressChecker(t, newHashedChecker([]common.Address{filteredAddr}))
+
+	// Clean tx between non-filtered addresses should forward and succeed
+	tx := builder.L2Info.PrepareTx("NormalUser", "AnotherUser", builder.L2Info.TransferGas, big.NewInt(1e12), nil)
+	err := forwarder.Client.SendTransaction(ctx, tx)
+	Require(t, err)
+	_, err = builder.L2.EnsureTxSucceeded(tx)
+	Require(t, err)
+
+	select {
+	case reports := <-collector.Reports:
+		t.Fatalf("unexpected filtered tx report for clean tx: %+v", reports)
+	case <-time.After(2 * time.Second):
 	}
-	t.Fatal("no retryable submission tx found in delayed messages")
-	return common.Hash{}
 }


### PR DESCRIPTION
Fixes [NIT-4645](https://linear.app/offchain-labs/issue/NIT-4645)
Pulls in https://github.com/OffchainLabs/go-ethereum/pull/657

TxPreChecker now reports filtered transactions to the filtering-report service via FilteringReportRPCClient when its address-filter dry-run rejects a tx. Records flow back through gasestimator.Run, avoiding a second statedb query. eth_estimateGas does not pass through TxPreChecker, so it won't trigger reports.