### PR TITLE
Sync SP1 README with new Makefile workflow; add run target

### DIFF
--- a/.github/workflows/zk-proving.yml
+++ b/.github/workflows/zk-proving.yml
@@ -64,10 +64,7 @@ jobs:
           
           echo "--- Running SP1 Validation ---"
           # Extracting only the hex string using grep -o
-          SP1_HASH=$(./target/sp1/sp1-runner \
-            --program target/sp1/dumped_replay_wasm.elf \
-            --stylus-compiler-program target/sp1/stylus-compiler-program \
-            --block-file target/sp1/block-inputs/stylus.json 2>&1 \
+          SP1_HASH=$(make -C crates/sp1 run BLOCK=stylus 2>&1 \
             | grep "Validation succeeds with hash" \
             | awk '{print $NF}')
           

--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ crates/wasm-libraries/soft-float/SoftFloat/build/Wasm-Clang/softfloat.a: $(DEP_P
 		crates/wasm-libraries/soft-float/SoftFloat/source/include/*.h \
 		crates/wasm-libraries/soft-float/SoftFloat/source/8086/*.c \
 		crates/wasm-libraries/soft-float/SoftFloat/source/8086/*.h
-	cd crates/wasm-libraries/soft-float/SoftFloat/build/Wasm-Clang && make $(MAKEFLAGS)
+	cd crates/wasm-libraries/soft-float/SoftFloat/build/Wasm-Clang && $(MAKE)
 
 crates/wasm-libraries/soft-float/bindings32.o: $(DEP_PREDICATE) crates/wasm-libraries/soft-float/bindings32.c
 	clang crates/wasm-libraries/soft-float/bindings32.c --sysroot $(WASI_SYSROOT) -I crates/wasm-libraries/soft-float/SoftFloat/source/include -target wasm32-wasip1 -Wconversion -c -o $@

--- a/crates/sp1/Makefile
+++ b/crates/sp1/Makefile
@@ -5,6 +5,9 @@ BROTLI_LIB_DIR   := $(TOP)/target/lib-sp1
 OUTPUT_DIR       := $(TOP)/target/sp1
 BLOCK_INPUTS_DIR := $(OUTPUT_DIR)/block-inputs
 
+# Name of the block input (without .json) for the `run` target; override with BLOCK=<name>.
+BLOCK ?= stylus
+
 # Bump SP1's maximum heap memory size.
 export SP1_ZKVM_MAX_MEMORY := 1099511627776
 
@@ -30,10 +33,13 @@ install-sp1: # Install the SP1 RISC-V toolchain.
 
 .PHONY: brotli
 brotli: # Build brotli for RISC-V (SP1); artifacts go to $(BROTLI_LIB_DIR).
-	@cp $(TOP)/crates/sp1/brotli_cmake_patch.txt $(TOP)/brotli/CMakeLists.txt
+	@echo "Building brotli for RISC-V (SP1)..."
 	@rm -rf $(BROTLI_BUILD_DIR) $(BROTLI_LIB_DIR)
 	@mkdir -p $(BROTLI_BUILD_DIR)
-	@if { cmake -S $(TOP)/brotli -B $(BROTLI_BUILD_DIR) \
+	@cp $(TOP)/brotli/CMakeLists.txt $(TOP)/brotli/CMakeLists.txt.bak; \
+	trap 'mv $(TOP)/brotli/CMakeLists.txt.bak $(TOP)/brotli/CMakeLists.txt' EXIT INT TERM; \
+	cp $(TOP)/crates/sp1/brotli_cmake_patch.txt $(TOP)/brotli/CMakeLists.txt; \
+	if { cmake -S $(TOP)/brotli -B $(BROTLI_BUILD_DIR) \
 		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 		-DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
 		-DCMAKE_SYSTEM_NAME=Generic \
@@ -95,6 +101,13 @@ build: nitro-deps
 	@cargo build --release -p sp1-runner
 	@cp $(TOP)/target/elf-compilation/riscv64im-succinct-zkvm-elf/release/stylus-compiler-program $(OUTPUT_DIR)
 	@cp $(TOP)/target/release/sp1-runner $(OUTPUT_DIR)
+
+.PHONY: run
+run: # Run sp1-runner on $(BLOCK_INPUTS_DIR)/$(BLOCK).json (override with BLOCK=<name>).
+	$(OUTPUT_DIR)/sp1-runner \
+		--program $(OUTPUT_DIR)/dumped_replay_wasm.elf \
+		--stylus-compiler-program $(OUTPUT_DIR)/stylus-compiler-program \
+		--block-file $(BLOCK_INPUTS_DIR)/$(BLOCK).json
 
 .PHONY: clean
 clean: # Remove all generated artifacts.

--- a/crates/sp1/README.md
+++ b/crates/sp1/README.md
@@ -8,12 +8,13 @@ To build this runner, of course you must be able to build a significant part of 
 
 One major dependency wasmer also requires you to have LLVM 21 installed. Please note that you must have LLVM 21.x.y installed. Wasmer requires this major version.
 
-The code included here requires a SP1 Rust toolchain with riscv64 support. You can use the following commands:
+The code included here requires a SP1 Rust toolchain with riscv64 support. You can install it via the Makefile target:
 
 ```bash
-$ curl -L https://sp1up.succinct.xyz | bash
-$ sp1up -v v6.0.0-beta.1
+$ make -C crates/sp1 install-sp1
 ```
+
+This runs `sp1up` and installs the RISC-V C toolchain under `$HOME/.sp1/`.
 
 To verify that correct toolchain have been installed, you can run the following 2 commands, and compare output:
 
@@ -25,44 +26,59 @@ riscv32im-succinct-zkvm-elf
 riscv64im-succinct-zkvm-elf
 ```
 
+All SP1-related build steps are driven by `crates/sp1/Makefile`. Run `make -C crates/sp1 help` to see every available target. The main ones are:
+
+* `install-sp1` — install the SP1 toolchain (see above).
+* `brotli` — build brotli for the RISC-V target; artifacts go to `target/lib-sp1`.
+* `nitro-deps` — build nitro dependencies needed by the SP1 runner (depends on `brotli`).
+* `build` — build the SP1 runner and its inputs; artifacts go to `target/sp1`.
+* `record-blocks` — run all block-recording system tests and dump block inputs to `target/sp1/block-inputs`.
+* `run` — execute `sp1-runner` on a recorded block; defaults to `stylus`, override with `BLOCK=<name>`.
+* `clean` — remove everything produced by the targets above.
+
 Now you can start the build process:
 
 ```bash
 $ git clone https://github.com/OffchainLabs/nitro
 $ # Checkout current PR
-$ ./crates/sp1/build.sh
+$ make -C crates/sp1 build
 ```
-
-To make things easier to understand, for now we are using a simple bash script. As the code grow more mature, we would merge the bash script into the top-level makefile.
 
 After the build process, all the files required by SP1 runner can be found in `target/sp1` folder. Some important files are:
 
-* `replay.wasm`: this is Arbitrum's STF built with `sp1` tag enabled, so it contains SP1 specific optimizations
+* `replay.wasm`: this is Arbitrum's STF, used as input to the SP1 builder.
 * `dumped_replay_wasm.elf`: this is the SP1 version of `replay.wasm`. The 2 fulfill the same task. It's just that `dumped_replay_wasm.elf` is in RISC-V architecture accepted by SP1, following SP1's ABIs.
 * `stylus-compiler-program`: this is a SP1 program wrapping wasmer's singlepass compiler. It can compile an Arbitrum stylus program into RISC-V format accepted by SP1.
 * `sp1-runner`: this is the SP1 runner that can execute / validate an Arbitrum block. One can see it as SP1 version of `jit` or `prover` in `arbitrator` workspace.
-* `*.json`: sample Arbitrum test blocks you can use for testing. In my run, `block_inputs_7.json` was generated.
 
 There are also other files in the folder, but you can safely ignore them. They are kept now for debugging purposes.
+
+To generate sample Arbitrum test blocks you can use for testing, run:
+
+```bash
+$ make -C crates/sp1 record-blocks
+```
+
+This runs the block-recording system tests (under the `block_recording` build tag) and writes the resulting JSON block inputs to `target/sp1/block-inputs/`:
+
+* `transfer.json` — a pure ETH transfer, no contract interactions.
+* `solidity.json` — 20 Solidity SSTORE operations, no Stylus.
+* `stylus.json` — a single Stylus call with one WASM storage write.
+* `stylus_heavy.json` — 32 cross-contract read/write pairs through a multicall Stylus program.
+* `mixed.json` — a mixed block: ETH transfers, an EVM call, and multiple Stylus programs.
 
 Now you can use the following command to execute an Arbitrum block using SP1 runner:
 
 ```bash
-$ ./target/sp1/sp1-runner \
-    --program target/sp1/dumped_replay_wasm.elf \
-    --stylus-compiler-program target/sp1/stylus-compiler-program \
-    --block-file target/sp1/block_inputs_7.json
+$ make -C crates/sp1 run BLOCK=stylus
 stderr: WARNING: Using insecure random number generator.
 stdout: Validation succeeds with hash 624b2d504238ba9fe94ad3e19d1036a51894bc209b7f0ead1331d22005d40178
 ```
 
-You can tweak `RUST_LOG` for more logs(e.g., running cycles and running time):
+Pass `BLOCK=<name>` to run against a different recorded block (for example `BLOCK=mixed`). You can also tweak `RUST_LOG` for more logs (e.g., running cycles and running time):
 
 ```bash
-$ RUST_LOG=info ./target/sp1/sp1-runner \
-    --program target/sp1/dumped_replay_wasm.elf \
-    --stylus-compiler-program target/sp1/stylus-compiler-program \
-    --block-file target/sp1/block_inputs_7.json
+$ RUST_LOG=info make -C crates/sp1 run BLOCK=mixed
 ```
 
 You can also compare the result hash with Arbitrum's own JIT engine:
@@ -71,9 +87,9 @@ You can also compare the result hash with Arbitrum's own JIT engine:
 $ ./target/bin/jit \
     --debug --cranelift \
     --binary target/machines/latest/replay.wasm \
-    --json-inputs=target/sp1/block_inputs_7.json
+    json --inputs=target/sp1/block-inputs/stylus.json
 Created the machine in 4081ms.
 Completed in 19ms with hash 624b2d504238ba9fe94ad3e19d1036a51894bc209b7f0ead1331d22005d40178.
 ```
 
-You can also generate other Arbitrum blocks to test. There is one caveat: for any stylus programs that might be executed, you must include the original wasm source in the block JSON file as well. SP1 runner works either with the original WASM source files(it will invoke stylus compiler program automatically), or the `rv64` target binary after compilation. You can also refer to [this commit](https://github.com/wakabat/nitro/commit/d924d4907ace4bd329b27dacd31ebad832b6eb90) where we patch nitro's tests to dump as many acceptable test blocks as possible.
+If you want to generate additional Arbitrum blocks beyond the ones recorded by `make record-blocks`, you can add new tests to `system_tests/block_recording_test.go` (guarded by the `block_recording` build tag). There is one caveat: for any stylus programs that might be executed, you must include the original wasm source in the block JSON file as well. SP1 runner works either with the original WASM source files (it will invoke stylus compiler program automatically), or the `rv64` target binary after compilation.


### PR DESCRIPTION
Follow-up to #4667, which moved SP1's build pipeline from build.sh to a per-target Makefile but left `crates/sp1/README.md` describing the old flow. This PR: 

- `crates/sp1/README.md`: replaces the deleted `build.sh` instructions with the Makefile-driven workflow: install-sp1, brotli, nitro-deps, build, record-blocks, run, clean. Documents the new `target/sp1/block-inputs/` layout (transfer.json, solidity.json, stylus.json, stylus_heavy.json, mixed.json) produced by record-blocks, updates every example invocation
  to use the new paths, and points users at `system_tests/block_recording_test.go` for adding new blocks.
- `crates/sp1/Makefile`: two small quality-of-life fixes plus a new target:
  - brotli: adds a `"Building brotli for RISC-V (SP1)…"` progress line, and backs up `brotli/CMakeLists.txt` before patching it so that a trap ... EXIT INT TERM restores the original on any exit path (success, failure, `Ctrl-C`). Previously the submodule was left dirty after every run.
   - New run target that wraps the sp1-runner invocation. Takes BLOCK=<name> (defaults to stylus), resolving to `target/sp1/block-inputs/$(BLOCK).json`. The recipe is intentionally unsilenced so make echoes the fully-expanded command for debugging.
- `.github/workflows/zk-proving.yml`: replaces the inline sp1-runner invocation with make -C crates/sp1 run BLOCK=stylus, so CI and the README now go through the same code path.

part of NIT-4820