### PR TITLE
Improve locking mechanism in backlogSizeInBytes()

### DIFF
--- a/broadcaster/backlog/backlog.go
+++ b/broadcaster/backlog/backlog.go
@@ -69,21 +69,26 @@ func (b *backlog) backlogSizeInBytes() (uint64, error) {
 		return 0, errors.New("the head or tail segment of feed backlog is nil")
 	}
 
-	headSeg.messagesLock.RLock()
-	if len(headSeg.messages) == 0 {
-		return 0, errors.New("head segment of the feed backlog is empty")
+	headMsg, err := func() (*message.BroadcastFeedMessage, error) {
+		headSeg.messagesLock.RLock()
+		defer headSeg.messagesLock.RUnlock()
+		if len(headSeg.messages) == 0 {
+			return nil, errors.New("head segment of the feed backlog is empty")
+		}
+		return headSeg.messages[0], nil
+	}()
+	if err != nil {
+		return 0, err
 	}
-	headMsg := headSeg.messages[0]
-	headSeg.messagesLock.RUnlock()
 
 	tailSeg.messagesLock.RLock()
+	defer tailSeg.messagesLock.RUnlock()
 	if len(tailSeg.messages) == 0 {
 		return 0, errors.New("tail segment of the feed backlog is empty")
 	}
 	tailMsg := tailSeg.messages[len(tailSeg.messages)-1]
-	size := tailMsg.CumulativeSumMsgSize
-	tailSeg.messagesLock.RUnlock()
 
+	size := tailMsg.CumulativeSumMsgSize
 	size -= headMsg.CumulativeSumMsgSize
 	size += headMsg.Size()
 	return size, nil

--- a/broadcaster/backlog/backlog_test.go
+++ b/broadcaster/backlog/backlog_test.go
@@ -412,6 +412,68 @@ func TestGet(t *testing.T) {
 	}
 }
 
+// TestBacklogSizeInBytesReleasesLockOnError ensures backlogSizeInBytes does
+// not leak the segment RLock on its error paths. A leaked RLock would block
+// every future writer on that segment (and, under Go's write-preferring
+// RWMutex, every subsequent reader as well), deadlocking the backlog.
+func TestBacklogSizeInBytesReleasesLockOnError(t *testing.T) {
+	assertLockReleased := func(t *testing.T, name string, seg *backlogSegment) {
+		t.Helper()
+		done := make(chan struct{})
+		go func() {
+			seg.messagesLock.Lock()
+			seg.messagesLock.Unlock()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s.messagesLock was left held after backlogSizeInBytes returned an error", name)
+		}
+	}
+
+	newBacklog := func() *backlog {
+		b := &backlog{config: func() *Config { return &DefaultTestConfig }}
+		b.lookupByIndex.Store(&containers.SyncMap[uint64, *backlogSegment]{})
+		return b
+	}
+
+	t.Run("EmptyTail", func(t *testing.T) {
+		b := newBacklog()
+		head := newBacklogSegment()
+		head.messages = message.CreateDummyBroadcastMessages([]arbutil.MessageIndex{40})
+		tail := newBacklogSegment()
+		head.nextSegment.Store(tail)
+		b.head.Store(head)
+		b.tail.Store(tail)
+
+		_, err := b.backlogSizeInBytes()
+		const want = "tail segment of the feed backlog is empty"
+		if err == nil || err.Error() != want {
+			t.Fatalf("expected error %q, got %v", want, err)
+		}
+		assertLockReleased(t, "tail", tail)
+		assertLockReleased(t, "head", head)
+	})
+
+	t.Run("EmptyHead", func(t *testing.T) {
+		b := newBacklog()
+		head := newBacklogSegment()
+		tail := newBacklogSegment()
+		tail.messages = message.CreateDummyBroadcastMessages([]arbutil.MessageIndex{40})
+		head.nextSegment.Store(tail)
+		b.head.Store(head)
+		b.tail.Store(tail)
+
+		_, err := b.backlogSizeInBytes()
+		const want = "head segment of the feed backlog is empty"
+		if err == nil || err.Error() != want {
+			t.Fatalf("expected error %q, got %v", want, err)
+		}
+		assertLockReleased(t, "head", head)
+	})
+}
+
 // TestBacklogRaceCondition performs read & write operations in separate
 // goroutines to ensure that the backlog does not have race conditions. The
 // `go test -race` command can be used to test this.

--- a/changelog/bragaigor-nit-4783.md
+++ b/changelog/bragaigor-nit-4783.md
@@ -1,0 +1,2 @@
+### Fixed
+- Improve locking mechanism in backlogSizeInBytes()


### PR DESCRIPTION
- backlog.backlogSizeInBytes had two error-return paths that returned while still holding `backlogSegment.messagesLock.RLock()`. A leaked RLock permanently blocks every subsequent writer on that segment, and because Go's sync.RWMutex is write-preferring, any later reader also queues behind the stuck writer — effectively deadlocking the backlog.
- Fix: scope each critical section with `defer RUnlock()` so every exit path releases the lock.
- Added regression test `TestBacklogSizeInBytesReleasesLockOnError` with `EmptyHead` and `EmptyTail` subtests. Each forces a specific error path, asserts the exact error message, and then probes the segment's write lock with a 2s timeout to prove the reader lock was released

closes NIT-4783