### PR TITLE
Improve Test Known to be Flaky on CI

### DIFF
--- a/changelog/rauljordan-deflake-inbox-blob-failure.md
+++ b/changelog/rauljordan-deflake-inbox-blob-failure.md
@@ -1,0 +1,2 @@
+### Ignored
+- De-flake `TestInboxReaderBlobFailureWithDelayedMessage`: scale `waitForFindInboxBatch` and `WaitForTx` by `NITRO_TEST_TIMEOUT_SCALE`, replace hard sleeps with polled waits, raise batch-poster poll interval from 10ms to 100ms, and route the second-node build through `WaitAndRun` so it respects the weighted semaphore

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -2350,9 +2350,12 @@ func Fatal(t *testing.T, printables ...interface{}) {
 
 // waitForFindInboxBatch polls FindInboxBatchContainingMessage until the batch
 // containing msgIdx is found, returning the batch number. Any error is treated
-// as immediately fatal. Calls t.Fatalf on timeout.
+// as immediately fatal. Calls t.Fatalf on timeout. The caller-supplied timeout
+// is scaled by NITRO_TEST_TIMEOUT_SCALE so loaded CI runners get proportional
+// headroom without every call site needing its own bump.
 func waitForFindInboxBatch(t *testing.T, node *arbnode.Node, msgIdx arbutil.MessageIndex, timeout, interval time.Duration) uint64 {
 	t.Helper()
+	timeout = time.Duration(float64(timeout) * getTestTimeoutScale())
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		batchNum, found, err := node.GetParentChainDataSource().FindInboxBatchContainingMessage(msgIdx)

--- a/system_tests/inbox_blob_failure_test.go
+++ b/system_tests/inbox_blob_failure_test.go
@@ -63,7 +63,9 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	builder.nodeConfig.BatchPoster.Enable = true
 	builder.nodeConfig.BatchPoster.Post4844Blobs = true
 	builder.nodeConfig.BatchPoster.MaxDelay = 0
-	builder.nodeConfig.BatchPoster.PollInterval = 10 * time.Millisecond
+	// 10ms is gratuitous — batch posting is bound by L1 block times, not poll
+	// latency — and a 10ms cadence starves the poster goroutine on loaded runners.
+	builder.nodeConfig.BatchPoster.PollInterval = 100 * time.Millisecond
 	builder.nodeConfig.DelayedSequencer.Enable = true
 	builder.nodeConfig.DelayedSequencer.FinalizeDistance = 1
 
@@ -86,7 +88,7 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	l2Block, err := builder.L2.Client.BlockByHash(ctx, txReceipt.BlockHash)
 	Require(t, err)
 
-	waitForFindInboxBatch(t, builder.L2.ConsensusNode, arbutil.MessageIndex(l2Block.NumberU64()), 3*time.Second, 100*time.Millisecond)
+	waitForFindInboxBatch(t, builder.L2.ConsensusNode, arbutil.MessageIndex(l2Block.NumberU64()), 30*time.Second, 200*time.Millisecond)
 
 	// Advance L1 more for batch-posting-report finality
 	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 5)
@@ -191,9 +193,9 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	waitForFindInboxBatch(t, builder.L2.ConsensusNode, arbutil.MessageIndex(verifyBlock.NumberU64()), 30*time.Second, 100*time.Millisecond)
 	AdvanceL1(t, ctx, builder.L1.Client, builder.L1Info, 5)
 
-	// Check if follower synced the new transaction
-	time.Sleep(3 * time.Second)
-	follVerifyReceipt, err := WaitForTx(ctx, testClientB.Client, verifyTx.Hash(), 3*time.Second)
+	// Poll the follower for the tx receipt — WaitForTx already loops, so just
+	// give it a generous budget instead of sleeping-then-checking with a tight one.
+	follVerifyReceipt, err := WaitForTx(ctx, testClientB.Client, verifyTx.Hash(), 30*time.Second)
 	if err != nil || follVerifyReceipt == nil {
 		t.Fatal("Follower did not sync new transaction after re-enabling blobs")
 	}
@@ -204,9 +206,7 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 	delayedTx := builder.L2Info.PrepareTx("Owner", "Owner", builder.L2Info.TransferGas, big.NewInt(3e12), nil)
 	SendSignedTxViaL1(t, ctx, builder.L1Info, builder.L1.Client, builder.L2.Client, delayedTx)
 
-	// Check if follower synced the delayed message
-	time.Sleep(3 * time.Second)
-	follDelayedReceipt, err := WaitForTx(ctx, testClientB.Client, delayedTx.Hash(), 3*time.Second)
+	follDelayedReceipt, err := WaitForTx(ctx, testClientB.Client, delayedTx.Hash(), 30*time.Second)
 	if err != nil || follDelayedReceipt == nil {
 		t.Fatal("Follower did not sync delayed message")
 	}
@@ -249,7 +249,12 @@ func TestInboxReaderBlobFailureWithDelayedMessage(t *testing.T) {
 // Build2ndNodeWithBlobReader builds a second node with a custom blob reader.
 func (b *NodeBuilder) Build2ndNodeWithBlobReader(t *testing.T, params *SecondNodeParams, blobReader daprovider.BlobReader) (*TestClient, func()) {
 	t.Helper()
-	DontWaitAndRun(b.ctx, 1, t.Name())
+	// Use WaitAndRun (weight 2, matching BuildL1) so a full second L2 node build
+	// participates in the weighted semaphore instead of being forced through regardless
+	// of runner load.
+	if err := WaitAndRun(b.ctx, 2, t.Name()); err != nil {
+		t.Fatal(err)
+	}
 	if b.L2 == nil {
 		t.Fatal("builder did not previously build an L2 Node")
 	}

--- a/system_tests/wrap_transaction_test.go
+++ b/system_tests/wrap_transaction_test.go
@@ -40,8 +40,12 @@ func GetPendingBlockNumber(ctx context.Context, client *ethclient.Client) (*big.
 	return blockNum.Add(blockNum, common.Big1), nil
 }
 
-// Will wait until txhash is in the blockchain and return its receipt
+// Will wait until txhash is in the blockchain and return its receipt.
+// The caller-supplied timeout is scaled by NITRO_TEST_TIMEOUT_SCALE so loaded
+// CI runners get proportional headroom without every call site needing its
+// own bump.
 func WaitForTx(ctxinput context.Context, client *ethclient.Client, txhash common.Hash, timeout time.Duration) (*types.Receipt, error) {
+	timeout = time.Duration(float64(timeout) * getTestTimeoutScale())
 	ctx, cancel := context.WithTimeout(ctxinput, timeout)
 	defer cancel()
 


### PR DESCRIPTION
This PR attempts to deflake`TestInboxReaderBlobFailureWithDelayedMessage` by doing the following:
1. Scale `waitForFindInboxBatch` and `WaitForTx` by `NITRO_TEST_TIMEOUT_SCALE`
2. Replace hard sleeps with polled waits, raise batch-poster poll interval from 10ms to 100ms
3. Route the second-node build through `WaitAndRun` so it respects the weighted semaphore