### PR TITLE
Periodic filter-set id reporting NIT-4689

### DIFF
--- a/changelog/mnasr-nit-4688.md
+++ b/changelog/mnasr-nit-4688.md
@@ -1,2 +1,2 @@
 ### Added
-- Added support for id-set-filter for address filter reporting
+- Added support for a filter-set ID in the address-filter hash list payload

--- a/changelog/mnasr-nit-4689.md
+++ b/changelog/mnasr-nit-4689.md
@@ -1,0 +1,2 @@
+### Added
+- Active sequencer now periodically reports the current address-filter set ID to the filtering-report service, which forwards it to a configured external HTTP endpoint

--- a/cmd/filtering-report/api/api.go
+++ b/cmd/filtering-report/api/api.go
@@ -11,21 +11,32 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/execution/gethexec"
 	"github.com/offchainlabs/nitro/util/sqsclient"
 )
 
 type FilteringReportAPI struct {
-	queueClient sqsclient.QueueClient
+	queueClient        sqsclient.QueueClient
+	filterSetReporting genericconf.HTTPClientConfig
+	httpClient         *http.Client
 }
 
-func NewFilteringReportAPI(queueClient sqsclient.QueueClient) (*FilteringReportAPI, error) {
+// NewFilteringReportAPI builds the API handler. When filterSetReporting.URL
+// is empty, ReportCurrentFilterSetId becomes a no-op so the service can run
+// without external forwarding configured.
+func NewFilteringReportAPI(queueClient sqsclient.QueueClient, filterSetReporting genericconf.HTTPClientConfig) (*FilteringReportAPI, error) {
 	if queueClient == nil {
 		return nil, errors.New("queueClient must not be nil")
 	}
-	return &FilteringReportAPI{
-		queueClient: queueClient,
-	}, nil
+	api := &FilteringReportAPI{
+		queueClient:        queueClient,
+		filterSetReporting: filterSetReporting,
+	}
+	if filterSetReporting.URL != "" {
+		api.httpClient = &http.Client{Timeout: filterSetReporting.Timeout}
+	}
+	return api, nil
 }
 
 var DefaultStackConfig = node.Config{
@@ -52,13 +63,14 @@ var DefaultStackConfig = node.Config{
 func NewStack(
 	stackConfig *node.Config,
 	queueClient sqsclient.QueueClient,
+	filterSetReporting genericconf.HTTPClientConfig,
 ) (*node.Node, error) {
 	stack, err := node.New(stackConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	api, err := NewFilteringReportAPI(queueClient)
+	api, err := NewFilteringReportAPI(queueClient, filterSetReporting)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/filtering-report/api/api_test.go
+++ b/cmd/filtering-report/api/api_test.go
@@ -5,22 +5,34 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/node"
 
+	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/execution/gethexec/addressfilter"
 	"github.com/offchainlabs/nitro/util/sqsclient"
 )
 
 func newTestStack(t *testing.T) *node.Node {
+	t.Helper()
+	return newTestStackWithFilterSetReporting(t, genericconf.HTTPClientConfig{})
+}
+
+func newTestStackWithFilterSetReporting(t *testing.T, filterSetReport genericconf.HTTPClientConfig) *node.Node {
 	t.Helper()
 
 	stackConfig := DefaultStackConfig
@@ -28,7 +40,7 @@ func newTestStack(t *testing.T) *node.Node {
 	stackConfig.HTTPPort = 0
 	stackConfig.WSHost = "127.0.0.1"
 	stackConfig.WSPort = 0
-	stack, err := NewStack(&stackConfig, &sqsclient.MockQueueClient{})
+	stack, err := NewStack(&stackConfig, &sqsclient.MockQueueClient{}, filterSetReport)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +121,7 @@ func TestReportFilteredTransactionsPartialFailure(t *testing.T) {
 	stackConfig.HTTPPort = 0
 	stackConfig.WSHost = "127.0.0.1"
 	stackConfig.WSPort = 0
-	stack, err := NewStack(&stackConfig, mock)
+	stack, err := NewStack(&stackConfig, mock, genericconf.HTTPClientConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,6 +171,117 @@ func TestReportFilteredTransactionsPartialFailure(t *testing.T) {
 	// All 3 sends should have been attempted (no fail-fast)
 	if mock.sendCount != 3 {
 		t.Fatalf("expected 3 send attempts, got %d", mock.sendCount)
+	}
+}
+
+func TestReportCurrentFilterSetId_NoEndpointIsNoOp(t *testing.T) {
+	stack := newTestStack(t)
+	client := stack.Attach()
+	defer client.Close()
+
+	report := addressfilter.FilterSetIdReport{
+		FilterSetId: uuid.New(),
+		ChainId:     big.NewInt(42161),
+		ReportedAt:  time.Now().UTC(),
+	}
+	if err := client.Call(nil, "filteringreport_reportCurrentFilterSetId", report); err != nil {
+		t.Fatalf("expected no-op call to succeed, got %v", err)
+	}
+}
+
+func TestReportCurrentFilterSetId_Posts(t *testing.T) {
+	var received atomic.Value
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected application/json, got %s", ct)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		var parsed addressfilter.FilterSetIdReport
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			t.Errorf("unmarshal body: %v", err)
+		}
+		received.Store(parsed)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	stack := newTestStackWithFilterSetReporting(t, genericconf.HTTPClientConfig{
+		URL:     server.URL,
+		Timeout: 5 * time.Second,
+	})
+	client := stack.Attach()
+	defer client.Close()
+
+	id := uuid.New()
+	chainID := big.NewInt(42161)
+	reportedAt := time.Now().UTC().Truncate(time.Second)
+	report := addressfilter.FilterSetIdReport{
+		FilterSetId: id,
+		ChainId:     chainID,
+		ReportedAt:  reportedAt,
+	}
+	if err := client.Call(nil, "filteringreport_reportCurrentFilterSetId", report); err != nil {
+		t.Fatalf("rpc call failed: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("expected 1 POST, got %d", calls.Load())
+	}
+	got, ok := received.Load().(addressfilter.FilterSetIdReport)
+	if !ok {
+		t.Fatal("server did not record a report")
+	}
+	if got.FilterSetId != id {
+		t.Errorf("filter-set id: want %s, got %s", id, got.FilterSetId)
+	}
+	if got.ChainId == nil || got.ChainId.Cmp(chainID) != 0 {
+		t.Errorf("chain id: want %s, got %v", chainID, got.ChainId)
+	}
+	if !got.ReportedAt.Equal(reportedAt) {
+		t.Errorf("reported-at: want %s, got %s", reportedAt, got.ReportedAt)
+	}
+}
+
+func TestReportCurrentFilterSetId_Non2xxError(t *testing.T) {
+	const errorBody = "upstream is down"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(errorBody))
+	}))
+	defer server.Close()
+
+	stack := newTestStackWithFilterSetReporting(t, genericconf.HTTPClientConfig{
+		URL:     server.URL,
+		Timeout: 5 * time.Second,
+	})
+	client := stack.Attach()
+	defer client.Close()
+
+	report := addressfilter.FilterSetIdReport{
+		FilterSetId: uuid.New(),
+		ChainId:     big.NewInt(1),
+		ReportedAt:  time.Now().UTC(),
+	}
+	err := client.Call(nil, "filteringreport_reportCurrentFilterSetId", report)
+	if err == nil {
+		t.Fatal("expected error for non-2xx response")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, server.URL) {
+		t.Errorf("error should contain endpoint URL %q, got: %s", server.URL, msg)
+	}
+	if !strings.Contains(msg, "500") {
+		t.Errorf("error should mention status 500, got: %s", msg)
+	}
+	if !strings.Contains(msg, errorBody) {
+		t.Errorf("error should contain response body snippet %q, got: %s", errorBody, msg)
 	}
 }
 

--- a/cmd/filtering-report/api/api_test.go
+++ b/cmd/filtering-report/api/api_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/node"
 
 	"github.com/offchainlabs/nitro/cmd/genericconf"
@@ -181,7 +182,7 @@ func TestReportCurrentFilterSetId_NoEndpointIsNoOp(t *testing.T) {
 
 	report := addressfilter.FilterSetIdReport{
 		FilterSetId: uuid.New(),
-		ChainId:     big.NewInt(42161),
+		ChainId:     (*hexutil.Big)(big.NewInt(42161)),
 		ReportedAt:  time.Now().UTC(),
 	}
 	if err := client.Call(nil, "filteringreport_reportCurrentFilterSetId", report); err != nil {
@@ -225,7 +226,7 @@ func TestReportCurrentFilterSetId_Posts(t *testing.T) {
 	reportedAt := time.Now().UTC().Truncate(time.Second)
 	report := addressfilter.FilterSetIdReport{
 		FilterSetId: id,
-		ChainId:     chainID,
+		ChainId:     (*hexutil.Big)(chainID),
 		ReportedAt:  reportedAt,
 	}
 	if err := client.Call(nil, "filteringreport_reportCurrentFilterSetId", report); err != nil {
@@ -241,7 +242,7 @@ func TestReportCurrentFilterSetId_Posts(t *testing.T) {
 	if got.FilterSetId != id {
 		t.Errorf("filter-set id: want %s, got %s", id, got.FilterSetId)
 	}
-	if got.ChainId == nil || got.ChainId.Cmp(chainID) != 0 {
+	if got.ChainId == nil || got.ChainId.ToInt().Cmp(chainID) != 0 {
 		t.Errorf("chain id: want %s, got %v", chainID, got.ChainId)
 	}
 	if !got.ReportedAt.Equal(reportedAt) {
@@ -266,7 +267,7 @@ func TestReportCurrentFilterSetId_Non2xxError(t *testing.T) {
 
 	report := addressfilter.FilterSetIdReport{
 		FilterSetId: uuid.New(),
-		ChainId:     big.NewInt(1),
+		ChainId:     (*hexutil.Big)(big.NewInt(1)),
 		ReportedAt:  time.Now().UTC(),
 	}
 	err := client.Call(nil, "filteringreport_reportCurrentFilterSetId", report)

--- a/cmd/filtering-report/api/report_current_filter_set_id.go
+++ b/cmd/filtering-report/api/report_current_filter_set_id.go
@@ -1,0 +1,58 @@
+// Copyright 2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/offchainlabs/nitro/execution/gethexec/addressfilter"
+)
+
+// errorBodyLimit caps how much of a non-2xx response body we surface in errors.
+const errorBodyLimit = 1024
+
+// ReportCurrentFilterSetId forwards the sequencer's current address-filter
+// set id to the configured external HTTP endpoint. When no endpoint is
+// configured the call is a no-op, which lets the RPC stay callable without
+// blocking startup of callers that do not care about this feature.
+func (a *FilteringReportAPI) ReportCurrentFilterSetId(ctx context.Context, report addressfilter.FilterSetIdReport) error {
+	endpoint := a.filterSetReporting.URL
+	if endpoint == "" {
+		return nil
+	}
+	body, err := json.Marshal(report)
+	if err != nil {
+		return fmt.Errorf("marshal filter-set id report: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request to %s: %w", endpoint, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("post to %s: %w", endpoint, err)
+	}
+	defer func() {
+		if _, drainErr := io.Copy(io.Discard, resp.Body); drainErr != nil {
+			log.Warn("failed draining filter-set id report response body", "err", drainErr)
+		}
+		resp.Body.Close()
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, errorBodyLimit))
+		if readErr != nil {
+			return fmt.Errorf("post to %s returned status %d (body read error: %w)", endpoint, resp.StatusCode, readErr)
+		}
+		return fmt.Errorf("post to %s returned status %d: %s", endpoint, resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/cmd/filtering-report/api/report_current_filter_set_id.go
+++ b/cmd/filtering-report/api/report_current_filter_set_id.go
@@ -52,7 +52,7 @@ func (a *FilteringReportAPI) ReportCurrentFilterSetId(ctx context.Context, repor
 		if readErr != nil {
 			return fmt.Errorf("post to %s returned status %d (body read error: %w)", endpoint, resp.StatusCode, readErr)
 		}
-		return fmt.Errorf("post to %s returned status %d: %s", endpoint, resp.StatusCode, string(respBody))
+		return fmt.Errorf("post to %s returned status %d: %q", endpoint, resp.StatusCode, respBody)
 	}
 	return nil
 }

--- a/cmd/filtering-report/forwarder/forwarder_test.go
+++ b/cmd/filtering-report/forwarder/forwarder_test.go
@@ -30,7 +30,7 @@ func newTestStack(t *testing.T, queueClient *sqsclient.MockQueueClient) *rpc.Cli
 	stackConfig.HTTPPort = 0
 	stackConfig.WSHost = "127.0.0.1"
 	stackConfig.WSPort = 0
-	stack, err := api.NewStack(&stackConfig, queueClient)
+	stack, err := api.NewStack(&stackConfig, queueClient, genericconf.HTTPClientConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/filtering-report/main.go
+++ b/cmd/filtering-report/main.go
@@ -41,8 +41,9 @@ type FilteringReportConfig struct {
 	IPC  genericconf.IPCConfig     `koanf:"ipc"`
 	Auth genericconf.AuthRPCConfig `koanf:"auth"`
 
-	Queue           sqsclient.QueueConfig `koanf:"queue"`
-	ReportForwarder forwarder.Config      `koanf:"report-forwarder"`
+	Queue              sqsclient.QueueConfig        `koanf:"queue"`
+	ReportForwarder    forwarder.Config             `koanf:"report-forwarder"`
+	FilterSetReporting genericconf.HTTPClientConfig `koanf:"filter-set-reporting"`
 }
 
 var HTTPConfigDefault = genericconf.HTTPConfig{
@@ -69,19 +70,20 @@ var IPCConfigDefault = genericconf.IPCConfig{
 }
 
 var DefaultFilteringReportConfig = FilteringReportConfig{
-	Conf:            genericconf.ConfConfigDefault,
-	LogLevel:        "INFO",
-	LogType:         "plaintext",
-	Metrics:         false,
-	MetricsServer:   genericconf.MetricsServerConfigDefault,
-	PProf:           false,
-	PprofCfg:        genericconf.PProfDefault,
-	HTTP:            HTTPConfigDefault,
-	WS:              WSConfigDefault,
-	IPC:             IPCConfigDefault,
-	Auth:            genericconf.AuthRPCConfigDefault,
-	Queue:           sqsclient.DefaultQueueConfig,
-	ReportForwarder: forwarder.DefaultConfig,
+	Conf:               genericconf.ConfConfigDefault,
+	LogLevel:           "INFO",
+	LogType:            "plaintext",
+	Metrics:            false,
+	MetricsServer:      genericconf.MetricsServerConfigDefault,
+	PProf:              false,
+	PprofCfg:           genericconf.PProfDefault,
+	HTTP:               HTTPConfigDefault,
+	WS:                 WSConfigDefault,
+	IPC:                IPCConfigDefault,
+	Auth:               genericconf.AuthRPCConfigDefault,
+	Queue:              sqsclient.DefaultQueueConfig,
+	ReportForwarder:    forwarder.DefaultConfig,
+	FilterSetReporting: genericconf.HTTPClientConfigDefault,
 }
 
 func (c *FilteringReportConfig) Validate() error {
@@ -90,6 +92,13 @@ func (c *FilteringReportConfig) Validate() error {
 	}
 	if err := c.ReportForwarder.Validate(); err != nil {
 		return fmt.Errorf("report-forwarder config: %w", err)
+	}
+	// FilterSetReporting is optional; an empty URL disables the feature, so
+	// only validate when the operator configured a URL.
+	if c.FilterSetReporting.URL != "" {
+		if err := c.FilterSetReporting.Validate(); err != nil {
+			return fmt.Errorf("filter-set-reporting config: %w", err)
+		}
 	}
 	return nil
 }
@@ -114,6 +123,7 @@ func addFlags(f *pflag.FlagSet) {
 
 	sqsclient.QueueConfigAddOptions("queue", f)
 	forwarder.ConfigAddOptions("report-forwarder", f)
+	genericconf.HTTPClientConfigAddOptions("filter-set-reporting", f)
 }
 
 func parseConfig(args []string) (*FilteringReportConfig, error) {
@@ -210,7 +220,7 @@ func mainImpl() int {
 	fwd.Start(ctx)
 	defer fwd.StopAndWait()
 
-	stack, err := api.NewStack(&stackConf, queueClient)
+	stack, err := api.NewStack(&stackConf, queueClient, config.FilterSetReporting)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error creating stack: %v\n", err)
 		return 1

--- a/execution/gethexec/addressfilter/filter_report.go
+++ b/execution/gethexec/addressfilter/filter_report.go
@@ -4,7 +4,10 @@
 package addressfilter
 
 import (
+	"math/big"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
@@ -14,6 +17,13 @@ import (
 // lint:require-exhaustive-initialization
 type DelayedReportData struct {
 	InboxRequestId common.Hash `json:"delayedInboxRequestId"`
+}
+
+// lint:require-exhaustive-initialization
+type FilterSetIdReport struct {
+	FilterSetId uuid.UUID `json:"filterSetId"`
+	ChainId     *big.Int  `json:"chainId"`
+	ReportedAt  time.Time `json:"reportedAt"`
 }
 
 // lint:require-exhaustive-initialization

--- a/execution/gethexec/addressfilter/filter_report.go
+++ b/execution/gethexec/addressfilter/filter_report.go
@@ -4,7 +4,6 @@
 package addressfilter
 
 import (
-	"math/big"
 	"time"
 
 	"github.com/google/uuid"
@@ -21,9 +20,9 @@ type DelayedReportData struct {
 
 // lint:require-exhaustive-initialization
 type FilterSetIdReport struct {
-	FilterSetId uuid.UUID `json:"filterSetId"`
-	ChainId     *big.Int  `json:"chainId"`
-	ReportedAt  time.Time `json:"reportedAt"`
+	FilterSetId uuid.UUID    `json:"filterSetId"`
+	ChainId     *hexutil.Big `json:"chainId"`
+	ReportedAt  time.Time    `json:"reportedAt"`
 }
 
 // lint:require-exhaustive-initialization

--- a/execution/gethexec/addressfilter/hash_store.go
+++ b/execution/gethexec/addressfilter/hash_store.go
@@ -99,6 +99,10 @@ func (h *HashStore) Digest() string {
 	return h.data.Load().digest
 }
 
+func (h *HashStore) Id() uuid.UUID {
+	return h.data.Load().id
+}
+
 func (h *HashStore) Size() int {
 	return len(h.data.Load().hashes)
 }

--- a/execution/gethexec/addressfilter/service.go
+++ b/execution/gethexec/addressfilter/service.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/offchainlabs/nitro/util/stopwaiter"
@@ -118,6 +120,15 @@ func (s *FilterService) GetHashStore() *HashStore {
 		return nil
 	}
 	return s.hashStore
+}
+
+// CurrentFilterSetId returns the filter-set id of the currently loaded hash
+// list, or uuid.Nil when the service is disabled or no list has been loaded.
+func (s *FilterService) CurrentFilterSetId() uuid.UUID {
+	if !s.config.Enable {
+		return uuid.Nil
+	}
+	return s.hashStore.Id()
 }
 
 func (s *FilterService) GetAddressChecker() *HashedAddressChecker {

--- a/execution/gethexec/addressfilter/service_test.go
+++ b/execution/gethexec/addressfilter/service_test.go
@@ -324,6 +324,21 @@ func TestParseHashListJSON(t *testing.T) {
 	if len(parsedJson.Hashes) != 1 {
 		t.Errorf("expected 1 hash, got %d", len(parsedJson.Hashes))
 	}
+
+	// Test with malformed id field: must fail loudly so operators catch
+	// provider misconfiguration.
+	badIdPayload := map[string]interface{}{
+		"salt": "2cef04bf-b23f-47ba-9c2f-4e7bd652c1c6",
+		"id":   "not-a-uuid",
+		"address_hashes": []map[string]interface{}{
+			{"hash": hex.EncodeToString(hashed_addr1[:])},
+		},
+	}
+	badIdJSON, _ := json.Marshal(badIdPayload)
+	_, err = parseHashListJSON(badIdJSON)
+	if err == nil {
+		t.Error("expected error for malformed id")
+	}
 }
 
 func TestConfig_Validate(t *testing.T) {

--- a/execution/gethexec/executionengine.go
+++ b/execution/gethexec/executionengine.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"path"
 	"runtime/pprof"
@@ -280,6 +281,14 @@ func NewExecutionEngine(
 		addressChecker:                 addressChecker,
 		filteringReportRPCClient:       filteringReportRPCClient,
 	}
+}
+
+func (s *ExecutionEngine) GetFilteringReportRPCClient() *FilteringReportRPCClient {
+	return s.filteringReportRPCClient
+}
+
+func (s *ExecutionEngine) ChainId() *big.Int {
+	return s.bc.Config().ChainID
 }
 
 func (s *ExecutionEngine) backlogCallDataUnits() uint64 {

--- a/execution/gethexec/filtering_report_client.go
+++ b/execution/gethexec/filtering_report_client.go
@@ -51,3 +51,10 @@ func (c *FilteringReportRPCClient) ReportFilteredTransactions(reports []addressf
 		return struct{}{}, err
 	})
 }
+
+func (c *FilteringReportRPCClient) ReportCurrentFilterSetId(report addressfilter.FilterSetIdReport) containers.PromiseInterface[struct{}] {
+	return stopwaiter.LaunchPromiseThread(c, func(ctx context.Context) (struct{}, error) {
+		err := c.client.CallContext(ctx, nil, FilteringReportNamespace+"_reportCurrentFilterSetId", report)
+		return struct{}{}, err
+	})
+}

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/spf13/pflag"
 
 	"github.com/ethereum/go-ethereum/arbitrum"
@@ -97,6 +98,7 @@ type SequencerConfig struct {
 	EnableProfiling              bool             `koanf:"enable-profiling" reload:"hot"`
 	Timeboost                    timeboost.Config `koanf:"timeboost"`
 	Dangerous                    DangerousConfig  `koanf:"dangerous"`
+	FilterSetReportingInterval   time.Duration    `koanf:"filter-set-reporting-interval" reload:"hot"`
 	expectedSurplusSoftThreshold int
 	expectedSurplusHardThreshold int
 }
@@ -186,6 +188,7 @@ var DefaultSequencerConfig = SequencerConfig{
 	EnableProfiling:              false,
 	Timeboost:                    timeboost.DefaultConfig,
 	Dangerous:                    DefaultDangerousConfig,
+	FilterSetReportingInterval:   time.Minute,
 }
 
 var DefaultDangerousConfig = DangerousConfig{
@@ -213,6 +216,7 @@ func SequencerConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.String(prefix+".expected-surplus-soft-threshold", DefaultSequencerConfig.ExpectedSurplusSoftThreshold, "if expected surplus is lower than this value, warnings are posted")
 	f.String(prefix+".expected-surplus-hard-threshold", DefaultSequencerConfig.ExpectedSurplusHardThreshold, "if expected surplus is lower than this value, new incoming transactions will be denied")
 	f.Bool(prefix+".enable-profiling", DefaultSequencerConfig.EnableProfiling, "enable CPU profiling and tracing")
+	f.Duration(prefix+".filter-set-reporting-interval", DefaultSequencerConfig.FilterSetReportingInterval, "interval at which the active sequencer reports its current address-filter set id to the filtering-report service (0 disables reporting)")
 }
 
 func DangerousAddOptions(prefix string, f *pflag.FlagSet) {
@@ -1727,7 +1731,59 @@ func (s *Sequencer) Start(ctxIn context.Context) error {
 		return 0
 	})
 
+	s.startFilterSetReporting()
+
 	return nil
+}
+
+// isActiveSequencer reports whether this node is currently the active
+// sequencer (i.e. not paused and not forwarding to another sequencer).
+func (s *Sequencer) isActiveSequencer() bool {
+	pauseChan, forwarder := s.GetPauseAndForwarder()
+	return pauseChan == nil && forwarder == nil
+}
+
+// reportFilterSetID POSTs the current address-filter set id to the
+// filtering-report service. A nil address-filter service, missing RPC client
+// or uuid.Nil filter-set id are all treated as nothing-to-report.
+func (s *Sequencer) reportFilterSetID(ctx context.Context) error {
+	if s.addressFilterService == nil {
+		return nil
+	}
+	filterSetID := s.addressFilterService.CurrentFilterSetId()
+	if filterSetID == uuid.Nil {
+		// The hash store starts at uuid.Nil until the first S3 fetch lands.
+		// Debug-log so an operator investigating a silent reporting loop
+		// during startup sees why nothing is being sent.
+		log.Debug("skipping filter-set id report: no id loaded yet")
+		return nil
+	}
+	rpcClient := s.execEngine.GetFilteringReportRPCClient()
+	if rpcClient == nil {
+		return nil
+	}
+	_, err := rpcClient.ReportCurrentFilterSetId(addressfilter.FilterSetIdReport{
+		FilterSetId: filterSetID,
+		ChainId:     s.execEngine.ChainId(),
+		ReportedAt:  time.Now().UTC(),
+	}).Await(ctx)
+	return err
+}
+
+func (s *Sequencer) startFilterSetReporting() {
+	interval := s.config().FilterSetReportingInterval
+	if interval <= 0 || s.execEngine.GetFilteringReportRPCClient() == nil {
+		return
+	}
+	s.CallIteratively(func(ctx context.Context) time.Duration {
+		if !s.isActiveSequencer() {
+			return interval
+		}
+		if err := s.reportFilterSetID(ctx); err != nil {
+			log.Warn("failed to report current filter-set id", "err", err)
+		}
+		return interval
+	})
 }
 
 type TxSource int

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/arbitrum"
 	"github.com/ethereum/go-ethereum/arbitrum_types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/txpool"
@@ -1743,11 +1744,18 @@ func (s *Sequencer) isActiveSequencer() bool {
 	return pauseChan == nil && forwarder == nil
 }
 
+// filterSetReportingDisabledRetry is the sleep used when reporting is
+// runtime-disabled (FilterSetReportingInterval <= 0). Keeping it short lets a
+// hot-reload to a positive interval be picked up within a minute, without
+// letting a misconfigured node spin on a zero-length wait.
+const filterSetReportingDisabledRetry = time.Minute
+
 // reportFilterSetID POSTs the current address-filter set id to the
 // filtering-report service. A nil address-filter service, missing RPC client
 // or uuid.Nil filter-set id are all treated as nothing-to-report.
 func (s *Sequencer) reportFilterSetID(ctx context.Context) error {
 	if s.addressFilterService == nil {
+		log.Debug("skipping filter-set id report: address-filter service not configured")
 		return nil
 	}
 	filterSetID := s.addressFilterService.CurrentFilterSetId()
@@ -1764,18 +1772,27 @@ func (s *Sequencer) reportFilterSetID(ctx context.Context) error {
 	}
 	_, err := rpcClient.ReportCurrentFilterSetId(addressfilter.FilterSetIdReport{
 		FilterSetId: filterSetID,
-		ChainId:     s.execEngine.ChainId(),
+		ChainId:     (*hexutil.Big)(s.execEngine.ChainId()),
 		ReportedAt:  time.Now().UTC(),
 	}).Await(ctx)
 	return err
 }
 
+// startFilterSetReporting schedules the periodic reporting loop whenever the
+// filtering-report RPC client is wired (its presence is immutable after node
+// construction). FilterSetReportingInterval carries reload:"hot", so it is
+// re-read on every tick; when the operator hot-reloads it to <=0 the loop
+// parks at filterSetReportingDisabledRetry instead of exiting, so a later
+// re-enable is picked up without restarting the node.
 func (s *Sequencer) startFilterSetReporting() {
-	interval := s.config().FilterSetReportingInterval
-	if interval <= 0 || s.execEngine.GetFilteringReportRPCClient() == nil {
+	if s.execEngine.GetFilteringReportRPCClient() == nil {
 		return
 	}
 	s.CallIteratively(func(ctx context.Context) time.Duration {
+		interval := s.config().FilterSetReportingInterval
+		if interval <= 0 {
+			return filterSetReportingDisabledRetry
+		}
 		if !s.isActiveSequencer() {
 			return interval
 		}

--- a/system_tests/tx_address_filter_test.go
+++ b/system_tests/tx_address_filter_test.go
@@ -640,10 +640,7 @@ func TestPeriodicFilterSetIdReporting(t *testing.T) {
 			http.Error(w, "bad json", http.StatusBadRequest)
 			return
 		}
-		select {
-		case reportCh <- report:
-		default:
-		}
+		reportCh <- report
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer externalEndpoint.Close()
@@ -720,7 +717,7 @@ func TestPeriodicFilterSetIdReporting(t *testing.T) {
 
 	first := waitForReport(id1)
 	require.NotNil(t, first.ChainId, "chain id should be set in report")
-	require.Equal(t, 0, first.ChainId.Cmp(expectedChainID), "chain id mismatch: want %s got %s", expectedChainID, first.ChainId)
+	require.Equal(t, 0, first.ChainId.ToInt().Cmp(expectedChainID), "chain id mismatch: want %s got %s", expectedChainID, first.ChainId.ToInt())
 	require.False(t, first.ReportedAt.IsZero(), "reported-at should be set")
 
 	// Rotate the filter set; the next reporting tick must pick up id2.
@@ -728,7 +725,7 @@ func TestPeriodicFilterSetIdReporting(t *testing.T) {
 	filterService.GetHashStore().Store(id2, salt, nil, "test-digest-2")
 
 	second := waitForReport(id2)
-	require.Equal(t, 0, second.ChainId.Cmp(expectedChainID), "chain id mismatch after rotation")
+	require.Equal(t, 0, second.ChainId.ToInt().Cmp(expectedChainID), "chain id mismatch after rotation")
 	require.True(t, second.ReportedAt.After(first.ReportedAt) || second.ReportedAt.Equal(first.ReportedAt),
 		"second report's reported-at (%s) should be >= first (%s)", second.ReportedAt, first.ReportedAt)
 }

--- a/system_tests/tx_address_filter_test.go
+++ b/system_tests/tx_address_filter_test.go
@@ -5,22 +5,30 @@ package arbtest
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	filteringreportapi "github.com/offchainlabs/nitro/cmd/filtering-report/api"
+	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/execution"
 	"github.com/offchainlabs/nitro/execution/gethexec/addressfilter"
 	"github.com/offchainlabs/nitro/execution/gethexec/eventfilter"
 	"github.com/offchainlabs/nitro/solgen/go/localgen"
 	"github.com/offchainlabs/nitro/util/s3client"
 	"github.com/offchainlabs/nitro/util/s3syncer"
+	"github.com/offchainlabs/nitro/util/sqsclient"
 )
 
 func isFilteredError(err error) bool {
@@ -603,4 +611,124 @@ func TestSyncBlockedUntilFilteringReady(t *testing.T) {
 	if !execNode.Synced(ctx) {
 		t.Fatal("Synced should return true when both SyncMonitor is synced and filtering is ready")
 	}
+}
+
+// TestPeriodicFilterSetIdReporting exercises the end-to-end flow:
+// sequencer -> filtering-report RPC -> external HTTP endpoint. It also
+// rotates the hash store mid-run to verify a new filter-set id is picked up.
+func TestPeriodicFilterSetIdReporting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Capture every POST sent to the "external provider".
+	reportCh := make(chan addressfilter.FilterSetIdReport, 16)
+	externalEndpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+			http.Error(w, "bad method", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			http.Error(w, "read failed", http.StatusInternalServerError)
+			return
+		}
+		var report addressfilter.FilterSetIdReport
+		if err := json.Unmarshal(body, &report); err != nil {
+			t.Errorf("unmarshal body: %v", err)
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		select {
+		case reportCh <- report:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer externalEndpoint.Close()
+
+	// Stand up the filtering-report service pointing at the external endpoint.
+	stackConfig := filteringreportapi.DefaultStackConfig
+	stackConfig.HTTPHost = "127.0.0.1"
+	stackConfig.HTTPPort = 0
+	stackConfig.WSHost = "127.0.0.1"
+	stackConfig.WSPort = 0
+	filteringReportStack, err := filteringreportapi.NewStack(
+		&stackConfig,
+		&sqsclient.MockQueueClient{},
+		genericconf.HTTPClientConfig{
+			URL:     externalEndpoint.URL,
+			Timeout: 5 * time.Second,
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, filteringReportStack.Start())
+	t.Cleanup(func() { filteringReportStack.Close() })
+
+	// Build an active sequencer node wired to the filtering-report service.
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, false)
+	builder.isSequencer = true
+	builder.execConfig.TransactionFiltering.FilteringReportRPCClient.URL = filteringReportStack.HTTPEndpoint()
+	builder.execConfig.Sequencer.FilterSetReportingInterval = 200 * time.Millisecond
+	cleanup := builder.Build(t)
+	defer cleanup()
+
+	// Inject an enabled filter service (without S3) so the sequencer has a
+	// filter-set id to report, and wire it into the sequencer via the
+	// test-only setter. Using a direct hash store Store() lets us control the
+	// id deterministically.
+	filterCfg := &addressfilter.Config{
+		Enable: true,
+		S3: s3syncer.Config{
+			Config:    s3client.Config{Region: "us-east-1"},
+			Bucket:    "test-bucket",
+			ObjectKey: "test-key",
+		},
+		PollInterval:              5 * time.Minute,
+		CacheSize:                 100,
+		AddressCheckerWorkerCount: 1,
+		AddressCheckerQueueSize:   10,
+	}
+	filterService, err := addressfilter.NewFilterService(filterCfg)
+	require.NoError(t, err)
+	builder.L2.ExecNode.Sequencer.SetAddressFilterServiceForTest(t, filterService)
+
+	salt, err := uuid.Parse("3ccf0cbf-b23f-47ba-9c2f-4e7bd672b4c7")
+	require.NoError(t, err)
+
+	// First id: assert we observe it at the external endpoint.
+	id1 := uuid.New()
+	filterService.GetHashStore().Store(id1, salt, nil, "test-digest-1")
+
+	expectedChainID := builder.L2.ExecNode.ExecEngine.ChainId()
+	waitForReport := func(wantID uuid.UUID) addressfilter.FilterSetIdReport {
+		t.Helper()
+		deadline := time.After(10 * time.Second)
+		for {
+			select {
+			case got := <-reportCh:
+				if got.FilterSetId == wantID {
+					return got
+				}
+				// Drop stale reports (e.g. from the previous id during rotation).
+			case <-deadline:
+				t.Fatalf("timed out waiting for report with filter-set id %s", wantID)
+			}
+		}
+	}
+
+	first := waitForReport(id1)
+	require.NotNil(t, first.ChainId, "chain id should be set in report")
+	require.Equal(t, 0, first.ChainId.Cmp(expectedChainID), "chain id mismatch: want %s got %s", expectedChainID, first.ChainId)
+	require.False(t, first.ReportedAt.IsZero(), "reported-at should be set")
+
+	// Rotate the filter set; the next reporting tick must pick up id2.
+	id2 := uuid.New()
+	filterService.GetHashStore().Store(id2, salt, nil, "test-digest-2")
+
+	second := waitForReport(id2)
+	require.Equal(t, 0, second.ChainId.Cmp(expectedChainID), "chain id mismatch after rotation")
+	require.True(t, second.ReportedAt.After(first.ReportedAt) || second.ReportedAt.Equal(first.ReportedAt),
+		"second report's reported-at (%s) should be >= first (%s)", second.ReportedAt, first.ReportedAt)
 }


### PR DESCRIPTION
Active sequencer periodically POSTs its current address-filter set id  (with chain id and timestamp) to the filtering-report service, which  forwards it to a configured external HTTP endpoint. No-op when the  endpoint URL or reporting interval is unconfigured.

Re-implementation of the closed PR #4598, rebased on fresh master, applied relevant comments. 