### PR TITLE
Fix installation-token redaction regex for new stateless token format

### DIFF
--- a/.github/buildspec.yml
+++ b/.github/buildspec.yml
@@ -28,7 +28,7 @@ phases:
           export GITHUB_TOKEN
           GITHUB_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '.token // empty')
           if [ -z "$GITHUB_TOKEN" ]; then
-            redacted=$(printf '%s' "$TOKEN_RESPONSE" | sed -E 's/(ghs_|ghu_)[A-Za-z0-9]+/\1REDACTED/g')
+            redacted=$(printf '%s' "$TOKEN_RESPONSE" | sed -E 's/(ghs_|ghu_)[A-Za-z0-9._-]+/\1REDACTED/g')
             echo "ERROR: installation token missing from response: ${redacted}" >&2
             exit 1
           fi
@@ -80,7 +80,7 @@ phases:
           export GITHUB_TOKEN
           GITHUB_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '.token // empty')
           if [ -z "$GITHUB_TOKEN" ]; then
-            redacted=$(printf '%s' "$TOKEN_RESPONSE" | sed -E 's/(ghs_|ghu_)[A-Za-z0-9]+/\1REDACTED/g')
+            redacted=$(printf '%s' "$TOKEN_RESPONSE" | sed -E 's/(ghs_|ghu_)[A-Za-z0-9._-]+/\1REDACTED/g')
             echo "ERROR: installation token missing from response: ${redacted}" >&2
             exit 1
           fi

--- a/.github/buildspec.yml
+++ b/.github/buildspec.yml
@@ -28,7 +28,7 @@ phases:
           export GITHUB_TOKEN
           GITHUB_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '.token // empty')
           if [ -z "$GITHUB_TOKEN" ]; then
-            redacted=$(printf '%s' "$TOKEN_RESPONSE" | sed -E 's/(ghs_|ghu_)[A-Za-z0-9._-]{36,}/\1REDACTED/g')
+            redacted=$(printf '%s' "$TOKEN_RESPONSE" | sed -E 's/(ghs_|ghu_)[A-Za-z0-9._-]+/\1REDACTED/g')
             echo "ERROR: installation token missing from response: ${redacted}" >&2
             exit 1
           fi
@@ -80,7 +80,7 @@ phases:
           export GITHUB_TOKEN
           GITHUB_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '.token // empty')
           if [ -z "$GITHUB_TOKEN" ]; then
-            redacted=$(printf '%s' "$TOKEN_RESPONSE" | sed -E 's/(ghs_|ghu_)[A-Za-z0-9._-]{36,}/\1REDACTED/g')
+            redacted=$(printf '%s' "$TOKEN_RESPONSE" | sed -E 's/(ghs_|ghu_)[A-Za-z0-9._-]+/\1REDACTED/g')
             echo "ERROR: installation token missing from response: ${redacted}" >&2
             exit 1
           fi

--- a/.github/buildspec.yml
+++ b/.github/buildspec.yml
@@ -28,7 +28,7 @@ phases:
           export GITHUB_TOKEN
           GITHUB_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '.token // empty')
           if [ -z "$GITHUB_TOKEN" ]; then
-            redacted=$(printf '%s' "$TOKEN_RESPONSE" | sed -E 's/(ghs_|ghu_)[A-Za-z0-9._-]+/\1REDACTED/g')
+            redacted=$(printf '%s' "$TOKEN_RESPONSE" | sed -E 's/(ghs_|ghu_)[A-Za-z0-9._-]{36,}/\1REDACTED/g')
             echo "ERROR: installation token missing from response: ${redacted}" >&2
             exit 1
           fi
@@ -80,7 +80,7 @@ phases:
           export GITHUB_TOKEN
           GITHUB_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '.token // empty')
           if [ -z "$GITHUB_TOKEN" ]; then
-            redacted=$(printf '%s' "$TOKEN_RESPONSE" | sed -E 's/(ghs_|ghu_)[A-Za-z0-9._-]+/\1REDACTED/g')
+            redacted=$(printf '%s' "$TOKEN_RESPONSE" | sed -E 's/(ghs_|ghu_)[A-Za-z0-9._-]{36,}/\1REDACTED/g')
             echo "ERROR: installation token missing from response: ${redacted}" >&2
             exit 1
           fi


### PR DESCRIPTION
Widens the installation-token redaction regex (only hit when `.token` extraction fails) to fully cover GitHub's new stateless token format — see [the announcement](https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header).

```
- sed -E 's/(ghs_|ghu_)[A-Za-z0-9]+/\1REDACTED/g'
+ sed -E 's/(ghs_|ghu_)[A-Za-z0-9._-]+/\1REDACTED/g'
```

New tokens are `ghs_<id>_<base64url JWT>` and contain `.`/`-`, which the old `[A-Za-z0-9]+` class didn't match — redaction stopped at the first one, leaking the rest of a real token into logs. No minimum length: GitHub's post recommends `{36,}`, but that reintroduces a hardcoded-length assumption (a 35-char tail goes fully unredacted) — the exact thing the post warns against — so this drops it. Same fix applied to nitro, nitro-private, and infrastructure (identical line in all three buildspecs).

Tracked in [SREP-3581](https://linear.app/offchain-labs/issue/SREP-3581/fix-github-app-installation-token-redaction-regex-for-new-stateless).
