### PR TITLE
fix(redis): default sentinel ports per address

### DIFF
--- a/changelog/haoshengzhen-redis-sentinel-default-port.md
+++ b/changelog/haoshengzhen-redis-sentinel-default-port.md
@@ -1,0 +1,2 @@
+### Fixed
+- Default missing Redis Sentinel ports per address when parsing `redis+sentinel` URLs.

--- a/util/redisutil/redisutil.go
+++ b/util/redisutil/redisutil.go
@@ -96,7 +96,7 @@ func getAddressesWithDefaults(u *url.URL) []string {
 	for _, urlHost := range urlHosts {
 		host, port, err := net.SplitHostPort(urlHost)
 		if err != nil {
-			host = u.Host
+			host = strings.TrimPrefix(strings.TrimSuffix(urlHost, "]"), "[")
 		}
 		if host == "" {
 			host = "localhost"

--- a/util/redisutil/redisutil_test.go
+++ b/util/redisutil/redisutil_test.go
@@ -1,0 +1,21 @@
+// Copyright 2021-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package redisutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseFailoverRedisUrlDefaultsPortPerAddress(t *testing.T) {
+	options, err := parseFailoverRedisUrl("redis+sentinel://sentinel-1,sentinel-2:26379/master")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"sentinel-1:6379", "sentinel-2:26379"}
+	if !reflect.DeepEqual(options.SentinelAddrs, want) {
+		t.Fatalf("unexpected sentinel addrs: have %v, want %v", options.SentinelAddrs, want)
+	}
+}


### PR DESCRIPTION
## Summary

When parsing `redis+sentinel` URLs with multiple sentinel addresses, an address without an explicit port used the full URL host list as its host fallback. For example:

`redis+sentinel://sentinel-1,sentinel-2:26379/master`

could produce an invalid first address instead of defaulting only `sentinel-1` to port `6379`.

This change applies the missing-port fallback per sentinel address, preserving explicitly configured ports on the other addresses. It also adds a regression test and a changelog fragment.

## Testing

- `gofmt`
- `git diff --check`
- Temporary Go reproduction confirming the old address parsing logic fails for mixed explicit/default sentinel ports, while the new logic returns `sentinel-1:6379` and `sentinel-2:26379`.
