### PR TITLE
feat: replace GCS TestPermissions health check with probe object round-trip

### DIFF
--- a/daprovider/anytrust/google_cloud_storage_service.go
+++ b/daprovider/anytrust/google_cloud_storage_service.go
@@ -7,11 +7,9 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"sort"
 	"time"
 
 	googlestorage "cloud.google.com/go/storage"
-	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
 	"google.golang.org/api/option"
 
@@ -159,22 +157,37 @@ func (gcs *GoogleCloudStorageService) String() string {
 }
 
 func (gcs *GoogleCloudStorageService) HealthCheck(ctx context.Context) error {
+	// GCP's testIamPermissions API does not evaluate conditional IAM bindings,
+	// so it always returns empty results when permissions are granted via a
+	// condition (e.g. resource.name.startsWith(...)). Instead, we verify
+	// storage access by performing an actual write/read/delete round-trip on a
+	// small probe object within our configured prefix.
+	probeKey := gcs.objectPrefix + ".health-check-probe"
 	bucket := gcs.operator.Bucket(gcs.bucket)
-	// check if we have bucket permissions
-	permissions := []string{
-		"storage.objects.create",
-		"storage.objects.delete",
-		"storage.objects.list",
-		"storage.objects.get",
+
+	// write
+	w := bucket.Object(probeKey).NewWriter(ctx)
+	if _, err := w.Write([]byte("health-check")); err != nil {
+		return fmt.Errorf("health check: failed to write probe object: %w", err)
 	}
-	perms, err := bucket.IAM().TestPermissions(ctx, permissions)
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("health check: failed to close probe object writer: %w", err)
+	}
+
+	// read
+	r, err := bucket.Object(probeKey).NewReader(ctx)
 	if err != nil {
-		return fmt.Errorf("could not check permissions: %w", err)
+		return fmt.Errorf("health check: failed to read probe object: %w", err)
 	}
-	sort.Strings(permissions)
-	sort.Strings(perms)
-	if !cmp.Equal(perms, permissions) {
-		return fmt.Errorf("permissions mismatch (-want +got):\n%s", cmp.Diff(permissions, perms))
+	if _, err := io.ReadAll(r); err != nil {
+		r.Close()
+		return fmt.Errorf("health check: failed to read probe object data: %w", err)
+	}
+	r.Close()
+
+	// delete
+	if err := bucket.Object(probeKey).Delete(ctx); err != nil {
+		return fmt.Errorf("health check: failed to delete probe object: %w", err)
 	}
 
 	return nil

--- a/daprovider/anytrust/google_cloud_storage_service.go
+++ b/daprovider/anytrust/google_cloud_storage_service.go
@@ -4,6 +4,7 @@ package anytrust
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -131,7 +132,12 @@ func (gcs *GoogleCloudStorageService) GetByHash(ctx context.Context, key common.
 	log.Trace("anytrust.GoogleCloudStorageService.GetByHash", "key", pretty.PrettyHash(key), "this", gcs)
 	buf, err := gcs.operator.Download(ctx, gcs.bucket, gcs.objectPrefix, key)
 	if err != nil {
-		log.Error("anytrust.GoogleCloudStorageService.GetByHash", "err", err)
+		// context.Canceled is expected when RedundantStorageService cancels
+		// the shared sub-context after a faster inner service already returned
+		// successfully. Logging it at ERROR level would be misleading.
+		if !errors.Is(err, context.Canceled) {
+			log.Error("anytrust.GoogleCloudStorageService.GetByHash", "err", err)
+		}
 		return nil, err
 	}
 	return buf, nil


### PR DESCRIPTION
## Problem

The GCS `HealthCheck` uses `bucket.IAM().TestPermissions()` to verify that the daserver service account has the required storage permissions. However, GCP's testIamPermissions API has a documented limitation: it does not evaluate conditional IAM bindings. When permissions are granted via a condition (e.g. `resource.name.startsWith("projects/_/buckets/my-bucket/objects/my-prefix/")`), the API always returns an empty list — even if the service account can actually read and write to the bucket.

## Fix                                                                                                                                                                                                                           

Replace the `TestPermissions` call with an actual write/read/delete round-trip on a small probe object at `<objectPrefix>.health-check-probe`. This exercises the real permissions path and works correctly for both unconditional and conditional IAM bindings.

## Notes

  - The probe object is written and immediately deleted on every health check invocation
  - No change to the public API or configuration
  - The `sort` and `go-cmp` imports are removed as they are no longer used