### PR TITLE
Profiling script with basic metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7134,6 +7134,7 @@ dependencies = [
  "sp1-build",
  "sp1-core-executor",
  "sp1-sdk",
+ "tracing",
  "wasmer",
  "wasmparser 0.245.1",
 ]

--- a/crates/sp1/Makefile
+++ b/crates/sp1/Makefile
@@ -109,6 +109,13 @@ run: # Run sp1-runner on $(BLOCK_INPUTS_DIR)/$(BLOCK).json (override with BLOCK=
 		--stylus-compiler-program $(OUTPUT_DIR)/stylus-compiler-program \
 		--block-file $(BLOCK_INPUTS_DIR)/$(BLOCK).json
 
+.PHONY: profile
+profile: # Profile bootloading, stylus compilation, and reexecution for BLOCK (default: stylus).
+	@python3 $(CURDIR)/profile.py \
+		--output-dir $(OUTPUT_DIR) \
+		--block-inputs-dir $(BLOCK_INPUTS_DIR) \
+		--block $(BLOCK)
+
 .PHONY: clean
 clean: # Remove all generated artifacts.
 	@rm -rf $(BROTLI_BUILD_DIR) $(BROTLI_LIB_DIR) $(OUTPUT_DIR)

--- a/crates/sp1/Makefile
+++ b/crates/sp1/Makefile
@@ -110,11 +110,10 @@ run: # Run sp1-runner on $(BLOCK_INPUTS_DIR)/$(BLOCK).json (override with BLOCK=
 		--block-file $(BLOCK_INPUTS_DIR)/$(BLOCK).json
 
 .PHONY: profile
-profile: # Profile bootloading, stylus compilation, and reexecution for BLOCK (default: stylus).
+profile: # Profile bootloading, stylus compilation, and reexecution across all block types.
 	@python3 $(CURDIR)/profile.py \
 		--output-dir $(OUTPUT_DIR) \
-		--block-inputs-dir $(BLOCK_INPUTS_DIR) \
-		--block $(BLOCK)
+		--block-inputs-dir $(BLOCK_INPUTS_DIR)
 
 .PHONY: clean
 clean: # Remove all generated artifacts.

--- a/crates/sp1/builder/Cargo.toml
+++ b/crates/sp1/builder/Cargo.toml
@@ -4,12 +4,17 @@ description = "A builder crate that builds SP1 programs, necessary metadata, the
 version = "0.1.0"
 edition = "2024"
 
+[[bin]]
+name = "sp1-builder"
+path = "main.rs"
+
 [dependencies]
 sp1-core-executor = { workspace = true }
 sp1-sdk = { workspace = true }
 
 clap = { workspace = true, features = ["cargo", "derive"] }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 wasmer = { workspace = true, features = ["llvm"] }
 wasmparser = { workspace = true }
 

--- a/crates/sp1/builder/main.rs
+++ b/crates/sp1/builder/main.rs
@@ -1,5 +1,4 @@
-use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::Arc};
-
+use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::Arc, time::SystemTime};
 use clap::Parser;
 use sp1_core_executor::{MinimalExecutor, Program};
 use sp1_sdk::{Elf, include_elf};
@@ -117,7 +116,9 @@ fn main() {
         // The executor will fail after bootloading completes because
         // the empty input buffer cannot be parsed as an Arbitrum block.
         // This is expected — we only need the bootloading side-effect (ELF dump).
+        let t0 = SystemTime::now();
         let _ = executor.execute_chunk();
+        let time_secs = t0.elapsed().unwrap().as_secs_f64();
 
         if let Ok(true) = std::fs::exists(&output) {
             println!("SP1 bootloading process completed successfully.");
@@ -128,6 +129,12 @@ fn main() {
                 output
             );
         }
+
+        tracing::info!(
+            "[PROFILE] bootloading: cycles={}, time_secs={:.3}",
+            executor.global_clk(),
+            time_secs,
+        );
 
         println!("Bootloaded program is written to {}", output);
     }

--- a/crates/sp1/builder/main.rs
+++ b/crates/sp1/builder/main.rs
@@ -1,4 +1,5 @@
 use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::Arc, time::SystemTime};
+
 use clap::Parser;
 use sp1_core_executor::{MinimalExecutor, Program};
 use sp1_sdk::{Elf, include_elf};

--- a/crates/sp1/profile.py
+++ b/crates/sp1/profile.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-Profile the SP1 zkVM pipeline for a given block input.
+Profile the SP1 zkVM pipeline across all block types.
 
 Usage:
-    python3 profile.py --output-dir TARGET/sp1 --block-inputs-dir TARGET/sp1/block-inputs --block stylus
+    python3 profile.py --output-dir TARGET/sp1 --block-inputs-dir TARGET/sp1/block-inputs
 
 Phases measured:
   bootloading         — SP1 execution time only (excludes WASM→LLVM compilation)
@@ -18,6 +18,8 @@ import os
 import re
 import subprocess
 import sys
+
+BLOCKS = ["transfer", "solidity", "stylus", "stylus_heavy", "mixed"]
 
 # ---------------------------------------------------------------------------
 # Log parsing
@@ -93,36 +95,52 @@ def fmt_secs(v: str | None) -> str:
         return v
 
 
+# A table row is either a data dict or a section sentinel {"section": name}.
+
 def print_table(rows: list[dict]) -> None:
     headers = ["Phase", "Wasm size", "SP1 cycles", "Time"]
 
-    display = []
+    # Collect display cells for data rows only (to compute column widths).
+    display: list[list[str] | str] = []  # str entries are section labels
     for r in rows:
-        display.append([
-            r["label"],
-            fmt_bytes(r.get("wasm_size")),
-            fmt_int(r.get("cycles")),
-            fmt_secs(r.get("time_secs")),
-        ])
+        if "section" in r:
+            display.append(r["section"])
+        else:
+            display.append([
+                r["label"],
+                fmt_bytes(r.get("wasm_size")),
+                fmt_int(r.get("cycles")),
+                fmt_secs(r.get("time_secs")),
+            ])
 
+    data_rows = [d for d in display if isinstance(d, list)]
     col_widths = [
-        max(len(headers[i]), max(len(d[i]) for d in display))
+        max(len(headers[i]), max(len(d[i]) for d in data_rows))
         for i in range(len(headers))
     ]
 
-    # First column (phase label) is left-aligned; the rest are right-aligned.
+    total_inner = sum(col_widths) + 3 * (len(col_widths) - 1)  # widths + " | " separators
+
     def fmt_cell(value: str, width: int, col: int) -> str:
         return value.ljust(width) if col == 0 else value.rjust(width)
 
-    sep = "+-" + "-+-".join("-" * w for w in col_widths) + "-+"
-    header_row = "| " + " | ".join(h.ljust(w) for h, w in zip(headers, col_widths)) + " |"
+    sep      = "+-" + "-+-".join("-" * w for w in col_widths) + "-+"
+    thick    = "+=" + "=+=".join("=" * w for w in col_widths) + "=+"
+    hdr_row  = "| " + " | ".join(h.ljust(w) for h, w in zip(headers, col_widths)) + " |"
 
     print()
     print(sep)
-    print(header_row)
+    print(hdr_row)
     print(sep)
-    for d in display:
-        print("| " + " | ".join(fmt_cell(c, w, i) for i, (c, w) in enumerate(zip(d, col_widths))) + " |")
+    for item in display:
+        if isinstance(item, str):
+            # Section header row: block name centered across full table width.
+            label = f" {item} "
+            print(thick)
+            print("| " + label.center(total_inner) + " |")
+            print(sep)
+        else:
+            print("| " + " | ".join(fmt_cell(c, w, i) for i, (c, w) in enumerate(zip(item, col_widths))) + " |")
     print(sep)
     print()
 
@@ -135,15 +153,11 @@ def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--output-dir", required=True, help="Path to target/sp1")
     ap.add_argument("--block-inputs-dir", required=True, help="Path to target/sp1/block-inputs")
-    ap.add_argument("--block", default="stylus", help="Block input name (without .json)")
     args = ap.parse_args()
 
     out = args.output_dir
-    block_file = f"{args.block_inputs_dir}/{args.block}.json"
 
-    print(f"\nProfiling block: {args.block}")
-
-    print("\n[1/2] Running sp1-builder (WASM→LLVM compilation + SP1 bootloading):")
+    print("\n[1] Running sp1-builder (WASM→LLVM compilation + SP1 bootloading):")
     boot_log = run(
         "sp1-builder",
         [
@@ -153,32 +167,38 @@ def main() -> None:
         ],
     )
 
-    print("\n[2/2] Running sp1-runner (stylus compilation + reexecution):")
-    run_log = run(
-        "sp1-runner",
-        [
-            f"{out}/sp1-runner",
-            "--program", f"{out}/dumped_replay_wasm.elf",
-            "--stylus-compiler-program", f"{out}/stylus-compiler-program",
-            "--block-file", block_file,
-        ],
-    )
-
-    profile_rows = parse_profile_lines(boot_log) + parse_profile_lines(run_log)
-
     table: list[dict] = []
-    stylus_count = 0
-    for row in profile_rows:
-        phase = row["phase"]
-        if phase == "bootloading":
-            table.append({"label": "bootloading", "cycles": row.get("cycles"), "time_secs": row.get("time_secs")})
-        elif phase == "stylus_compilation":
-            stylus_count += 1
-            table.append({"label": f"stylus_compilation [{stylus_count}]", "wasm_size": row.get("wasm_size"), "cycles": row.get("cycles"), "time_secs": row.get("time_secs")})
-        elif phase == "reexecution":
-            table.append({"label": "reexecution", "cycles": row.get("cycles"), "time_secs": row.get("time_secs")})
 
-    if not table:
+    boot_rows = parse_profile_lines(boot_log)
+    for row in boot_rows:
+        if row["phase"] == "bootloading":
+            table.append({"label": "bootloading", "cycles": row.get("cycles"), "time_secs": row.get("time_secs")})
+
+    print(f"\n[2] Running sp1-runner on {len(BLOCKS)} block types:")
+    for i, block in enumerate(BLOCKS, 1):
+        block_file = f"{args.block_inputs_dir}/{block}.json"
+        run_log = run(
+            f"sp1-runner [{block}]",
+            [
+                f"{out}/sp1-runner",
+                "--program", f"{out}/dumped_replay_wasm.elf",
+                "--stylus-compiler-program", f"{out}/stylus-compiler-program",
+                "--block-file", block_file,
+            ],
+        )
+
+        table.append({"section": block})
+        stylus_count = 0
+        for row in parse_profile_lines(run_log):
+            phase = row["phase"]
+            if phase == "stylus_compilation":
+                stylus_count += 1
+                table.append({"label": f"stylus_compilation [{stylus_count}]", "wasm_size": row.get("wasm_size"), "cycles": row.get("cycles"), "time_secs": row.get("time_secs")})
+            elif phase == "reexecution":
+                table.append({"label": "reexecution", "cycles": row.get("cycles"), "time_secs": row.get("time_secs")})
+
+    data_rows = [r for r in table if "section" not in r]
+    if not data_rows:
         print("\nNo [PROFILE] lines found. Make sure RUST_LOG is not suppressing INFO logs.", file=sys.stderr)
         sys.exit(1)
 

--- a/crates/sp1/profile.py
+++ b/crates/sp1/profile.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Profile the SP1 zkVM pipeline for a given block input.
+
+Usage:
+    python3 profile.py --output-dir TARGET/sp1 --block-inputs-dir TARGET/sp1/block-inputs --block stylus
+
+Phases measured:
+  bootloading         — SP1 execution time only (excludes WASM→LLVM compilation)
+  stylus_compilation  — one row per Stylus program compiled inside sp1-runner
+  reexecution         — full block re-execution inside sp1-runner
+
+All times are read from [PROFILE] log lines emitted by the binaries themselves.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+# ---------------------------------------------------------------------------
+# Log parsing
+# ---------------------------------------------------------------------------
+
+_PROFILE_RE = re.compile(r"\[PROFILE] (\w+): (.*)")
+_KV_RE = re.compile(r"(\w+)=([^\s,]+)")
+
+
+def parse_profile_lines(text: str) -> list[dict]:
+    rows = []
+    for line in text.splitlines():
+        m = _PROFILE_RE.search(line)
+        if not m:
+            continue
+        phase, kvs = m.group(1), m.group(2)
+        row = {"phase": phase}
+        for k, v in _KV_RE.findall(kvs):
+            row[k] = v
+        rows.append(row)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Running subprocesses
+# ---------------------------------------------------------------------------
+
+def run(label: str, cmd: list[str]) -> str:
+    """Run cmd, print a progress label, return combined stderr+stdout."""
+    print(f"  {label}...", flush=True)
+    env = os.environ.copy()
+    # Ensure INFO-level tracing is visible so [PROFILE] lines are emitted.
+    env.setdefault("RUST_LOG", "info")
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    combined = result.stderr + result.stdout
+    if result.returncode not in (0, 1):
+        # exit code 1 is expected from sp1-builder (bootloading stops early)
+        print(f"\nERROR: {label} exited with code {result.returncode}", file=sys.stderr)
+        print(combined, file=sys.stderr)
+        sys.exit(1)
+    return combined
+
+
+# ---------------------------------------------------------------------------
+# Table formatting
+# ---------------------------------------------------------------------------
+
+def fmt_int(v: str | None) -> str:
+    if v is None:
+        return "—"
+    try:
+        return f"{int(v):,}"
+    except ValueError:
+        return v
+
+
+def fmt_bytes(v: str | None) -> str:
+    if v is None:
+        return "—"
+    try:
+        n = int(v)
+        return f"{n / 1024:.1f} KiB" if n >= 1024 else f"{n} B"
+    except ValueError:
+        return v
+
+
+def fmt_secs(v: str | None) -> str:
+    if v is None:
+        return "—"
+    try:
+        return f"{float(v):.3f}s"
+    except ValueError:
+        return v
+
+
+def print_table(rows: list[dict]) -> None:
+    headers = ["Phase", "Wasm size", "SP1 cycles", "Time"]
+
+    display = []
+    for r in rows:
+        display.append([
+            r["label"],
+            fmt_bytes(r.get("wasm_size")),
+            fmt_int(r.get("cycles")),
+            fmt_secs(r.get("time_secs")),
+        ])
+
+    col_widths = [
+        max(len(headers[i]), max(len(d[i]) for d in display))
+        for i in range(len(headers))
+    ]
+
+    # First column (phase label) is left-aligned; the rest are right-aligned.
+    def fmt_cell(value: str, width: int, col: int) -> str:
+        return value.ljust(width) if col == 0 else value.rjust(width)
+
+    sep = "+-" + "-+-".join("-" * w for w in col_widths) + "-+"
+    header_row = "| " + " | ".join(h.ljust(w) for h, w in zip(headers, col_widths)) + " |"
+
+    print()
+    print(sep)
+    print(header_row)
+    print(sep)
+    for d in display:
+        print("| " + " | ".join(fmt_cell(c, w, i) for i, (c, w) in enumerate(zip(d, col_widths))) + " |")
+    print(sep)
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--output-dir", required=True, help="Path to target/sp1")
+    ap.add_argument("--block-inputs-dir", required=True, help="Path to target/sp1/block-inputs")
+    ap.add_argument("--block", default="stylus", help="Block input name (without .json)")
+    args = ap.parse_args()
+
+    out = args.output_dir
+    block_file = f"{args.block_inputs_dir}/{args.block}.json"
+
+    print(f"\nProfiling block: {args.block}")
+
+    print("\n[1/2] Running sp1-builder (WASM→LLVM compilation + SP1 bootloading):")
+    boot_log = run(
+        "sp1-builder",
+        [
+            "cargo", "run", "--release", "-p", "sp1-builder", "--",
+            "--replay-wasm", f"{out}/replay.wasm",
+            "--output-folder", out,
+        ],
+    )
+
+    print("\n[2/2] Running sp1-runner (stylus compilation + reexecution):")
+    run_log = run(
+        "sp1-runner",
+        [
+            f"{out}/sp1-runner",
+            "--program", f"{out}/dumped_replay_wasm.elf",
+            "--stylus-compiler-program", f"{out}/stylus-compiler-program",
+            "--block-file", block_file,
+        ],
+    )
+
+    profile_rows = parse_profile_lines(boot_log) + parse_profile_lines(run_log)
+
+    table: list[dict] = []
+    stylus_count = 0
+    for row in profile_rows:
+        phase = row["phase"]
+        if phase == "bootloading":
+            table.append({"label": "bootloading", "cycles": row.get("cycles"), "time_secs": row.get("time_secs")})
+        elif phase == "stylus_compilation":
+            stylus_count += 1
+            table.append({"label": f"stylus_compilation [{stylus_count}]", "wasm_size": row.get("wasm_size"), "cycles": row.get("cycles"), "time_secs": row.get("time_secs")})
+        elif phase == "reexecution":
+            table.append({"label": "reexecution", "cycles": row.get("cycles"), "time_secs": row.get("time_secs")})
+
+    if not table:
+        print("\nNo [PROFILE] lines found. Make sure RUST_LOG is not suppressing INFO logs.", file=sys.stderr)
+        sys.exit(1)
+
+    print_table(table)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/sp1/runner/src/main.rs
+++ b/crates/sp1/runner/src/main.rs
@@ -73,11 +73,11 @@ async fn main() {
                 std::process::exit(2);
             }
             let b = SystemTime::now();
+            tracing::info!("Exit code: {}", executor.exit_code());
             tracing::info!(
-                "Exit code: {}, cycles: {}, execution time: {:?}",
-                executor.exit_code(),
+                "[PROFILE] reexecution: cycles={}, time_secs={:.3}",
                 executor.global_clk(),
-                b.duration_since(a).unwrap(),
+                b.duration_since(a).unwrap().as_secs_f64(),
             );
 
             executor.exit_code() as i32
@@ -177,9 +177,10 @@ fn run_in_sp1(cli: &Cli, wasm: &[u8]) -> Vec<u8> {
         std::process::exit(executor.exit_code() as i32);
     }
     tracing::info!(
-        "Completed stylus compilation in SP1, cycles: {}, execution time: {:?}",
+        "[PROFILE] stylus_compilation: wasm_size={}, cycles={}, time_secs={:.3}",
+        wasm.len(),
         executor.global_clk(),
-        b.duration_since(a).unwrap(),
+        b.duration_since(a).unwrap().as_secs_f64(),
     );
 
     let public_value_stream = executor.into_public_values_stream();


### PR DESCRIPTION
SP1 profiling infrastructure + block recording fixes                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                          
Adds `make -C crates/sp1 profile` which runs the full SP1 pipeline (bootloading once, then all five block types) and prints a summary table of SP1 cycles and execution time per phase.

Changes:
  - `sp1-builder/src/main.rs` — emits `[PROFILE] bootloading: cycles=N, time_secs=F` after the SP1 executor finishes (excludes WASM→LLVM compilation time)
  - `sp1-runner/src/main.rs` — emits `[PROFILE] stylus_compilation: wasm_size=N, cycles=N, time_secs=F` per Stylus program and `[PROFILE] reexecution: cycles=N, time_secs=F` at the end
  - `crates/sp1/profile.py` — parses the above log lines and renders the table

Local run yields:
```
+------------------------+-----------+---------------+---------+
| Phase                  | Wasm size | SP1 cycles    | Time    |
+------------------------+-----------+---------------+---------+
| bootloading            |         — | 1,154,235,304 | 26.546s |
+========================+===========+===============+=========+
|                           transfer                           |
+------------------------+-----------+---------------+---------+
| reexecution            |         — |   165,082,262 |  4.552s |
+========================+===========+===============+=========+
|                           solidity                           |
+------------------------+-----------+---------------+---------+
| reexecution            |         — |   292,987,072 |  8.588s |
+========================+===========+===============+=========+
|                            stylus                            |
+------------------------+-----------+---------------+---------+
| stylus_compilation [1] |   7.3 KiB |   177,478,588 |  1.401s |
| reexecution            |         — |   207,731,546 |  5.089s |
+========================+===========+===============+=========+
|                         stylus_heavy                         |
+------------------------+-----------+---------------+---------+
| stylus_compilation [1] |   7.3 KiB |   177,478,588 |  1.408s |
| stylus_compilation [2] |  14.7 KiB |   357,699,896 |  2.788s |
| reexecution            |         — | 2,355,782,899 | 39.043s |
+========================+===========+===============+=========+
|                            mixed                             |
+------------------------+-----------+---------------+---------+
| stylus_compilation [1] |   7.3 KiB |   177,478,588 |  1.401s |
| stylus_compilation [2] |  11.0 KiB |   281,955,418 |  2.208s |
| reexecution            |         — |   288,816,648 |  6.851s |
+------------------------+-----------+---------------+---------+
```

part of NIT-4820