### PR TITLE
fix: Skip extra header columns in iostat parsing

### DIFF
--- a/changelog/inomurko-iostat-header-columns.md
+++ b/changelog/inomurko-iostat-header-columns.md
@@ -1,0 +1,2 @@
+### Fixed
+- Skip extra header columns in iostat parsing

--- a/util/iostat/iostat.go
+++ b/util/iostat/iostat.go
@@ -85,8 +85,8 @@ func Run(ctx context.Context, interval int, receiver chan DeviceStats) {
 		var err error
 		for i, field := range fields {
 			if i >= len(data) {
-				// Some iostat builds emit a header with more columns than a data row
-				// (e.g. trailing header tokens without values). Skip the rest of the header.
+				// Some iostat builds emit a header with more columns than a data row.
+				// Stop matching schema fields once the data row is exhausted.
 				break
 			}
 			switch field {

--- a/util/iostat/iostat.go
+++ b/util/iostat/iostat.go
@@ -84,6 +84,11 @@ func Run(ctx context.Context, interval int, receiver chan DeviceStats) {
 		stat := DeviceStats{}
 		var err error
 		for i, field := range fields {
+			if i >= len(data) {
+				// Some iostat builds emit a header with more columns than a data row
+				// (e.g. trailing header tokens without values). Skip the rest of the header.
+				break
+			}
 			switch field {
 			case "Device", "Device:":
 				stat.DeviceName = data[i]

--- a/util/iostat/iostat.go
+++ b/util/iostat/iostat.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -69,8 +70,20 @@ func Run(ctx context.Context, interval int, receiver chan DeviceStats) {
 		log.Error("Failed to start iostat command", "err", err)
 		return
 	}
+	parseStream(stdout, receiver)
+	if err := cmd.Process.Kill(); err != nil {
+		log.Error("Failed to kill iostat process", "err", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		log.Error("Error waiting for iostat to exit", "err", err)
+	}
+	stdout.Close()
+	log.Info("Iostat command terminated")
+}
+
+func parseStream(r io.Reader, receiver chan<- DeviceStats) {
 	var fields []string
-	scanner := bufio.NewScanner(stdout)
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if strings.HasPrefix(line, "Device") {
@@ -87,6 +100,7 @@ func Run(ctx context.Context, interval int, receiver chan DeviceStats) {
 			if i >= len(data) {
 				// Some iostat builds emit a header with more columns than a data row.
 				// Stop matching schema fields once the data row is exhausted.
+				log.Warn("iostat row has fewer columns than header", "headerCols", len(fields), "dataCols", len(data), "header", fields, "row", data)
 				break
 			}
 			switch field {
@@ -110,14 +124,6 @@ func Run(ctx context.Context, interval int, receiver chan DeviceStats) {
 		receiver <- stat
 	}
 	if scanner.Err() != nil {
-		log.Error("Iostat scanner error", err, scanner.Err())
+		log.Error("Iostat scanner error", "err", scanner.Err())
 	}
-	if err := cmd.Process.Kill(); err != nil {
-		log.Error("Failed to kill iostat process", "err", err)
-	}
-	if err := cmd.Wait(); err != nil {
-		log.Error("Error waiting for iostat to exit", "err", err)
-	}
-	stdout.Close()
-	log.Info("Iostat command terminated")
 }

--- a/util/iostat/iostat_test.go
+++ b/util/iostat/iostat_test.go
@@ -1,0 +1,74 @@
+// Copyright 2024-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+package iostat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseStream(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []DeviceStats
+	}{
+		{
+			name: "well formed row",
+			input: `
+Device r/s w/s await
+nvme0n1 1.25 2.50 3.75
+`,
+			want: []DeviceStats{{
+				DeviceName:      "nvme0n1",
+				ReadsPerSecond:  1.25,
+				WritesPerSecond: 2.50,
+				Await:           3.75,
+			}},
+		},
+		{
+			name: "header has more columns than data row",
+			input: `
+Device r/s w/s await
+nvme0n1 1.25 2.50
+`,
+			want: []DeviceStats{{
+				DeviceName:      "nvme0n1",
+				ReadsPerSecond:  1.25,
+				WritesPerSecond: 2.50,
+				Await:           0,
+			}},
+		},
+		{
+			name: "device header with trailing colon",
+			input: `
+Device: r/s w/s await
+nvme0n1 4.25 5.50 6.75
+`,
+			want: []DeviceStats{{
+				DeviceName:      "nvme0n1",
+				ReadsPerSecond:  4.25,
+				WritesPerSecond: 5.50,
+				Await:           6.75,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			receiver := make(chan DeviceStats)
+			go func() {
+				parseStream(strings.NewReader(tt.input), receiver)
+				close(receiver)
+			}()
+
+			var got []DeviceStats
+			for stat := range receiver {
+				got = append(got, stat)
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/util/iostat/iostat_test.go
+++ b/util/iostat/iostat_test.go
@@ -18,9 +18,9 @@ func TestParseStream(t *testing.T) {
 		{
 			name: "well formed row",
 			input: `
-Device r/s w/s await
-nvme0n1 1.25 2.50 3.75
-`,
+				Device r/s w/s await
+				nvme0n1 1.25 2.50 3.75
+			`,
 			want: []DeviceStats{{
 				DeviceName:      "nvme0n1",
 				ReadsPerSecond:  1.25,
@@ -31,9 +31,9 @@ nvme0n1 1.25 2.50 3.75
 		{
 			name: "header has more columns than data row",
 			input: `
-Device r/s w/s await
-nvme0n1 1.25 2.50
-`,
+				Device r/s w/s await
+				nvme0n1 1.25 2.50
+			`,
 			want: []DeviceStats{{
 				DeviceName:      "nvme0n1",
 				ReadsPerSecond:  1.25,
@@ -44,9 +44,9 @@ nvme0n1 1.25 2.50
 		{
 			name: "device header with trailing colon",
 			input: `
-Device: r/s w/s await
-nvme0n1 4.25 5.50 6.75
-`,
+				Device: r/s w/s await
+				nvme0n1 4.25 5.50 6.75
+			`,
 			want: []DeviceStats{{
 				DeviceName:      "nvme0n1",
 				ReadsPerSecond:  4.25,


### PR DESCRIPTION
Skip parsing when a stats row has fewer fields than the last Device header row.

It breaks when i >= len(data), i.e. when this data row has fewer whitespace-separated fields than the header has columns (or than we’ve consumed so far).


```
{
        "@timestamp": "2026-04-25 16:36:53.602",
        "@message": {
            "time": "2026-04-25T16:36:53.602931801Z",
            "stream": "stderr",
            "_p": "F",
            "log": "panic: runtime error: index out of range [7] with length 7",
            "kubernetes": {
                "pod_name": "sequencer-00-6bb98c996d-9npgf",
                "container_name": "nitro-sequencer-00"
            }
        },
        "kubernetes.pod_name": "sequencer-00-6bb98c996d-9npgf"
    },
    {
        "@timestamp": "2026-04-25 16:36:53.635",
        "@message": {
            "time": "2026-04-25T16:36:53.635989261Z",
            "stream": "stderr",
            "_p": "F",
            "log": "",
            "kubernetes": {
                "pod_name": "sequencer-00-6bb98c996d-9npgf",
                "container_name": "nitro-sequencer-00"
            }
        },
        "kubernetes.pod_name": "sequencer-00-6bb98c996d-9npgf"
    },
    {
        "@timestamp": "2026-04-25 16:36:53.636",
        "@message": {
            "time": "2026-04-25T16:36:53.636010651Z",
            "stream": "stderr",
            "_p": "F",
            "log": "goroutine 68 [running]:",
            "kubernetes": {
                "pod_name": "sequencer-00-6bb98c996d-9npgf",
                "container_name": "nitro-sequencer-00"
            }
        },
        "kubernetes.pod_name": "sequencer-00-6bb98c996d-9npgf"
    },
    {
        "@timestamp": "2026-04-25 16:36:53.695",
        "@message": {
            "time": "2026-04-25T16:36:53.695956669Z",
            "stream": "stderr",
            "_p": "F",
            "log": "github.com/offchainlabs/nitro/util/iostat.Run({0x373bce8, 0xc0005595e0}, 0x162e9a5?, 0xc0000a4f50)",
            "kubernetes": {
                "pod_name": "sequencer-00-6bb98c996d-9npgf",
                "container_name": "nitro-sequencer-00"
            }
        },
        "kubernetes.pod_name": "sequencer-00-6bb98c996d-9npgf"
    },
    {
        "@timestamp": "2026-04-25 16:36:53.696",
        "@message": {
            "time": "2026-04-25T16:36:53.696583445Z",
            "stream": "stderr",
            "_p": "F",
            "log": "\t/workspace/util/iostat/iostat.go:91 +0xa06",
            "kubernetes": {
                "pod_name": "sequencer-00-6bb98c996d-9npgf",
                "container_name": "nitro-sequencer-00"
            }
        },
        "kubernetes.pod_name": "sequencer-00-6bb98c996d-9npgf"
    },
    {
        "@timestamp": "2026-04-25 16:36:53.733",
        "@message": {
            "time": "2026-04-25T16:36:53.733730975Z",
            "stream": "stderr",
            "_p": "F",
            "log": "created by github.com/offchainlabs/nitro/util/iostat.RegisterAndPopulateMetrics in goroutine 59",
            "kubernetes": {
                "pod_name": "sequencer-00-6bb98c996d-9npgf",
                "container_name": "nitro-sequencer-00"
            }
        },
        "kubernetes.pod_name": "sequencer-00-6bb98c996d-9npgf"
    },
    {
        "@timestamp": "2026-04-25 16:36:53.733",
        "@message": {
            "time": "2026-04-25T16:36:53.733827792Z",
            "stream": "stderr",
            "_p": "F",
            "log": "\t/workspace/util/iostat/iostat.go:23 +0x12c",
            "kubernetes": {
                "pod_name": "sequencer-00-6bb98c996d-9npgf",
                "container_name": "nitro-sequencer-00"
            }
        },
        "kubernetes.pod_name": "sequencer-00-6bb98c996d-9npgf"
    },
```