### PR TITLE
fix: add forge version check to check-build.sh

### DIFF
--- a/changelog/tenderdeve-nit-4379.md
+++ b/changelog/tenderdeve-nit-4379.md
@@ -1,0 +1,2 @@
+### Internal
+- Validate forge version (1.0.0) in `scripts/check-build.sh` and emit a clear remediation message when an incompatible version is installed

--- a/scripts/check-build.sh
+++ b/scripts/check-build.sh
@@ -200,10 +200,11 @@ fi
 # Newer forge versions (> 1.0.0) use solar instead of solc for Yul compilation,
 # which causes `make build` to fail.
 if command_exists forge; then
-    FORGE_INSTALLED_VERSION=$(forge --version | head -n 1 | awk '{print $2}')
-    if compare_versions "$forge_max_version" "$FORGE_INSTALLED_VERSION" "exact"; then
-        echo -e "${GREEN}forge version $FORGE_INSTALLED_VERSION is installed (compatible).${NC}"
-    else
+    FORGE_INSTALLED_VERSION=$(forge --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+    if [[ -z "$FORGE_INSTALLED_VERSION" ]]; then
+        echo -e "${RED}Could not parse forge version from \`forge --version\`.${NC}"
+        EXIT_CODE=1
+    elif compare_versions "$forge_version_needed" "$FORGE_INSTALLED_VERSION" "exact"; then
         echo -e "${RED}forge version $FORGE_INSTALLED_VERSION is not compatible. Version $forge_max_version is required (newer versions use solar instead of solc for Yul compilation). Run: foundryup --version $forge_max_version${NC}"
         EXIT_CODE=1
     fi

--- a/scripts/check-build.sh
+++ b/scripts/check-build.sh
@@ -11,7 +11,7 @@ NC='\033[0m' # No Color
 node_version_needed="v24"
 rust_version_needed="1.93.0"
 golangci_lint_version_needed="2.5.0"
-forge_max_version="1.0.0"
+forge_version_needed="1.0.0"
 
 if [[ -f go.mod ]]; then
     go_version_needed=$(grep "^go " go.mod | awk '{print $2}')
@@ -188,29 +188,26 @@ else
     EXIT_CODE=1
 fi
 
-# Check Foundry installation
-if command_exists foundryup; then
-    echo -e "${GREEN}Foundry is installed.${NC}"
-else
-    echo -e "${RED}Foundry is not installed.${NC}"
-    EXIT_CODE=1
-fi
-
-# Check forge installation and version compatibility
+# Check Foundry / forge installation and version compatibility
 # Newer forge versions (> 1.0.0) use solar instead of solc for Yul compilation,
 # which causes `make build` to fail.
-if command_exists forge; then
+if ! command_exists foundryup; then
+    echo -e "${RED}Foundry is not installed.${NC}"
+    EXIT_CODE=1
+elif ! command_exists forge; then
+    echo -e "${RED}forge is not installed. Run: foundryup --version $forge_version_needed${NC}"
+    EXIT_CODE=1
+else
     FORGE_INSTALLED_VERSION=$(forge --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
     if [[ -z "$FORGE_INSTALLED_VERSION" ]]; then
         echo -e "${RED}Could not parse forge version from \`forge --version\`.${NC}"
         EXIT_CODE=1
     elif compare_versions "$forge_version_needed" "$FORGE_INSTALLED_VERSION" "exact"; then
-        echo -e "${RED}forge version $FORGE_INSTALLED_VERSION is not compatible. Version $forge_max_version is required (newer versions use solar instead of solc for Yul compilation). Run: foundryup --version $forge_max_version${NC}"
+        echo -e "${GREEN}forge version $FORGE_INSTALLED_VERSION is installed.${NC}"
+    else
+        echo -e "${RED}forge version $FORGE_INSTALLED_VERSION is not compatible. Version $forge_version_needed is required (newer versions use solar instead of solc for Yul compilation). Run: foundryup --version $forge_version_needed${NC}"
         EXIT_CODE=1
     fi
-else
-    echo -e "${RED}forge is not installed. Install Foundry and run: foundryup --version $forge_max_version${NC}"
-    EXIT_CODE=1
 fi
 
 if [ $EXIT_CODE != 0 ]; then

--- a/scripts/check-build.sh
+++ b/scripts/check-build.sh
@@ -11,6 +11,7 @@ NC='\033[0m' # No Color
 node_version_needed="v24"
 rust_version_needed="1.93.0"
 golangci_lint_version_needed="2.5.0"
+forge_max_version="1.0.0"
 
 if [[ -f go.mod ]]; then
     go_version_needed=$(grep "^go " go.mod | awk '{print $2}')
@@ -192,6 +193,22 @@ if command_exists foundryup; then
     echo -e "${GREEN}Foundry is installed.${NC}"
 else
     echo -e "${RED}Foundry is not installed.${NC}"
+    EXIT_CODE=1
+fi
+
+# Check forge installation and version compatibility
+# Newer forge versions (> 1.0.0) use solar instead of solc for Yul compilation,
+# which causes `make build` to fail.
+if command_exists forge; then
+    FORGE_INSTALLED_VERSION=$(forge --version | head -n 1 | awk '{print $2}')
+    if compare_versions "$forge_max_version" "$FORGE_INSTALLED_VERSION" "exact"; then
+        echo -e "${GREEN}forge version $FORGE_INSTALLED_VERSION is installed (compatible).${NC}"
+    else
+        echo -e "${RED}forge version $FORGE_INSTALLED_VERSION is not compatible. Version $forge_max_version is required (newer versions use solar instead of solc for Yul compilation). Run: foundryup --version $forge_max_version${NC}"
+        EXIT_CODE=1
+    fi
+else
+    echo -e "${RED}forge is not installed. Install Foundry and run: foundryup --version $forge_max_version${NC}"
     EXIT_CODE=1
 fi
 


### PR DESCRIPTION
## Summary
- Add forge version validation to `scripts/check-build.sh`
- Ensures forge 1.0.0 is installed before proceeding with the build
- Prints a clear error explaining that newer forge versions use `solar` instead of `solc` for Yul compilation, which breaks the build
- Suggests `foundryup --version 1.0.0` as remediation

The check follows the same pattern as existing tool version checks in the script, using the `command_exists` and `compare_versions` helpers.

Fixes #4379

## Test plan
- [ ] Run `./scripts/check-build.sh` with forge 1.0.0 installed — should pass
- [ ] Run with a newer forge version — should fail with a clear message
- [ ] Run without forge installed — should fail with "forge not found"