### PR TITLE
Fix invalid Prometheus metric names from iostat parse glitches

### DIFF
--- a/changelog/sophoah-fix-iostat-invalid-device-metric-name.md
+++ b/changelog/sophoah-fix-iostat-invalid-device-metric-name.md
@@ -1,0 +1,3 @@
+### Fixed
+- Fix Prometheus scrape failures caused by `iostat` occasionally parsing a numeric string as a device name; `parseStream` now skips rows whose device name parses as a float
+- Sanitize `iostat` device names via the shared `metricsutil.CanonicalizeMetricName` helper in `RegisterAndPopulateMetrics` instead of only replacing hyphens, so any invalid Prometheus metric-name character is handled

--- a/util/iostat/iostat.go
+++ b/util/iostat/iostat.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+
+	"github.com/offchainlabs/nitro/util/metricsutil"
 )
 
 func RegisterAndPopulateMetrics(ctx context.Context, spawnInterval, maxDeviceCount int) {
@@ -33,8 +35,7 @@ func RegisterAndPopulateMetrics(ctx context.Context, spawnInterval, maxDeviceCou
 		if _, ok := deviceMetrics[stat.DeviceName]; !ok {
 			// Register metrics for a maximum of maxDeviceCount (fail safe in case iostat command returns incorrect names indefinitely)
 			if len(deviceMetrics) < maxDeviceCount {
-				// Replace hyphens with underscores to avoid metric name issues
-				sanitizedDeviceName := strings.ReplaceAll(stat.DeviceName, "-", "_")
+				sanitizedDeviceName := metricsutil.CanonicalizeMetricName(stat.DeviceName)
 				baseMetricName := fmt.Sprintf("iostat/%s/", sanitizedDeviceName)
 				deviceMetrics[stat.DeviceName] = make(map[string]*metrics.GaugeFloat64)
 				deviceMetrics[stat.DeviceName]["readspersecond"] = metrics.NewRegisteredGaugeFloat64(baseMetricName+"readspersecond", nil)
@@ -119,6 +120,10 @@ func parseStream(r io.Reader, receiver chan<- DeviceStats) {
 			}
 		}
 		if stat.DeviceName == "" {
+			continue
+		}
+		if _, err := strconv.ParseFloat(stat.DeviceName, 64); err == nil {
+			log.Warn("iostat returned a numeric device name, skipping implausible row", "deviceName", stat.DeviceName)
 			continue
 		}
 		receiver <- stat

--- a/util/iostat/iostat_test.go
+++ b/util/iostat/iostat_test.go
@@ -54,6 +54,14 @@ func TestParseStream(t *testing.T) {
 				Await:           6.75,
 			}},
 		},
+		{
+			name: "numeric device name is dropped",
+			input: `
+				Device r/s w/s await
+				99.99 1.25 2.50 3.75
+			`,
+			want: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/util/metricsutil/metricsutil_test.go
+++ b/util/metricsutil/metricsutil_test.go
@@ -1,0 +1,29 @@
+// Copyright 2021-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package metricsutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalizeMetricName(t *testing.T) {
+	tests := []struct {
+		name   string
+		metric string
+		want   string
+	}{
+		{name: "hyphenated LVM device vg0-swap", metric: "vg0-swap", want: "vg0_swap"},
+		{name: "hyphenated LVM device vg0-root", metric: "vg0-root", want: "vg0_root"},
+		{name: "already valid device name nvme0n1", metric: "nvme0n1", want: "nvme0n1"},
+		{name: "already valid device name loop0", metric: "loop0", want: "loop0"},
+		{name: "dotted numeric token", metric: "99.99", want: "99_99"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, CanonicalizeMetricName(tt.metric))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Prometheus scraping a Nitro node's `/debug/metrics/prometheus` endpoint failed entirely with:

```
Error scraping target: invalid metric type "99_await gauge"
```

The node itself was emitting an illegal metric name, not a Prometheus config problem. The `iostat_*` metrics come from `util/iostat/iostat.go`, which spawns `iostat -dNxy 1` and parses its stdout to register per-device gauges (`iostat_<device>_{await,readspersecond,writespersecond}`). A parse glitch caused the literal string `"99.99"` to get captured as a device name. Real devices on the affected host are things like `vg0-root`, `nvme0n1`, `loop0`, never a bare decimal number. That produced `iostat_99.99_await`, which is invalid per the Prometheus exposition format since metric names have to match `[a-zA-Z_:][a-zA-Z0-9_:]*` and dots aren't allowed.

A single invalid metric name aborts the whole scrape, not just that one series. And go-ethereum's metrics registry never unregisters a metric once it's created, so this one bad row permanently broke metrics collection for the node until it was restarted.

There was already some sanitization in place (`strings.ReplaceAll(stat.DeviceName, "-", "_")`, added in #2491 for LVM device names like `vg0-root`), but it only handled hyphens, never dots or anything else. Nothing validated that a parsed token actually looked like a plausible device name before it got registered as a metric.

## Fix

Two changes in `util/iostat/iostat.go`:

1. `parseStream` now skips a row if its parsed device name parses successfully as a float (e.g. `99.99`), since real device names never do. This stops the bad rows from reaching metric registration in the first place.
2. `RegisterAndPopulateMetrics` now sanitizes device names with the existing shared `metricsutil.CanonicalizeMetricName` helper (already used elsewhere in the codebase for this) instead of just replacing hyphens, so any other invalid character gets handled too.

## Testing

Added a `parseStream` test case confirming a row with a numeric device name (`99.99`) gets dropped.

Added `util/metricsutil/metricsutil_test.go`, which didn't exist before, confirming `CanonicalizeMetricName` sanitizes real device names seen in production (`vg0-swap`, `vg0-root`, `nvme0n1`, `loop0`) the same way the old hyphen-only replacement did. So this change doesn't rename any existing legitimate metric, it only changes behavior for the previously-broken case.

`go test`, `go vet`, and `gofmt` all pass for `util/iostat` and `util/metricsutil`.