### PR TITLE
Apply Sharding to PathDB Tests in CI

### DIFF
--- a/.github/workflows/_go-tests.yml
+++ b/.github/workflows/_go-tests.yml
@@ -16,7 +16,10 @@ on:
       run-flaky:
         required: false
         type: boolean
-      run-pathdb:
+      run-pathdb-a:
+        required: false
+        type: boolean
+      run-pathdb-b:
         required: false
         type: boolean
       run-stylus:
@@ -52,7 +55,10 @@ on:
       run-defaults-b-mel:
         required: false
         type: boolean
-      run-pathdb-mel:
+      run-pathdb-a-mel:
+        required: false
+        type: boolean
+      run-pathdb-b-mel:
         required: false
         type: boolean
 
@@ -91,12 +97,19 @@ jobs:
 
       # --------------------- PATHDB MODE ---------------------
 
-      - name: run tests without race detection and path state scheme
-        if: inputs.run-pathdb
+      - name: run tests without race detection and path state scheme (A-batch)
+        if: inputs.run-pathdb-a
         run: >-
           ${{ github.workspace }}/.github/workflows/gotestsum.sh
           --tags cionly --timeout 90m --cover --test_state_scheme path
-          --junitfile test-results/junit-pathdb.xml
+          --junitfile test-results/junit-pathdb-a.xml --run '^Test[A-L]' --reduce-parallelism
+
+      - name: run tests without race detection and path state scheme (B-batch)
+        if: inputs.run-pathdb-b
+        run: >-
+          ${{ github.workspace }}/.github/workflows/gotestsum.sh
+          --tags cionly --timeout 90m --cover --test_state_scheme path
+          --junitfile test-results/junit-pathdb-b.xml --skip '^Test[A-L]' --reduce-parallelism
 
       # --------------------- DEFAULTS MODE ---------------------
 
@@ -116,12 +129,19 @@ jobs:
 
       # --------------------- PATHDB MEL MODE ---------------------
 
-      - name: run tests without race detection and path state scheme (MEL)
-        if: inputs.run-pathdb-mel
+      - name: run tests without race detection and path state scheme (A-batch, MEL)
+        if: inputs.run-pathdb-a-mel
         run: >-
           ${{ github.workspace }}/.github/workflows/gotestsum.sh
           --tags cionly --timeout 90m --cover --test_state_scheme path
-          --junitfile test-results/junit-pathdb-mel.xml --test_mel
+          --junitfile test-results/junit-pathdb-a-mel.xml --run '^Test[A-L]' --reduce-parallelism --test_mel
+
+      - name: run tests without race detection and path state scheme (B-batch, MEL)
+        if: inputs.run-pathdb-b-mel
+        run: >-
+          ${{ github.workspace }}/.github/workflows/gotestsum.sh
+          --tags cionly --timeout 90m --cover --test_state_scheme path
+          --junitfile test-results/junit-pathdb-b-mel.xml --skip '^Test[A-L]' --reduce-parallelism --test_mel
 
       # --------------------- DEFAULTS MEL MODE ---------------------
 

--- a/.github/workflows/_standard-go-test-suite.yml
+++ b/.github/workflows/_standard-go-test-suite.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-mode: [defaults-A, defaults-B, flaky, pathdb, challenge, stylus, l3challenge, defaults-A-MEL, defaults-B-MEL, pathdb-MEL]
+        test-mode: [defaults-A, defaults-B, flaky, pathdb-A, pathdb-B, challenge, stylus, l3challenge, defaults-A-MEL, defaults-B-MEL, pathdb-A-MEL, pathdb-B-MEL]
     uses: ./.github/workflows/_go-tests.yml
     secrets: inherit
     with:
@@ -16,10 +16,12 @@ jobs:
       run-defaults-a: ${{ matrix.test-mode == 'defaults-A' }}
       run-defaults-b: ${{ matrix.test-mode == 'defaults-B' }}
       run-flaky: ${{ matrix.test-mode == 'flaky' }}
-      run-pathdb: ${{ matrix.test-mode == 'pathdb' }}
+      run-pathdb-a: ${{ matrix.test-mode == 'pathdb-A' }}
+      run-pathdb-b: ${{ matrix.test-mode == 'pathdb-B' }}
       run-challenge: ${{ matrix.test-mode == 'challenge' }}
       run-stylus: ${{ matrix.test-mode == 'stylus' }}
       run-l3challenge: ${{ matrix.test-mode == 'l3challenge' }}
       run-defaults-a-mel: ${{ matrix.test-mode == 'defaults-A-MEL' }}
       run-defaults-b-mel: ${{ matrix.test-mode == 'defaults-B-MEL' }}
-      run-pathdb-mel: ${{ matrix.test-mode == 'pathdb-MEL' }}
+      run-pathdb-a-mel: ${{ matrix.test-mode == 'pathdb-A-MEL' }}
+      run-pathdb-b-mel: ${{ matrix.test-mode == 'pathdb-B-MEL' }}

--- a/changelog/rauljordan-shard-path-db.md
+++ b/changelog/rauljordan-shard-path-db.md
@@ -1,0 +1,2 @@
+### Fixed
+ - Shard pathdb and pathdb-MEL CI jobs into A/B halves and run them with `--reduce-parallelism` to eliminate timeout-driven flakes under runner contention


### PR DESCRIPTION
# Background

This PR splits pathdb / pathdb-MEL CI jobs into A/B shards and adds `--reduce-parallelism`, mirroring the pattern already used by defaults-A/B and pebble-a/b.

## Motivation
pathdb is the dominant CI flake mode. Nine of the top-ten failing runs over the past 7 days were pathdb or pathdb-MEL, each terminating at an identical ~101 min wall-clock. We know that pathdb is the only heavy mode that runs the entire test surface in a single job. Every comparable mode is already split:

defaults-A/B use ^Test[A-L] / skip ^Test[A-L]
pebble-a/b use ^Test[A-N] / skip ^Test[A-N] and --reduce-parallelism
From data on a healthy run, pathdb packs ~181 min of per-test CPU time into one 90m job (vs ~90 / 152 min for defaults-A / defaults-B: they split the same total across two jobs). 

When the arbitrator-ci runner pool is contended, pathdb's inner parallelism collapses from ~8× to ~1.8× and it blows through the timeout.

Simulating a ^Test[A-L] partition over the pathdb junit gives 97.1 min / 84.1 min — a 1.16× balance, better than the existing defaults split (1.68×).

Changes
- [x] Replace run-pathdb with run-pathdb-a / run-pathdb-b.
- [x] Replace run-pathdb-mel with run-pathdb-a-mel / run-pathdb-b-mel.
- [x] Split the pathdb and pathdb-MEL steps on ^Test[A-L], each writing its own junit file.
- [x] Add --reduce-parallelism to all four pathdb shards (matches pebble).
- [x] Matrix emits pathdb-A, pathdb-B, pathdb-A-MEL, pathdb-B-MEL in place of the two single entries; inputs wired to the new toggles.
- [x] Timeout stays at 90m per shard. Each shard does roughly half the previous work, leaving ~6× headroom even if parallelism fully collapses under contention.

With these changes, no job should reach the 90m timeout boundary