### PR TITLE
execution: preserve parent-chain blockhash transitions

### DIFF
--- a/changelog/exocognosis-nit-4718.md
+++ b/changelog/exocognosis-nit-4718.md
@@ -1,0 +1,2 @@
+### Fixed
+- Prevent sequencer parent-chain block number jumps from leaving stale hashes in the ArbOS blockhash ring buffer.

--- a/execution/gethexec/sequencer.go
+++ b/execution/gethexec/sequencer.go
@@ -1430,6 +1430,13 @@ func (s *Sequencer) createBlock(ctx context.Context) (returnValue bool) {
 		return true
 	}
 
+	selectedL1Block := nextSequencerParentChainBlockNumber(l1Block, lastBlock)
+	if selectedL1Block != l1Block {
+		log.Debug("limiting parent chain block advancement to preserve blockhash history",
+			"observed", l1Block, "selected", selectedL1Block)
+		l1Block = selectedL1Block
+	}
+
 	header := &arbostypes.L1IncomingMessageHeader{
 		Kind:        arbostypes.L1MessageType_L2Message,
 		Poster:      l1pricing.BatchPosterAddress,

--- a/execution/gethexec/sequencer_l1_block.go
+++ b/execution/gethexec/sequencer_l1_block.go
@@ -1,0 +1,24 @@
+// Copyright 2021-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package gethexec
+
+import "github.com/ethereum/go-ethereum/core/types"
+
+// nextSequencerParentChainBlockNumber limits each sequenced L2 block to one
+// parent-chain block of progress. HeaderReader subscribers may miss intermediate
+// headers, especially when polling, but ArbOS associates the previous L2 block
+// hash with each parent-chain block transition. Advancing one block at a time
+// ensures every transition is recorded in order instead of leaving a stale
+// ring-buffer slot behind.
+func nextSequencerParentChainBlockNumber(observed uint64, lastL2Block *types.Header) uint64 {
+	lastBlockInfo := types.DeserializeHeaderExtraInformation(lastL2Block)
+	if lastBlockInfo.ArbOSFormatVersion == 0 {
+		return observed
+	}
+	previous := lastBlockInfo.L1BlockNumber
+	if observed > previous && observed-previous > 1 {
+		return previous + 1
+	}
+	return observed
+}

--- a/execution/gethexec/sequencer_l1_block_test.go
+++ b/execution/gethexec/sequencer_l1_block_test.go
@@ -1,0 +1,106 @@
+// Copyright 2021-2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+package gethexec
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func TestNextSequencerParentChainBlockNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   uint64
+		previous uint64
+		observed uint64
+		expected uint64
+	}{
+		{
+			name:     "legacy header is unchanged",
+			observed: 102,
+			expected: 102,
+		},
+		{
+			name:     "same parent chain block",
+			format:   params.ArbosVersion_51,
+			previous: 100,
+			observed: 100,
+			expected: 100,
+		},
+		{
+			name:     "next parent chain block",
+			format:   params.ArbosVersion_51,
+			previous: 100,
+			observed: 101,
+			expected: 101,
+		},
+		{
+			name:     "one skipped parent chain block",
+			format:   params.ArbosVersion_51,
+			previous: 100,
+			observed: 102,
+			expected: 101,
+		},
+		{
+			name:     "multiple skipped parent chain blocks",
+			format:   params.ArbosVersion_51,
+			previous: 100,
+			observed: 500,
+			expected: 101,
+		},
+		{
+			name:     "lower observation is unchanged",
+			format:   params.ArbosVersion_51,
+			previous: 100,
+			observed: 99,
+			expected: 99,
+		},
+		{
+			name:     "maximum block number does not overflow",
+			format:   params.ArbosVersion_51,
+			previous: math.MaxUint64 - 1,
+			observed: math.MaxUint64,
+			expected: math.MaxUint64,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lastL2Block := arbosL2Header(test.previous, test.format)
+			actual := nextSequencerParentChainBlockNumber(test.observed, lastL2Block)
+			if actual != test.expected {
+				t.Fatalf("expected parent chain block %d, got %d", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestNextSequencerParentChainBlockNumberCatchesUpInOrder(t *testing.T) {
+	const observed = uint64(105)
+	lastL2Block := arbosL2Header(100, params.ArbosVersion_51)
+
+	for expected := uint64(101); expected <= observed; expected++ {
+		actual := nextSequencerParentChainBlockNumber(observed, lastL2Block)
+		if actual != expected {
+			t.Fatalf("expected parent chain block %d, got %d", expected, actual)
+		}
+		lastL2Block = arbosL2Header(actual, params.ArbosVersion_51)
+	}
+}
+
+func arbosL2Header(l1BlockNumber uint64, arbosFormatVersion uint64) *types.Header {
+	header := &types.Header{
+		BaseFee:    big.NewInt(1),
+		Difficulty: big.NewInt(1),
+	}
+	types.HeaderInfo{
+		L1BlockNumber:      l1BlockNumber,
+		ArbOSFormatVersion: arbosFormatVersion,
+	}.UpdateHeaderWithInfo(header)
+	return header
+}


### PR DESCRIPTION
## Summary

Prevent the sequencer from skipping parent-chain blockhash transitions when its header reader observes a jump in the L1 block number.

This change:

- reads the parent-chain block number serialized in the previous L2 header
- limits each newly sequenced L2 block to one parent-chain block of advancement
- lets subsequent L2 blocks catch up in order when the reader has missed multiple L1 headers
- adds table-driven coverage for normal progression, skipped observations, legacy headers, lower observations, and the maximum block number boundary
- adds a release-note fragment for the fix

## Problem

If the previous L2 header records parent-chain block `N` and the header reader next observes `N+2`, the sequencer currently places `N+2` directly in the next incoming message. ArbOS then associates the previous L2 block hash with parent-chain block `N+1`. The ring-buffer entry for block `N` is never updated, so an older value can remain in that slot and reappear after the 256-entry ring wraps.

Lowering the header reader polling interval reduces how often this happens, but it does not guarantee that every intermediate header will be observed. Network delays and temporary reader stalls can still produce jumps.

## Solution

Before constructing the sequencer message header, compare the latest observed parent-chain block number with the number stored in the previous L2 header. When the observation is more than one block ahead, use `previous + 1` for the new message. If the observation remains ahead, each following L2 block advances one more step until the sequencer catches up.

For example, an observation jump from `N` to `N+2` now produces transitions through `N+1` and then `N+2`. ArbOS receives the previous L2 block hash for each transition and updates the corresponding ring-buffer slots in order.

Normal one-block progress, unchanged observations, and lower observations keep their existing behavior. Headers without ArbOS metadata also keep the existing behavior for compatibility.

## Consensus considerations

Changing `ApplyInternalTxUpdate` directly would alter the ArbOS state transition for historical input and would require an ArbOS version gate plus coordinated activation. This change avoids that consensus risk by correcting the sequencer-produced input before it enters deterministic execution. Validators continue to replay the exact incoming message chosen by the sequencer.

After a missed observation, the parent-chain number exposed by newly produced L2 blocks can temporarily trail the reader's latest observation. It catches up by one parent-chain block per produced L2 block. Existing stale ring-buffer entries are not rewritten, but they age out as the ring advances. The change prevents new gaps on the sequencer path described in the issue.

## Validation

- `go test ./execution/gethexec -run '^TestNextSequencerParentChainBlockNumber' -count=1`
- `go run ./linters ./execution/gethexec`
- `go vet ./execution/gethexec`
- `git diff --check`

Fixes #4718
